### PR TITLE
Gracefully handle missing jobstat in background worker

### DIFF
--- a/.unreleased/pr_8969
+++ b/.unreleased/pr_8969
@@ -1,0 +1,1 @@
+Fixes: #8969 Gracefully handle missing job stat in background worker

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -248,9 +248,7 @@ worker_state_cleanup(ScheduledBgwJob *sjob)
 
 		job_stat = ts_bgw_job_stat_find(sjob->job.fd.id);
 
-		Assert(job_stat != NULL);
-
-		if (!ts_bgw_job_stat_end_was_marked(job_stat))
+		if (job_stat && !ts_bgw_job_stat_end_was_marked(job_stat))
 		{
 			/*
 			 * Usually the job process will mark the end, but if the job gets


### PR DESCRIPTION
This would lead to an assertion in debug builds and a segfault in
production builds.

Fixes #8037 