### PR TITLE
Show dimensions view chunk interval as Interval for UUIDv7

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,4 @@
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
 -- Block update if CAggs in old format are found
 DO
 $$

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,3 +1,4 @@
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
 --
 -- Rebuild the catalog table `_timescaledb_catalog.continuous_agg` to add `finalized` column
 --

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -238,14 +238,14 @@ SELECT ht.schema_name AS hypertable_schema,
     'Time'
   END AS dimension_type,
   CASE WHEN dim.interval_length IS NOT NULL THEN
-    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date']::regtype[]) THEN
+    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date', 'uuid']::regtype[]) THEN
       _timescaledb_functions.to_interval(dim.interval_length)
     ELSE
       NULL
     END
   END AS time_interval,
   CASE WHEN dim.interval_length IS NOT NULL THEN
-    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date']::regtype[]) THEN
+    CASE WHEN dim.column_type = ANY(ARRAY['timestamp','timestamptz','date', 'uuid']::regtype[]) THEN
       NULL
     ELSE
       dim.interval_length

--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -17,6 +17,13 @@ SELECT create_hypertable('uuid_events', 'id', chunk_time_interval => interval '1
 --------------------------
  (1,public,uuid_events,t)
 
+SELECT time_interval
+FROM timescaledb_information.dimensions
+WHERE hypertable_name = 'uuid_events';
+ time_interval 
+---------------
+ @ 1 day
+
 --
 -- Test that inserting boundary values generates the right constraints
 -- on chunks.

--- a/test/sql/uuid.sql
+++ b/test/sql/uuid.sql
@@ -16,6 +16,10 @@ SELECT create_hypertable('uuid_events', 'id', chunk_time_interval => true);
 
 SELECT create_hypertable('uuid_events', 'id', chunk_time_interval => interval '1 day');
 
+SELECT time_interval
+FROM timescaledb_information.dimensions
+WHERE hypertable_name = 'uuid_events';
+
 --
 -- Test that inserting boundary values generates the right constraints
 -- on chunks.


### PR DESCRIPTION
Change the dimensions informational view to show the chunk time interval as an "Interval" for UUIDv7-partitioned hypertables.

Disable-check: force-changelog-file