### PR TITLE
POC for rewriting queries with Caggs, add early validations

### DIFF
--- a/.unreleased/pr_8967
+++ b/.unreleased/pr_8967
@@ -1,0 +1,2 @@
+Implements: #8967 Rewriting queries with continuous aggregates exactly matching query aggregation
+Setting: `enable_cagg_rewrites`: enables rewriting queries with CAggs. Off by default. `cagg_rewrites_debug_info`: prints CAgg rewrites diagnostics. Off by default.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -132,6 +132,6 @@ add_subdirectory(with_clause)
 # file properties if the target was added in the same directory, so just move it
 # all here.
 set(IMPORTED_SOURCES import/allpaths.c import/heapswap.c import/list.c
-                     import/planner.c import/ts_explain.c)
+                     import/planner.c import/setrefs.c import/ts_explain.c)
 set_source_files_properties(${IMPORTED_SOURCES} PROPERTIES SKIP_LINTING ON)
 target_sources(${PROJECT_NAME} PRIVATE ${IMPORTED_SOURCES})

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -340,6 +340,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.continuous_agg_invalidate_mat_ht = continuous_agg_invalidate_mat_ht_all_default,
 	.continuous_agg_dml_invalidate = continuous_agg_dml_invalidate_default,
 	.continuous_agg_update_options = continuous_agg_update_options_default,
+	.continuous_agg_apply_rewrites_tsl = NULL,
 	.continuous_agg_validate_query = error_no_default_fn_pg_community,
 	.continuous_agg_get_bucket_function = error_no_default_fn_pg_community,
 	.continuous_agg_get_bucket_function_info = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -111,6 +111,7 @@ typedef struct CrossModuleFunctions
 										  bool update);
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
+	Query *(*continuous_agg_apply_rewrites_tsl)(Query *parse);
 	PGFunction continuous_agg_validate_query;
 	PGFunction continuous_agg_get_bucket_function;
 	PGFunction continuous_agg_get_bucket_function_info;

--- a/src/guc.c
+++ b/src/guc.c
@@ -149,7 +149,10 @@ TSDLLEXPORT bool ts_guc_enable_delete_after_compression = false;
 TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh = false;
 
 bool ts_guc_enable_partitioned_hypertables = false;
-
+#if PG16_GE
+TSDLLEXPORT bool ts_guc_enable_cagg_rewrites = false;
+TSDLLEXPORT bool ts_guc_cagg_rewrites_debug_info = false;
+#endif
 /* default value of ts_guc_max_open_chunks_per_insert and
  * ts_guc_max_cached_chunks_per_hypertable will be set as their respective boot-value when the
  * GUC mechanism starts up */
@@ -873,7 +876,29 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+#if PG16_GE
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_cagg_rewrites"),
+							 "Enable rewriting queries with Caggs",
+							 "Enable rewriting queries with eligible continuous aggregates",
+							 &ts_guc_enable_cagg_rewrites,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 
+	DefineCustomBoolVariable(MAKE_EXTOPTION("cagg_rewrites_debug_info"),
+							 "Print debug info about whether queries can be rewritten with Caggs",
+							 "Print debug info about whether queries can be rewritten with Caggs",
+							 &ts_guc_cagg_rewrites_debug_info,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+#endif
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compression_wal_markers"),
 							 "Enable WAL markers for compression ops",
 							 "Enable the generation of markers in the WAL stream which mark the "

--- a/src/guc.h
+++ b/src/guc.h
@@ -80,6 +80,10 @@ extern TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan;
 extern TSDLLEXPORT bool ts_guc_enable_multikey_skip_scan;
 extern TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier;
 extern TSDLLEXPORT bool ts_guc_debug_skip_scan_info;
+#if PG16_GE
+extern TSDLLEXPORT bool ts_guc_enable_cagg_rewrites;
+extern TSDLLEXPORT bool ts_guc_cagg_rewrites_debug_info;
+#endif
 
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;

--- a/src/import/setrefs.c
+++ b/src/import/setrefs.c
@@ -1,0 +1,186 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ *
+ * These function were copied from the PostgreSQL core planner, since
+ * they were declared static in the core planner, but we need them for
+ * our manipulations.
+ */
+#include <postgres.h>
+
+#include "setrefs.h"
+
+#include <nodes/makefuncs.h>
+#include <optimizer/tlist.h>
+#include <rewrite/rewriteDefine.h>
+
+/* Methods for efficient rewrite of query expressions with subquery targets,
+ * borrowed from PostgreSQL and simplified for our use
+ * as we call these methods before planning is done.
+ */
+
+typedef struct
+{
+	ts_indexed_tlist *subplan_itlist;
+	int newvarno;
+	int rtoffset;
+	bool match;
+} replace_tlist_expr_context;
+
+ts_indexed_tlist *
+ts_build_tlist_index(List *tlist)
+{
+	ts_indexed_tlist *itlist;
+	ts_tlist_vinfo *vinfo;
+	ListCell *l;
+
+	/* Create data structure with enough slots for all tlist entries */
+	itlist = (ts_indexed_tlist *) palloc(offsetof(ts_indexed_tlist, vars) +
+										 list_length(tlist) * sizeof(ts_tlist_vinfo));
+
+	itlist->tlist = tlist;
+	itlist->has_non_vars = false;
+
+	/* Find the Vars and fill in the index array */
+	vinfo = itlist->vars;
+	foreach (l, tlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(l);
+		if (tle->resjunk)
+			continue;
+
+		if (tle->expr && IsA(tle->expr, Var))
+		{
+			Var *var = (Var *) tle->expr;
+
+			vinfo->varno = var->varno;
+			vinfo->varattno = var->varattno;
+			vinfo->resno = tle->resno;
+			vinfo++;
+		}
+		else
+			itlist->has_non_vars = true;
+	}
+
+	itlist->num_vars = (vinfo - itlist->vars);
+
+	return itlist;
+}
+
+static Var *
+search_indexed_tlist_for_var(Var *var, ts_indexed_tlist *itlist, int newvarno, int rtoffset)
+{
+	int varno = var->varno;
+	AttrNumber varattno = var->varattno;
+	ts_tlist_vinfo *vinfo;
+	int i;
+
+	vinfo = itlist->vars;
+	i = itlist->num_vars;
+	while (i-- > 0)
+	{
+		if (vinfo->varno == varno && vinfo->varattno == varattno)
+		{
+			/* Found a match */
+			Var *newvar = makeVar(newvarno,
+								  vinfo->resno,
+								  var->vartype,
+								  var->vartypmod,
+								  var->varcollid,
+								  var->varlevelsup);
+			return newvar;
+		}
+		vinfo++;
+	}
+	return NULL; /* no match */
+}
+
+static Var *
+search_indexed_tlist_for_non_var(Expr *node, ts_indexed_tlist *itlist, int newvarno)
+{
+	TargetEntry *tle;
+
+	/*
+	 * If it's a simple Const, replacing it with a Var is silly, even if there
+	 * happens to be an identical Const below; a Var is more expensive to
+	 * execute than a Const.  What's more, replacing it could confuse some
+	 * places in the executor that expect to see simple Consts for, eg,
+	 * dropped columns.
+	 */
+	if (IsA(node, Const))
+		return NULL;
+
+	tle = tlist_member(node, itlist->tlist);
+	if (tle)
+	{
+		/* Found a matching subplan output expression */
+		Var *newvar;
+
+		newvar = makeVarFromTargetEntry(newvarno, tle);
+		newvar->varnosyn = 0; /* wasn't ever a plain Var */
+		newvar->varattnosyn = 0;
+		return newvar;
+	}
+	return NULL; /* no match */
+}
+
+static Node *
+replace_tlist_expr_mutator(Node *node, replace_tlist_expr_context *context)
+{
+	Var *newvar;
+
+	if (node == NULL)
+		return NULL;
+	if (IsA(node, Var))
+	{
+		Var *var = (Var *) node;
+
+		newvar = search_indexed_tlist_for_var(var,
+											  context->subplan_itlist,
+											  context->newvarno,
+											  context->rtoffset);
+		if (!newvar)
+		{
+			context->match = false;
+			return node;
+		}
+		return (Node *) newvar;
+	}
+	/* Try matching more complex expressions too, if tlist has any */
+	if (context->subplan_itlist->has_non_vars)
+	{
+		newvar = search_indexed_tlist_for_non_var((Expr *) node,
+												  context->subplan_itlist,
+												  context->newvarno);
+		if (newvar)
+			return (Node *) newvar;
+	}
+	return expression_tree_mutator(node, replace_tlist_expr_mutator, context);
+}
+
+/* Will try to rewrite query expression with subquery targets,
+ * returns NULL if can't fully rewrite the expression.
+ */
+Node *
+ts_replace_tlist_expr(Node *node, ts_indexed_tlist *subplan_itlist, int newvarno, int rtoffset)
+{
+	replace_tlist_expr_context context;
+
+	context.subplan_itlist = subplan_itlist;
+	context.newvarno = newvarno;
+	context.rtoffset = rtoffset;
+	context.match = true;
+	Node *result = replace_tlist_expr_mutator(node, &context);
+	if (!context.match)
+		return NULL;
+	else
+		return result;
+}

--- a/src/import/setrefs.h
+++ b/src/import/setrefs.h
@@ -1,0 +1,36 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+#include "export.h"
+#include <access/attnum.h>
+#include <nodes/nodeFuncs.h>
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ */
+
+typedef struct
+{
+	int varno;			 /* RT index of Var */
+	AttrNumber varattno; /* attr number of Var */
+	AttrNumber resno;	 /* TLE position of Var */
+} ts_tlist_vinfo;
+
+typedef struct
+{
+	List *tlist;								/* underlying target list */
+	int num_vars;								/* number of plain Var tlist entries */
+	bool has_non_vars;							/* are there other entries? */
+	ts_tlist_vinfo vars[FLEXIBLE_ARRAY_MEMBER]; /* has num_vars entries */
+} ts_indexed_tlist;
+
+extern TSDLLEXPORT ts_indexed_tlist *ts_build_tlist_index(List *tlist);
+extern TSDLLEXPORT Node *ts_replace_tlist_expr(Node *node, ts_indexed_tlist *subplan_itlist,
+											   int newvarno, int rtoffset);

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -63,6 +63,7 @@
 #include "nodes/chunk_append/chunk_append.h"
 #include "planner.h"
 #include "time_utils.h"
+#include "utils.h"
 #include "uuid.h"
 
 typedef struct CollectQualCtx
@@ -76,16 +77,6 @@ typedef struct CollectQualCtx
 } CollectQualCtx;
 
 static void propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx);
-
-static bool
-is_time_bucket_function(Expr *node)
-{
-	if (IsA(node, FuncExpr) &&
-		strncmp(get_func_name(castNode(FuncExpr, node)->funcid), "time_bucket", NAMEDATALEN) == 0)
-		return true;
-
-	return false;
-}
 
 static void
 ts_add_append_rel_infos(PlannerInfo *root, List *appinfos)
@@ -441,7 +432,7 @@ extract_time_bucket_qual(Expr *node, TimeBucketQual *tbqual)
 		return false;
 	}
 
-	if (!is_time_bucket_function((Expr *) time_bucket) || tbqual->value->constisnull)
+	if (!ts_is_time_bucket_function((Expr *) time_bucket) || tbqual->value->constisnull)
 		return false;
 
 	Const *width = linitial(time_bucket->args);

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1541,6 +1541,32 @@ ts_continuous_agg_get_query(ContinuousAgg *cagg)
 	return cagg_view_query;
 }
 
+Query *
+ts_continuous_agg_get_finalized_query(ContinuousAgg *cagg)
+{
+	Oid cagg_view_oid;
+	Relation cagg_view_rel;
+	RuleLock *cagg_view_rules;
+	RewriteRule *rule;
+	Query *cagg_view_query;
+
+	cagg_view_oid = ts_get_relation_relid(NameStr(cagg->data.user_view_schema),
+										  NameStr(cagg->data.user_view_name),
+										  false);
+	cagg_view_rel = table_open(cagg_view_oid, AccessShareLock);
+	cagg_view_rules = cagg_view_rel->rd_rules;
+	Assert(cagg_view_rules && cagg_view_rules->numLocks == 1);
+
+	rule = cagg_view_rules->rules[0];
+	if (rule->event != CMD_SELECT)
+		ereport(ERROR, (errcode(ERRCODE_TS_UNEXPECTED), errmsg("unexpected rule event for view")));
+
+	cagg_view_query = (Query *) copyObject(linitial(rule->actions));
+	table_close(cagg_view_rel, NoLock);
+
+	return cagg_view_query;
+}
+
 /*
  * Get the width of a fixed size bucket
  */

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -191,6 +191,8 @@ extern TSDLLEXPORT int64 ts_compute_beginning_of_the_next_bucket_variable(
 
 extern TSDLLEXPORT Query *ts_continuous_agg_get_query(ContinuousAgg *cagg);
 
+extern TSDLLEXPORT Query *ts_continuous_agg_get_finalized_query(ContinuousAgg *cagg);
+
 extern TSDLLEXPORT int64
 ts_continuous_agg_fixed_bucket_width(const ContinuousAggBucketFunction *bucket_function);
 extern TSDLLEXPORT int64

--- a/src/utils.c
+++ b/src/utils.c
@@ -23,6 +23,7 @@
 #include <fmgr.h>
 #include <funcapi.h>
 #include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
 #include <parser/parse_coerce.h>
 #include <parser/parse_func.h>
 #include <parser/scansup.h>
@@ -2067,4 +2068,42 @@ ts_list_to_string(List *list, append_cell_func append)
 		}
 	}
 	return info.data;
+}
+
+typedef struct FindAggrefsContext
+{
+	List *aggrefs; /* all non-nested Aggrefs found in a node */
+} FindAggrefsContext;
+
+static bool
+find_aggrefs_walker(Node *node, FindAggrefsContext *context)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Aggref))
+	{
+		context->aggrefs = lappend(context->aggrefs, node);
+		/* don't recurse inside Aggrefs */
+		return false;
+	}
+
+	return expression_tree_walker(node, find_aggrefs_walker, context);
+}
+
+List *
+ts_find_aggrefs(Node *node)
+{
+	FindAggrefsContext agg_ctx = { .aggrefs = NULL };
+	find_aggrefs_walker(node, &agg_ctx);
+	return agg_ctx.aggrefs;
+}
+
+bool
+ts_is_time_bucket_function(Expr *node)
+{
+	if (IsA(node, FuncExpr) &&
+		strncmp(get_func_name(castNode(FuncExpr, node)->funcid), "time_bucket", NAMEDATALEN) == 0)
+		return true;
+
+	return false;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -372,3 +372,5 @@ extern TSDLLEXPORT void ts_relation_set_reloption(Relation rel, List *options, L
 extern TSDLLEXPORT Jsonb *ts_errdata_to_jsonb(ErrorData *edata, Name proc_schema, Name proc_name);
 extern TSDLLEXPORT char *ts_get_attr_expr(Relation rel, AttrNumber attno);
 extern TSDLLEXPORT char *ts_list_to_string(List *list, append_cell_func append);
+extern TSDLLEXPORT List *ts_find_aggrefs(Node *node);
+extern TSDLLEXPORT bool ts_is_time_bucket_function(Expr *node);

--- a/tsl/src/bgw_policy/process_hyper_inval_api.c
+++ b/tsl/src/bgw_policy/process_hyper_inval_api.c
@@ -136,8 +136,7 @@ policy_process_hyper_inval_add(PG_FUNCTION_ARGS)
 	Hypertable *ht = ts_hypertable_cache_get_cache_and_entry(ht_oid, CACHE_FLAG_NONE, &hcache);
 
 	/* Check that we have a continuous aggregate attached */
-	List *caggs = ts_continuous_aggs_find_by_raw_table_id(ht->fd.id);
-	if (list_length(caggs) == 0)
+	if (!ts_hypertable_has_continuous_aggregates(ht->fd.id))
 		ereport(ERROR,
 				errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				errmsg("\"%s\" does not have an associated continuous aggregate",

--- a/tsl/src/continuous_aggs/CMakeLists.txt
+++ b/tsl/src/continuous_aggs/CMakeLists.txt
@@ -9,5 +9,6 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/options.c
     ${CMAKE_CURRENT_SOURCE_DIR}/planner.c
     ${CMAKE_CURRENT_SOURCE_DIR}/refresh.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/rewrite_with_caggs.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utils.c)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -14,20 +14,16 @@
 #include "extension.h"
 #include "guc.h"
 
-static Const *check_time_bucket_argument(Node *arg, char *position, bool process_checks);
-static void caggtimebucketinfo_init(ContinuousAggTimeBucketInfo *src, int32 hypertable_id,
-									Oid hypertable_oid, AttrNumber hypertable_partition_colno,
-									Oid hypertable_partition_coltype,
-									int64 hypertable_partition_col_interval,
-									int32 parent_mat_hypertable_id);
+static Const *check_time_bucket_argument(Node *arg, char *position, bool process_checks,
+										 StringInfo msg, bool for_rewrites);
 static void process_additional_timebucket_parameter(ContinuousAggBucketFunction *bf, Const *arg,
 													bool *custom_origin);
 static void process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf,
 										  bool process_checks, bool is_cagg_create,
-										  AttrNumber htpartcolno);
+										  AttrNumber htpartcolno, StringInfo msg,
+										  bool for_rewrites);
 static void caggtimebucket_validate(ContinuousAggTimeBucketInfo *tbinfo, List *groupClause,
 									List *targetList, List *rtable, bool is_cagg_create);
-static bool cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail);
 static Datum get_bucket_width_datum(ContinuousAggTimeBucketInfo bucket_info);
 static int64 get_bucket_width(ContinuousAggTimeBucketInfo bucket_info);
 static FuncExpr *build_conversion_call(Oid type, FuncExpr *boundary);
@@ -36,7 +32,6 @@ static Const *cagg_boundary_make_lower_bound(Oid type);
 static Node *build_union_query_quals(int32 ht_id, Oid partcoltype, Oid opno, int varno,
 									 AttrNumber attno);
 static RangeTblEntry *makeRangeTblEntry(Query *subquery, const char *aliasname);
-static bool time_bucket_info_has_fixed_width(const ContinuousAggBucketFunction *bf);
 
 #define INTERNAL_TO_DATE_FUNCTION "to_date"
 #define INTERNAL_TO_TSTZ_FUNCTION "to_timestamp"
@@ -44,7 +39,8 @@ static bool time_bucket_info_has_fixed_width(const ContinuousAggBucketFunction *
 #define BOUNDARY_FUNCTION "cagg_watermark"
 
 static Const *
-check_time_bucket_argument(Node *arg, char *position, bool process_checks)
+check_time_bucket_argument(Node *arg, char *position, bool process_checks, StringInfo msg,
+						   bool for_rewrites)
 {
 	if (IsA(arg, NamedArgExpr))
 		arg = (Node *) castNode(NamedArgExpr, arg)->arg;
@@ -52,11 +48,20 @@ check_time_bucket_argument(Node *arg, char *position, bool process_checks)
 	Node *expr = eval_const_expressions(NULL, arg);
 
 	if (process_checks && !IsA(expr, Const))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("only immutable expressions allowed in time bucket function"),
-				 errhint("Use an immutable expression as %s argument to the time bucket function.",
-						 position)));
+	{
+		if (!for_rewrites)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("only immutable expressions allowed in time bucket function"),
+					 errhint("Use an immutable expression as %s argument to the time bucket "
+							 "function.",
+							 position)));
+		else if (msg)
+			appendStringInfo(msg,
+							 "non-immutable expression as %s argument to the time bucket function",
+							 position);
+		return NULL;
+	}
 
 	return castNode(Const, expr);
 }
