### PR TITLE
Add GUC for default chunk time interval 

### DIFF
--- a/.unreleased/pr_8983
+++ b/.unreleased/pr_8983
@@ -1,0 +1,1 @@
+Implements: #8983 Add GUC for default chunk time interval

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -14,10 +14,68 @@
 #include "export.h"
 #include "time_utils.h"
 #include "ts_catalog/catalog.h"
+#include "utils.h"
 
 typedef struct PartitioningInfo PartitioningInfo;
 typedef struct DimensionSlice DimensionSlice;
 typedef struct DimensionVec DimensionVec;
+
+/*
+ * The chunk interval of an open partitioning dimension.
+ *
+ * The type can either be INTERVALOID or an INT(2|4|8)OID.
+ */
+typedef struct ChunkInterval
+{
+	Oid type;
+	/* Interval value storage */
+	union
+	{
+		int64 integer_interval; /* For INT8OID, INT4OID, INT2OID */
+		Interval interval;		/* For INTERVALOID */
+	};
+} ChunkInterval;
+
+/*
+ * Get the interval value as a Datum from a ChunkInterval.
+ * On 32-bit platforms, int64 is pass-by-reference so we need Int64GetDatumFast.
+ */
+static inline Datum
+chunk_interval_get_datum(const ChunkInterval *ci)
+{
+	switch (ci->type)
+	{
+		case INT2OID:
+			return Int16GetDatum((int16) ci->integer_interval);
+		case INT4OID:
+			return Int32GetDatum((int32) ci->integer_interval);
+		case INT8OID:
+			/* int64 is pass-by-ref on 32-bit, pass-by-val on 64-bit */
+			return Int64GetDatumFast(ci->integer_interval);
+		case INTERVALOID:
+			/* Interval is always pass-by-ref */
+			return IntervalPGetDatum(&((ChunkInterval *) ci)->interval);
+		default:
+			Ensure(false, "unsupported chunk interval type %d", ci->type);
+			return UnassignedDatum;
+	}
+}
+
+static inline void
+chunk_interval_set(ChunkInterval *chunk_interval, Datum interval, Oid type)
+{
+	chunk_interval->type = type;
+
+	/* Store interval value in appropriate union field */
+	if (type == INT8OID)
+		chunk_interval->integer_interval = DatumGetInt64(interval);
+	else if (type == INTERVALOID)
+		chunk_interval->interval = *DatumGetIntervalP(interval);
+	else if (type == INT4OID)
+		chunk_interval->integer_interval = DatumGetInt32(interval);
+	else if (type == INT2OID)
+		chunk_interval->integer_interval = DatumGetInt16(interval);
+}
 
 typedef enum DimensionType
 {
@@ -105,8 +163,7 @@ typedef struct DimensionInfo
 	NameData colname;
 	Oid coltype;
 	DimensionType type;
-	Datum interval_datum;
-	Oid interval_type; /* Type of the interval datum */
+	ChunkInterval chunk_interval;
 	int64 interval;
 	int32 num_slices;
 	regproc partitioning_func;
@@ -119,7 +176,8 @@ typedef struct DimensionInfo
 } DimensionInfo;
 
 #define DIMENSION_INFO_IS_SET(di) (di != NULL && OidIsValid((di)->table_relid))
-#define DIMENSION_INFO_IS_VALID(di) (info->num_slices_is_set || OidIsValid(info->interval_type))
+#define DIMENSION_INFO_IS_VALID(di)                                                                \
+	(info->num_slices_is_set || OidIsValid(info->chunk_interval.type))
 
 extern Hyperspace *ts_dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension,
 									 MemoryContext mctx);

--- a/src/utils.h
+++ b/src/utils.h
@@ -41,7 +41,7 @@
 #define UnassignedDatum (Datum) 0
 
 static inline int64
