### PR TITLE
Refactor time_bucket() transform to support UUIDv7

### DIFF
--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -35,6 +35,7 @@
 #include <optimizer/restrictinfo.h>
 #include <optimizer/tlist.h>
 #include <parser/parse_func.h>
+#include <parser/parse_type.h>
 #include <parser/parsetree.h>
 #include <partitioning/partbounds.h>
 #include <utils/builtins.h>
@@ -42,23 +43,24 @@
 #include <utils/errcodes.h>
 #include <utils/fmgroids.h>
 #include <utils/fmgrprotos.h>
+#include <utils/lsyscache.h>
 #include <utils/syscache.h>
+#include <utils/timestamp.h>
+#include <utils/typcache.h>
+#include <utils/uuid.h>
 
 #include "compat/compat.h"
+#include "annotations.h"
 #include "chunk.h"
 #include "cross_module_fn.h"
-#include "extension.h"
-#include "extension_constants.h"
 #include "guc.h"
 #include "hypertable.h"
 #include "hypertable_restrict_info.h"
 #include "import/planner.h"
 #include "nodes/chunk_append/chunk_append.h"
-#include "partialize.h"
-#include "partitioning.h"
 #include "planner.h"
 #include "time_utils.h"
-#include "ts_catalog/array_utils.h"
+#include "uuid.h"
 
 typedef struct CollectQualCtx
 {
@@ -130,29 +132,64 @@ is_timestamptz_op_interval(Expr *expr)
 		   (c1->consttype == INTERVALOID && c2->consttype == TIMESTAMPTZOID);
 }
 
-static Datum
-int_get_datum(int64 value, Oid type)
+static Const *
+integral_timeval_to_const(int64 value, Oid type)
 {
+	bool typbyval = get_typbyval(type);
+
 	switch (type)
 	{
 		case INT2OID:
-			return Int16GetDatum(value);
+			return makeConst(type, -1, InvalidOid, 2, Int16GetDatum(value), false, typbyval);
 		case INT4OID:
-			return Int32GetDatum(value);
+			return makeConst(type, -1, InvalidOid, 4, Int32GetDatum(value), false, typbyval);
 		case INT8OID:
-			return Int64GetDatum(value);
+			return makeConst(type, -1, InvalidOid, 8, Int64GetDatum(value), false, typbyval);
+		case DATEOID:
+			return makeConst(type,
+							 -1,
+							 InvalidOid,
+							 sizeof(DateADT),
+							 DateADTGetDatum(value),
+							 false,
+							 typbyval);
 		case TIMESTAMPOID:
-			return TimestampGetDatum(value);
+			return makeConst(type,
+							 -1,
+							 InvalidOid,
+							 sizeof(Timestamp),
+							 TimestampGetDatum(value),
+							 false,
+							 typbyval);
 		case TIMESTAMPTZOID:
-			return TimestampTzGetDatum(value);
+			return makeConst(type,
+							 -1,
+							 InvalidOid,
+							 sizeof(TimestampTz),
+							 TimestampTzGetDatum(value),
+							 false,
+							 typbyval);
+		case UUIDOID:
+		{
+			/*
+			 * UUIDv7 doesn't support timestamps smaller than the UNIX epoch. However, caggs often
+			 * refresh from "beginning of time" so we need to restrict the lower boundary value to
+			 * the UNIX epoch.
+			 */
+			if (value <= UNIX_EPOCH_AS_TIMESTAMP)
+				value = UNIX_EPOCH_AS_TIMESTAMP;
+
+			pg_uuid_t *uuid = ts_create_uuid_v7_from_timestamptz((TimestampTz) value, true);
+			return makeConst(type, -1, InvalidOid, UUID_LEN, UUIDPGetDatum(uuid), false, typbyval);
+		}
 		default:
-			elog(ERROR, "unsupported datatype in int_get_datum: %s", format_type_be(type));
+			elog(ERROR, "unsupported datatype in %s: %s", __func__, format_type_be(type));
 			pg_unreachable();
 	}
 }
 
 static int64
