### PR TITLE
Remove redundant entry from latest-dev.sql

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,8 +1,3 @@
-CREATE FUNCTION _timescaledb_functions.bloom1_contains_any(_timescaledb_internal.bloom1, anyarray)
-RETURNS bool
-AS '@MODULE_PATHNAME@', 'ts_update_placeholder'
-LANGUAGE C IMMUTABLE PARALLEL SAFE;
-
 DROP FUNCTION IF EXISTS _timescaledb_functions.policy_job_stat_history_retention;
 DROP VIEW IF EXISTS timescaledb_information.chunks;
 


### PR DESCRIPTION
All functions are created when the update script is compiled so
creating functions in latest-dev is not required.

Disable-check: approval-count
Disable-check: force-changelog-file