@@ -64,7 +69,7 @@ check_time_bucket_argument(Node *arg, char *position, bool process_checks)
 /*
  * Initialize caggtimebucket.
  */
-static void
+void
 caggtimebucketinfo_init(ContinuousAggTimeBucketInfo *src, int32 hypertable_id, Oid hypertable_oid,
 						AttrNumber hypertable_partition_colno, Oid hypertable_partition_coltype,
 						int64 hypertable_partition_col_interval, int32 parent_mat_hypertable_id)
@@ -232,7 +237,8 @@ process_additional_timebucket_parameter(ContinuousAggBucketFunction *bf, Const *
  */
 static void
 process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf, bool process_checks,
-							  bool is_cagg_create, AttrNumber htpartcolno)
+							  bool is_cagg_create, AttrNumber htpartcolno, StringInfo msg,
+							  bool for_rewrites)
 {
 	Node *width_arg;
 	Node *col_arg;
@@ -249,10 +255,18 @@ process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf, boo
 
 	if (process_checks && htpartcolno != InvalidAttrNumber &&
 		(!(IsA(col_arg, Var)) || castNode(Var, col_arg)->varattno != htpartcolno))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("time bucket function must reference the primary hypertable "
-						"dimension column")));
+	{
+		if (!for_rewrites)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("time bucket function must reference the primary hypertable "
+							"dimension column")));
+		else if (msg)
+			appendStringInfoString(msg,
+								   "time bucket function must reference the primary hypertable "
+								   "dimension column");
+		return;
+	}
 
 	nargs = list_length(fe->args);
 	Assert(nargs >= 2 && nargs <= 5);
@@ -276,7 +290,13 @@ process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf, boo
 	 */
 	if (nargs >= 3)
 	{
-		Const *arg = check_time_bucket_argument(lthird(fe->args), "third", process_checks);
+		Const *arg = check_time_bucket_argument(lthird(fe->args),
+												"third",
+												process_checks,
+												msg,
+												for_rewrites);
+		if (!arg)
+			return;
 		process_additional_timebucket_parameter(bf, arg, &custom_origin);
 	}
 
@@ -290,21 +310,37 @@ process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf, boo
 	 */
 	if (nargs >= 4)
 	{
-		Const *arg = check_time_bucket_argument(lfourth(fe->args), "fourth", process_checks);
+		Const *arg = check_time_bucket_argument(lfourth(fe->args),
+												"fourth",
+												process_checks,
+												msg,
+												for_rewrites);
+		if (!arg)
+			return;
 		process_additional_timebucket_parameter(bf, arg, &custom_origin);
 	}
 
 	if (nargs == 5)
 	{
-		Const *arg = check_time_bucket_argument(lfifth(fe->args), "fifth", process_checks);
+		Const *arg = check_time_bucket_argument(lfifth(fe->args),
+												"fifth",
+												process_checks,
+												msg,
+												for_rewrites);
+		if (!arg)
+			return;
 		process_additional_timebucket_parameter(bf, arg, &custom_origin);
 	}
 
 	if (process_checks && custom_origin && TIMESTAMP_NOT_FINITE(bf->bucket_time_origin))
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("invalid origin value: infinity")));
+		if (!for_rewrites)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid origin value: infinity")));
+		else if (msg)
+			appendStringInfoString(msg, "invalid time bucket origin value: infinity");
+		return;
 	}
 
 	/*
@@ -345,14 +381,19 @@ process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf, boo
 			}
 		}
 	}
-	else
+	else if (process_checks)
 	{
-		if (process_checks)
+		if (!for_rewrites)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("only immutable expressions allowed in time bucket function"),
 					 errhint("Use an immutable expression as first argument to the time bucket "
 							 "function.")));
+		else if (msg)
+			appendStringInfoString(msg,
+								   "non-immutable expression as first argument to the time bucket "
+								   "function");
+		return;
 	}
 
 	bf->bucket_function = fe->funcid;
@@ -365,17 +406,18 @@ process_timebucket_parameters(FuncExpr *fe, ContinuousAggBucketFunction *bf, boo
  * <col> is the hypertable's partitioning column and other invariants. Then fill
  * the `bucket_width` and other fields of `tbinfo`.
  */
-static void
-caggtimebucket_validate(ContinuousAggTimeBucketInfo *tbinfo, List *groupClause, List *targetList,
-						List *rtable, bool is_cagg_create)
+bool
+caggtimebucket_validate_common(ContinuousAggBucketFunction *bf, List *groupClause, List *targetList,
+							   List *rtable, int ht_partcolno, StringInfo msg, bool is_cagg_create,
+							   const bool for_rewrites)
 {
 	ListCell *l;
 	bool found = false;
 
 	/* Make sure tbinfo was initialized. This assumption is used below. */
-	Assert(tbinfo->bf->bucket_integer_width == 0);
-	Assert(tbinfo->bf->bucket_time_timezone == NULL);
-	Assert(TIMESTAMP_NOT_FINITE(tbinfo->bf->bucket_time_origin));
+	Assert(bf->bucket_integer_width == 0);
+	Assert(bf->bucket_time_timezone == NULL);
+	Assert(TIMESTAMP_NOT_FINITE(bf->bucket_time_origin));
 
 	List *group_exprs = get_sortgrouplist_exprs(groupClause, targetList);
 
@@ -424,72 +466,122 @@ caggtimebucket_validate(ContinuousAggTimeBucketInfo *tbinfo, List *groupClause, 
 			}
 
 			if (found)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("continuous aggregate view cannot contain"
-								" multiple time bucket functions")));
+			{
+				if (!for_rewrites)
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("continuous aggregate view cannot contain"
+									" multiple time bucket functions")));
+				else if (msg)
+					appendStringInfoString(msg,
+										   "multiple time bucket functions are not supported with "
+										   "CAggs");
+				return false;
+			}
 			else
 				found = true;
 
 			process_timebucket_parameters(fe,
-										  tbinfo->bf,
+										  bf,
 										  true,
 										  is_cagg_create,
-										  tbinfo->htpartcolno);
+										  ht_partcolno,
+										  msg,
+										  for_rewrites);
+			if (!OidIsValid(bf->bucket_function))
+				return false;
 		}
 	}
 
-	if (tbinfo->bf->bucket_time_offset != NULL &&
-		TIMESTAMP_NOT_FINITE(tbinfo->bf->bucket_time_origin) == false)
+	if (bf->bucket_time_offset != NULL && TIMESTAMP_NOT_FINITE(bf->bucket_time_origin) == false)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("using offset and origin in a time_bucket function at the same time is not "
-						"supported")));
+		if (!for_rewrites)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("using offset and origin in a time_bucket function at the same time is "
+							"not "
+							"supported")));
+		else if (msg)
+			appendStringInfoString(msg,
+								   "using offset and origin in a time_bucket function at the same "
+								   "time is "
+								   "not "
+								   "supported");
+		return false;
 	}
 
-	if (!time_bucket_info_has_fixed_width(tbinfo->bf))
+	if (!time_bucket_info_has_fixed_width(bf))
 	{
 		/* Variable-sized buckets can be used only with intervals. */
-		Assert(tbinfo->bf->bucket_time_width != NULL);
-		Assert(IS_TIME_BUCKET_INFO_TIME_BASED(tbinfo->bf));
+		Assert(bf->bucket_time_width != NULL);
+		Assert(IS_TIME_BUCKET_INFO_TIME_BASED(bf));
 
-		if ((tbinfo->bf->bucket_time_width->month != 0) &&
-			((tbinfo->bf->bucket_time_width->day != 0) ||
-			 (tbinfo->bf->bucket_time_width->time != 0)))
-		{
+		if ((bf->bucket_time_width->month != 0) &&
+			((bf->bucket_time_width->day != 0) || (bf->bucket_time_width->time != 0)))
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("invalid interval specified"),
 					 errhint("Use either months or days and hours, but not months, days and hours "
 							 "together")));
-		}
 	}
 
 	if (!found)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("continuous aggregate view must include a valid time bucket function")));
+	{
+		if (!for_rewrites)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg(
+						 "continuous aggregate view must include a valid time bucket function")));
+		else if (msg)
+			appendStringInfoString(msg, "should be a valid time bucket function in the query");
+
+		return false;
+	}
+	return true;
+}
+
+static void
+caggtimebucket_validate(ContinuousAggTimeBucketInfo *tbinfo, List *groupClause, List *targetList,
+						List *rtable, bool is_cagg_create)
+{
+	bool for_rewrite = false;
+	caggtimebucket_validate_common(tbinfo->bf,
+								   groupClause,
+								   targetList,
+								   rtable,
+								   tbinfo->htpartcolno,
+								   NULL,
+								   is_cagg_create,
+								   for_rewrite);
 }
 
 /*
- * Check query and extract error details and error hints.
+ * Check query for Cagg support, extract error details and error hints.
  *
  * Returns:
- *   True if the query is supported, false otherwise with hints and errors
- *   added.
+ *   True if the query is supported
+ *   (either for Cagg view or for query rewrite with Cagg, see for_rewrites),
+ *   false otherwise with hints and errors added
+ *   if hint and error string buffers are provided.
  */
-static bool
-cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail)
+bool
+cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail,
+					 const bool for_rewrites)
 {
 	if (!query->jointree->fromlist)
 	{
-		appendStringInfoString(hint, "FROM clause missing in the query");
+		if (!for_rewrites)
+			appendStringInfoString(hint, "FROM clause missing in the query");
+		else if (hint)
+			appendStringInfoString(hint, "FROM clause missing in the query");
 		return false;
 	}
 	if (query->commandType != CMD_SELECT)
 	{
-		appendStringInfoString(hint, "Use a SELECT query in the continuous aggregate view.");
+		if (!for_rewrites)
+			appendStringInfoString(hint, "Use a SELECT query in the continuous aggregate view.");
+		else if (hint)
+			appendStringInfoString(hint, "not a SELECT query");
 		return false;
 	}
 
@@ -497,29 +589,44 @@ cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail)
 	{
 		if (ts_guc_enable_cagg_window_functions)
 		{
-			elog(WARNING,
-				 "window function support is experimental and may result in unexpected results "
-				 "depending on the functions used.");
+			if (!for_rewrites)
+				elog(WARNING,
+					 "window function support is experimental and may result in unexpected results "
+					 "depending on the functions used.");
+
+			else if (hint)
+				appendStringInfoString(hint, "Window function in a query");
 		}
 		else
 		{
-			appendStringInfoString(detail, "Window function support not enabled.");
-			appendStringInfoString(hint,
-								   "Enable experimental window function support by setting "
-								   "timescaledb.enable_cagg_window_functions.");
+			if (!for_rewrites)
+			{
+				appendStringInfoString(detail, "Window function support not enabled.");
+				appendStringInfoString(hint,
+									   "Enable experimental window function support by setting "
+									   "timescaledb.enable_cagg_window_functions.");
+			}
+			else if (hint)
+				appendStringInfoString(hint, "Window function in a query");
 			return false;
 		}
 	}
 
 	if (query->hasDistinctOn || query->distinctClause)
 	{
-		appendStringInfoString(detail,
-							   "DISTINCT / DISTINCT ON queries are not supported by continuous "
-							   "aggregates.");
+		if (!for_rewrites)
+			appendStringInfoString(detail,
+								   "DISTINCT / DISTINCT ON queries are not supported by continuous "
+								   "aggregates.");
+		else if (hint)
+			appendStringInfoString(hint,
+								   "DISTINCT / DISTINCT ON queries are not supported by continuous "
+								   "aggregates.");
 		return false;
 	}
 
-	if (query->limitOffset || query->limitCount)
+	/* Can apply LIMIT to queries rewritten with Caggs */
+	if (!for_rewrites && (query->limitOffset || query->limitCount))
 	{
 		appendStringInfoString(detail,
 							   "LIMIT and LIMIT OFFSET are not supported in queries defining "
@@ -532,60 +639,307 @@ cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail)
 
 	if (query->hasRecursive || query->hasSubLinks || query->cteList)
 	{
-		appendStringInfoString(detail,
-							   "CTEs and subqueries are not supported by "
-							   "continuous aggregates.");
+		if (!for_rewrites)
+			appendStringInfoString(detail,
+								   "CTEs and subqueries are not supported by "
+								   "continuous aggregates.");
+		else if (hint)
+			appendStringInfoString(hint,
+								   "CTEs and sublinks are not supported by "
+								   "continuous aggregates.");
 		return false;
 	}
 
 	if (query->hasForUpdate || query->hasModifyingCTE)
 	{
-		appendStringInfoString(detail,
-							   "Data modification is not allowed in continuous aggregate view "
-							   "definitions.");
+		if (!for_rewrites)
+			appendStringInfoString(detail,
+								   "Data modification is not allowed in continuous aggregate view "
+								   "definitions.");
+		else if (hint)
+			appendStringInfoString(hint,
+								   "Data modification is not allowed in continuous aggregates");
 		return false;
 	}
 
 	if (query->hasRowSecurity)
 	{
-		appendStringInfoString(detail,
-							   "Row level security is not supported by continuous aggregate "
-							   "views.");
+		if (!for_rewrites)
+			appendStringInfoString(detail,
+								   "Row level security is not supported by continuous aggregate "
+								   "views.");
+		else if (hint)
+			appendStringInfoString(hint,
+								   "Row level security is not supported by continuous aggregates");
 		return false;
 	}
 
 	if (query->groupingSets)
 	{
-		appendStringInfoString(detail,
-							   "GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by "
-							   "continuous aggregates");
-		appendStringInfoString(hint,
-							   "Define multiple continuous aggregates with different grouping "
-							   "levels.");
+		if (!for_rewrites)
+		{
+			appendStringInfoString(detail,
+								   "GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by "
+								   "continuous aggregates");
+			appendStringInfoString(hint,
+								   "Define multiple continuous aggregates with different grouping "
+								   "levels.");
+		}
+		else if (hint)
+			appendStringInfoString(hint,
+								   "GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by "
+								   "continuous aggregates");
 		return false;
 	}
 
 	if (query->setOperations)
 	{
-		appendStringInfoString(detail,
-							   "UNION, EXCEPT & INTERSECT are not supported by continuous "
-							   "aggregates");
+		if (!for_rewrites)
+			appendStringInfoString(detail,
+								   "UNION, EXCEPT & INTERSECT are not supported by continuous "
+								   "aggregates");
+		else if (hint)
+			appendStringInfoString(hint,
+								   "UNION, EXCEPT & INTERSECT are not supported by continuous "
+								   "aggregates");
 		return false;
 	}
 
 	if (!query->groupClause)
 	{
 		/*
-		 * Query can have aggregate without group by , so look
+		 * Query can have aggregate without group by, so look
 		 * for groupClause.
 		 */
-		appendStringInfoString(hint,
-							   "Include at least one aggregate function"
-							   " and a GROUP BY clause with time bucket.");
+		if (!for_rewrites)
+			appendStringInfoString(hint,
+								   "Include at least one aggregate function"
+								   " and a GROUP BY clause with time bucket.");
+		else if (hint)
+			appendStringInfoString(hint, "no GROUP BY clause in the query");
 		return false;
 	}
 
 	return true; /* Query was OK and is supported. */
+}
+
+bool
+cagg_query_rtes_supported(RangeTblEntry *rte, RangeTblEntry **ht_rte, StringInfo detail,
+						  const bool for_rewrites)
+{
+	if (rte->rtekind == RTE_RELATION
+		/* Allow for processed views in Caggs used in a query */
+		|| (for_rewrites && rte->relkind == RELKIND_VIEW))
+	{
+		bool is_hypertable =
+			ts_is_hypertable(rte->relid) || ts_continuous_agg_find_by_relid(rte->relid);
+
+		if (is_hypertable && !(*ht_rte))
+		{
+			*ht_rte = rte;
+		}
+		else if (is_hypertable && (*ht_rte))
+		{
+			if (!for_rewrites)
+				appendStringInfoString(detail,
+									   "Only one hypertable is allowed in continuous aggregate "
+									   "view.");
+			else if (detail)
+				appendStringInfo(detail,
+								 "More than one hypertable in the query: \"%s\" and \"%s\"",
+								 rte->eref->aliasname,
+								 (*ht_rte)->eref->aliasname);
+			return false;
+		}
+
+		if (is_hypertable && rte->inh == false && !(for_rewrites && rte->relkind == RELKIND_VIEW))
+		{
+			if (!for_rewrites)
+				appendStringInfoString(detail,
+									   "FROM ONLY on hypertables is not allowed in continuous "
+									   "aggregate.");
+			else if (detail)
+				appendStringInfo(detail,
+								 "FROM ONLY on hypertable \"%s\" is not allowed in continuous "
+								 "aggregate.",
+								 rte->eref->aliasname);
+			return false;
+		}
+	}
+	/* Only inner joins are allowed. */
+	if (rte->jointype != JOIN_INNER && rte->jointype != JOIN_LEFT)
+	{
+		if (detail)
+			appendStringInfoString(detail,
+								   "only INNER or LEFT joins are supported in continuous "
+								   "aggregates");
+		return false;
+	}
+
+	/* Subquery only using LATERAL */
+	if (rte->subquery && !rte->lateral && !(for_rewrites && rte->relkind == RELKIND_VIEW))
+	{
+		if (!for_rewrites)
+			appendStringInfoString(detail, "Sub-queries are not supported in FROM clause.");
+		else if (detail)
+			appendStringInfoString(detail,
+								   "only LATERAL subqueries in FROM clause are supported in "
+								   "continuous aggregates.");
+		return false;
+	}
+
+	/* TABLESAMPLE not allowed */
+	if (rte->tablesample)
+	{
+		if (detail)
+			appendStringInfoString(detail, "TABLESAMPLE is not supported in continuous aggregate.");
+		return false;
+	}
+	return true;
+}
+
+const Dimension *
+cagg_hypertable_dim_supported(RangeTblEntry *ht_rte, Hypertable *ht, StringInfo msg,
+							  StringInfo detail, StringInfo hint, const bool for_rewrites)
+{
+	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
+	{
+		if (!for_rewrites)
+			appendStringInfoString(msg, "hypertable is an internal compressed hypertable");
+		else if (msg)
+			appendStringInfo(msg,
+							 "hypertable \"%s.%s\" is an internal compressed hypertable",
+							 NameStr(ht->fd.schema_name),
+							 NameStr(ht->fd.table_name));
+		return NULL;
+	}
+
+	if (ht_rte->relkind == RELKIND_RELATION)
+	{
+		ContinuousAggHypertableStatus status = ts_continuous_agg_hypertable_status(ht->fd.id);
+
+		/* Prevent create a CAGG over an existing materialization hypertable. */
+		if (status == HypertableIsMaterialization || status == HypertableIsMaterializationAndRaw)
+		{
+			const ContinuousAgg *cagg =
+				ts_continuous_agg_find_by_mat_hypertable_id(ht->fd.id, false);
+			Assert(cagg != NULL);
+			if (!for_rewrites)
+			{
+				appendStringInfoString(msg,
+									   "hypertable is a continuous aggregate materialization "
+									   "table");
+				appendStringInfo(detail,
+								 "Materialization hypertable \"%s.%s\".",
+								 NameStr(ht->fd.schema_name),
+								 NameStr(ht->fd.table_name));
+				appendStringInfo(hint,
+								 "Do you want to use continuous aggregate \"%s.%s\" instead?",
+								 NameStr(cagg->data.user_view_schema),
+								 NameStr(cagg->data.user_view_name));
+			}
+			else if (msg)
+			{
+				appendStringInfo(msg,
+								 "hypertable \"%s.%s\" is a continuous aggregate materialization "
+								 "table",
+								 NameStr(ht->fd.schema_name),
+								 NameStr(ht->fd.table_name));
+			}
+			return NULL;
+		}
+	}
+
+	/* Get primary partitioning column information. */
+	const Dimension *part_dimension = hyperspace_get_open_dimension(ht->space, 0);
+	/*
+	 * NOTE: if we ever allow custom partitioning functions we'll need to
+	 *       change part_dimension->fd.column_type to partitioning_type
+	 *       below, along with any other fallout.
+	 */
+	if (part_dimension == NULL || part_dimension->partitioning != NULL)
+	{
+		if (msg)
+			appendStringInfoString(msg,
+								   "custom partitioning functions not supported with continuous "
+								   "aggregates");
+		return NULL;
+	}
+
+	if (IS_INTEGER_TYPE(ts_dimension_get_partition_type(part_dimension)) &&
+		ht_rte->relkind == RELKIND_RELATION)
+	{
+		const char *funcschema = NameStr(part_dimension->fd.integer_now_func_schema);
+		const char *funcname = NameStr(part_dimension->fd.integer_now_func);
+
+		if (strlen(funcschema) == 0 || strlen(funcname) == 0)
+		{
+			if (!for_rewrites)
+			{
+				appendStringInfo(msg,
+								 "custom time function required on hypertable \"%s\"",
+								 get_rel_name(ht->main_table_relid));
+				appendStringInfoString(detail,
+									   "An integer-based hypertable requires a custom time "
+									   "function to support continuous aggregates.");
+				appendStringInfoString(hint, "Set a custom time function on the hypertable.");
+			}
+			else if (msg)
+				appendStringInfo(msg,
+								 "custom time function required on integer-based hypertable \"%s\"",
+								 get_rel_name(ht->main_table_relid));
+			return NULL;
+		}
+	}
+	return part_dimension;
+}
+bool
+
+cagg_timebucket_equal(ContinuousAggBucketFunction *bf1, ContinuousAggBucketFunction *bf2)
+{
+	if (bf1->bucket_time_based != bf2->bucket_time_based)
+		return false;
+
+	if (bf1->bucket_fixed_interval != bf2->bucket_fixed_interval)
+		return false;
+
+	if (bf1->bucket_time_based)
+	{
+		if (bf1->bucket_time_origin != bf2->bucket_time_origin)
+			return false;
+
+		if ((bf1->bucket_time_offset && !bf2->bucket_time_offset) ||
+			(!bf1->bucket_time_offset && bf2->bucket_time_offset))
+			return false;
+		if (bf1->bucket_time_offset && bf2->bucket_time_offset)
+		{
+			Datum offset1 = IntervalPGetDatum(bf1->bucket_time_offset);
+			Datum offset2 = IntervalPGetDatum(bf2->bucket_time_offset);
+			bool equal_offsets = DatumGetBool(DirectFunctionCall2(interval_eq, offset1, offset2));
+			if (!equal_offsets)
+				return false;
+		}
+
+		if ((bf1->bucket_time_timezone && !bf2->bucket_time_timezone) ||
+			(!bf1->bucket_time_timezone && bf2->bucket_time_timezone))
+			return false;
+		if (bf1->bucket_time_timezone && bf2->bucket_time_timezone &&
+			strcmp(bf1->bucket_time_timezone, bf2->bucket_time_timezone) != 0)
+			return false;
+	}
+	else
+	{
+		if (bf1->bucket_integer_offset != bf2->bucket_integer_offset)
+			return false;
+	}
+
+	int64 bucket_width1 = ts_continuous_agg_bucket_width(bf1);
+	int64 bucket_width2 = ts_continuous_agg_bucket_width(bf2);
+
+	if (bucket_width1 != bucket_width2)
+		return false;
+
+	return true;
 }
 
 static Datum