-const_datum_get_int(Const *cnst)
+const_to_integral_timeval(const Const *cnst)
 {
 	Assert(!cnst->constisnull);
 
@@ -170,9 +207,19 @@ const_datum_get_int(Const *cnst)
 			return DatumGetTimestamp(cnst->constvalue);
 		case TIMESTAMPTZOID:
 			return DatumGetTimestampTz(cnst->constvalue);
+		case UUIDOID:
+		{
+			/*
+			 * While it is possible to extract the timestamp from a UUID, there is currently no use
+			 * case where this function is used since the UUID-based time_bucket() function returns
+			 * a timestamptz. Thus, any value compared to is also a timestamptz and not a UUID.
+			 * */
+			TS_FALLTHROUGH;
+		}
 		default:
 			elog(ERROR,
-				 "unsupported datatype in const_datum_get_int: %s",
+				 "unsupported datatype in %s: %s",
+				 __func__,
 				 format_type_be(cnst->consttype));
 			pg_unreachable();
 	}
@@ -329,49 +376,177 @@ constify_timestamptz_op_interval(PlannerInfo *root, OpExpr *constraint)
 									constraint->inputcollid);
 }
 
+typedef struct TimeBucketInfo
+{
+	Oid rettype;	/* Type of the return value */
+	Const *width;	/* Bucket width */
+	Node *timeval;	/* Bucket "time" value */
+	Oid timetype;	/* Type of the time value */
+	uint16 numargs; /* Number of bucket function arguments */
+} TimeBucketInfo;
+
+/*
+ * Representation of a parse time bucket Qual:
+ *
+ *  <time_bucket() OP value>
+ */
+typedef struct TimeBucketQual
+{
+	TimeBucketInfo tb;
+	int strategy;
+	Const *value;
+} TimeBucketQual;
+
+/*
+ * Parse an expression of form <time_bucket(width, column) OP value> and extract the important
+ * components into a TimeBucketQual struct.
+ *
+ * Returns false if the expression does not fit the expected format.
+ */
 static bool
