### PR TITLE
Disable postgres build cache for macos

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -114,7 +114,7 @@ jobs:
     # leading to a tainted cache
     - name: Cache PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
       id: cache-postgresql
-      if: matrix.snapshot != 'snapshot'
+      if: matrix.snapshot != 'snapshot' && runner.os == 'Linux'
       uses: actions/cache@v4
       with:
         path: ~/${{ env.PG_SRC_DIR }}


### PR DESCRIPTION
Caching for MacOS is currently broken in GitHub
https://github.com/actions/runner-images/issues/13341

Disable-check: approval-count
Disable-check: force-changelog-file