@@ -660,17 +1014,20 @@ cagg_validate_query(const Query *query, const char *cagg_schema, const char *cag
 	ContinuousAggTimeBucketInfo bucket_info = { 0 };
 	ContinuousAggTimeBucketInfo bucket_info_parent = { 0 };
 	Hypertable *ht = NULL, *ht_parent = NULL;
-	RangeTblEntry *rte = NULL;
+	RangeTblEntry *ht_rte = NULL;
+	StringInfoData msg;
 	StringInfoData hint;
 	StringInfoData detail;
 	bool is_hierarchical = false;
 	Query *prev_query = NULL;
 	ContinuousAgg *cagg_parent = NULL;
+	bool for_rewrites = false;
 
+	initStringInfo(&msg);
 	initStringInfo(&hint);
 	initStringInfo(&detail);
 
-	if (!cagg_query_supported(query, &hint, &detail))
+	if (!cagg_query_supported(query, &hint, &detail, for_rewrites))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -678,87 +1035,50 @@ cagg_validate_query(const Query *query, const char *cagg_schema, const char *cag
 				 hint.len > 0 ? errhint("%s", hint.data) : 0,
 				 detail.len > 0 ? errdetail("%s", detail.data) : 0));
 	}
-
-	int num_hypertables = 0;
 	ListCell *lc;
 	foreach (lc, query->rtable)
 	{
 		RangeTblEntry *inner_rte = lfirst_node(RangeTblEntry, lc);
 
-		if (inner_rte->rtekind == RTE_RELATION)
+		/* Check whether RTEs are valid in a Cagg, should have 1 hypertable among them */
+		if (!cagg_query_rtes_supported(inner_rte, &ht_rte, &detail, false))
 		{
-			bool is_hypertable = ts_is_hypertable(inner_rte->relid) ||
-								 ts_continuous_agg_find_by_relid(inner_rte->relid);
-
-			if (is_hypertable)
-			{
-				num_hypertables++;
-				if (rte == NULL)
-					rte = copyObject(inner_rte);
-			}
-
-			if (is_hypertable && inner_rte->inh == false)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("invalid continuous aggregate view"),
-						 errdetail(
-							 "FROM ONLY on hypertables is not allowed in continuous aggregate.")));
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid continuous aggregate view"),
+					 detail.len > 0 ? errdetail("%s", detail.data) : 0));
 		}
-
-		/* Only inner joins are allowed. */
-		if (inner_rte->jointype != JOIN_INNER && inner_rte->jointype != JOIN_LEFT)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("only INNER or LEFT joins are supported in continuous aggregates")));
-
-		/* Subquery only using LATERAL */
-		if (inner_rte->subquery && !inner_rte->lateral)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid continuous aggregate view"),
-					 errdetail("Sub-queries are not supported in FROM clause.")));
-
-		/* TABLESAMPLE not allowed */
-		if (inner_rte->tablesample)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("invalid continuous aggregate view"),
-					 errdetail("TABLESAMPLE is not supported in continuous aggregate.")));
 	}
 
-	if (num_hypertables > 1)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("invalid continuous aggregate view"),
-				 errdetail("Only one hypertable is allowed in continuous aggregate view.")));
-
-	if (rte == NULL)
+	if (ht_rte == NULL)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("invalid continuous aggregate view"),
 				 errdetail("At least one hypertable should be used in the view definition.")));
 	}
+	else
+		ht_rte = copyObject(ht_rte);
 
 	const Dimension *part_dimension = NULL;
 	int32 parent_mat_hypertable_id = INVALID_HYPERTABLE_ID;
 	Cache *hcache = ts_hypertable_cache_pin();
 
-	if (rte->relkind == RELKIND_RELATION)
+	if (ht_rte->relkind == RELKIND_RELATION)
 	{
-		ht = ts_hypertable_cache_get_entry(hcache, rte->relid, CACHE_FLAG_MISSING_OK);
+		ht = ts_hypertable_cache_get_entry(hcache, ht_rte->relid, CACHE_FLAG_MISSING_OK);
 
 		if (!ht)
 		{
 			ts_cache_release(&hcache);
 			ereport(ERROR,
 					(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-					 errmsg("table \"%s\" is not a hypertable", get_rel_name(rte->relid))));
+					 errmsg("table \"%s\" is not a hypertable", get_rel_name(ht_rte->relid))));
 		}
 	}
 	else
 	{
-		cagg_parent = ts_continuous_agg_find_by_relid(rte->relid);
+		cagg_parent = ts_continuous_agg_find_by_relid(ht_rte->relid);
 
 		if (!cagg_parent)
 		{
@@ -803,72 +1123,15 @@ cagg_validate_query(const Query *query, const char *cagg_schema, const char *cag
 					   get_rel_name(ht->main_table_relid));
 	}
 
-	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
+	part_dimension = cagg_hypertable_dim_supported(ht_rte, ht, &msg, &detail, &hint, for_rewrites);
+	if (!part_dimension)
 	{
 		ts_cache_release(&hcache);
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("hypertable is an internal compressed hypertable")));
-	}
-
-	if (rte->relkind == RELKIND_RELATION)
-	{
-		ContinuousAggHypertableStatus status = ts_continuous_agg_hypertable_status(ht->fd.id);
-
-		/* Prevent create a CAGG over an existing materialization hypertable. */
-		if (status == HypertableIsMaterialization || status == HypertableIsMaterializationAndRaw)
-		{
-			const ContinuousAgg *cagg =
-				ts_continuous_agg_find_by_mat_hypertable_id(ht->fd.id, false);
-			Assert(cagg != NULL);
-
-			ts_cache_release(&hcache);
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("hypertable is a continuous aggregate materialization table"),
-					 errdetail("Materialization hypertable \"%s.%s\".",
-							   NameStr(ht->fd.schema_name),
-							   NameStr(ht->fd.table_name)),
-					 errhint("Do you want to use continuous aggregate \"%s.%s\" instead?",
-							 NameStr(cagg->data.user_view_schema),
-							 NameStr(cagg->data.user_view_name))));
-		}
-	}
-
-	/* Get primary partitioning column information. */
-	part_dimension = hyperspace_get_open_dimension(ht->space, 0);
-
-	/*
-	 * NOTE: if we ever allow custom partitioning functions we'll need to
-	 *       change part_dimension->fd.column_type to partitioning_type
-	 *       below, along with any other fallout.
-	 */
-	if (part_dimension == NULL || part_dimension->partitioning != NULL)
-	{
-		ts_cache_release(&hcache);
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("custom partitioning functions not supported"
-						" with continuous aggregates")));
-	}
-
-	if (IS_INTEGER_TYPE(ts_dimension_get_partition_type(part_dimension)) &&
-		rte->relkind == RELKIND_RELATION)
-	{
-		const char *funcschema = NameStr(part_dimension->fd.integer_now_func_schema);
-		const char *funcname = NameStr(part_dimension->fd.integer_now_func);
-
-		if (strlen(funcschema) == 0 || strlen(funcname) == 0)
-		{
-			ts_cache_release(&hcache);
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("custom time function required on hypertable \"%s\"",
-							get_rel_name(ht->main_table_relid)),
-					 errdetail("An integer-based hypertable requires a custom time function to "
-							   "support continuous aggregates."),
-					 errhint("Set a custom time function on the hypertable.")));
-		}
+				 msg.len > 0 ? errmsg("%s", msg.data) : errmsg("Feature not supported"),
+				 detail.len > 0 ? errdetail("%s", detail.data) : 0,
+				 hint.len > 0 ? errhint("%s", hint.data) : 0));
 	}
 
 	caggtimebucketinfo_init(&bucket_info,
@@ -906,7 +1169,7 @@ cagg_validate_query(const Query *query, const char *cagg_schema, const char *cag
 							is_cagg_create);
 
 	/* Check row security settings for the table. */
-	if (ts_has_row_security(rte->relid))
+	if (ts_has_row_security(ht_rte->relid))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot create continuous aggregate on hypertable with row security")));
@@ -1481,7 +1744,7 @@ build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *
 /*
  * Returns true if the time bucket size is fixed
  */
-static bool
+bool
 time_bucket_info_has_fixed_width(const ContinuousAggBucketFunction *bf)
 {
 	if (!IS_TIME_BUCKET_INFO_TIME_BASED(bf))
@@ -1574,7 +1837,7 @@ ts_cagg_get_bucket_function_info(Oid view_oid)
 
 			Assert(finfo->is_bucketing_func);
 
-			process_timebucket_parameters(fe, bf, false, false, InvalidAttrNumber);
+			process_timebucket_parameters(fe, bf, false, false, InvalidAttrNumber, NULL, false);
 			break;
 		}
 	}

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -148,3 +148,28 @@ cagg_get_time_min(const ContinuousAgg *cagg)
 }
 
 ContinuousAggBucketFunction *ts_cagg_get_bucket_function_info(Oid view_oid);
+
+/* Methods checking validity of Caggs and Cagg rewrites */
+extern bool cagg_query_supported(const Query *query, StringInfo hint, StringInfo detail,
+								 const bool for_rewrites);
+extern bool cagg_query_rtes_supported(RangeTblEntry *rte, RangeTblEntry **ht_rte, StringInfo detail,
+									  const bool for_rewrites);
+extern const Dimension *cagg_hypertable_dim_supported(RangeTblEntry *ht_rte, Hypertable *ht,
+													  StringInfo msg, StringInfo detail,
+													  StringInfo hint, const bool for_rewrites);
+extern bool function_allowed_in_cagg_definition(Oid funcid);
+extern void caggtimebucketinfo_init(ContinuousAggTimeBucketInfo *src, int32 hypertable_id,
+									Oid hypertable_oid, AttrNumber hypertable_partition_colno,
+									Oid hypertable_partition_coltype,
+									int64 hypertable_partition_col_interval,
+									int32 parent_mat_hypertable_id);
+extern ContinuousAggBucketFunction *cagg_get_bucket_function_info(Oid view_oid);
+extern bool time_bucket_info_has_fixed_width(const ContinuousAggBucketFunction *bf);
+
+extern bool cagg_timebucket_equal(ContinuousAggBucketFunction *bf1,
+								  ContinuousAggBucketFunction *bf2);
+
+extern bool caggtimebucket_validate_common(ContinuousAggBucketFunction *bf, List *groupClause,
+										   List *targetList, List *rtable, int ht_partcolno,
+										   StringInfo msg, bool is_cagg_create,
+										   const bool for_rewrites);

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -38,6 +38,7 @@
 #include "refresh.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/continuous_agg.h"
+#include "ts_catalog/continuous_aggs_watermark.h"
 
 /*
  * Invalidation processing for continuous aggregates.
@@ -1235,4 +1236,83 @@ invalidation_store_free(InvalidationStore *store)
 	FreeTupleDesc(store->tupdesc);
 	tuplestore_end(store->tupstore);
 	pfree(store);
+}
+
+bool
+invalidation_hypertable_has_invalidations(int32 hyper_id)
+{
+	bool found = false;
+	ScanIterator iterator;
+	hypertable_invalidation_scan_init(&iterator, hyper_id, AccessShareLock);
+	iterator.ctx.limit = 1; /* we only need to know if there is at least one */
+
+	ts_scan_iterator_start_scan(&iterator);
+	if (ts_scan_iterator_next(&iterator))
+		found = true;
+	ts_scan_iterator_close(&iterator);
+
+	return found;
+}
+
+bool
+invalidation_cagg_has_pending_mat_ranges(ContinuousAgg *cagg)
+{
+	bool found = false;
+	int32 cagg_hyper_id = cagg->data.mat_hypertable_id;
+
+	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
+													AccessShareLock,
+													CurrentMemoryContext);
+	iterator.ctx.index = catalog_get_index(ts_catalog_get(),
+										   CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
+										   CONTINUOUS_AGGS_MATERIALIZATION_RANGES_IDX);
+	ts_scan_iterator_scan_key_init(&iterator,
+								   Anum_continuous_aggs_materialization_ranges_materialization_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(cagg_hyper_id));
+	iterator.ctx.limit = 1; /* we only need to know if there is at least one */
+
+	ts_scan_iterator_start_scan(&iterator);
+	if (ts_scan_iterator_next(&iterator))
+		found = true;
+	ts_scan_iterator_close(&iterator);
+
+	return found;
+}
+
+bool
+invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
+{
+	bool found = false;
+	int32 cagg_hyper_id = cagg->data.mat_hypertable_id;
+
+	ScanIterator iterator;
+	cagg_invalidations_scan_by_hypertable_init(&iterator, cagg_hyper_id, AccessShareLock);
+
+	int64 watermark = ts_cagg_watermark_get(cagg_hyper_id);
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti;
+		Invalidation logentry;
+
+		ti = ts_scan_iterator_tuple_info(&iterator);
+
+		invalidation_entry_set_from_cagg_invalidation(&logentry,
+													  ti,
+													  cagg->partition_type,
+													  cagg->bucket_function);
+		/* Entries which cannot be invalidations */
+		if (logentry.greatest_modified_value == INVAL_NEG_INFINITY ||
+			logentry.lowest_modified_value >= watermark)
+			continue;
+		else
+		{
+			found = true;
+			break;
+		}
+	}
+	ts_scan_iterator_close(&iterator);
+
+	return found;
 }

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -56,3 +56,6 @@ invalidation_expand_to_bucket_boundaries(Invalidation *inv, Oid time_type_oid,
 										 const ContinuousAggBucketFunction *bucket_function);
 extern HeapTuple create_invalidation_tup(const TupleDesc tupdesc, int32 cagg_hyper_id, int64 start,
 										 int64 end);
+extern bool invalidation_hypertable_has_invalidations(int32 hyper_id);
+extern bool invalidation_cagg_has_invalidations(ContinuousAgg *cagg);
+extern bool invalidation_cagg_has_pending_mat_ranges(ContinuousAgg *cagg);