-extract_opexpr_parts(Expr *node, OpExpr **op, FuncExpr **time_bucket, Expr **value, Oid *opno)
+extract_time_bucket_qual(Expr *node, TimeBucketQual *tbqual)
 {
 	if (!IsA(node, OpExpr))
-	{
 		return false;
-	}
 
-	*op = castNode(OpExpr, node);
-	if (list_length((*op)->args) != 2)
-	{
+	OpExpr *op = castNode(OpExpr, node);
+
+	if (list_length((op)->args) != 2)
 		return false;
-	}
 
-	Expr *left = linitial((*op)->args);
-	Expr *right = lsecond((*op)->args);
+	Expr *left = linitial((op)->args);
+	Expr *right = lsecond((op)->args);
+	FuncExpr *time_bucket;
+
+	MemSet(tbqual, 0, sizeof(TimeBucketQual));
+
+	Oid opno = InvalidOid;
 
 	if (IsA(left, FuncExpr) && IsA(right, Const))
 	{
-		*time_bucket = castNode(FuncExpr, left);
-		*value = right;
-		*opno = (*op)->opno;
+		time_bucket = castNode(FuncExpr, left);
+		tbqual->value = castNode(Const, right);
+		opno = op->opno;
 	}
-	else if (IsA(right, FuncExpr))
+	else if (IsA(right, FuncExpr) && IsA(left, Const))
 	{
-		*time_bucket = castNode(FuncExpr, right);
-		*value = left;
-		*opno = get_commutator((*op)->opno);
-
-		if (!OidIsValid(opno))
-			return false;
+		time_bucket = castNode(FuncExpr, right);
+		tbqual->value = castNode(Const, left);
+		opno = get_commutator(op->opno);
 	}
 	else
 	{
 		return false;
 	}
 
-	if (!is_time_bucket_function((Expr *) *time_bucket) || !IsA(*value, Const) ||
-		castNode(Const, *value)->constisnull)
-	{
+	if (!is_time_bucket_function((Expr *) time_bucket) || tbqual->value->constisnull)
 		return false;
-	}
 
+	Const *width = linitial(time_bucket->args);
+	/* Get the time/partitioning column argument */
+	Node *timearg = lsecond(time_bucket->args);
+
+	if (!IsA(width, Const) || width->constisnull)
+		return false;
+
+	tbqual->tb.numargs = list_length(time_bucket->args);
+	tbqual->tb.width = width;
+	tbqual->tb.timeval = timearg;
+	tbqual->tb.timetype = exprType(timearg);
+	tbqual->tb.rettype = exprType((Node *) time_bucket);
+
+	/* 3 or more args should have Const 3rd arg */
+	if (list_length(time_bucket->args) > 2 && !IsA(lthird(time_bucket->args), Const))
+		return false;
+
+	/* 5 args variants should have Const 4th and 5th arg */
+	if (list_length(time_bucket->args) == 5 &&
+		(!IsA(lfourth(time_bucket->args), Const) || !IsA(lfifth(time_bucket->args), Const)))
+		return false;
+
+	Assert(list_length(time_bucket->args) == 2 || list_length(time_bucket->args) == 3 ||
+		   list_length(time_bucket->args) == 5);
+
+	TypeCacheEntry *tce = lookup_type_cache(tbqual->tb.rettype, TYPECACHE_BTREE_OPFAMILY);
+	tbqual->strategy = get_op_opfamily_strategy(opno, tce->btree_opf);
+
+	return true;
+}
+
+/*
+ * Convert at time_bucket() width argument (typically Interval or integer) to a microseconds
+ * integer. Also check that the width (interval) doesn't overflow the time value.
+ */
+static bool
+time_bucket_width_to_integral(const Const *width, Oid bucket_type, int64 integral_value,
+							  int64 *integral_width)
+{
+	switch (width->consttype)
+	{
+		case INT2OID:
+		case INT4OID:
+		case INT8OID:
+
+			/* We can support the offset variants of time_bucket as the
+			 * amount of shifting they do is never bigger than the bucketing
+			 * width.
+			 */
+			*integral_width = const_to_integral_timeval(width);
+
+			if (integral_value >= ts_time_get_max(bucket_type) - *integral_width)
+				return false;
+			break;
+		case INTERVALOID:
+		{
+			Interval *interval = DatumGetIntervalP(width->constvalue);
+			/*
+			 * Optimization can't be applied when interval has month component.
+			 */
+			if (interval->month != 0)
+				return false;
+
+			if (bucket_type == DATEOID)
+			{
+				/* bail out if interval->time can't be exactly represented as a double */
+				if (interval->time >= 0x3FFFFFFFFFFFFFLL)
+					return false;
+
+				*integral_width =
+					interval->day + ceil((double) interval->time / (double) USECS_PER_DAY);
+
+				if (integral_value >= (TS_DATE_END - *integral_width))
+					return false;
+			}
+			else if (bucket_type == TIMESTAMPOID || bucket_type == TIMESTAMPTZOID)
+			{
+				/*
+				 * If width interval has day component we merge it with time component
+				 */
+				*integral_width = interval->time;
+
+				if (interval->day != 0)
+				{
+					/*
+					 * if our transformed restriction would overflow we skip adding it
+					 */
+					if (interval->time >= TS_TIMESTAMP_END - interval->day * USECS_PER_DAY)
+						return false;
+
+					*integral_width += interval->day * USECS_PER_DAY;
+				}
+
+				if (integral_value >= (TS_TIMESTAMP_END - *integral_width))
+					return false;
+			}
+			else
+			{
+				return false;
+			}
+			break;
+		}
+		default:
+			return false;
+	}
 	return true;
 }
 