-interval_to_usec(Interval *interval)
+interval_to_usec(const Interval *interval)
 {
 	return (interval->month * DAYS_PER_MONTH * USECS_PER_DAY) + (interval->day * USECS_PER_DAY) +
 		   interval->time;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -1073,3 +1073,405 @@ ERROR:  cannot create hypertable for table "test" because it is part of a public
 DROP PUBLICATION publication_test;
 DROP TABLE test;
 RESET client_min_messages;
+-- Test default_chunk_time_interval GUC
+-- Tests that the GUC correctly sets the default chunk interval for hypertables
+-- with different time column types (timestamp, timestamptz, date) and integer types.
+-- Show initial state (should be NULL meaning legacy defaults)
+SHOW timescaledb.default_chunk_time_interval;
+ timescaledb.default_chunk_time_interval 
+-----------------------------------------
+ 
+
+-- No default_chunk_time_interval set (NULL) - uses legacy defaults
+CREATE TABLE test_no_guc_timestamptz(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_no_guc_timestamptz', 'time');
+           create_hypertable           
+---------------------------------------
+ (28,public,test_no_guc_timestamptz,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_no_guc_timestamptz';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_no_guc_timestamptz;
+CREATE TABLE test_no_guc_timestamp(time TIMESTAMP NOT NULL, val INT);
+SELECT create_hypertable('test_no_guc_timestamp', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+HINT:  Use datatype TIMESTAMPTZ instead.
+          create_hypertable          
+-------------------------------------
+ (29,public,test_no_guc_timestamp,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_no_guc_timestamp';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_no_guc_timestamp;
+CREATE TABLE test_no_guc_date(time DATE NOT NULL, val INT);
+SELECT create_hypertable('test_no_guc_date', 'time');
+       create_hypertable        
+--------------------------------
+ (30,public,test_no_guc_date,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_no_guc_date';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_no_guc_date;
+CREATE TABLE test_no_guc_uuid(time UUID NOT NULL, val INT);
+SELECT create_hypertable('test_no_guc_uuid', 'time');
+       create_hypertable        
+--------------------------------
+ (31,public,test_no_guc_uuid,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_no_guc_uuid';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_no_guc_uuid;
+-- Set default_chunk_time_interval to '1 week' and create hypertables
+SET timescaledb.default_chunk_time_interval = '1 week';
+SHOW timescaledb.default_chunk_time_interval;
+ timescaledb.default_chunk_time_interval 
+-----------------------------------------
+ 1 week
+
+CREATE TABLE test_guc_timestamptz(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_guc_timestamptz', 'time');
+         create_hypertable          
+------------------------------------
+ (32,public,test_guc_timestamptz,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_timestamptz';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_guc_timestamptz;
+CREATE TABLE test_guc_timestamp(time TIMESTAMP NOT NULL, val INT);
+SELECT create_hypertable('test_guc_timestamp', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+HINT:  Use datatype TIMESTAMPTZ instead.
+        create_hypertable         
+----------------------------------
+ (33,public,test_guc_timestamp,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_timestamp';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_guc_timestamp;
+CREATE TABLE test_guc_date(time DATE NOT NULL, val INT);
+SELECT create_hypertable('test_guc_date', 'time');
+      create_hypertable      
+-----------------------------
+ (34,public,test_guc_date,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_date';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_guc_date;
+CREATE TABLE test_guc_uuid(time UUID NOT NULL, val INT);
+SELECT create_hypertable('test_guc_uuid', 'time');
+      create_hypertable      
+-----------------------------
+ (35,public,test_guc_uuid,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_uuid';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_guc_uuid;
+-- Set default_chunk_time_interval to '1 day'
+SET timescaledb.default_chunk_time_interval = '1 day';
+SHOW timescaledb.default_chunk_time_interval;
+ timescaledb.default_chunk_time_interval 
+-----------------------------------------
+ 1 day
+
+CREATE TABLE test_guc_1day_timestamptz(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_guc_1day_timestamptz', 'time');
+            create_hypertable            
+-----------------------------------------
+ (36,public,test_guc_1day_timestamptz,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_1day_timestamptz';
+ time_interval 
+---------------
+ @ 1 day
+
+DROP TABLE test_guc_1day_timestamptz;
+-- Set default_chunk_time_interval to '1 month'
+SET timescaledb.default_chunk_time_interval = '1 month';
+SHOW timescaledb.default_chunk_time_interval;
+ timescaledb.default_chunk_time_interval 
+-----------------------------------------
+ 1 month
+
+CREATE TABLE test_guc_1month_timestamptz(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_guc_1month_timestamptz', 'time');
+             create_hypertable             
+-------------------------------------------
+ (37,public,test_guc_1month_timestamptz,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_1month_timestamptz';
+ time_interval 
+---------------
+ @ 30 days
+
+DROP TABLE test_guc_1month_timestamptz;
+-- Integer partition types have their own defaults and do not use the GUC
+SET timescaledb.default_chunk_time_interval = '1 week';
+CREATE TABLE test_guc_bigint(time BIGINT NOT NULL, val INT);
+SELECT create_hypertable('test_guc_bigint', 'time');
+       create_hypertable       
+-------------------------------
+ (38,public,test_guc_bigint,t)
+
+SELECT integer_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_bigint';
+ integer_interval 
+------------------
+          1000000
+
+DROP TABLE test_guc_bigint;
+CREATE TABLE test_guc_int(time INT NOT NULL, val INT);
+SELECT create_hypertable('test_guc_int', 'time');
+     create_hypertable      
+----------------------------
+ (39,public,test_guc_int,t)
+
+SELECT integer_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_int';
+ integer_interval 
+------------------
+           100000
+
+DROP TABLE test_guc_int;
+CREATE TABLE test_guc_smallint(time SMALLINT NOT NULL, val INT);
+SELECT create_hypertable('test_guc_smallint', 'time');
+        create_hypertable        
+---------------------------------
+ (40,public,test_guc_smallint,t)
+
+SELECT integer_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_guc_smallint';
+ integer_interval 
+------------------
+            10000
+
+DROP TABLE test_guc_smallint;
+-- Explicit chunk_time_interval should override the GUC
+SET timescaledb.default_chunk_time_interval = '1 week';
+CREATE TABLE test_override_timestamptz(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_override_timestamptz', 'time', chunk_time_interval => INTERVAL '2 days');
+            create_hypertable            
+-----------------------------------------
+ (41,public,test_override_timestamptz,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_override_timestamptz';
+ time_interval 
+---------------
+ @ 2 days
+
+DROP TABLE test_override_timestamptz;
+-- Reset GUC to NULL (legacy behavior)
+RESET timescaledb.default_chunk_time_interval;
+SHOW timescaledb.default_chunk_time_interval;
+ timescaledb.default_chunk_time_interval 
+-----------------------------------------
+ 
+
+CREATE TABLE test_reset_timestamptz(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_reset_timestamptz', 'time');
+          create_hypertable           
+--------------------------------------
+ (42,public,test_reset_timestamptz,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_reset_timestamptz';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_reset_timestamptz;
+-- Invalid interval should fail
+\set ON_ERROR_STOP 0
+SET timescaledb.default_chunk_time_interval = 'not_an_interval';
+ERROR:  invalid input syntax for type interval: "not_an_interval"
+SET timescaledb.default_chunk_time_interval = '123abc';
+ERROR:  invalid input syntax for type interval: "123abc"
+\set ON_ERROR_STOP 1
+-- add_dimension does not use the GUC, keeps legacy behavior requiring explicit interval
+RESET timescaledb.default_chunk_time_interval;
+SET timescaledb.default_chunk_time_interval = '3 days';
+CREATE TABLE test_add_dim(time TIMESTAMPTZ NOT NULL, time2 TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_add_dim', 'time');
+     create_hypertable      
+----------------------------
+ (43,public,test_add_dim,t)
+
+-- First dimension uses GUC
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_add_dim';
+ time_interval 
+---------------
+ @ 3 days
+
+-- add_dimension without explicit interval should fail
+\set ON_ERROR_STOP 0
+SELECT add_dimension('test_add_dim', 'time2');
+ERROR:  must specify either the number of partitions or an interval
+\set ON_ERROR_STOP 1
+-- add_dimension with explicit interval works
+SELECT add_dimension('test_add_dim', 'time2', chunk_time_interval => INTERVAL '1 day');
+          add_dimension           
+----------------------------------
+ (56,public,test_add_dim,time2,t)
+
+SELECT column_name, time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_add_dim'
+  ORDER BY dimension_number;
+ column_name | time_interval 
+-------------+---------------
+ time        | @ 3 days
+ time2       | @ 1 day
+
+DROP TABLE test_add_dim;
+-- Session-level GUC changes
+RESET timescaledb.default_chunk_time_interval;
+SET timescaledb.default_chunk_time_interval = '5 days';
+CREATE TABLE test_session_1(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_session_1', 'time');
+      create_hypertable       
+------------------------------
+ (44,public,test_session_1,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_session_1';
+ time_interval 
+---------------
+ @ 5 days
+
+-- Change GUC mid-session
+SET timescaledb.default_chunk_time_interval = '10 days';
+CREATE TABLE test_session_2(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_session_2', 'time');
+      create_hypertable       
+------------------------------
+ (45,public,test_session_2,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_session_2';
+ time_interval 
+---------------
+ @ 10 days
+
+DROP TABLE test_session_1;
+DROP TABLE test_session_2;
+-- Transaction-level GUC with SET LOCAL
+RESET timescaledb.default_chunk_time_interval;
+SET timescaledb.default_chunk_time_interval = '1 week';
+BEGIN;
+SET LOCAL timescaledb.default_chunk_time_interval = '2 weeks';
+CREATE TABLE test_local_guc(time TIMESTAMPTZ NOT NULL, val INT);
+SELECT create_hypertable('test_local_guc', 'time');
+      create_hypertable       
+------------------------------
+ (46,public,test_local_guc,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_local_guc';
+ time_interval 
+---------------
+ @ 14 days
+
+COMMIT;
+-- After commit, GUC should be back to session level (1 week)
+SHOW timescaledb.default_chunk_time_interval;
+ timescaledb.default_chunk_time_interval 
+-----------------------------------------
+ 1 week
+
+DROP TABLE test_local_guc;
+-- UUID partition type with various intervals
+RESET timescaledb.default_chunk_time_interval;
+SET timescaledb.default_chunk_time_interval = '1 day';
+CREATE TABLE test_uuid_1day(time UUID NOT NULL, val INT);
+SELECT create_hypertable('test_uuid_1day', 'time');
+      create_hypertable       
+------------------------------
+ (47,public,test_uuid_1day,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_uuid_1day';
+ time_interval 
+---------------
+ @ 1 day
+
+DROP TABLE test_uuid_1day;
+SET timescaledb.default_chunk_time_interval = '1 hour';
+CREATE TABLE test_uuid_1hour(time UUID NOT NULL, val INT);
+SELECT create_hypertable('test_uuid_1hour', 'time');
+       create_hypertable       
+-------------------------------
+ (48,public,test_uuid_1hour,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_uuid_1hour';
+ time_interval 
+---------------
+ @ 1 hour
+
+DROP TABLE test_uuid_1hour;
+-- UUID with explicit override should work
+SET timescaledb.default_chunk_time_interval = '1 week';
+CREATE TABLE test_uuid_override(time UUID NOT NULL, val INT);
+SELECT create_hypertable('test_uuid_override', 'time', chunk_time_interval => INTERVAL '12 hours');
+        create_hypertable         
+----------------------------------
+ (49,public,test_uuid_override,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_uuid_override';
+ time_interval 
+---------------
+ @ 12 hours
+
+DROP TABLE test_uuid_override;
+-- UUID with no GUC set (legacy default)
+RESET timescaledb.default_chunk_time_interval;
+CREATE TABLE test_uuid_legacy(time UUID NOT NULL, val INT);
+SELECT create_hypertable('test_uuid_legacy', 'time');
+       create_hypertable        
+--------------------------------
+ (50,public,test_uuid_legacy,t)
+
+SELECT time_interval FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 'test_uuid_legacy';
+ time_interval 
+---------------
+ @ 7 days
+
+DROP TABLE test_uuid_legacy;
+-- Cleanup
+RESET timescaledb.default_chunk_time_interval;

--- a/test/expected/create_table_with.out
+++ b/test/expected/create_table_with.out
@@ -264,3 +264,93 @@ SELECT hypertable_name, column_name FROM timescaledb_information.dimensions WHER
  t14             | TiMe
 
 ROLLBACK;
+-- Test default_chunk_time_interval GUC interaction with CREATE TABLE WITH
+-- Tests that the GUC correctly sets the default chunk interval when using
+-- CREATE TABLE WITH syntax instead of create_hypertable().
+-- GUC set to '1 week' should be used by CREATE TABLE WITH
+BEGIN;
+SET timescaledb.default_chunk_time_interval = '1 week';
+CREATE TABLE t_guc_week(time timestamptz NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+SELECT hypertable_name, time_interval
+  FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 't_guc_week';
+ hypertable_name | time_interval 
+-----------------+---------------
+ t_guc_week      | @ 7 days
+
+ROLLBACK;
+-- GUC set to '1 day' with different time types
+BEGIN;
+SET timescaledb.default_chunk_time_interval = '1 day';
+CREATE TABLE t_guc_timestamptz(time timestamptz NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+CREATE TABLE t_guc_timestamp(time timestamp NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+CREATE TABLE t_guc_date(time date NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+SELECT hypertable_name, time_interval
+  FROM timescaledb_information.dimensions
+  WHERE hypertable_name LIKE 't_guc_%'
+  ORDER BY hypertable_name;
+  hypertable_name  | time_interval 
+-------------------+---------------
+ t_guc_date        | @ 1 day
+ t_guc_timestamp   | @ 1 day
+ t_guc_timestamptz | @ 1 day
+
+ROLLBACK;
+-- Explicit tsdb.chunk_interval should override the GUC
+BEGIN;
+SET timescaledb.default_chunk_time_interval = '1 week';
+CREATE TABLE t_guc_override(time timestamptz NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time', tsdb.chunk_interval='2 days');
+SELECT hypertable_name, time_interval
+  FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 't_guc_override';
+ hypertable_name | time_interval 
+-----------------+---------------
+ t_guc_override  | @ 2 days
+
+ROLLBACK;
+-- Integer partition types have their own default and do not use the GUC
+BEGIN;
+SET timescaledb.default_chunk_time_interval = '1 week';
+CREATE TABLE t_guc_int(time int8 NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+SELECT hypertable_name, integer_interval
+  FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 't_guc_int';
+ hypertable_name | integer_interval 
+-----------------+------------------
+ t_guc_int       |          1000000
+
+ROLLBACK;
+-- No GUC set (NULL) should use legacy defaults
+BEGIN;
+RESET timescaledb.default_chunk_time_interval;
+CREATE TABLE t_no_guc(time timestamptz NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+SELECT hypertable_name, time_interval
+  FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 't_no_guc';
+ hypertable_name | time_interval 
+-----------------+---------------
+ t_no_guc        | @ 7 days
+
+ROLLBACK;
+-- GUC with UUID partition type
+BEGIN;
+SET timescaledb.default_chunk_time_interval = '12 hours';
+CREATE TABLE t_guc_uuid(time uuid NOT NULL, device text, value float)
+  WITH (tsdb.hypertable, tsdb.partition_column='time');
+SELECT hypertable_name, time_interval
+  FROM timescaledb_information.dimensions
+  WHERE hypertable_name = 't_guc_uuid';
+ hypertable_name | time_interval 
+-----------------+---------------
+ t_guc_uuid      | @ 12 hours
+
+ROLLBACK;
+-- Cleanup
+RESET timescaledb.default_chunk_time_interval;


### PR DESCRIPTION
When auto-tuning of the chunk time interval is available, we'd like to be able to set a small default interval and tune into a bigger one (going from big to small is not great because big intervals lock you in). When auto-tuning is not available, it makes sense that the default is bigger.

With this change, a default chunk time interval can be set with a new GUC `timescaledb.default_chunk_time_interval`. The GUC expects a text-format PostgreSQL INTERVAL type (e.g., '1 day' or '1 week'). It is only possible to set the default chunk time interval for hypertables that use an INTERVAL-compatible partitioning type, i.e., TIMESTAMP(TZ), DATE, and UUID (version 7). The default value of the GUC is "null", which means the current behavior is preserved (i.e., the hard-coded defaults are used).

Hypertables partitioned on an integer type are not affected by the new GUC. Since there is no natural "unit" for an integer time column, it is less clear what a reasonable default would be.

Depends on https://github.com/timescale/timescaledb/pull/8982