--- a/tsl/src/continuous_aggs/rewrite_with_caggs.c
+++ b/tsl/src/continuous_aggs/rewrite_with_caggs.c
@@ -1,0 +1,901 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include "rewrite_with_caggs.h"
+
+#include <optimizer/tlist.h>
+#include <parser/parse_relation.h>
+#include <rewrite/rewriteDefine.h>
+#include <utils/acl.h>
+#include <utils/date.h>
+#include <utils/timestamp.h>
+
+#include "guc.h"
+#include "import/setrefs.h"
+#include "invalidation.h"
+#include "utils.h"
+
+#if PG16_GE
+
+static bool match_lists(List *src, List *tgt);
+
+/* Wrappers for common methods checking Cagg view query validity */
+static void
+check_query_for_cagg_rewrites(CaggRewriteContext *cagg_rewrite_ctx, Query *query)
+{
+	bool for_rewrites = true;
+	cagg_rewrite_ctx->eligible =
+		cagg_query_supported(query, &(cagg_rewrite_ctx->msg), NULL, for_rewrites);
+}
+
+static void
+check_query_rtes_for_cagg_rewrites(CaggRewriteContext *cagg_rewrite_ctx, RangeTblEntry *rte)
+{
+	bool for_rewrites = true;
+	cagg_rewrite_ctx->eligible = cagg_query_rtes_supported(rte,
+														   &(cagg_rewrite_ctx->ht_rte),
+														   &(cagg_rewrite_ctx->msg),
+														   for_rewrites);
+}
+
+static const Dimension *
+check_hypertable_dim_for_cagg_rewrites(CaggRewriteContext *cagg_rewrite_ctx)
+{
+	bool for_rewrites = true;
+	const Dimension *ret = cagg_hypertable_dim_supported(cagg_rewrite_ctx->ht_rte,
+														 cagg_rewrite_ctx->ht,
+														 &(cagg_rewrite_ctx->msg),
+														 NULL,
+														 NULL,
+														 for_rewrites);
+	cagg_rewrite_ctx->eligible = (ret != NULL);
+	return ret;
+}
+
+/* Methods to match Vars in queries with same tables joined in different but equivalent order
+ */
+typedef struct
+{
+	int sublevels_up;		  /* (current) nesting depth */
+	const AttrMap *varno_map; /* map array for user attnos */
+} map_varnos_context;
+
+static Node *
+map_varnos_mutator(Node *node, map_varnos_context *context)
+{
+	if (node == NULL)
+		return NULL;
+	if (IsA(node, Var))
+	{
+		Var *var = (Var *) node;
+		if (var->varlevelsup == (Index) context->sublevels_up &&
+			var->varno <= context->varno_map->maplen)
+		{
+			/* Found a variable, make the substitution */
+			Var *newvar = (Var *) copyObject(var);
+
+			int new_varno = context->varno_map->attnums[var->varno - 1] + 1;
+			newvar->varno = new_varno;
+			/* If the syntactic referent is same RTE, fix it too */
+			if (newvar->varnosyn == (Index) var->varno)
+				newvar->varnosyn = newvar->varno;
+
+			return (Node *) newvar;
+		}
+	}
+	else if (IsA(node, Query))
+	{
+		/* Recurse into RTE subquery or not-yet-planned sublink subquery */
+		Query *newnode;
+
+		context->sublevels_up++;
+		newnode = query_tree_mutator((Query *) node, map_varnos_mutator, context, 0);
+		context->sublevels_up--;
+		return (Node *) newnode;
+	}
+	return expression_tree_mutator(node, map_varnos_mutator, context);
+}
+
+static Node *
+map_varnos(Node *node, const AttrMap *varno_map)
+{
+	map_varnos_context context;
+
+	context.sublevels_up = 0;
+	context.varno_map = varno_map;
+
+	/*
+	 * Must be prepared to start with a Query or a bare expression tree; if
+	 * it's a Query, we don't want to increment sublevels_up.
+	 */
+	return query_or_expression_tree_mutator(node, map_varnos_mutator, &context, 0);
+}
+
+/* Collect flattened quals for comparison */
+typedef struct CollectQualsContext
+{
+	List *quals;
+
+} CollectQualsContext;
+
+static void
+flatten_qual(Node *node, CollectQualsContext *ctx)
+{
+	Node *qual = eval_const_expressions(NULL, node);
+	qual = (Node *) canonicalize_qual((Expr *) qual, false);
+	qual = (Node *) make_ands_implicit((Expr *) qual);
+	if (qual && IsA(qual, List))
+		ctx->quals = list_concat(ctx->quals, (List *) qual);
+	else if (qual)
+		ctx->quals = lappend(ctx->quals, qual);
+}
+
+static bool
+collect_quals_walker(Node *node, CollectQualsContext *context)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, FromExpr))
+		flatten_qual(((FromExpr *) node)->quals, context);
+	else if (IsA(node, JoinExpr))
+		flatten_qual(((JoinExpr *) node)->quals, context);
+
+	return expression_tree_walker(node, collect_quals_walker, context);
+}
+
+/* Either collect and flatten quals from Query::jointree
+ * or flatten a standalone qual like Query::havingQual */
+static List *
+collect_flattened_quals(Node *node)
+{
+	CollectQualsContext ctx = { .quals = NULL };
+	if (IsA(node, FromExpr))
+		collect_quals_walker(node, &ctx);
+	else
+		flatten_qual(node, &ctx);
+
+	return ctx.quals;
+}
+
+/* Match expressions, check equivalencies if possible */
+static bool
+match_expr(Node *expr1, Node *expr2)
+{
+	if (IsA(expr1, RangeTblEntry) && IsA(expr2, RangeTblEntry))
+	{
+		RangeTblEntry *rte1 = castNode(RangeTblEntry, expr1);
+		RangeTblEntry *rte2 = castNode(RangeTblEntry, expr2);
+		if (rte1->relkind == rte2->relkind && rte1->relkind == RELKIND_VIEW &&
+			rte1->relid == rte2->relid)
+			return true;
+		if (rte1->rtekind != rte2->rtekind || rte1->relid != rte2->relid)
+			return false;
+		if (rte1->rtekind == RTE_RELATION)
+			return true;
+		else if (rte1->rtekind == RTE_SUBQUERY)
+		{
+			return (rte1->lateral == rte2->lateral && rte1->inFromCl == rte2->inFromCl &&
+					equal(rte1->subquery, rte2->subquery));
+		}
+		else
+			return equal(rte1, rte2);
+	}
+	/* Time buckets are matched separately */
+	else if (ts_is_time_bucket_function((Expr *) expr1))
+		return true;
+	else if (equal(expr1, expr2))
+		return true;
+	/* Check for equivalent OpExprs like "a=5" and "5=a" or "a<b" and "b>a" */
+	else if (IsA(expr1, OpExpr) && IsA(expr2, OpExpr))
+	{
+		OpExpr *op1 = castNode(OpExpr, expr1);
+		OpExpr *op2 = castNode(OpExpr, expr2);
+		if (list_length(op1->args) == 2 && list_length(op2->args) == 2 &&
+			match_expr((Node *) linitial(op1->args), (Node *) lsecond(op2->args)) &&
+			match_expr((Node *) linitial(op2->args), (Node *) lsecond(op1->args)))
+		{
+			Oid pred_op = get_commutator(op1->opno);
+			if (OidIsValid(pred_op) && pred_op == op2->opno)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+/* Match every item in src to an item in tgt
+ */
+bool
+match_lists(List *src, List *tgt)
+{
+	ListCell *ls;
+	ListCell *lt;
+
+	foreach (ls, src)
+	{
+		bool match = false;
+		Node *src_item = (Node *) lfirst(ls);
+		/* We want to use custom "match_expr" instead of "equal", so can't use "list_member" */
+		foreach (lt, tgt)
+		{
+			Node *tgt_item = (Node *) lfirst(lt);
+			if (match_expr(src_item, tgt_item))
+			{
+				match = true;
+				break;
+			}
+		}
+		if (!match)
+			return false;
+	}
+	return true;
+}
+
+static inline void
+add_optional_debug_info(ContinuousAgg *cagg, StringInfo *str, char *init_str)
+{
+	if (ts_guc_cagg_rewrites_debug_info)
+	{
+		if (*str == NULL)
+		{
+			*str = makeStringInfo();
+			appendStringInfoString(*str, init_str);
+		}
+		appendStringInfo(*str,
+						 " \"%s.%s\"",
+						 NameStr(cagg->data.user_view_schema),
+						 NameStr(cagg->data.user_view_name));
+	}
+}
+
+/* Tries to match aggregation query over a hypertable to Caggs defined on this hypertable */
+static void
+match_query_to_cagg(CaggRewriteContext *cagg_rewrite_ctx, Query *query, bool do_rewrite)
+{
+	if (!ts_hypertable_has_continuous_aggregates(cagg_rewrite_ctx->ht->fd.id))
+	{
+		cagg_rewrite_ctx->eligible = false;
+		if (ts_guc_cagg_rewrites_debug_info)
+			appendStringInfo(&(cagg_rewrite_ctx->msg),
+							 "no continuous aggregates defined on %s",
+							 cagg_rewrite_ctx->ht_name.data);
+		return;
+	}
+
+	if (invalidation_hypertable_has_invalidations(cagg_rewrite_ctx->ht->fd.id))
+	{
+		cagg_rewrite_ctx->eligible = false;
+		if (ts_guc_cagg_rewrites_debug_info)
+			appendStringInfo(&(cagg_rewrite_ctx->msg),
+							 "invalidated ranges are present in hypertable %s",
+							 cagg_rewrite_ctx->ht_name.data);
+		return;
+	}
+
+	/* Diagnostics on matching steps  */
+	StringInfo not_realtime = NULL;
+	StringInfo invalidated = NULL;
+	StringInfo pending_ranges = NULL;
+	StringInfo nonmatching_buckets = NULL;
+	StringInfo nonmatching_joins = NULL;
+	StringInfo nonmatching_groupby = NULL;
+	StringInfo nonmatching_aggrefs = NULL;
+	StringInfo nonmatching_quals = NULL;
+	StringInfo nonmatching_having_quals = NULL;
+	StringInfo nonmatching_targets = NULL;
+
+	List *caggs = ts_continuous_aggs_find_by_raw_table_id(cagg_rewrite_ctx->ht->fd.id);
+	ListCell *l;
+	foreach (l, caggs)
+	{
+		ContinuousAgg *cagg = lfirst(l);
+		/* Can only rewrite with Caggs with matching bucket */
+		if (!cagg_timebucket_equal(cagg->bucket_function, cagg_rewrite_ctx->tbinfo.bf))
+		{
+			add_optional_debug_info(cagg, &nonmatching_buckets, "Buckets do not match:");
+			continue;
+		}
+		/* TEMP: only consider real-time Caggs */
+		if (cagg->data.materialized_only)
+		{
+			add_optional_debug_info(cagg, &not_realtime, "Caggs are not real-time:");
+			continue;
+		}
+		/* TEMP: only consider Caggs with no invalidations */
+		if (invalidation_cagg_has_invalidations(cagg))
+		{
+			add_optional_debug_info(cagg, &invalidated, "Invalidated caggs:");
+			continue;
+		}
+		/* TEMP: only consider Caggs with no pending materialization ranges */
+		if (invalidation_cagg_has_pending_mat_ranges(cagg))
+		{
+			add_optional_debug_info(cagg,
+									&pending_ranges,
+									"Caggs with pending materialization ranges:");
+			continue;
+		}
+
+		Query *view_query = ts_continuous_agg_get_query(cagg);
+
+		/* joins need to be matched exactly */
+		if (list_length(query->rtable) != list_length(view_query->rtable))
+		{
+			add_optional_debug_info(cagg, &nonmatching_joins, "Joins do not match:");
+			continue;
+		}
+		/* group clauses also need to be matched as we don't allow reaggregation (yet) */
+		if (list_length(query->groupClause) != list_length(view_query->groupClause))
+		{
+			add_optional_debug_info(cagg, &nonmatching_groupby, "Grouping clauses do not match:");
+			continue;
+		}
+		/* If Cagg has quals, they'll need to be exactly matched in the query */
+		if ((view_query->jointree->quals && !query->jointree->quals) ||
+			(!view_query->jointree->quals && query->jointree->quals))
+		{
+			add_optional_debug_info(cagg, &nonmatching_quals, "WHERE/ON quals do not match:");
+			continue;
+		}
+		if ((view_query->havingQual && !query->havingQual) ||
+			(!view_query->havingQual && query->havingQual))
+		{
+			add_optional_debug_info(cagg, &nonmatching_having_quals, "HAVING quals do not match:");
+			continue;
+		}
+
+		/* Adjust user permissions in view query to those of input query so that we can match those
+		 * queries */
+		Assert(query->rteperminfos);
+		Oid userOid = ((RTEPermissionInfo *) linitial(query->rteperminfos))->checkAsUser;
+		setRuleCheckAsUser((Node *) view_query, userOid);
+
+		bool ht_only = false;
+		AttrMap *varno_map = NULL;
+#if PG18_GE
+		/* hypertable RTE + group RTE */
+		ht_only = (list_length(query->rtable) == 2);
+#else
+		ht_only = (list_length(query->rtable) == 1);
+#endif
+		ListCell *lq;
+		ListCell *lv;
+		bool same_join_order = true;
+		/* have to match a join
+		 * "FROM t1, t2" can be matched to "FROM t2, t1"
+		 * so we'll record if this is the same join but with different order
+		 */
+		if (!ht_only)
+		{
+			int varno_maplen = list_length(query->rtable);
+#if PG18_GE
+			--varno_maplen;
+#endif
+			varno_map = make_attrmap(varno_maplen);
+			int qrti = 0;
+			bool match = true;
+			foreach (lq, query->rtable)
+			{
+				RangeTblEntry *qrte = lfirst_node(RangeTblEntry, lq);
+#if PG18_GE
+				if (qrte->rtekind == RTE_GROUP)
+					break;
+#endif
+				bool found = false;
+				int vrti = 0;
+				foreach (lv, view_query->rtable)
+				{
+					RangeTblEntry *vrte = lfirst_node(RangeTblEntry, lv);
+					if (match_expr((Node *) qrte, (Node *) vrte))
+					{
+						found = true;
+						varno_map->attnums[qrti] = vrti;
+						if (qrti != vrti)
+							same_join_order = false;
+						break;
+					}
+					++vrti;
+				}
+				if (!found)
+				{
+					match = false;
+					break;
+				}
+				++qrti;
+			}
+			if (!match)
+			{
+				free_attrmap(varno_map);
+				varno_map = NULL;
+				add_optional_debug_info(cagg, &nonmatching_joins, "Joins do not match:");
+				continue;
+			}
+			if (same_join_order)
+			{
+				free_attrmap(varno_map);
+				varno_map = NULL;
+			}
+		}
+
+		Query *newquery = (Query *) copyObject(query);
+		if (varno_map)
+			newquery = (Query *) map_varnos((Node *) newquery, varno_map);
+
+		bool timebucket_only = (list_length(newquery->groupClause) == 1);
+		/* have to match group expressions */
+		if (!timebucket_only)
+		{
+			List *query_group_exprs;
+			List *view_group_exprs;
+#if PG18_LT
+			query_group_exprs =
+				get_sortgrouplist_exprs(newquery->groupClause, newquery->targetList);
+			view_group_exprs =
+				get_sortgrouplist_exprs(view_query->groupClause, view_query->targetList);
+#else
+			RangeTblEntry *qrte = llast_node(RangeTblEntry, newquery->rtable);
+			Assert(qrte->rtekind == RTE_GROUP);
+			query_group_exprs = qrte->groupexprs;
+
+			RangeTblEntry *vrte = llast_node(RangeTblEntry, view_query->rtable);
+			Assert(vrte->rtekind == RTE_GROUP);
+			view_group_exprs = vrte->groupexprs;
+#endif
+			/* TBD: exclude time buckets from the group exprs to be matched */
+			if (!match_lists(view_group_exprs, query_group_exprs))
+			{
+				add_optional_debug_info(cagg,
+										&nonmatching_groupby,
+										"Grouping clauses do not match:");
+				continue;
+			}
+		}
+
+		/* have to match aggregate expressions */
+		List *qaggrefs = ts_find_aggrefs((Node *) newquery->targetList);
+		List *vaggrefs = ts_find_aggrefs((Node *) view_query->targetList);
+		/* every query aggregate should match Cagg aggregate */
+		if (!match_lists(qaggrefs, vaggrefs))
+		{
+			add_optional_debug_info(cagg, &nonmatching_aggrefs, "Query aggregates do not match:");
+			continue;
+		}
+		/* have to match view HAVING quals, if any */
+		if (view_query->havingQual)
+		{
+			List *query_having = collect_flattened_quals(newquery->havingQual);
+			List *view_having = collect_flattened_quals(view_query->havingQual);
+			/* Every Cagg havingQual needs to be matched in the query and vice versa */
+			if (!match_lists(view_having, query_having))
+			{
+				add_optional_debug_info(cagg,
+										&nonmatching_having_quals,
+										"HAVING quals do not match:");
+				continue;
+			}
+			if (!match_lists(query_having, view_having))
+			{
+				add_optional_debug_info(cagg,
+										&nonmatching_having_quals,
+										"HAVING quals do not match:");
+				continue;
+			}
+		}
+
+		/* have to exactly match join and where quals, if any
+		 * we flatten quals as we collect them
+		 */
+		List *query_quals = collect_flattened_quals((Node *) newquery->jointree);
+		List *view_quals = collect_flattened_quals((Node *) view_query->jointree);
+		/* Cannot trust same length lists as can have duplicate quals */
+		if (!match_lists(view_quals, query_quals))
+		{
+			add_optional_debug_info(cagg, &nonmatching_quals, "WHERE/JOIN quals do not match:");
+			continue;
+		}
+		if (!match_lists(query_quals, view_quals))
+		{
+			add_optional_debug_info(cagg, &nonmatching_quals, "WHERE/JOIN quals do not match:");
+			continue;
+		}
+
+		/* Have to derive query TLEs and query HAVING from view TLEs
+		 * i.e. (query.bucket + 1)*2 from (view.bucket + 1)
+		 */
+		ts_indexed_tlist *itlist = ts_build_tlist_index(view_query->targetList);
+
+		List *new_tlist = NULL;
+		ListCell *lsrc;
+		foreach (lsrc, newquery->targetList)
+		{
+			TargetEntry *tle = (TargetEntry *) lfirst(lsrc);
+			if (tle->resjunk)
+				continue;
+			Node *new_entry = ts_replace_tlist_expr((Node *) tle, itlist, 1, 0);
+			if (!new_entry)
+			{
+				new_tlist = NULL;
+				break;
+			}
+			else
+				new_tlist = lappend(new_tlist, new_entry);
+		}
+
+		if (new_tlist)
+			newquery->targetList = new_tlist;
+		else
+		{
+			add_optional_debug_info(cagg,
+									&nonmatching_targets,
+									"Query targets cannot be derived from Cagg targets:");
+			continue;
+		}
+
+		/* Found matching CAgg: rewrite query with it if asked */
+		cagg_rewrite_ctx->cagg = cagg;
+		if (!do_rewrite)
+			return;
+
+		/* rewrite the query with Cagg:
+		 * TLEs are already rewritten,
+		 * also need to drop quals, group exprs, joins,
+		 * keep order by and limit.
+		 */
+		Query *cagg_finalized_query = ts_continuous_agg_get_finalized_query(cagg);
+		Assert(cagg_finalized_query);
+
+		query->targetList = newquery->targetList;
+		query->groupClause = NULL;
+		query->hasAggs = false;
+		query->havingQual = NULL;
+#if PG18_GE
+		query->hasGroupRTE = false;
+#endif
+		RangeTblEntry *newrte = makeNode(RangeTblEntry);
+		newrte->rtekind = RTE_RELATION;
+		newrte->relkind = RELKIND_VIEW;
+		newrte->relid = cagg->relid;
+		newrte->inh = false;
+		newrte->alias = NULL;
+		newrte->eref = makeAlias(NameStr(cagg->data.user_view_name), NIL);
+		newrte->subquery = NULL;
+		newrte->inFromCl = true;
+		query->rtable = list_make1(newrte);
+
+		query->rteperminfos = NULL;
+		/* Add empty perminfo for the new RTE to make build_simple_rel happy. */
+		RTEPermissionInfo *perminfo = addRTEPermissionInfo(&query->rteperminfos, newrte);
+		perminfo->requiredPerms |= ACL_SELECT;
+		/* why? */
+		perminfo->inh = true;
+		int attno = 0;
+		foreach (lv, cagg_finalized_query->targetList)
+		{
+			TargetEntry *tle = lfirst_node(TargetEntry, lv);
+			if (tle->resjunk)
+				continue;
+			newrte->eref->colnames = lappend(newrte->eref->colnames, makeString(tle->resname));
+			attno = list_length(newrte->eref->colnames) - FirstLowInvalidHeapAttributeNumber;
+			perminfo->selectedCols = bms_add_member(perminfo->selectedCols, attno);
+		}
+		foreach (lq, query->targetList)
+		{
+			TargetEntry *tle = lfirst_node(TargetEntry, lq);
+			tle->resorigtbl = newrte->relid;
+			if (IsA(tle->expr, Var))
+				tle->resorigcol = castNode(Var, tle->expr)->varattno;
+		}
+
+		RangeTblRef *rtr = makeNode(RangeTblRef);
+		rtr->rtindex = 1;
+		query->jointree = makeFromExpr(list_make1(rtr), NULL);
+
+		break;
+	}
+
+	if (!cagg_rewrite_ctx->cagg)
+	{
+		cagg_rewrite_ctx->eligible = false;
+		if (ts_guc_cagg_rewrites_debug_info)
+		{
+			appendStringInfo(&(cagg_rewrite_ctx->msg),
+							 "none of continuous aggregates defined on %s are matching the "
+							 "query:\n",
+							 cagg_rewrite_ctx->ht_name.data);
+			if (not_realtime)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", not_realtime->data);
+				pfree(not_realtime);
+			}
+			if (invalidated)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", invalidated->data);
+				pfree(invalidated);
+			}
+			if (pending_ranges)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", pending_ranges->data);
+				pfree(pending_ranges);
+			}
+			if (nonmatching_buckets)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_buckets->data);
+				pfree(nonmatching_buckets);
+			}
+			if (nonmatching_joins)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_joins->data);
+				pfree(nonmatching_joins);
+			}
+			if (nonmatching_groupby)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_groupby->data);
+				pfree(nonmatching_groupby);
+			}
+			if (nonmatching_aggrefs)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_aggrefs->data);
+				pfree(nonmatching_aggrefs);
+			}
+			if (nonmatching_quals)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_quals->data);
+				pfree(nonmatching_quals);
+			}
+			if (nonmatching_having_quals)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_having_quals->data);
+				pfree(nonmatching_having_quals);
+			}
+			if (nonmatching_targets)
+			{
+				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", nonmatching_targets->data);
+				pfree(nonmatching_targets);
+			}
+		}
+	}
+}
+
+typedef struct
+{
+	Oid cagg_relid;
+	bool is_root_query;
+	char *subquery_alias;
+	bool rewritten_with_caggs;
+} RewriteWithCaggsContext;
+
+static bool
+rewrite_query_with_caggs(Node *node, RewriteWithCaggsContext *context)
+{
+	if (node == NULL)
+		return false;
+
+	/* FROM subquery can be a Cagg (user or internal) view: don't rewrite it with Caggs in this case
+	 */
+	if (IsA(node, RangeTblEntry))
+	{
+		RangeTblEntry *rte = castNode(RangeTblEntry, node);
+		if (rte->rtekind == RTE_SUBQUERY &&
+			(ts_guc_enable_cagg_rewrites || ts_guc_cagg_rewrites_debug_info))
+		{
+			context->subquery_alias = rte->eref->aliasname;
+			if (rte->relkind == RELKIND_VIEW)
+			{
+				const char *view_name = get_rel_name(rte->relid);
+				const char *view_schema = get_namespace_name(get_rel_namespace(rte->relid));
+				ContinuousAgg *cagg = ts_continuous_agg_find_by_view_name(view_schema,
+																		  view_name,
+																		  ContinuousAggAnyView);
+				if (cagg)
+				{
+					/* Enter Cagg view query*/
+					if (!OidIsValid(context->cagg_relid))
+						context->cagg_relid = cagg->relid;
+					/* Leave the same Cagg view query */
+					else if (context->cagg_relid == cagg->relid)
+						context->cagg_relid = InvalidOid;
+				}
+			}
+		}
+		return false;
+	}
+	else if (IsA(node, CommonTableExpr))
+	{
+		CommonTableExpr *cte = (CommonTableExpr *) node;
+		context->subquery_alias = cte->ctename;
+	}
+	else if (IsA(node, Query))
+	{
+		Query *query = castNode(Query, node);
+		ListCell *lc;
+		bool ret;
+
+		CaggRewriteContext cagg_rewrite_ctx = { 0 };
+		cagg_rewrite_ctx.eligible = (ts_guc_enable_cagg_rewrites || ts_guc_cagg_rewrites_debug_info)
+									/* Not inside Cagg query */
+									&& !OidIsValid(context->cagg_relid);
+		if (!OidIsValid(context->cagg_relid) && ts_guc_cagg_rewrites_debug_info)
+		{
+			initStringInfo(&cagg_rewrite_ctx.msg);
+		}
+		if (cagg_rewrite_ctx.eligible)
+		{
+			check_query_for_cagg_rewrites(&cagg_rewrite_ctx, query);
+		}
+
+		Cache *hcache = ts_hypertable_cache_pin();
+		foreach (lc, query->rtable)
+		{
+			RangeTblEntry *rte = lfirst_node(RangeTblEntry, lc);
+			Hypertable *ht;
+
+			if (cagg_rewrite_ctx.eligible)
+				check_query_rtes_for_cagg_rewrites(&cagg_rewrite_ctx, rte);
+
+			if (cagg_rewrite_ctx.eligible && rte->rtekind == RTE_RELATION)
+			{
+				ht = ts_hypertable_cache_get_entry(hcache, rte->relid, CACHE_FLAG_MISSING_OK);
+
+				/* Record hypertable in case query will be eligible for Cagg rewrites */
+				if (ht)
+					cagg_rewrite_ctx.ht = ht;
+			}
+		}
+
+		if (cagg_rewrite_ctx.eligible && !cagg_rewrite_ctx.ht_rte)
+		{
+			cagg_rewrite_ctx.eligible = false;
+			if (ts_guc_cagg_rewrites_debug_info)
+				appendStringInfoString(&cagg_rewrite_ctx.msg,
+									   "at least one hypertable should be used in the query");
+		}
+
+		/* Found a hypertable, check that time bucket is valid and on hypertable time dimension */
+		if (cagg_rewrite_ctx.eligible)
+		{
+			/* "ht_rte" must be a Cagg, obtain its hypertable */
+			if (!cagg_rewrite_ctx.ht)
+			{
+				cagg_rewrite_ctx.cagg_parent =
+					ts_continuous_agg_find_by_relid(cagg_rewrite_ctx.ht_rte->relid);
+				Assert(cagg_rewrite_ctx.cagg_parent);
+				cagg_rewrite_ctx.ht =
+					ts_hypertable_cache_get_entry_by_id(hcache,
+														cagg_rewrite_ctx.cagg_parent->data
+															.mat_hypertable_id);
+			}
+			Assert(cagg_rewrite_ctx.ht);
+			/* Record hypertable full name so we can release hcache */
+			if (ts_guc_cagg_rewrites_debug_info)
+			{
+				initStringInfo(&cagg_rewrite_ctx.ht_name);
+				appendStringInfo(&cagg_rewrite_ctx.ht_name,
+								 "\"%s.%s\"",
+								 (cagg_rewrite_ctx.cagg_parent ?
+									  NameStr(cagg_rewrite_ctx.cagg_parent->data.user_view_schema) :
+									  NameStr(cagg_rewrite_ctx.ht->fd.schema_name)),
+								 (cagg_rewrite_ctx.cagg_parent ?
+									  NameStr(cagg_rewrite_ctx.cagg_parent->data.user_view_name) :
+									  NameStr(cagg_rewrite_ctx.ht->fd.table_name)));
+			}
+
+			const Dimension *part_dimension =
+				check_hypertable_dim_for_cagg_rewrites(&cagg_rewrite_ctx);
+			Assert(part_dimension || !cagg_rewrite_ctx.eligible);
+			if (part_dimension)
+			{
+				caggtimebucketinfo_init(&cagg_rewrite_ctx.tbinfo,
+										cagg_rewrite_ctx.ht->fd.id,
+										cagg_rewrite_ctx.ht->main_table_relid,
+										part_dimension->column_attno,
+										part_dimension->fd.column_type,
+										part_dimension->fd.interval_length,
+										INVALID_HYPERTABLE_ID);
+				/* Release hcache before "caggtimebucket_validate_common" as it can error out */
+				ts_cache_release(&hcache);
+
+				bool is_cagg_create = false;
+				bool for_rewrites = true;
+				cagg_rewrite_ctx.eligible =
+					caggtimebucket_validate_common(cagg_rewrite_ctx.tbinfo.bf,
+												   query->groupClause,
+												   query->targetList,
+												   query->rtable,
+												   cagg_rewrite_ctx.tbinfo.htpartcolno,
+												   &(cagg_rewrite_ctx.msg),
+												   is_cagg_create,
+												   for_rewrites);
+			}
+			else
+			{
+				ts_cache_release(&hcache);
+			}
+		}
+		else
+		{
+			ts_cache_release(&hcache);
+		}
+
+		/* Validated all we could before retrieving CAggs for the hypertable,
+		 * now we'll try to match available CAggs to the query.
+		 * If CAgg rewrites are disabled we will do match without rewriting, for debug info.
+		 */
+		if (cagg_rewrite_ctx.eligible)
+			match_query_to_cagg(&cagg_rewrite_ctx, query, ts_guc_enable_cagg_rewrites);
+
+		if (cagg_rewrite_ctx.cagg && ts_guc_enable_cagg_rewrites)
+			context->rewritten_with_caggs = true;
+
+		if (!OidIsValid(context->cagg_relid) && ts_guc_cagg_rewrites_debug_info)
+		{
+			StringInfoData query_label;
+			initStringInfo(&query_label);
+			if (context->is_root_query)
+				appendStringInfoString(&query_label, "Query");
+			else if (context->subquery_alias)
+				appendStringInfo(&query_label, "Subquery \"%s\"", context->subquery_alias);
+			else
+				appendStringInfo(&query_label, "Sublink");
+
+			if (cagg_rewrite_ctx.cagg)
+			{
+				if (ts_guc_enable_cagg_rewrites)
+					elog(INFO,
+						 "%s was rewritten with Cagg \"%s.%s\"",
+						 query_label.data,
+						 NameStr(cagg_rewrite_ctx.cagg->data.user_view_schema),
+						 NameStr(cagg_rewrite_ctx.cagg->data.user_view_name));
+				else
+					elog(INFO,
+						 "%s can be rewritten with Cagg \"%s.%s\"",
+						 query_label.data,
+						 NameStr(cagg_rewrite_ctx.cagg->data.user_view_schema),
+						 NameStr(cagg_rewrite_ctx.cagg->data.user_view_name));
+			}
+			else
+				elog(INFO,
+					 "%s cannot be rewritten with CAggs: %s",
+					 query_label.data,
+					 cagg_rewrite_ctx.msg.data);
+		}
+
+		if (context->is_root_query)
+			context->is_root_query = false;
+		context->subquery_alias = NULL;
+
+		ret = query_tree_walker(query,
+								rewrite_query_with_caggs,
+								context,
+								QTW_EXAMINE_RTES_BEFORE | QTW_EXAMINE_RTES_AFTER);
+		return ret;
+	}
+
+	return expression_tree_walker(node, rewrite_query_with_caggs, context);
+}
+
+Query *
+continuous_agg_apply_rewrites(Query *parse)
+{
+	Query *result = parse;
+	RewriteWithCaggsContext rewrite_with_caggs_context = { 0 };
+	rewrite_with_caggs_context.is_root_query = true;
+	rewrite_with_caggs_context.subquery_alias = NULL;
+	rewrite_query_with_caggs((Node *) parse, &rewrite_with_caggs_context);
+	/*
+	 *  we need to rewrite the query to fire Cagg view rules
+	 *  if query was rewritten with Caggs
+	 */
+	if (rewrite_with_caggs_context.rewritten_with_caggs)
+	{
+		Query *copied_query = copyObject(parse);
+		AcquireRewriteLocks(copied_query, true, false);
+		List *rewritten = QueryRewrite(copied_query);
+		Assert(list_length(rewritten) == 1);
+		result = linitial_node(Query, rewritten);
+	}
+	return result;
+}
+
+#endif