@@ -412,250 +587,87 @@ extract_opexpr_parts(Expr *node, OpExpr **op, FuncExpr **time_bucket, Expr **val
 Expr *
 ts_transform_time_bucket_comparison(Expr *node)
 {
-	FuncExpr *time_bucket;
-	Expr *value;
-	OpExpr *op;
-	Oid opno;
+	TimeBucketQual tbqual;
 
-	if (!extract_opexpr_parts(node, &op, &time_bucket, &value, &opno))
+	if (!extract_time_bucket_qual(node, &tbqual))
+		return NULL;
+
+	/*
+	 * The qual is an expression <time_bucket OP value> or <value OP time_bucket>. Convert the value
+	 * to integral time format.
+	 */
+	int64 integral_value = const_to_integral_timeval(tbqual.value);
+	Const *newvalue = NULL;
+
+	/*
+	 * We strip the time_bucket() from the expression, leaving the input "time" argument. Depending
+	 * on the comparison OP, the value might need adjustment. Then the value is converted to the
+	 * input/column type for time_bucket(). In most cases, the value's original type and the bucket
+	 * input type is the same (e.g. TIMESTAMPTZ), but in some cases they differ. For example, it is
+	 * possible to compare an int8 bucket function with an int4 value. In the case of UUID bucket,
+	 * the bucket function's input type (UUID) is different from the output type (TIMESTAMPTZ), so
+	 * the timestamp value needs to be converted to a boundary UUID.
+	 */
+	switch (tbqual.strategy)
 	{
-		return NULL;
-	}
-
-	Const *width = linitial(time_bucket->args);
-	/* Get the time/partitioning column argument */
-	Node *timearg = lsecond(time_bucket->args);
-
-	if (!IsA(width, Const) || width->constisnull)
-		return NULL;
-
-	if (exprType(timearg) == UUIDOID)
-	{
-		/*
-		 * For time_bucket() on UUID, the input and output types do not match, so it is not
-		 * possible to transform a time_bucket() to an expression on the UUID input type since it
-		 * will compare a UUID to a timestamptz.
-		 */
-		return NULL;
-	}
-
-	/* 3 or more args should have Const 3rd arg */
-	if (list_length(time_bucket->args) > 2 && !IsA(lthird(time_bucket->args), Const))
-		return NULL;
-
-	/* 5 args variants should have Const 4th and 5th arg */
-	if (list_length(time_bucket->args) == 5 &&
-		(!IsA(lfourth(time_bucket->args), Const) || !IsA(lfifth(time_bucket->args), Const)))
-		return NULL;
-
-	Assert(list_length(time_bucket->args) == 2 || list_length(time_bucket->args) == 3 ||
-		   list_length(time_bucket->args) == 5);
-
-	TypeCacheEntry *tce;
-	int strategy;
-
-	tce = lookup_type_cache(exprType((Node *) time_bucket), TYPECACHE_BTREE_OPFAMILY);
-	strategy = get_op_opfamily_strategy(opno, tce->btree_opf);
-
-	if (strategy == BTGreaterStrategyNumber || strategy == BTGreaterEqualStrategyNumber)
-	{
-		/* Since time_bucket will always shift the input to the left this
-		 * transformation is always safe even in the presence of offset variants.
-		 *
-		 * column > value
-		 */
-		op = copyObject(op);
-		op->args = list_make2(timearg, value);
-
-		/*
-		 * if we switched operator we need to adjust OpExpr as well
-		 */
-		if (op->opno != opno)
+		case BTGreaterStrategyNumber:
+		case BTGreaterEqualStrategyNumber:
+			/*
+			 * Since time_bucket will always shift the input to the left this
+			 * transformation is always safe even in the presence of offset variants.
+			 *
+			 * Handle expressions of form:
+			 *
+			 *  - column > value
+			 *  - column >= value
+			 */
+			newvalue = integral_timeval_to_const(integral_value, tbqual.tb.timetype);
+			break;
+		case BTLessStrategyNumber:
+		case BTLessEqualStrategyNumber:
 		{
-			op->opno = opno;
-			op->opfuncid = InvalidOid;
-		}
+			/*
+			 * Handle expressions of form:
+			 *
+			 *  - column < value + width
+			 *  - column <= value + width
+			 *  */
+			int64 integral_width = 0;
 
-		return &op->xpr;
-	}
-	else if (strategy == BTLessStrategyNumber || strategy == BTLessEqualStrategyNumber)
-	{
-		/* column < value + width */
-		Expr *subst;
-		Datum datum;
-		int64 integralValue, integralWidth;
-
-		switch (tce->type_id)
-		{
-			case INT2OID:
-			case INT4OID:
-			case INT8OID:
-				/* We can support the offset variants of time_bucket as the
-				 * amount of shifting they do is never bigger than the bucketing
-				 * width.
-				 */
-				integralValue = const_datum_get_int(castNode(Const, value));
-				integralWidth = const_datum_get_int(width);
-
-				if (integralValue >= ts_time_get_max(tce->type_id) - integralWidth)
-					return NULL;
-
-				/*
-				 * When the time_bucket constraint matches the start of the bucket
-				 * and we have a less than constraint and no offset  we can skip
-				 * adding the full bucket.
-				 */
-				if (strategy == BTLessStrategyNumber && list_length(time_bucket->args) == 2 &&
-					integralValue % integralWidth == 0)
-					datum = int_get_datum(integralValue, tce->type_id);
-				else
-					datum = int_get_datum(integralValue + integralWidth, tce->type_id);
-
-				subst = (Expr *) makeConst(tce->type_id,
-										   -1,
-										   InvalidOid,
-										   tce->typlen,
-										   datum,
-										   false,
-										   tce->typbyval);
-				break;
-
-			case DATEOID:
-			{
-				/* We can support the offset/origin variants of time_bucket
-				 * as the amount of shifting they do is never bigger than the
-				 * bucketing width.
-				 */
-				Assert(width->consttype == INTERVALOID);
-				Interval *interval = DatumGetIntervalP(width->constvalue);
-
-				/*
-				 * Optimization can't be applied when interval has month component.
-				 */
-				if (interval->month != 0)
-					return NULL;
-
-				/* bail out if interval->time can't be exactly represented as a double */
-				if (interval->time >= 0x3FFFFFFFFFFFFFLL)
-					return NULL;
-
-				integralValue = const_datum_get_int(castNode(Const, value));
-				integralWidth =
-					interval->day + ceil((double) interval->time / (double) USECS_PER_DAY);
-
-				if (integralValue >= (TS_DATE_END - integralWidth))
-					return NULL;
-
-				/*
-				 * When the time_bucket constraint matches the start of the bucket
-				 * and we have a less than constraint and no offset or origin we can
-				 * skip adding the full bucket.
-				 */
-				if (strategy == BTLessStrategyNumber && list_length(time_bucket->args) == 2 &&
-					integralValue % integralWidth == 0)
-					datum = DateADTGetDatum(integralValue);
-				else
-					datum = DateADTGetDatum(integralValue + integralWidth);
-
-				subst = (Expr *) makeConst(tce->type_id,
-										   -1,
-										   InvalidOid,
-										   tce->typlen,
-										   datum,
-										   false,
-										   tce->typbyval);
-
-				break;
-			}
-			case TIMESTAMPOID:
-			case TIMESTAMPTZOID:
-			{
-				/* We can support the offset/origin/timezone variants of time_bucket
-				 * as the amount of shifting they do is never bigger than the
-				 * bucketing width.
-				 */
-				Assert(width->consttype == INTERVALOID);
-				Interval *interval = DatumGetIntervalP(width->constvalue);
-
-				/*
-				 * Optimization can't be applied when interval has month component.
-				 */
-				if (interval->month != 0)
-					return NULL;
-
-				/*
-				 * If width interval has day component we merge it with time component
-				 */
-
-				integralWidth = interval->time;
-				if (interval->day != 0)
-				{
-					/*
-					 * if our transformed restriction would overflow we skip adding it
-					 */
-					if (interval->time >= TS_TIMESTAMP_END - interval->day * USECS_PER_DAY)
-						return NULL;
-
-					integralWidth += interval->day * USECS_PER_DAY;
-				}
-
-				integralValue = const_datum_get_int(castNode(Const, value));
-
-				if (integralValue >= (TS_TIMESTAMP_END - integralWidth))
-					return NULL;
-
-				/*
-				 * When the time_bucket constraint matches the start of the bucket
-				 * and we have a less than constraint and no other modifying arguments
-				 * we can skip adding the full bucket.
-				 */
-				if (strategy == BTLessStrategyNumber && list_length(time_bucket->args) == 2 &&
-					integralValue % integralWidth == 0)
-					datum = int_get_datum(integralValue, tce->type_id);
-				else
-					datum = int_get_datum(integralValue + integralWidth, tce->type_id);
-
-				subst = (Expr *) makeConst(tce->type_id,
-										   -1,
-										   InvalidOid,
-										   tce->typlen,
-										   datum,
-										   false,
-										   tce->typbyval);
-
-				break;
-			}
-
-			default:
+			if (!time_bucket_width_to_integral(tbqual.tb.width,
+											   tbqual.tb.rettype,
+											   integral_value,
+											   &integral_width))
 				return NULL;
+
+			if (tbqual.strategy == BTLessStrategyNumber && tbqual.tb.numargs == 2 &&
+				integral_value % integral_width == 0)
+				newvalue = integral_timeval_to_const(integral_value, tbqual.tb.timetype);
+			else
+				newvalue =
+					integral_timeval_to_const(integral_value + integral_width, tbqual.tb.timetype);
+
+			break;
 		}
-
-		/*
-		 * adjust toplevel expression if datatypes changed
-		 * this can happen when comparing int4 values against int8 time_bucket
-		 */
-		if (tce->type_id != castNode(Const, value)->consttype)
-		{
-			opno =
-				ts_get_operator(get_opname(opno), PG_CATALOG_NAMESPACE, tce->type_id, tce->type_id);
-
-			if (!OidIsValid(opno))
-				return NULL;
-		}
-
-		op = copyObject(op);
-
-		/*
-		 * if we changed operator we need to adjust OpExpr as well
-		 */
-		if (op->opno != opno)
-		{
-			op->opno = opno;
-			op->opfuncid = get_opcode(opno);
-		}
-
-		op->args = list_make2(lsecond(time_bucket->args), subst);
+		default:
+			return NULL;
 	}
+
+	Assert(newvalue != NULL);
+
+	/* Create a new "unwrapped" OpExpr using the time_bucket() input/column type */
+	TypeCacheEntry *tce = lookup_type_cache(tbqual.tb.timetype, TYPECACHE_BTREE_OPFAMILY);
+	Oid opno = get_opfamily_member(tce->btree_opf,
+								   tce->btree_opintype,
+								   tce->btree_opintype,
+								   tbqual.strategy);
+
+	OpExpr *op = (OpExpr *) copyObject(node);
+	op->args = list_make2(tbqual.tb.timeval, newvalue);
+	op->opno = opno;
+
+	/* The operator might have changed, so reset the function ID */
+	op->opfuncid = InvalidOid;
 
 	return &op->xpr;
 }
@@ -1056,6 +1068,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 
 	Chunk **chunks = NULL;
 	unsigned int num_chunks = 0;
+
 	chunks = get_chunks(&ctx, root, rel, ht, include_osm, &num_chunks);
 	/* Can have zero chunks. */
 	Assert(num_chunks == 0 || chunks != NULL);

--- a/src/uuid.h
+++ b/src/uuid.h
@@ -9,6 +9,8 @@
 #include <fmgr.h>
 #include <utils/uuid.h>
 
+#define UNIX_EPOCH_AS_TIMESTAMP (0 - ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY))
+
 extern pg_uuid_t *ts_uuid_create(void);
 extern pg_uuid_t *ts_create_uuid_v7_from_unixtime_us(int64 unixtime_us, bool boundary,
 													 bool set_version);

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -1821,44 +1821,44 @@ DEALLOCATE P8;
    Sort Key: hyper."time"
    ->  Append
          ->  Seq Scan on _hyper_1_2_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_7_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 11) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+         Filter: (("time" > '11'::bigint) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
 
 :PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
 
 \qecho time_bucket exclusion with date
 time_bucket exclusion with date

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -1821,44 +1821,44 @@ DEALLOCATE P8;
    Sort Key: hyper."time"
    ->  Append
          ->  Seq Scan on _hyper_1_2_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_7_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 11) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+         Filter: (("time" > '11'::bigint) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
 
 :PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
 
 \qecho time_bucket exclusion with date
 time_bucket exclusion with date

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -1821,44 +1821,44 @@ DEALLOCATE P8;
    Sort Key: hyper."time"
    ->  Append
          ->  Seq Scan on _hyper_1_2_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_7_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 11) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+         Filter: (("time" > '11'::bigint) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
 
 :PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
 
 \qecho time_bucket exclusion with date
 time_bucket exclusion with date

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -1821,44 +1821,44 @@ DEALLOCATE P8;
    Sort Key: hyper."time"
    ->  Append
          ->  Seq Scan on _hyper_1_2_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_7_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+               Filter: (("time" > '10'::bigint) AND ("time" < '100'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 11) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+         Filter: (("time" > '11'::bigint) AND ("time" < '19'::bigint) AND (time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
 
 :PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_1_2_chunk."time"
    ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (("time" > 10) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         Filter: (("time" > '10'::bigint) AND ("time" < '20'::bigint) AND (10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
 
 \qecho time_bucket exclusion with date
 time_bucket exclusion with date

--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -318,17 +318,11 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) >= :'chunk_range_end'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: uuid_events.id DESC
-   ->  HashAggregate
-         Group Key: uuid_events.id
-         ->  Append
-               ->  Seq Scan on _hyper_1_8_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) >= 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_7_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) >= 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_6_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) >= 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: _hyper_1_8_chunk.id
+   ->  Index Scan Backward using "8_8_uuid_events_pkey" on _hyper_1_8_chunk
+         Index Cond: (id >= '01942976-3400-7000-8000-000000000000'::uuid)
+         Filter: (time_bucket('@ 1 day'::interval, id) >= 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) >= :'chunk_range_end'
@@ -342,17 +336,16 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) > :'chunk_range_start'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: uuid_events.id DESC
-   ->  HashAggregate
-         Group Key: uuid_events.id
-         ->  Append
-               ->  Seq Scan on _hyper_1_8_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) > 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_7_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) > 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_6_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) > 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: uuid_events.id
+   ->  Custom Scan (ChunkAppend) on uuid_events
+         Order: uuid_events.id DESC
+         ->  Index Scan Backward using "8_8_uuid_events_pkey" on _hyper_1_8_chunk
+               Index Cond: (id > '0194244f-d800-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) > 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "7_7_uuid_events_pkey" on _hyper_1_7_chunk
+               Index Cond: (id > '0194244f-d800-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) > 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) > :'chunk_range_start'
@@ -366,17 +359,16 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) < :'chunk_range_end'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: uuid_events.id DESC
-   ->  HashAggregate
-         Group Key: uuid_events.id
-         ->  Append
-               ->  Seq Scan on _hyper_1_8_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_7_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_6_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: uuid_events.id
+   ->  Custom Scan (ChunkAppend) on uuid_events
+         Order: uuid_events.id DESC
+         ->  Index Scan Backward using "7_7_uuid_events_pkey" on _hyper_1_7_chunk
+               Index Cond: (id < '01942976-3400-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "6_6_uuid_events_pkey" on _hyper_1_6_chunk
+               Index Cond: (id < '01942976-3400-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) < :'chunk_range_end'
@@ -392,17 +384,19 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) <= :'chunk_range_start'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: uuid_events.id DESC
-   ->  HashAggregate
-         Group Key: uuid_events.id
-         ->  Append
-               ->  Seq Scan on _hyper_1_8_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_7_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_6_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: uuid_events.id
+   ->  Custom Scan (ChunkAppend) on uuid_events
+         Order: uuid_events.id DESC
+         ->  Index Scan Backward using "8_8_uuid_events_pkey" on _hyper_1_8_chunk
+               Index Cond: (id <= '01942976-3400-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "7_7_uuid_events_pkey" on _hyper_1_7_chunk
+               Index Cond: (id <= '01942976-3400-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "6_6_uuid_events_pkey" on _hyper_1_6_chunk
+               Index Cond: (id <= '01942976-3400-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) <= :'chunk_range_start'

--- a/test/sql/uuid.sql
+++ b/test/sql/uuid.sql
@@ -16,7 +16,6 @@ SELECT create_hypertable('uuid_events', 'id', chunk_time_interval => true);
 
 SELECT create_hypertable('uuid_events', 'id', chunk_time_interval => interval '1 day');
 
-
 --
 -- Test that inserting boundary values generates the right constraints
 -- on chunks.

--- a/tsl/test/expected/cagg_uuid.out
+++ b/tsl/test/expected/cagg_uuid.out
@@ -175,6 +175,7 @@ select count(*) from ts_events;
   4331
 
 CALL refresh_continuous_aggregate('daily_uuid_events', NULL, NULL);
+WARNING:  disabling direct compress because of too small batch size
 CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
 SELECT * FROM daily_uuid_events ORDER BY day;
              day              |  temp  
@@ -235,6 +236,8 @@ VALUES
 -- Test refresh via policy
 SELECT add_continuous_aggregate_policy('daily_uuid_events', start_offset => NULL, end_offset => NULL, schedule_interval => '1 minute') AS job_id \gset
 CALL run_job(:job_id);
+WARNING:  disabling direct compress because of too small batch size
+WARNING:  disabling direct compress because of too small batch size
 CALL refresh_continuous_aggregate('weekly_uuid_events', NULL, NULL);
 CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
 CALL refresh_continuous_aggregate('weekly_ts_events', NULL, NULL);


### PR DESCRIPTION
TimescaleDB performs a plan-time optimization to enable chunk exclusion for time_bucket() queries where a time_bucket() expression is part of the WHERE clause. The general form of the WHERE clause is:

`time_bucket(width, column) OP value`

The optimization transforms such expressions so that the restriction is directly on the time column instead of the bucket expression. This makes chunk exclusion work.

This change adds support for transforming UUIDv7 time_bucket() expressions. One complication of the UUIDv7 bucket is that it doesn't follow the exact same pattern as other buckets where the time input type is of the same type as the compared value. The bucket input "time" is a UUIDv7 while the output type and type of the compared to value is TIMESTAMPTZ. Therefore, the timestamp value needs to be converted to a boundary UUIDv7.

To make this work without too much of a special case for UUID, the code for the optimization needed some refactoring.

Disable-check: force-changelog-file