### PR TITLE
Fix EquivalenceClass index update for RelOptInfo

### DIFF
--- a/.unreleased/pr_8990
+++ b/.unreleased/pr_8990
@@ -1,0 +1,1 @@
+Fixes: #8990 Fix EquivalenceClass index update for RelOptInfo

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -376,15 +376,14 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig, Relids child_relids
 			else
 				newec->ec_members = lappend(newec->ec_members, em);
 
+#endif
 			int i = -1;
 			while ((i = bms_next_member(em->em_relids, i)) >= 0)
 			{
-				RelOptInfo *child_rel = root->simple_rel_array[i];
+				RelOptInfo *rel = root->simple_rel_array[i];
 
-				child_rel->eclass_indexes =
-					bms_add_member(child_rel->eclass_indexes, root->eq_classes->length);
+				rel->eclass_indexes = bms_add_member(rel->eclass_indexes, root->eq_classes->length);
 			}
-#endif
 		}
 	}
 	/* if any transforms were found return new ec */

--- a/tsl/test/expected/plan_skip_scan_dagg-16.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-16.out
@@ -3476,16 +3476,28 @@ stable expression in targetlist on skip_scan_htc
          Sort Key: ((skip_scan_htc.dev + 1))
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_26_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_27_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_28_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_29_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
 
 -- But expressions over distinct aggregates are supported
 :PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;

--- a/tsl/test/expected/plan_skip_scan_dagg-17.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-17.out
@@ -3476,16 +3476,28 @@ stable expression in targetlist on skip_scan_htc
          Sort Key: ((skip_scan_htc.dev + 1))
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_26_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_26_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_26_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_6_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_27_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_27_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_27_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_7_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_28_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_28_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_28_chunk (actual rows=11.00 loops=1)
          ->  Result (actual rows=2505.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_3_8_chunk (actual rows=2505.00 loops=1)
-                     ->  Seq Scan on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
+                     ->  Sort (actual rows=11.00 loops=1)
+                           Sort Key: compress_hyper_4_29_chunk.dev
+                           Sort Method: quicksort 
+                           ->  Index Scan using compress_hyper_4_29_chunk_dev__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_4_29_chunk (actual rows=11.00 loops=1)
 
 -- But expressions over distinct aggregates are supported
 :PREFIX SELECT count(DISTINCT dev) + 1, sum(DISTINCT dev)/count(DISTINCT dev), 'q1_15' FROM :TABLE;

--- a/tsl/test/shared/expected/gapfill-15.out
+++ b/tsl/test/shared/expected/gapfill-15.out
@@ -220,14 +220,13 @@ LIMIT 1;
 FROM gapfill_plan_test
 ORDER BY 1;
 --- QUERY PLAN ---
- Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   ->  Result
-         ->  Append
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
+ Result
+   ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+         Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
 
 SET max_parallel_workers_per_gather TO 0;
 -- test sort optimizations with locf
@@ -289,14 +288,13 @@ ORDER BY 1,2;
 FROM gapfill_plan_test
 ORDER BY 2,1;
 --- QUERY PLAN ---
- Sort
-   Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   ->  Result
-         ->  Append
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
+ Result
+   ->  Merge Append
+         Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
 
 DROP TABLE gapfill_plan_test;
 \set METRICS metrics_int
@@ -3015,15 +3013,14 @@ FROM metrics
 GROUP BY 1;
 --- QUERY PLAN ---
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Result
+               ->  Merge Append
+                     Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
 
 -- issue #3834
 -- test projection handling in gapfill

--- a/tsl/test/shared/expected/gapfill-16.out
+++ b/tsl/test/shared/expected/gapfill-16.out
@@ -220,14 +220,13 @@ LIMIT 1;
 FROM gapfill_plan_test
 ORDER BY 1;
 --- QUERY PLAN ---
- Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   ->  Result
-         ->  Append
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
+ Result
+   ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+         Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
 
 SET max_parallel_workers_per_gather TO 0;
 -- test sort optimizations with locf
@@ -289,16 +288,13 @@ ORDER BY 1,2;
 FROM gapfill_plan_test
 ORDER BY 2,1;
 --- QUERY PLAN ---
- Incremental Sort
-   Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   Presorted Key: gapfill_plan_test.value
-   ->  Result
-         ->  Merge Append
-               Sort Key: gapfill_plan_test.value
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+ Result
+   ->  Merge Append
+         Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
 
 DROP TABLE gapfill_plan_test;
 \set METRICS metrics_int
@@ -3017,15 +3013,14 @@ FROM metrics
 GROUP BY 1;
 --- QUERY PLAN ---
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Result
+               ->  Merge Append
+                     Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
 
 -- issue #3834
 -- test projection handling in gapfill

--- a/tsl/test/shared/expected/gapfill-17.out
+++ b/tsl/test/shared/expected/gapfill-17.out
@@ -220,14 +220,13 @@ LIMIT 1;
 FROM gapfill_plan_test
 ORDER BY 1;
 --- QUERY PLAN ---
- Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   ->  Result
-         ->  Append
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
-               ->  Seq Scan on _hyper_X_X_chunk
+ Result
+   ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+         Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
+         ->  Index Scan Backward using _hyper_X_X_chunk_gapfill_plan_test_time_idx on _hyper_X_X_chunk
 
 SET max_parallel_workers_per_gather TO 0;
 -- test sort optimizations with locf
@@ -289,16 +288,13 @@ ORDER BY 1,2;
 FROM gapfill_plan_test
 ORDER BY 2,1;
 --- QUERY PLAN ---
- Incremental Sort
-   Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-   Presorted Key: gapfill_plan_test.value
-   ->  Result
-         ->  Merge Append
-               Sort Key: gapfill_plan_test.value
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
-               ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+ Result
+   ->  Merge Append
+         Sort Key: gapfill_plan_test.value, (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
+         ->  Index Only Scan using _hyper_X_X_chunk_gapfill_plan_test_indx on _hyper_X_X_chunk
 
 DROP TABLE gapfill_plan_test;
 \set METRICS metrics_int
@@ -3017,15 +3013,14 @@ FROM metrics
 GROUP BY 1;
 --- QUERY PLAN ---
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
-                           ->  Seq Scan on _hyper_X_X_chunk
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Result
+               ->  Merge Append
+                     Sort Key: (time_bucket_gapfill('@ 364 days'::interval, metrics."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+                     ->  Index Scan Backward using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
 
 -- issue #3834
 -- test projection handling in gapfill


### PR DESCRIPTION
Add new EquivalenceClass to RelOptInfo->eclass_indexes so that compressed_rel_setup_equivalence_classes() can consider the transformed EC when selecting paths, enabling optimal index scan selection on compressed chunks.

PR https://github.com/timescale/timescaledb/pull/8986 Has the fix for the redundant sort node being generated being generated in plan_skip_scan_dagg test