--- a/tsl/src/continuous_aggs/rewrite_with_caggs.h
+++ b/tsl/src/continuous_aggs/rewrite_with_caggs.h
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include "common.h"
+#include "ts_catalog/catalog.h"
+#include "ts_catalog/continuous_agg.h"
+
+#if PG16_GE
+typedef struct CaggRewriteContext
+{
+	bool eligible;						/* whether query is eligible for Caggs match */
+	RangeTblEntry *ht_rte;				/* Parent RTE for candidate Caggs */
+	Hypertable *ht;						/* Parent hypertable for candidate Caggs */
+	ContinuousAgg *cagg_parent;			/* parent Cagg for candidate Caggs */
+	ContinuousAgg *cagg;				/* matching Cagg, if match is found */
+	ContinuousAggTimeBucketInfo tbinfo; /* query bucket info to be matched with Caggs buckets*/
+	StringInfoData ht_name;				/* Cagg hypertable full name for debug info */
+	StringInfoData msg;					/* collects debug info */
+} CaggRewriteContext;
+
+Query *continuous_agg_apply_rewrites(Query *parse);
+
+#endif

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -33,6 +33,7 @@
 #include "continuous_aggs/invalidation.h"
 #include "continuous_aggs/options.h"
 #include "continuous_aggs/refresh.h"
+#include "continuous_aggs/rewrite_with_caggs.h"
 #include "continuous_aggs/utils.h"
 #include "cross_module_fn.h"
 #include "export.h"
