### PR TITLE
conn_ssl.c: add explicit OPENSSL_API_COMPAT

### DIFF
--- a/src/net/conn_ssl.c
+++ b/src/net/conn_ssl.c
@@ -5,6 +5,9 @@
  */
 #include <postgres.h>
 
+#undef OPENSSL_API_COMPAT
+#define OPENSSL_API_COMPAT 10100000L
+
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 


### PR DESCRIPTION
In v18, the minimum openssl version was bumped from 1.1.0 to 1.1.1. That means postgres.h brings not OPENSSL_API_COMPAT=10100000L anymore, but 10101000L or greater. Given that conn_ssl.c uses the older API, this may lead to issues at compile time or runtime, depending on the ssl library's version and eagerness to trim older APIs from their headers and from their shared objects.

Example of warnings at compilation time:

/timescaledb/src/net/conn_ssl.c: In function ‘_conn_ssl_init’: /timescaledb/src/net/conn_ssl.c:273:2: warning: implicit declaration of function ‘SSL_library_init’; did you mean ‘SSL_in_init’? [-Wimplicit-function-declaration]
  SSL_library_init();
  ^~~~~~~~~~~~~~~~
  SSL_in_init
/timescaledb/src/net/conn_ssl.c:275:2: warning: implicit declaration of function ‘SSL_load_error_strings’; did you mean ‘ERR_lib_error_string’? [-Wimplicit-function-declaration]
  SSL_load_error_strings();
  ^~~~~~~~~~~~~~~~~~~~~~
  ERR_lib_error_string
/timescaledb/src/net/conn_ssl.c: In function ‘_conn_ssl_fini’: /timescaledb/src/net/conn_ssl.c:282:2: warning: implicit declaration of function ‘ERR_free_strings’; did you mean ‘ERR_load_strings’? [-Wimplicit-function-declaration]
  ERR_free_strings();
  ^~~~~~~~~~~~~~~~
  ERR_load_strings

Example at runtime if those warnings are ignored, and the compiler and linker assume the loader will find the symbols later:

psql -c 'CREATE EXTENSION timescaledb' -d postgres
  ERROR:  could not load library "[...]/lib/timescaledb-2.23.0.so":
  [...]/lib/timescaledb-2.23.0.so: undefined symbol: SSL_load_error_strings

Considering that conn_ssl.c depends on the older APIs, the minimum change is be to disregard the value that comes from postgres.h, and redefine it for this unit. Longer term, it would be best to improve conn_ssl.c so it uses newer APIs.