### PR TITLE
Run update tests for PG18

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        pg: [15, 16, 17]
+        pg: [15, 16, 17, 18]
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -54,6 +54,10 @@ for version in ${ALL_VERSIONS}; do
     if [ "${PG_MAJOR_VERSION}" -le 16 ]; then
         VERSIONS="${VERSIONS} ${version}"
     fi
+  elif [ "${minor_version}" -le 22 ]; then
+    if [ "${PG_MAJOR_VERSION}" -le 17 ]; then
+        VERSIONS="${VERSIONS} ${version}"
+    fi
   else
     VERSIONS="${VERSIONS} ${version}"
   fi

--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -22,7 +22,7 @@ BEGIN
     FOR constraint_row IN
     SELECT c.conname, h.id AS hypertable_id FROM _timescaledb_catalog.hypertable h INNER JOIN
            pg_constraint c ON (c.conrelid = format('%I.%I', h.schema_name, h.table_name)::regclass)
-        WHERE c.contype != 'c'
+        WHERE c.contype NOT IN ('c','n')
     LOOP
         SELECT count(*) FROM _timescaledb_catalog.chunk c
         WHERE c.hypertable_id = constraint_row.hypertable_id


### PR DESCRIPTION
Update tests for PG18 were initially not added because we didnt
have multiple versions supporting PG18.

Disable-check: approval-count
Disable-check: force-changelog-file