@@ -134,6 +135,9 @@ CrossModuleFunctions tsl_cm_functions = {
 	.continuous_agg_invalidate_mat_ht = continuous_agg_invalidate_mat_ht,
 	.continuous_agg_dml_invalidate = continuous_agg_dml_invalidate,
 	.continuous_agg_update_options = continuous_agg_update_options,
+#if PG16_GE
+	.continuous_agg_apply_rewrites_tsl = continuous_agg_apply_rewrites,
+#endif
 	.continuous_agg_validate_query = continuous_agg_validate_query,
 	.continuous_agg_get_bucket_function = continuous_agg_get_bucket_function,
 	.continuous_agg_get_bucket_function_info = continuous_agg_get_bucket_function_info,

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -1089,7 +1089,8 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions FULL JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket;
-ERROR:  only INNER or LEFT joins are supported in continuous aggregates
+ERROR:  invalid continuous aggregate view
+DETAIL:  only INNER or LEFT joins are supported in continuous aggregates
 CREATE MATERIALIZED VIEW cagg_right
 WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
@@ -1098,7 +1099,8 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions RIGHT JOIN devices
 ON conditions.device_id = devices.device_id
 GROUP BY name, bucket;
-ERROR:  only INNER or LEFT joins are supported in continuous aggregates
+ERROR:  invalid continuous aggregate view
+DETAIL:  only INNER or LEFT joins are supported in continuous aggregates
 \set ON_ERROR_STOP 1
 -- LEFT JOIN is allowed
 CREATE MATERIALIZED VIEW cagg_left_join

--- a/tsl/test/expected/cagg_rewrites.out
+++ b/tsl/test/expected/cagg_rewrites.out
@@ -1,0 +1,1294 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set TEST_BASE_NAME cagg_rewrites
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('include/%s_error.sql', :'TEST_BASE_NAME') AS "TEST_ERROR_NAME",
+    format('include/%s_materialize.sql', :'TEST_BASE_NAME') AS "TEST_MAT_NAME",
+    format('%s/results/%s_results_rewritten.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_REWRITTEN",
+    format('%s/results/%s_results_not_rewritten.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_NOT_REWRITTEN" \gset
+SELECT format('\! diff -u --label "Original results" --label "Rewritten results" %s %s', :'TEST_RESULTS_NOT_REWRITTEN', :'TEST_RESULTS_REWRITTEN') AS "DIFF_CMD" \gset
+\ir :TEST_LOAD_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
+CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
+    AS $$ SELECT length($1)::BIGINT $$
+    LANGUAGE SQL IMMUTABLE;
+CREATE TABLE conditions(
+  day TIMESTAMPTZ NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+  device_id int NOT NULL
+);
+SELECT table_name FROM create_hypertable('conditions', 'day', chunk_time_interval => INTERVAL '1 day');
+ table_name 
+------------
+ conditions
+
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Berlin', 22,2),
+  ('2021-06-16', 'Stockholm', 24,3),
+  ('2021-06-17', 'London', 24,4),
+  ('2021-06-18', 'London', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Berlin', 31,1),
+  ('2021-06-22', 'Stockholm', 34,1),
+  ('2021-06-23', 'Stockholm', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'London', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT table_name FROM create_hypertable('conditions_dup', 'day', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
+psql:include/cagg_rewrites_load.sql:35: NOTICE:  migrating data to chunks
+   table_name   
+----------------
+ conditions_dup
+
+CREATE TABLE conditions_custom AS SELECT * FROM conditions;
+SELECT table_name FROM create_hypertable('conditions_custom', 'city', chunk_time_interval => 6, time_partitioning_func => 'text_part_func', migrate_data => true);
+psql:include/cagg_rewrites_load.sql:38: NOTICE:  migrating data to chunks
+    table_name     
+-------------------
+ conditions_custom
+
+CREATE TABLE conditions_int(
+  day int NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+  device_id int NOT NULL
+);
+INSERT INTO conditions_int SELECT (day::date - '2021-06-19'::date), city, temperature, device_id FROM conditions;
+SELECT table_name FROM create_hypertable('conditions_int', 'day', chunk_time_interval =>1, migrate_data => true);
+psql:include/cagg_rewrites_load.sql:47: NOTICE:  migrating data to chunks
+   table_name   
+----------------
+ conditions_int
+
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+CREATE TABLE location (location_id INTEGER, name TEXT);
+INSERT INTO location VALUES (1, 'Moscow'), (2, 'Berlin'), (3, 'London'), (4, 'Stockholm');
+CREATE VIEW devices_view AS SELECT * FROM devices;
+-- 1-table Caggs
+CREATE MATERIALIZED VIEW cagg1
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY bucket;
+psql:include/cagg_rewrites_load.sql:65: NOTICE:  refreshing continuous aggregate "cagg1"
+CREATE MATERIALIZED VIEW cagg1_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day, "offset"=>'30m'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY bucket;
+psql:include/cagg_rewrites_load.sql:74: NOTICE:  refreshing continuous aggregate "cagg1_tz"
+CREATE MATERIALIZED VIEW cagg1_origin
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 UTC'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY bucket;
+psql:include/cagg_rewrites_load.sql:83: NOTICE:  refreshing continuous aggregate "cagg1_origin"
+CREATE MATERIALIZED VIEW cagg2
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket;
+psql:include/cagg_rewrites_load.sql:91: NOTICE:  refreshing continuous aggregate "cagg2"
+CREATE MATERIALIZED VIEW cagg3
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1;
+psql:include/cagg_rewrites_load.sql:100: NOTICE:  refreshing continuous aggregate "cagg3"
+-- A Cagg over integer dimension
+CREATE OR REPLACE FUNCTION conditions_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 150;
+$BODY$;
+SELECT set_integer_now_func('conditions_int','conditions_int_now');
+ set_integer_now_func 
+----------------------
+ 
+
+CREATE MATERIALIZED VIEW cagg3_int
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(3, day, 1) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket;
+psql:include/cagg_rewrites_load.sql:116: NOTICE:  refreshing continuous aggregate "cagg3_int"
+-- Caggs with joins
+CREATE MATERIALIZED VIEW cagg_join
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket
+ORDER BY bucket;
+psql:include/cagg_rewrites_load.sql:127: NOTICE:  refreshing continuous aggregate "cagg_join"
+-- Create CAgg with more joins and additional WHERE conditions
+CREATE MATERIALIZED VIEW cagg_more_conds
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name,
+   devices.device_id * 2
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id;
+psql:include/cagg_rewrites_load.sql:141: NOTICE:  refreshing continuous aggregate "cagg_more_conds"
+-- Hierarchical CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg1
+WITH (timescaledb.continuous, timescaledb.materialized_only=FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id
+GROUP BY 1;
+psql:include/cagg_rewrites_load.sql:150: NOTICE:  refreshing continuous aggregate "cagg_on_cagg1"
+-- Joining a hypertable and view
+CREATE MATERIALIZED VIEW cagg_view
+WITH (timescaledb.continuous, timescaledb.materialized_only=FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+psql:include/cagg_rewrites_load.sql:161: NOTICE:  refreshing continuous aggregate "cagg_view"
+-- Join on lateral subquery
+CREATE MATERIALIZED VIEW cagg_lateral WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE)
+AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket, q.name, avg(temperature)  from conditions,
+LATERAL (SELECT * FROM devices WHERE devices.device_id = conditions.device_id) q
+GROUP BY bucket, q.name;
+psql:include/cagg_rewrites_load.sql:168: NOTICE:  refreshing continuous aggregate "cagg_lateral"
+SELECT h.schema_name AS "MAT_SCHEMA_NAME",
+       h.table_name AS "MAT_TABLE_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'cagg1'
+\gset
+SET timescaledb.cagg_rewrites_debug_info = 1;
+SET timescaledb.enable_cagg_rewrites = 1;
+-- Make sure Cagg was used in a plan for an eligible query
+EXPLAIN (buffers off, costs off, timing off, summary off) SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1
+LIMIT 3;
+INFO:  Query was rewritten with Cagg "public.cagg2"
+--- QUERY PLAN ---
+ Limit
+   ->  Append
+         ->  Subquery Scan on "*SELECT* 1"
+               ->  Result
+                     ->  Custom Scan (ChunkAppend) on _materialized_hypertable_8
+                           Order: _materialized_hypertable_8.bucket
+                           ->  Index Scan Backward using _hyper_8_51_chunk__materialized_hypertable_8_bucket_idx on _hyper_8_51_chunk
+                           ->  Index Scan Backward using _hyper_8_50_chunk__materialized_hypertable_8_bucket_idx on _hyper_8_50_chunk
+                                 Index Cond: (bucket < 'Mon Jun 28 17:00:00 2021 PDT'::timestamp with time zone)
+         ->  Subquery Scan on "*SELECT* 2"
+               ->  GroupAggregate
+                     Group Key: (time_bucket('@ 2 days'::interval, day))
+                     ->  Sort
+                           Sort Key: (time_bucket('@ 2 days'::interval, day))
+                           ->  Result
+                                 One-Time Filter: false
+
+-- run tests on queries eligible for Cagg rewrites and diff results
+\o :TEST_RESULTS_REWRITTEN
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- (cagg1)
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:11: INFO:  Query was rewritten with Cagg "public.cagg1"
+-- (cagg2)
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+psql:include/cagg_rewrites_query.sql:19: INFO:  Query was rewritten with Cagg "public.cagg2"
+-- (cagg3)
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1
+ORDER BY 1, 2;
+psql:include/cagg_rewrites_query.sql:27: INFO:  Query was rewritten with Cagg "public.cagg3"
+-- (cagg3) with equivalent Having
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING (2-1) < count(device_id)
+ORDER BY 1, 2;
+psql:include/cagg_rewrites_query.sql:36: INFO:  Query was rewritten with Cagg "public.cagg3"
+-- (cagg_join), flip join order
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM devices, conditions
+WHERE devices.device_id = conditions.device_id
+GROUP BY name, bucket
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:45: INFO:  Query was rewritten with Cagg "public.cagg_join"
+-- (cagg_more_conds) w/o one target
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+psql:include/cagg_rewrites_query.sql:58: INFO:  Query was rewritten with Cagg "public.cagg_more_conds"
+-- (cagg_more_conds) with expressions in conditions and targets
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   (devices.device_id * 2) + 1,
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE 1+0 < location_id AND
+      conditions.temperature > 29-1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+psql:include/cagg_rewrites_query.sql:72: INFO:  Query was rewritten with Cagg "public.cagg_more_conds"
+-- Hierarchical Caggs and Caggs on views
+-- (cagg_on_cagg1)
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id
+GROUP BY 1 ORDER BY 1, 2;
+psql:include/cagg_rewrites_query.sql:81: INFO:  Query was rewritten with Cagg "public.cagg_on_cagg1"
+-- (cagg_view)
+ALTER MATERIALIZED VIEW cagg_view SET (timescaledb.materialized_only=false);
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id
+ORDER BY 1, 2, 3, 4;
+psql:include/cagg_rewrites_query.sql:92: INFO:  Query was rewritten with Cagg "public.cagg_view"
+-- (cagg_lateral)
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket, q.name, avg(temperature)  from conditions,
+LATERAL (SELECT * FROM devices WHERE devices.device_id = conditions.device_id) q
+GROUP BY bucket, q.name
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:98: INFO:  Query was rewritten with Cagg "public.cagg_lateral"
+-- (cagg1_tz)
+SELECT time_bucket(INTERVAL '1 day', day, "offset"=>'30m'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:106: INFO:  Query was rewritten with Cagg "public.cagg1_tz"
+-- (cagg1_origin)
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 UTC'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1,2,3
+LIMIT 3;
+psql:include/cagg_rewrites_query.sql:115: INFO:  Query was rewritten with Cagg "public.cagg1_origin"
+-- (cagg3_int)
+SELECT time_bucket(3, day, 1) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket
+ORDER BY 1,2,3;
+psql:include/cagg_rewrites_query.sql:123: INFO:  Query was rewritten with Cagg "public.cagg3_int"
+-- Cagg rewrites in subqueries/SET ops
+-- (cagg1) CTE
+WITH con AS (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket)
+SELECT * FROM con
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:134: INFO:  Query cannot be rewritten with CAggs: CTEs and sublinks are not supported by continuous aggregates.
+psql:include/cagg_rewrites_query.sql:134: INFO:  Subquery "con" was rewritten with Cagg "public.cagg1"
+-- (cagg1) subquery
+SELECT * FROM (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket) con
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:142: INFO:  Query cannot be rewritten with CAggs: no GROUP BY clause in the query
+psql:include/cagg_rewrites_query.sql:142: INFO:  Subquery "con" was rewritten with Cagg "public.cagg1"
+-- (cagg2) sublink
+SELECT * from conditions
+WHERE EXISTS (SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature) AS avg_temp
+FROM conditions
+GROUP BY bucket)
+ORDER BY 1, 2, 3, 4;
+psql:include/cagg_rewrites_query.sql:150: INFO:  Query cannot be rewritten with CAggs: CTEs and sublinks are not supported by continuous aggregates.
+psql:include/cagg_rewrites_query.sql:150: INFO:  Sublink was rewritten with Cagg "public.cagg2"
+-- Union of cagg2 and cagg3
+SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+UNION ALL
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_query.sql:165: INFO:  Query cannot be rewritten with CAggs: FROM clause missing in the query
+psql:include/cagg_rewrites_query.sql:165: INFO:  Subquery "*SELECT* 1" was rewritten with Cagg "public.cagg2"
+psql:include/cagg_rewrites_query.sql:165: INFO:  Subquery "*SELECT* 2" was rewritten with Cagg "public.cagg3"
+\o
+SET timescaledb.enable_cagg_rewrites = 0;
+SET timescaledb.cagg_rewrites_debug_info = 0;
+\o :TEST_RESULTS_NOT_REWRITTEN
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- (cagg1)
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+-- (cagg2)
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+-- (cagg3)
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1
+ORDER BY 1, 2;
+-- (cagg3) with equivalent Having
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING (2-1) < count(device_id)
+ORDER BY 1, 2;
+-- (cagg_join), flip join order
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM devices, conditions
+WHERE devices.device_id = conditions.device_id
+GROUP BY name, bucket
+ORDER BY 1, 2, 3;
+-- (cagg_more_conds) w/o one target
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+-- (cagg_more_conds) with expressions in conditions and targets
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   (devices.device_id * 2) + 1,
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE 1+0 < location_id AND
+      conditions.temperature > 29-1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+-- Hierarchical Caggs and Caggs on views
+-- (cagg_on_cagg1)
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id
+GROUP BY 1 ORDER BY 1, 2;
+-- (cagg_view)
+ALTER MATERIALIZED VIEW cagg_view SET (timescaledb.materialized_only=false);
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id
+ORDER BY 1, 2, 3, 4;
+-- (cagg_lateral)
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket, q.name, avg(temperature)  from conditions,
+LATERAL (SELECT * FROM devices WHERE devices.device_id = conditions.device_id) q
+GROUP BY bucket, q.name
+ORDER BY 1, 2, 3;
+-- (cagg1_tz)
+SELECT time_bucket(INTERVAL '1 day', day, "offset"=>'30m'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+-- (cagg1_origin)
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 UTC'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1,2,3
+LIMIT 3;
+-- (cagg3_int)
+SELECT time_bucket(3, day, 1) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket
+ORDER BY 1,2,3;
+-- Cagg rewrites in subqueries/SET ops
+-- (cagg1) CTE
+WITH con AS (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket)
+SELECT * FROM con
+ORDER BY 1, 2, 3;
+-- (cagg1) subquery
+SELECT * FROM (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket) con
+ORDER BY 1, 2, 3;
+-- (cagg2) sublink
+SELECT * from conditions
+WHERE EXISTS (SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature) AS avg_temp
+FROM conditions
+GROUP BY bucket)
+ORDER BY 1, 2, 3, 4;
+-- Union of cagg2 and cagg3
+SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+UNION ALL
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1
+ORDER BY 1, 2, 3;
+\o
+-- compare results for original queries vs. queries rewritten with Caggs
+:DIFF_CMD
+SET timescaledb.cagg_rewrites_debug_info = 1;
+-- Test queries ineligible for Cagg rewrites, display diagnostics on why
+\ir :TEST_ERROR_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Queries generally not eligible for rewrite
+-- No FROM
+SELECT 1;
+psql:include/cagg_rewrites_error.sql:8: INFO:  Query cannot be rewritten with CAggs: FROM clause missing in the query
+ ?column? 
+----------
+        1
+
+-- Not SELECT
+BEGIN;
+DELETE FROM conditions WHERE device_id = 4;
+psql:include/cagg_rewrites_error.sql:12: INFO:  Query cannot be rewritten with CAggs: not a SELECT query
+ROLLBACK;
+-- Has window function
+SELECT device_id, AVG(temperature) OVER (ORDER BY device_id) FROM conditions ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:16: INFO:  Query cannot be rewritten with CAggs: Window function in a query
+ device_id |         avg         
+-----------+---------------------
+         1 | 30.2500000000000000
+
+-- Has DISTINCT
+SELECT DISTINCT location FROM devices ORDER BY 1;
+psql:include/cagg_rewrites_error.sql:19: INFO:  Query cannot be rewritten with CAggs: DISTINCT / DISTINCT ON queries are not supported by continuous aggregates.
+ location  
+-----------
+ Berlin
+ London
+ Moscow
+ Stockholm
+
+SELECT DISTINCT ON(device_id) device_id, location FROM devices ORDER BY 1;
+psql:include/cagg_rewrites_error.sql:20: INFO:  Query cannot be rewritten with CAggs: DISTINCT / DISTINCT ON queries are not supported by continuous aggregates.
+ device_id | location  
+-----------+-----------
+         1 | Moscow
+         2 | Berlin
+         3 | London
+         4 | Stockholm
+
+-- Has CTE/sublinks which subqueries are also not eligible for rewrite (has grouping sets; no groupby)
+WITH con as (SELECT device_id, AVG(temperature) FROM conditions GROUP BY ROLLUP (device_id)) SELECT * FROM con ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:23: INFO:  Query cannot be rewritten with CAggs: CTEs and sublinks are not supported by continuous aggregates.
+psql:include/cagg_rewrites_error.sql:23: INFO:  Subquery "con" cannot be rewritten with CAggs: GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
+ device_id |         avg         
+-----------+---------------------
+         1 | 30.2500000000000000
+
+SELECT * FROM conditions WHERE temperature = (SELECT AVG(temperature) FROM conditions);
+psql:include/cagg_rewrites_error.sql:24: INFO:  Query cannot be rewritten with CAggs: CTEs and sublinks are not supported by continuous aggregates.
+psql:include/cagg_rewrites_error.sql:24: INFO:  Sublink cannot be rewritten with CAggs: no GROUP BY clause in the query
+ day | city | temperature | device_id 
+-----+------+-------------+-----------
+
+-- Has row-level security
+ALTER TABLE location ENABLE ROW LEVEL SECURITY;
+SELECT location_id, max(name) from location group by location_id;
+psql:include/cagg_rewrites_error.sql:28: INFO:  Query cannot be rewritten with CAggs: Row level security is not supported by continuous aggregates
+ location_id |    max    
+-------------+-----------
+           3 | London
+           4 | Stockholm
+           2 | Berlin
+           1 | Moscow
+
+ALTER TABLE location DISABLE ROW LEVEL SECURITY;
+-- ineligible because of relations used in a query
+-- no hypertable
+SELECT location, count(device_id)
+FROM devices
+GROUP BY location
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:37: INFO:  Query cannot be rewritten with CAggs: at least one hypertable should be used in the query
+ location | count 
+----------+-------
+ Berlin   |     1
+
+-- two hypertables
+SELECT time_bucket(INTERVAL '3 days', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   count(conditions_dup.device_id)
+FROM conditions_dup, conditions
+WHERE conditions_dup.device_id = conditions.device_id
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:46: INFO:  Query cannot be rewritten with CAggs: More than one hypertable in the query: "conditions" and "conditions_dup"
+            bucket            |         avg         | count 
+------------------------------+---------------------+-------
+ Sun Jun 13 17:00:00 2021 PDT | 24.1818181818181818 |    11
+
+-- Full Outer Join
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM devices FULL OUTER JOIN conditions
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:55: INFO:  Query cannot be rewritten with CAggs: only INNER or LEFT joins are supported in continuous aggregates
+            bucket            |         avg         |   name   
+------------------------------+---------------------+----------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 | thermo_1
+
+-- Has non-lateral subquery; the subquery has TABLESAMPLE
+SELECT time_bucket(INTERVAL '1 day', d) AS bucket,
+   AVG(temp) AS avg,
+   device_id
+FROM (SELECT device_id, max (day) as d, avg(temperature) as temp FROM conditions TABLESAMPLE SYSTEM (0) group by device_id) con
+GROUP BY device_id, bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:63: INFO:  Query cannot be rewritten with CAggs: only LATERAL subqueries in FROM clause are supported in continuous aggregates.
+psql:include/cagg_rewrites_error.sql:63: INFO:  Subquery "con" cannot be rewritten with CAggs: TABLESAMPLE is not supported in continuous aggregate.
+ bucket | avg | device_id 
+--------+-----+-----------
+
+-- Query over Cagg materialization table
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+   device_id
+FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
+GROUP BY device_id, bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:70: INFO:  Query cannot be rewritten with CAggs: hypertable "_timescaledb_internal._materialized_hypertable_5" is a continuous aggregate materialization table
+            bucket            | device_id 
+------------------------------+-----------
+ Sun Jun 13 17:00:00 2021 PDT |         1
+
+-- Query over hypertable with custom partitioning
+SELECT time_bucket('5', text_part_func(city)), avg(temperature)
+  FROM conditions_custom
+GROUP BY 1;
+psql:include/cagg_rewrites_error.sql:75: INFO:  Query cannot be rewritten with CAggs: custom partitioning functions not supported with continuous aggregates
+ time_bucket |         avg         
+-------------+---------------------
+           5 | 29.2142857142857143
+
+-- ineligible time buckets
+-- no time bucket
+SELECT day,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY day
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:85: INFO:  Query cannot be rewritten with CAggs: should be a valid time bucket function in the query
+             day              |         avg         | count 
+------------------------------+---------------------+-------
+ Mon Jun 14 00:00:00 2021 PDT | 26.0000000000000000 |     1
+
+-- several time buckets
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket1, time_bucket(INTERVAL '3 days', day) AS bucket3,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY 1,2
+ORDER BY 1,2 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:93: INFO:  Query cannot be rewritten with CAggs: multiple time bucket functions are not supported with CAggs
+           bucket1            |           bucket3            |         avg         | count 
+------------------------------+------------------------------+---------------------+-------
+ Sun Jun 13 17:00:00 2021 PDT | Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 |     1
+
+-- time bucket not on primary dimension
+SELECT time_bucket(1, temperature) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:101: INFO:  Query cannot be rewritten with CAggs: time bucket function must reference the primary hypertable dimension column
+ bucket |         avg         | count 
+--------+---------------------+-------
+     22 | 22.0000000000000000 |     1
+
+-- time bucket with non-const 1st argument
+SELECT time_bucket(('2026-01-08 15:00:00'::timestamptz - day), day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 0
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:110: INFO:  Query cannot be rewritten with CAggs: non-immutable expression as first argument to the time bucket function
+            bucket            |         avg         | count 
+------------------------------+---------------------+-------
+ Fri Feb 23 08:00:00 2018 PST | 31.0000000000000000 |     1
+
+-- infinity origin
+SELECT time_bucket(INTERVAL '3 days', day, 'infinity'::timestamptz) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:118: INFO:  Query cannot be rewritten with CAggs: invalid time bucket origin value: infinity
+               bucket                |         avg         | count 
+-------------------------------------+---------------------+-------
+ Fri Jun 11 21:00:54.775807 2021 PDT | 26.0000000000000000 |     1
+
+-- origin and offset at the same time
+SELECT time_bucket(INTERVAL '3 days', day, "offset"=>'30m'::interval, origin=>'2000-01-01 01:00:00 PST'::timestamptz, timezone=>'UTC') AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:126: INFO:  Query cannot be rewritten with CAggs: using offset and origin in a time_bucket function at the same time is not supported
+            bucket            |         avg         | count 
+------------------------------+---------------------+-------
+ Sat Jun 12 02:30:00 2021 PDT | 24.0000000000000000 |     2
+
+-- No Caggs match a candidate query
+-- no Caggs
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions_dup
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:136: INFO:  Query cannot be rewritten with CAggs: no continuous aggregates defined on "public.conditions_dup"
+            bucket            |         avg         | count 
+------------------------------+---------------------+-------
+ Sun Jun 13 17:00:00 2021 PDT | 24.0000000000000000 |     3
+
+-- no matching Caggs
+ALTER MATERIALIZED VIEW cagg_view SET (timescaledb.materialized_only=true);
+-- Almost cagg1 but unmatched groupby
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:146: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg_join" "public.cagg_more_conds" "public.cagg_lateral"
+Grouping clauses do not match: "public.cagg1"
+
+            bucket            |         avg         
+------------------------------+---------------------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000
+
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket, city
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:152: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg_join" "public.cagg_more_conds" "public.cagg_lateral"
+Grouping clauses do not match: "public.cagg1"
+
+            bucket            |         avg         
+------------------------------+---------------------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000
+
+-- Almost cagg1 but unmatched aggregate
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg, max(city) as city, device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:159: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg_join" "public.cagg_more_conds" "public.cagg_lateral"
+Query aggregates do not match: "public.cagg1"
+
+            bucket            |         avg         |  city  | device_id 
+------------------------------+---------------------+--------+-----------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 | Moscow |         1
+
+-- Almost cagg3 but unmatched having
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 0
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:168: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+HAVING quals do not match: "public.cagg3"
+
+            bucket            |         avg         | count 
+------------------------------+---------------------+-------
+ Sun Jun 13 17:00:00 2021 PDT | 24.0000000000000000 |     3
+
+-- Almost caggs_more_conds but target doesn't match
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name,
+   devices.device_id
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:181: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg1" "public.cagg_join" "public.cagg_lateral"
+Query targets cannot be derived from Cagg targets: "public.cagg_more_conds"
+
+            bucket            |         avg         | count |   name   | device_id 
+------------------------------+---------------------+-------+----------+-----------
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |     1 | thermo_1 |         1
+
+-- Almost caggs_more_conds but a qual does not match
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature < 20
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:193: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg1" "public.cagg_join" "public.cagg_lateral"
+WHERE/JOIN quals do not match: "public.cagg_more_conds"
+
+ bucket | avg | count | name 
+--------+-----+-------+------
+
+-- Almost caggs_more_conds but only one qual matches
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      location_id > 1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+psql:include/cagg_rewrites_error.sql:206: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg1" "public.cagg_join" "public.cagg_lateral"
+WHERE/JOIN quals do not match: "public.cagg_more_conds"
+
+            bucket            |         avg         | count |   name   
+------------------------------+---------------------+-------+----------
+ Mon Jun 14 17:00:00 2021 PDT | 22.0000000000000000 |     1 | thermo_2
+ Tue Jun 15 17:00:00 2021 PDT | 24.0000000000000000 |     1 | thermo_3
+
+-- Almost caggs_more_conds but quals do not match due to commuted operand
+-- while OpExpr arguments are the same
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id < 1 AND
+      conditions.temperature < 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+psql:include/cagg_rewrites_error.sql:220: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg1" "public.cagg_join" "public.cagg_lateral"
+WHERE/JOIN quals do not match: "public.cagg_more_conds"
+
+ bucket | avg | count | name 
+--------+-----+-------+------
+
+-- Almost cagg_tz but bucket offset doesn't match
+SELECT time_bucket(INTERVAL '1 day', day,  "offset"=>'15s'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+psql:include/cagg_rewrites_error.sql:228: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 07:00:15 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 07:00:15 2021 PDT | 22.0000000000000000 |         2
+ Tue Jun 15 07:00:15 2021 PDT | 24.0000000000000000 |         3
+
+-- same as above but offset vs. no offset
+SELECT time_bucket(INTERVAL '1 day', day, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+psql:include/cagg_rewrites_error.sql:236: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 07:00:00 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 07:00:00 2021 PDT | 22.0000000000000000 |         2
+ Tue Jun 15 07:00:00 2021 PDT | 24.0000000000000000 |         3
+
+-- Almost cagg_tz but bucket time zone doesn't match
+SELECT time_bucket(INTERVAL '1 day', day,  "offset"=>'30m'::interval, timezone=>'Europe/Berlin') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+psql:include/cagg_rewrites_error.sql:244: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 15:30:00 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 15:30:00 2021 PDT | 22.0000000000000000 |         2
+ Tue Jun 15 15:30:00 2021 PDT | 24.0000000000000000 |         3
+
+-- Almost cagg_origin but origins do not match
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-03') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+psql:include/cagg_rewrites_error.sql:252: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 01:00:00 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 01:00:00 2021 PDT | 22.0000000000000000 |         2
+ Tue Jun 15 01:00:00 2021 PDT | 24.0000000000000000 |         3
+
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 Europe/Berlin'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+psql:include/cagg_rewrites_error.sql:259: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 16:00:00 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 16:00:00 2021 PDT | 22.0000000000000000 |         2
+ Tue Jun 15 16:00:00 2021 PDT | 24.0000000000000000 |         3
+
+-- Almost cagg3_int but integer offsets do not match
+SELECT time_bucket(3, day, 2) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_error.sql:266: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions_int" are matching the query:
+Buckets do not match: "public.cagg3_int"
+
+ bucket |         avg         | count 
+--------+---------------------+-------
+     -7 | 26.0000000000000000 |     1
+     -4 | 23.3333333333333333 |     3
+     -1 | 28.3333333333333333 |     3
+      2 | 33.0000000000000000 |     3
+      5 | 32.6666666666666667 |     3
+      8 | 31.0000000000000000 |     1
+
+SELECT time_bucket(3, day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket  ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_error.sql:272: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions_int" are matching the query:
+Buckets do not match: "public.cagg3_int"
+
+ bucket |         avg         | count 
+--------+---------------------+-------
+     -6 | 24.0000000000000000 |     2
+     -3 | 25.0000000000000000 |     3
+      0 | 29.6666666666666667 |     3
+      3 | 34.0000000000000000 |     3
+      6 | 31.6666666666666667 |     3
+
+-- Report on a query ineligible for hierarchical Cagg
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id AND devices.device_id > 1
+GROUP BY 1 ORDER BY 1 LIMIT 1;
+psql:include/cagg_rewrites_error.sql:279: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.cagg1" are matching the query:
+WHERE/JOIN quals do not match: "public.cagg_on_cagg1"
+
+            bucket            |     temperature     
+------------------------------+---------------------
+ Mon Jun 14 17:00:00 2021 PDT | 22.0000000000000000
+
+-- External params from prepared statements cannot be used in place of Consts
+PREPARE prep1 AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > $1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+EXECUTE prep1(28);
+psql:include/cagg_rewrites_error.sql:295: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg1" "public.cagg_join" "public.cagg_lateral"
+WHERE/JOIN quals do not match: "public.cagg_more_conds"
+
+            bucket            |         avg         | count |   name   
+------------------------------+---------------------+-------+----------
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |     1 | thermo_1
+ Mon Jun 21 17:00:00 2021 PDT | 34.0000000000000000 |     1 | thermo_1
+
+DEALLOCATE prep1;
+PREPARE prep2 AS
+SELECT time_bucket($1, day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+EXECUTE prep2(INTERVAL '1 day');
+psql:include/cagg_rewrites_error.sql:311: INFO:  Query cannot be rewritten with CAggs: non-immutable expression as first argument to the time bucket function
+            bucket            |         avg         | count |   name   
+------------------------------+---------------------+-------+----------
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |     1 | thermo_1
+ Mon Jun 21 17:00:00 2021 PDT | 34.0000000000000000 |     1 | thermo_1
+
+DEALLOCATE prep2;
+-- Internal params cannot be used in place of Consts
+SELECT * FROM (VALUES (1), (1)) a(v),
+  LATERAL
+  (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+   FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+   JOIN location ON conditions.city = location.name
+   WHERE location_id > a.v AND
+      conditions.temperature > 28
+   GROUP BY devices.name, bucket, devices.device_id) q
+ORDER BY 1,2,3,4
+LIMIT 2;
+psql:include/cagg_rewrites_error.sql:327: INFO:  Query cannot be rewritten with CAggs: no GROUP BY clause in the query
+psql:include/cagg_rewrites_error.sql:327: INFO:  Subquery "a" cannot be rewritten with CAggs: no GROUP BY clause in the query
+psql:include/cagg_rewrites_error.sql:327: INFO:  Subquery "q" cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+Joins do not match: "public.cagg1" "public.cagg_join" "public.cagg_lateral"
+WHERE/JOIN quals do not match: "public.cagg_more_conds"
+
+ v |            bucket            |         avg         | count |   name   
+---+------------------------------+---------------------+-------+----------
+ 1 | Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |     1 | thermo_1
+ 1 | Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |     1 | thermo_1
+
+-- Test queries needing live data in addition to Cagg-materialized data
+\ir :TEST_MAT_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for rewrites with Caggs with different degrees of materialization
+-- Backfilled data makes all Caggs on a hypertable ineligible for rewrites until they are refreshed
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-15', 'Moscow', 23,1),
+  ('2021-06-17', 'Berlin', 24,2),
+  ('2021-06-17', 'Stockholm', 21,3);
+psql:include/cagg_rewrites_materialize.sql:11: INFO:  Query cannot be rewritten with CAggs: not a SELECT query
+-- (cagg1) is eligible but invalidated
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_materialize.sql:19: INFO:  Query cannot be rewritten with CAggs: invalidated ranges are present in hypertable "public.conditions"
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 17:00:00 2021 PDT | 22.0000000000000000 |         2
+ Mon Jun 14 17:00:00 2021 PDT | 23.0000000000000000 |         1
+ Tue Jun 15 17:00:00 2021 PDT | 24.0000000000000000 |         3
+ Wed Jun 16 17:00:00 2021 PDT | 21.0000000000000000 |         3
+ Wed Jun 16 17:00:00 2021 PDT | 24.0000000000000000 |         2
+ Wed Jun 16 17:00:00 2021 PDT | 24.0000000000000000 |         4
+ Thu Jun 17 17:00:00 2021 PDT | 27.0000000000000000 |         4
+ Fri Jun 18 17:00:00 2021 PDT | 28.0000000000000000 |         4
+ Sat Jun 19 17:00:00 2021 PDT | 30.0000000000000000 |         1
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |         1
+ Mon Jun 21 17:00:00 2021 PDT | 34.0000000000000000 |         1
+ Tue Jun 22 17:00:00 2021 PDT | 34.0000000000000000 |         2
+ Wed Jun 23 17:00:00 2021 PDT | 34.0000000000000000 |         2
+ Thu Jun 24 17:00:00 2021 PDT | 32.0000000000000000 |         3
+ Fri Jun 25 17:00:00 2021 PDT | 32.0000000000000000 |         3
+ Sat Jun 26 17:00:00 2021 PDT | 31.0000000000000000 |         3
+
+-- After (cagg2) is refreshed it's eligible again,
+-- the rest of the caggs have their materialization invalidation logs updated
+-- while hypertable invalidation logs are cleared
+SET timescaledb.cagg_rewrites_debug_info = 0;
+CALL refresh_continuous_aggregate('cagg2', NULL, NULL);
+SET timescaledb.cagg_rewrites_debug_info = 1;
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+psql:include/cagg_rewrites_materialize.sql:33: INFO:  Query can be rewritten with Cagg "public.cagg2"
+            bucket            | count 
+------------------------------+-------
+ Sat Jun 12 17:00:00 2021 PDT |     1
+ Mon Jun 14 17:00:00 2021 PDT |     3
+ Wed Jun 16 17:00:00 2021 PDT |     4
+
+-- (cagg1) is still not eligible as it's not refreshed since last backfill
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+psql:include/cagg_rewrites_materialize.sql:41: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs are not real-time: "public.cagg_view"
+Invalidated caggs: "public.cagg1" "public.cagg_join" "public.cagg_more_conds" "public.cagg_lateral"
+Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "public.cagg3"
+
+            bucket            |         avg         | device_id 
+------------------------------+---------------------+-----------
+ Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000 |         1
+ Mon Jun 14 17:00:00 2021 PDT | 22.0000000000000000 |         2
+ Mon Jun 14 17:00:00 2021 PDT | 23.0000000000000000 |         1
+ Tue Jun 15 17:00:00 2021 PDT | 24.0000000000000000 |         3
+ Wed Jun 16 17:00:00 2021 PDT | 21.0000000000000000 |         3
+ Wed Jun 16 17:00:00 2021 PDT | 24.0000000000000000 |         2
+ Wed Jun 16 17:00:00 2021 PDT | 24.0000000000000000 |         4
+ Thu Jun 17 17:00:00 2021 PDT | 27.0000000000000000 |         4
+ Fri Jun 18 17:00:00 2021 PDT | 28.0000000000000000 |         4
+ Sat Jun 19 17:00:00 2021 PDT | 30.0000000000000000 |         1
+ Sun Jun 20 17:00:00 2021 PDT | 31.0000000000000000 |         1
+ Mon Jun 21 17:00:00 2021 PDT | 34.0000000000000000 |         1
+ Tue Jun 22 17:00:00 2021 PDT | 34.0000000000000000 |         2
+ Wed Jun 23 17:00:00 2021 PDT | 34.0000000000000000 |         2
+ Thu Jun 24 17:00:00 2021 PDT | 32.0000000000000000 |         3
+ Fri Jun 25 17:00:00 2021 PDT | 32.0000000000000000 |         3
+ Sat Jun 26 17:00:00 2021 PDT | 31.0000000000000000 |         3
+
+-- Caggs with pending materialization ranges are not eligible.
+-- Insert new row into hypertable, remove (cagg2) watermark and then refresh it.
+-- It will create pending materialization range on (cagg2) as refresh will error out.
+SET timescaledb.cagg_rewrites_debug_info = 0;
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-16', 'Berlin', 23, 2);
+SELECT ca.mat_hypertable_id AS "CAGG2_ID", watermark AS "CAGG2_WATERMARK"
+FROM _timescaledb_catalog.continuous_agg ca INNER JOIN _timescaledb_catalog.continuous_aggs_watermark wm
+ON (ca.mat_hypertable_id = wm.mat_hypertable_id) WHERE user_view_name = 'cagg2';
+ CAGG2_ID | CAGG2_WATERMARK  
+----------+------------------
+        8 | 1624924800000000
+
+\gset
+-- This will create pending materialization range
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark WHERE mat_hypertable_id = :CAGG2_ID;
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cagg2', NULL, NULL);
+psql:include/cagg_rewrites_materialize.sql:59: ERROR:  watermark not defined for continuous aggregate: 8
+\set ON_ERROR_STOP 1
+-- Restore deleted watermark so that we can query (cagg2) again
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark values(:CAGG2_ID, :CAGG2_WATERMARK);
+SET timescaledb.cagg_rewrites_debug_info = 1;
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+psql:include/cagg_rewrites_materialize.sql:71: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
+Caggs with pending materialization ranges: "public.cagg2"
+Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
+
+            bucket            | count 
+------------------------------+-------
+ Sat Jun 12 17:00:00 2021 PDT |     1
+ Mon Jun 14 17:00:00 2021 PDT |     4
+ Wed Jun 16 17:00:00 2021 PDT |     4
+
+-- cleanup materialization ranges
+TRUNCATE TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges;
+RESET timescaledb.cagg_rewrites_debug_info;
+RESET timescaledb.enable_cagg_rewrites;
+DROP MATERIALIZED VIEW cagg_on_cagg1 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg1 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg1_tz CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg1_origin CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg2 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg3 CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg3_int CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg_join CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg_more_conds CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg_view CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP MATERIALIZED VIEW cagg_lateral CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DROP TABLE conditions CASCADE;
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE conditions_custom CASCADE;
+DROP TABLE conditions_int CASCADE;
+DROP VIEW devices_view CASCADE;
+DROP TABLE devices CASCADE;
+DROP TABLE location CASCADE;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -200,7 +200,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
-  list(APPEND TEST_FILES cagg_planning.sql skip_scan_dagg.sql)
+  list(APPEND TEST_FILES cagg_planning.sql cagg_rewrites.sql skip_scan_dagg.sql)
   list(APPEND TEST_TEMPLATES plan_skip_scan_dagg.sql.in)
 endif()
 

--- a/tsl/test/sql/cagg_rewrites.sql
+++ b/tsl/test/sql/cagg_rewrites.sql
@@ -1,0 +1,71 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set TEST_BASE_NAME cagg_rewrites
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('include/%s_error.sql', :'TEST_BASE_NAME') AS "TEST_ERROR_NAME",
+    format('include/%s_materialize.sql', :'TEST_BASE_NAME') AS "TEST_MAT_NAME",
+    format('%s/results/%s_results_rewritten.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_REWRITTEN",
+    format('%s/results/%s_results_not_rewritten.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_NOT_REWRITTEN" \gset
+
+SELECT format('\! diff -u --label "Original results" --label "Rewritten results" %s %s', :'TEST_RESULTS_NOT_REWRITTEN', :'TEST_RESULTS_REWRITTEN') AS "DIFF_CMD" \gset
+
+\ir :TEST_LOAD_NAME
+
+SET timescaledb.cagg_rewrites_debug_info = 1;
+SET timescaledb.enable_cagg_rewrites = 1;
+
+-- Make sure Cagg was used in a plan for an eligible query
+EXPLAIN (buffers off, costs off, timing off, summary off) SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1
+LIMIT 3;
+
+-- run tests on queries eligible for Cagg rewrites and diff results
+\o :TEST_RESULTS_REWRITTEN
+\ir :TEST_QUERY_NAME
+\o
+
+SET timescaledb.enable_cagg_rewrites = 0;
+SET timescaledb.cagg_rewrites_debug_info = 0;
+
+\o :TEST_RESULTS_NOT_REWRITTEN
+\ir :TEST_QUERY_NAME
+\o
+
+-- compare results for original queries vs. queries rewritten with Caggs
+:DIFF_CMD
+
+SET timescaledb.cagg_rewrites_debug_info = 1;
+-- Test queries ineligible for Cagg rewrites, display diagnostics on why
+\ir :TEST_ERROR_NAME
+
+-- Test queries needing live data in addition to Cagg-materialized data
+\ir :TEST_MAT_NAME
+
+RESET timescaledb.cagg_rewrites_debug_info;
+RESET timescaledb.enable_cagg_rewrites;
+
+DROP MATERIALIZED VIEW cagg_on_cagg1 CASCADE;
+DROP MATERIALIZED VIEW cagg1 CASCADE;
+DROP MATERIALIZED VIEW cagg1_tz CASCADE;
+DROP MATERIALIZED VIEW cagg1_origin CASCADE;
+DROP MATERIALIZED VIEW cagg2 CASCADE;
+DROP MATERIALIZED VIEW cagg3 CASCADE;
+DROP MATERIALIZED VIEW cagg3_int CASCADE;
+DROP MATERIALIZED VIEW cagg_join CASCADE;
+DROP MATERIALIZED VIEW cagg_more_conds CASCADE;
+DROP MATERIALIZED VIEW cagg_view CASCADE;
+DROP MATERIALIZED VIEW cagg_lateral CASCADE;
+
+DROP TABLE conditions CASCADE;
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE conditions_custom CASCADE;
+DROP TABLE conditions_int CASCADE;
+DROP VIEW devices_view CASCADE;
+DROP TABLE devices CASCADE;
+DROP TABLE location CASCADE;

--- a/tsl/test/sql/include/cagg_rewrites_error.sql
+++ b/tsl/test/sql/include/cagg_rewrites_error.sql
@@ -1,0 +1,328 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Queries generally not eligible for rewrite
+
+-- No FROM
+SELECT 1;
+
+-- Not SELECT
+BEGIN;
+DELETE FROM conditions WHERE device_id = 4;
+ROLLBACK;
+
+-- Has window function
+SELECT device_id, AVG(temperature) OVER (ORDER BY device_id) FROM conditions ORDER BY 1 LIMIT 1;
+
+-- Has DISTINCT
+SELECT DISTINCT location FROM devices ORDER BY 1;
+SELECT DISTINCT ON(device_id) device_id, location FROM devices ORDER BY 1;
+
+-- Has CTE/sublinks which subqueries are also not eligible for rewrite (has grouping sets; no groupby)
+WITH con as (SELECT device_id, AVG(temperature) FROM conditions GROUP BY ROLLUP (device_id)) SELECT * FROM con ORDER BY 1 LIMIT 1;
+SELECT * FROM conditions WHERE temperature = (SELECT AVG(temperature) FROM conditions);
+
+-- Has row-level security
+ALTER TABLE location ENABLE ROW LEVEL SECURITY;
+SELECT location_id, max(name) from location group by location_id;
+ALTER TABLE location DISABLE ROW LEVEL SECURITY;
+
+-- ineligible because of relations used in a query
+
+-- no hypertable
+SELECT location, count(device_id)
+FROM devices
+GROUP BY location
+ORDER BY 1 LIMIT 1;
+
+-- two hypertables
+SELECT time_bucket(INTERVAL '3 days', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   count(conditions_dup.device_id)
+FROM conditions_dup, conditions
+WHERE conditions_dup.device_id = conditions.device_id
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+
+-- Full Outer Join
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM devices FULL OUTER JOIN conditions
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket
+ORDER BY 1 LIMIT 1;
+
+-- Has non-lateral subquery; the subquery has TABLESAMPLE
+SELECT time_bucket(INTERVAL '1 day', d) AS bucket,
+   AVG(temp) AS avg,
+   device_id
+FROM (SELECT device_id, max (day) as d, avg(temperature) as temp FROM conditions TABLESAMPLE SYSTEM (0) group by device_id) con
+GROUP BY device_id, bucket
+ORDER BY 1 LIMIT 1;
+
+-- Query over Cagg materialization table
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+   device_id
+FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
+GROUP BY device_id, bucket
+ORDER BY 1 LIMIT 1;
+
+-- Query over hypertable with custom partitioning
+SELECT time_bucket('5', text_part_func(city)), avg(temperature)
+  FROM conditions_custom
+GROUP BY 1;
+
+-- ineligible time buckets
+
+-- no time bucket
+SELECT day,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY day
+ORDER BY 1 LIMIT 1;
+
+-- several time buckets
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket1, time_bucket(INTERVAL '3 days', day) AS bucket3,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY 1,2
+ORDER BY 1,2 LIMIT 1;
+
+-- time bucket not on primary dimension
+SELECT time_bucket(1, temperature) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+
+-- time bucket with non-const 1st argument
+SELECT time_bucket(('2026-01-08 15:00:00'::timestamptz - day), day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 0
+ORDER BY 1 LIMIT 1;
+
+-- infinity origin
+SELECT time_bucket(INTERVAL '3 days', day, 'infinity'::timestamptz) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+
+-- origin and offset at the same time
+SELECT time_bucket(INTERVAL '3 days', day, "offset"=>'30m'::interval, origin=>'2000-01-01 01:00:00 PST'::timestamptz, timezone=>'UTC') AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+
+-- No Caggs match a candidate query
+
+-- no Caggs
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions_dup
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+
+-- no matching Caggs
+ALTER MATERIALIZED VIEW cagg_view SET (timescaledb.materialized_only=true);
+
+-- Almost cagg1 but unmatched groupby
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket
+ORDER BY 1 LIMIT 1;
+
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket, city
+ORDER BY 1 LIMIT 1;
+
+-- Almost cagg1 but unmatched aggregate
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg, max(city) as city, device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1 LIMIT 1;
+
+-- Almost cagg3 but unmatched having
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 0
+ORDER BY 1 LIMIT 1;
+
+-- Almost caggs_more_conds but target doesn't match
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name,
+   devices.device_id
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1 LIMIT 1;
+
+-- Almost caggs_more_conds but a qual does not match
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature < 20
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1 LIMIT 1;
+
+-- Almost caggs_more_conds but only one qual matches
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      location_id > 1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+
+-- Almost caggs_more_conds but quals do not match due to commuted operand
+-- while OpExpr arguments are the same
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id < 1 AND
+      conditions.temperature < 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+
+-- Almost cagg_tz but bucket offset doesn't match
+SELECT time_bucket(INTERVAL '1 day', day,  "offset"=>'15s'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+
+-- same as above but offset vs. no offset
+SELECT time_bucket(INTERVAL '1 day', day, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+
+-- Almost cagg_tz but bucket time zone doesn't match
+SELECT time_bucket(INTERVAL '1 day', day,  "offset"=>'30m'::interval, timezone=>'Europe/Berlin') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+
+-- Almost cagg_origin but origins do not match
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-03') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 Europe/Berlin'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3 LIMIT 3;
+
+-- Almost cagg3_int but integer offsets do not match
+SELECT time_bucket(3, day, 2) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket ORDER BY 1, 2, 3;
+
+SELECT time_bucket(3, day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket  ORDER BY 1, 2, 3;
+
+-- Report on a query ineligible for hierarchical Cagg
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id AND devices.device_id > 1
+GROUP BY 1 ORDER BY 1 LIMIT 1;
+
+-- External params from prepared statements cannot be used in place of Consts
+PREPARE prep1 AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > $1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+
+EXECUTE prep1(28);
+DEALLOCATE prep1;
+
+PREPARE prep2 AS
+SELECT time_bucket($1, day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+
+EXECUTE prep2(INTERVAL '1 day');
+DEALLOCATE prep2;
+
+-- Internal params cannot be used in place of Consts
+SELECT * FROM (VALUES (1), (1)) a(v),
+  LATERAL
+  (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+   FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+   JOIN location ON conditions.city = location.name
+   WHERE location_id > a.v AND
+      conditions.temperature > 28
+   GROUP BY devices.name, bucket, devices.device_id) q
+ORDER BY 1,2,3,4
+LIMIT 2;
+

--- a/tsl/test/sql/include/cagg_rewrites_load.sql
+++ b/tsl/test/sql/include/cagg_rewrites_load.sql
@@ -1,0 +1,176 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+SET timezone TO PST8PDT;
+
+CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
+    AS $$ SELECT length($1)::BIGINT $$
+    LANGUAGE SQL IMMUTABLE;
+
+CREATE TABLE conditions(
+  day TIMESTAMPTZ NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+  device_id int NOT NULL
+);
+SELECT table_name FROM create_hypertable('conditions', 'day', chunk_time_interval => INTERVAL '1 day');
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Berlin', 22,2),
+  ('2021-06-16', 'Stockholm', 24,3),
+  ('2021-06-17', 'London', 24,4),
+  ('2021-06-18', 'London', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Berlin', 31,1),
+  ('2021-06-22', 'Stockholm', 34,1),
+  ('2021-06-23', 'Stockholm', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'London', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT table_name FROM create_hypertable('conditions_dup', 'day', chunk_time_interval => INTERVAL '1 day', migrate_data => true);
+
+CREATE TABLE conditions_custom AS SELECT * FROM conditions;
+SELECT table_name FROM create_hypertable('conditions_custom', 'city', chunk_time_interval => 6, time_partitioning_func => 'text_part_func', migrate_data => true);
+
+CREATE TABLE conditions_int(
+  day int NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+  device_id int NOT NULL
+);
+INSERT INTO conditions_int SELECT (day::date - '2021-06-19'::date), city, temperature, device_id FROM conditions;
+SELECT table_name FROM create_hypertable('conditions_int', 'day', chunk_time_interval =>1, migrate_data => true);
+
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+
+CREATE TABLE location (location_id INTEGER, name TEXT);
+INSERT INTO location VALUES (1, 'Moscow'), (2, 'Berlin'), (3, 'London'), (4, 'Stockholm');
+
+CREATE VIEW devices_view AS SELECT * FROM devices;
+
+-- 1-table Caggs
+CREATE MATERIALIZED VIEW cagg1
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY bucket;
+
+CREATE MATERIALIZED VIEW cagg1_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day, "offset"=>'30m'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY bucket;
+
+CREATE MATERIALIZED VIEW cagg1_origin
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 UTC'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY bucket;
+
+CREATE MATERIALIZED VIEW cagg2
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket;
+
+CREATE MATERIALIZED VIEW cagg3
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1;
+
+-- A Cagg over integer dimension
+CREATE OR REPLACE FUNCTION conditions_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 150;
+$BODY$;
+SELECT set_integer_now_func('conditions_int','conditions_int_now');
+
+CREATE MATERIALIZED VIEW cagg3_int
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(3, day, 1) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket;
+
+-- Caggs with joins
+CREATE MATERIALIZED VIEW cagg_join
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket
+ORDER BY bucket;
+
+-- Create CAgg with more joins and additional WHERE conditions
+CREATE MATERIALIZED VIEW cagg_more_conds
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name,
+   devices.device_id * 2
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id;
+
+-- Hierarchical CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg1
+WITH (timescaledb.continuous, timescaledb.materialized_only=FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id
+GROUP BY 1;
+
+-- Joining a hypertable and view
+CREATE MATERIALIZED VIEW cagg_view
+WITH (timescaledb.continuous, timescaledb.materialized_only=FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+
+-- Join on lateral subquery
+CREATE MATERIALIZED VIEW cagg_lateral WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE)
+AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket, q.name, avg(temperature)  from conditions,
+LATERAL (SELECT * FROM devices WHERE devices.device_id = conditions.device_id) q
+GROUP BY bucket, q.name;
+
+SELECT h.schema_name AS "MAT_SCHEMA_NAME",
+       h.table_name AS "MAT_TABLE_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'cagg1'
+\gset
+

--- a/tsl/test/sql/include/cagg_rewrites_materialize.sql
+++ b/tsl/test/sql/include/cagg_rewrites_materialize.sql
@@ -1,0 +1,74 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Tests for rewrites with Caggs with different degrees of materialization
+
+-- Backfilled data makes all Caggs on a hypertable ineligible for rewrites until they are refreshed
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-15', 'Moscow', 23,1),
+  ('2021-06-17', 'Berlin', 24,2),
+  ('2021-06-17', 'Stockholm', 21,3);
+
+-- (cagg1) is eligible but invalidated
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+
+-- After (cagg2) is refreshed it's eligible again,
+-- the rest of the caggs have their materialization invalidation logs updated
+-- while hypertable invalidation logs are cleared
+SET timescaledb.cagg_rewrites_debug_info = 0;
+CALL refresh_continuous_aggregate('cagg2', NULL, NULL);
+SET timescaledb.cagg_rewrites_debug_info = 1;
+
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+
+-- (cagg1) is still not eligible as it's not refreshed since last backfill
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+
+-- Caggs with pending materialization ranges are not eligible.
+-- Insert new row into hypertable, remove (cagg2) watermark and then refresh it.
+-- It will create pending materialization range on (cagg2) as refresh will error out.
+SET timescaledb.cagg_rewrites_debug_info = 0;
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-16', 'Berlin', 23, 2);
+
+SELECT ca.mat_hypertable_id AS "CAGG2_ID", watermark AS "CAGG2_WATERMARK"
+FROM _timescaledb_catalog.continuous_agg ca INNER JOIN _timescaledb_catalog.continuous_aggs_watermark wm
+ON (ca.mat_hypertable_id = wm.mat_hypertable_id) WHERE user_view_name = 'cagg2';
+\gset
+
+-- This will create pending materialization range
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark WHERE mat_hypertable_id = :CAGG2_ID;
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cagg2', NULL, NULL);
+\set ON_ERROR_STOP 1
+
+-- Restore deleted watermark so that we can query (cagg2) again
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark values(:CAGG2_ID, :CAGG2_WATERMARK);
+
+SET timescaledb.cagg_rewrites_debug_info = 1;
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+
+-- cleanup materialization ranges
+TRUNCATE TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges;

--- a/tsl/test/sql/include/cagg_rewrites_query.sql
+++ b/tsl/test/sql/include/cagg_rewrites_query.sql
@@ -1,0 +1,165 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- (cagg1)
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+
+-- (cagg2)
+SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+ORDER BY 1, 2
+LIMIT 3;
+
+-- (cagg3)
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1
+ORDER BY 1, 2;
+
+-- (cagg3) with equivalent Having
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING (2-1) < count(device_id)
+ORDER BY 1, 2;
+
+-- (cagg_join), flip join order
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   name
+FROM devices, conditions
+WHERE devices.device_id = conditions.device_id
+GROUP BY name, bucket
+ORDER BY 1, 2, 3;
+
+-- (cagg_more_conds) w/o one target
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE location_id > 1 AND
+      conditions.temperature > 28
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+
+-- (cagg_more_conds) with expressions in conditions and targets
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   COUNT(location_id),
+   (devices.device_id * 2) + 1,
+   devices.name
+FROM conditions LEFT JOIN devices ON conditions.device_id = devices.device_id
+JOIN location ON conditions.city = location.name
+WHERE 1+0 < location_id AND
+      conditions.temperature > 29-1
+GROUP BY devices.name, bucket, devices.device_id
+ORDER BY 1,2,3,4
+LIMIT 2;
+
+-- Hierarchical Caggs and Caggs on views
+
+-- (cagg_on_cagg1)
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM cagg1, devices
+WHERE devices.device_id = cagg1.device_id
+GROUP BY 1 ORDER BY 1, 2;
+
+-- (cagg_view)
+ALTER MATERIALIZED VIEW cagg_view SET (timescaledb.materialized_only=false);
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id
+ORDER BY 1, 2, 3, 4;
+
+-- (cagg_lateral)
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket, q.name, avg(temperature)  from conditions,
+LATERAL (SELECT * FROM devices WHERE devices.device_id = conditions.device_id) q
+GROUP BY bucket, q.name
+ORDER BY 1, 2, 3;
+
+-- (cagg1_tz)
+SELECT time_bucket(INTERVAL '1 day', day, "offset"=>'30m'::interval, timezone=>'Australia/Sydney') AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1, 2, 3;
+
+-- (cagg1_origin)
+SELECT time_bucket(INTERVAL '1 day', day, origin=>'2001-01-02 00:00:00 UTC'::timestamptz) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket
+ORDER BY 1,2,3
+LIMIT 3;
+
+-- (cagg3_int)
+SELECT time_bucket(3, day, 1) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions_int
+GROUP BY bucket
+ORDER BY 1,2,3;
+
+-- Cagg rewrites in subqueries/SET ops
+
+-- (cagg1) CTE
+WITH con AS (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket)
+SELECT * FROM con
+ORDER BY 1, 2, 3;
+
+-- (cagg1) subquery
+SELECT * FROM (SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature) AS avg,
+   device_id
+FROM conditions
+GROUP BY device_id, bucket) con
+ORDER BY 1, 2, 3;
+
+-- (cagg2) sublink
+SELECT * from conditions
+WHERE EXISTS (SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature) AS avg_temp
+FROM conditions
+GROUP BY bucket)
+ORDER BY 1, 2, 3, 4;
+
+-- Union of cagg2 and cagg3
+SELECT time_bucket(INTERVAL '2 days', day) AS bucket,
+   AVG(temperature),
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+UNION ALL
+SELECT time_bucket(INTERVAL '3 days', day) AS bucket,
+   AVG(temperature) AS avg,
+   count(device_id)
+FROM conditions
+GROUP BY bucket
+HAVING count(device_id) > 1
+ORDER BY 1, 2, 3;


### PR DESCRIPTION
POC checks whether queries can be rewritten with Caggs and rewrites queries with Caggs if it can.

See write-up on the feature [here](https://docs.google.com/document/d/1lJx6m-ugGh_gD-4DwGWX9m_TPWW2M60V3OB9fBIEqy8/edit?usp=sharing).

GUCs `enable_cagg_rewites` and `cagg_rewrites_debug_info` are OFF by default.  If only  `cagg_rewrites_debug_info`  is ON diagnostics on whether query can be rewritten with Caggs will be printed but query won't be rewritten.

Only real-time Caggs are currently considered as candidates.
Reaggregation is out of scope for this POC i.e. we look for exact match on time buckets and aggregates provided by Caggs.

Validation methods in `tsl/src/continuous_aggs/common.c`  were refactored so they could be reused by Cagg rewrites validations.

`PG15 `is currently not supported as view queries in `PG15_LE` have dummy range table entries which complicates expression matching. As we plan to stop `PG15 `support in 6 months it seems like an unnecessary complication to deal with.

TODO:

- [x] Comprehensive unit tests covering all negative and positive cases
- [x] Dealing with Hierarchical Caggs rewrites
- [x] Matching on equivalent expressions as in "a=5" matches "5=a".
- [x] Dealing with params, making sure all matches are done on immutable expressions.
- [x] Matching LATERAL subqueries in Caggs
- [x] Checking whether Caggs have active invalidations or pending materialization ranges to exclude them from the candidates

Issue timescale/eng-database#810 should complete "Query rewrites with Caggs" project by adding fully real-time mode which, for each Cagg used in a query, will combine materialized data plus live data above the current Cagg watermark and live data from current Cagg invalidated ranges.

Completing timescale/eng-database#810 will ensure that for every query eligible to be rewritten with Caggs we will use as much materialized data as possible while still providing the same output whether the query was rewritten with a Cagg or not.