### PR TITLE
Add pathkey replacement for ColumnarScanPath

### DIFF
--- a/.unreleased/pr_8986
+++ b/.unreleased/pr_8986
@@ -1,0 +1,1 @@
+Fixes: #8986 Add pathkey replacement for ColumnarScanPath

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -310,6 +310,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.create_upper_paths_hook = NULL,
 	.set_rel_pathlist_dml = NULL,
 	.set_rel_pathlist_query = NULL,
+	.sort_transform_replace_pathkeys = NULL,
 	.process_altertable_cmd = NULL,
 	.process_rename_cmd = NULL,
 

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -80,6 +80,8 @@ typedef struct CrossModuleFunctions
 	void (*set_rel_pathlist_dml)(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
 	void (*set_rel_pathlist_query)(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *,
 								   Hypertable *);
+	void (*sort_transform_replace_pathkeys)(void *path, List *transformed_pathkeys,
+											List *original_pathkeys);
 
 	/* gapfill */
 	PGFunction gapfill_marker;

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -557,13 +557,18 @@ ts_sort_transform_replace_pathkeys(void *node, List *transformed_pathkeys, List 
 
 	if (IsA(path, CustomPath))
 	{
-		/*
-		 * We should only see ChunkAppend here.
-		 */
 		CustomPath *custom = castNode(CustomPath, path);
 		ts_sort_transform_replace_pathkeys(custom->custom_paths,
 										   transformed_pathkeys,
 										   original_pathkeys);
+
+		/* Need to handle tsl-specific custom path types */
+		if (ts_cm_functions->sort_transform_replace_pathkeys != NULL)
+		{
+			ts_cm_functions->sort_transform_replace_pathkeys(path,
+															 transformed_pathkeys,
+															 original_pathkeys);
+		}
 	}
 	else if (IsA(path, MergeAppendPath))
 	{

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -77,6 +77,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.create_upper_paths_hook = tsl_create_upper_paths_hook,
 	.set_rel_pathlist_dml = tsl_set_rel_pathlist_dml,
 	.set_rel_pathlist_query = tsl_set_rel_pathlist_query,
+	.sort_transform_replace_pathkeys = tsl_sort_transform_replace_pathkeys,
 
 	/* bgw policies */
 	.policy_compression_add = policy_compression_add,

--- a/tsl/src/planner.h
+++ b/tsl/src/planner.h
@@ -15,5 +15,7 @@ void tsl_create_upper_paths_hook(PlannerInfo *, UpperRelationKind, RelOptInfo *,
 								 TsRelType, Hypertable *, void *);
 void tsl_set_rel_pathlist_query(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
 void tsl_set_rel_pathlist_dml(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
+void tsl_sort_transform_replace_pathkeys(void *path, List *transformed_pathkeys,
+										 List *original_pathkeys);
 void tsl_preprocess_query(Query *parse, int *cursor_opts);
 void tsl_postprocess_plan(PlannedStmt *stmt);

--- a/tsl/test/expected/plan_skip_scan_dagg-16.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-16.out
@@ -3476,28 +3476,16 @@ stable expression in targetlist on skip_scan_htc
          Sort Key: ((skip_scan_htc.dev + 1))
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_26_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_27_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_28_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_29_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
 
 -- But expressions over distinct aggregates are supported
 :PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;

--- a/tsl/test/expected/plan_skip_scan_dagg-17.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-17.out
@@ -3476,28 +3476,16 @@ stable expression in targetlist on skip_scan_htc
          Sort Key: ((skip_scan_htc.dev + 1))
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_26_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_27_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_28_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_29_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
 
 -- But expressions over distinct aggregates are supported
 :PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;

--- a/tsl/test/expected/plan_skip_scan_dagg-18.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-18.out
@@ -3471,28 +3471,16 @@ stable expression in targetlist on skip_scan_htc
          Sort Key: ((skip_scan_htc.dev + 1))
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_26_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_27_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_28_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=2505.00 loops=1)
-                     ->  Sort (actual rows=11.00 loops=1)
-                           Sort Key: compress_hyper_4_29_chunk.dev
-                           Sort Method: quicksort 
-                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
+                     ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
 
 -- But expressions over distinct aggregates are supported
 :PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;


### PR DESCRIPTION
Pathkey replacement in sort_transform.c only handled the standard Path.pathkeys field. ColumnarScanPath has an additional required_compressed_pathkeys field that also needs replacement during sort transformation.

Introduce a new TSL hook sort_transform_replace_pathkeys_hook to handle pathkey replacement for TSL-specific custom path types like ColumnarScan that have additional pathkey fields.

Fixes #8963