### PR TITLE
Ensure no XID is assigned during chunk query

### DIFF
--- a/.unreleased/pr_8989
+++ b/.unreleased/pr_8989
@@ -1,0 +1,1 @@
+Fixes: #8989 Ensure no XID is assigned during chunk query

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -179,6 +179,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_by_id_with_slice_lock(int32 id, LOCKMODE 
 
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_id(int32 id, bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid_locked(Oid relid, LOCKMODE lockmode,
+													   const ScanTupLock *slice_lock,
 													   bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found);
 extern TSDLLEXPORT void ts_chunk_free(Chunk *chunk);

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -460,7 +460,8 @@ preprocess_query(Node *node, PreprocessQueryContext *context)
 						 * We want to distinguish between the two cases here by
 						 * marking the chunk when rte->inh is true.
 						 */
-						Chunk *chunk = ts_chunk_get_by_relid(rte->relid, false);
+						Chunk *chunk =
+							ts_chunk_get_by_relid_locked(rte->relid, NoLock, NULL, false);
 						if (chunk && rte->inh)
 							rte_mark_for_expansion(rte);
 					}

--- a/tsl/src/chunk_split.c
+++ b/tsl/src/chunk_split.c
@@ -13,6 +13,7 @@
 #include <catalog/pg_collation.h>
 #include <catalog/pg_constraint.h>
 #include <commands/tablecmds.h>
+#include <nodes/lockoptions.h>
 #include <storage/bufmgr.h>
 #include <storage/lockdefs.h>
 #include <utils/acl.h>
@@ -909,8 +910,13 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 	Oid relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	const Chunk *chunk;
 	Relation srcrel;
+	ScanTupLock slice_lock = {
+		.lockmode = LockTupleNoKeyExclusive,
+		.waitpolicy = LockWaitBlock,
+		.lockflags = TUPLE_LOCK_FLAG_FIND_LAST_VERSION,
+	};
 
-	chunk = ts_chunk_get_by_relid_locked(relid, AccessExclusiveLock, true);
+	chunk = ts_chunk_get_by_relid_locked(relid, AccessExclusiveLock, &slice_lock, true);
 
 	/* Chunk already locked, so use NoLock */
 	srcrel = table_open(relid, NoLock);

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -20,6 +20,7 @@
 #include <parser/parse_relation.h>
 #include <parser/parsetree.h>
 #include <planner/planner.h>
+#include <storage/lockdefs.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
@@ -2251,8 +2252,14 @@ columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Ch
 	/*
 	 * Add the compressed chunk to the baserel cache. Note that it belongs to
 	 * a different hypertable, the internal compression table.
+	 *
+	 * Ensure we do not grab a slice lock because that will assign a transaction ID that could
+	 * unnecessarily block other operations.
 	 */
-	const Chunk *compressed_chunk = ts_chunk_get_by_relid(info->settings->fd.compress_relid, true);
+	const Chunk *compressed_chunk = ts_chunk_get_by_relid_locked(info->settings->fd.compress_relid,
+																 AccessShareLock,
+																 NULL,
+																 true);
 	ts_add_baserel_cache_entry_for_chunk(info->settings->fd.compress_relid,
 										 ts_planner_get_hypertable(compressed_chunk
 																	   ->hypertable_relid,

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -335,7 +335,7 @@ SELECT txid_current_if_assigned() IS NULL;
 ----------
  t
 
-SELECT COUNT(*) FROM :chunk LIMIT 1;
+SELECT COUNT(*) FROM :chunk;
  count 
 -------
      1
@@ -343,6 +343,6 @@ SELECT COUNT(*) FROM :chunk LIMIT 1;
 SELECT txid_current_if_assigned() IS NULL;
  ?column? 
 ----------
- f
+ t
 
 COMMIT;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2728,7 +2728,7 @@ SELECT txid_current_if_assigned() IS NULL;
 ----------
  t
 
-SELECT COUNT(*) FROM :chunk LIMIT 1;
+SELECT COUNT(*) FROM :chunk;
  count 
 -------
      1
@@ -2736,7 +2736,7 @@ SELECT COUNT(*) FROM :chunk LIMIT 1;
 SELECT txid_current_if_assigned() IS NULL;
  ?column? 
 ----------
- f
+ t
 
 COMMIT;
 DROP TABLE test_xid_compressed;

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -237,6 +237,6 @@ SELECT * FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1515628
 SELECT show_chunks('chunkapi') AS chunk LIMIT 1 \gset
 BEGIN;
 SELECT txid_current_if_assigned() IS NULL;
-SELECT COUNT(*) FROM :chunk LIMIT 1;
+SELECT COUNT(*) FROM :chunk;
 SELECT txid_current_if_assigned() IS NULL;
 COMMIT;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1254,7 +1254,7 @@ SELECT compress_chunk(show_chunks('test_xid_compressed'));
 SELECT show_chunks('test_xid_compressed') AS chunk LIMIT 1 \gset
 BEGIN;
 SELECT txid_current_if_assigned() IS NULL;
-SELECT COUNT(*) FROM :chunk LIMIT 1;
+SELECT COUNT(*) FROM :chunk;
 SELECT txid_current_if_assigned() IS NULL;
 COMMIT;
 


### PR DESCRIPTION
When querying hypertables, the dimension slices of the queried chunks are locked using a row-level (tuple) lock. This will automatically assign a transaction ID to the query because PostgreSQL stores row-level locks in the tuple (i.e., on disk) instead of in memory. Writing to the tuple requires a transaction ID and a lock on the transaction.

However, these additional locks could create problems since they might block other operations. For example, it prevents creating replication slots as long as the locks are held.

This change fixes the tuple lock issue for cases when chunks are queried directly so that replication slots can be created while the chunk is read.

Disable-check: commit-count