### PR TITLE
Fix race condition in regresscheck-shared

### DIFF
--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -954,36 +954,34 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where device_id <> 1 AND device_id <> 2;ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches decompressed: 48
-   Tuples decompressed: 41022
+   Batches deleted: 48
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk metrics_compressed_1
          Delete on _hyper_X_X_chunk metrics_compressed_2
          Delete on _hyper_X_X_chunk metrics_compressed_3
-         ->  Append (actual rows=41022.00 loops=1)
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_1 (actual rows=10794.00 loops=1)
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_1 (actual rows=0.00 loops=1)
                      Filter: ((device_id <> 1) AND (device_id <> 2))
                      Rows Removed by Filter: 1598
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_2 (actual rows=15114.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_2 (actual rows=0.00 loops=1)
                      Filter: ((device_id <> 1) AND (device_id <> 2))
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_3 (actual rows=15114.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_3 (actual rows=0.00 loops=1)
                      Filter: ((device_id <> 1) AND (device_id <> 2))
 
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where device_id > 1 AND device_id < 3;ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches decompressed: 16
-   Tuples decompressed: 13674
+   Batches deleted: 16
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk metrics_compressed_1
          Delete on _hyper_X_X_chunk metrics_compressed_2
          Delete on _hyper_X_X_chunk metrics_compressed_3
-         ->  Append (actual rows=13674.00 loops=1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk metrics_compressed_1 (actual rows=3598.00 loops=1)
+         ->  Append (actual rows=0.00 loops=1)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk metrics_compressed_1 (actual rows=0.00 loops=1)
                      Index Cond: ((device_id > 1) AND (device_id < 3))
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_2 (actual rows=5038.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_2 (actual rows=0.00 loops=1)
                      Filter: ((device_id > 1) AND (device_id < 3))
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_3 (actual rows=5038.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_3 (actual rows=0.00 loops=1)
                      Filter: ((device_id > 1) AND (device_id < 3))
 
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where v3 IS NOT NULL AND device_id IS NOT NULL AND device_id = 1;ROLLBACK;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -112,9 +112,8 @@ ORDER BY time, device_id;
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Filter: (device_id < 0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Filter: (device_id < 0)
-               Rows Removed by Filter: 18
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
 
@@ -233,9 +232,8 @@ ORDER BY time, device_id;
          ->  Append (actual rows=0.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Filter: (device_id IS NULL)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
                ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
 
@@ -696,9 +694,9 @@ SET enable_seqscan TO FALSE;
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
@@ -1231,9 +1229,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 50
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=29)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 
@@ -1246,9 +1243,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 81
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -112,9 +112,8 @@ ORDER BY time, device_id;
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Filter: (device_id < 0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Filter: (device_id < 0)
-               Rows Removed by Filter: 18
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
 
@@ -233,9 +232,8 @@ ORDER BY time, device_id;
          ->  Append (actual rows=0.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Filter: (device_id IS NULL)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
                ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Index Cond: (device_id IS NULL)
 
@@ -696,9 +694,9 @@ SET enable_seqscan TO FALSE;
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
@@ -1231,9 +1229,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 50
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=29)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 
@@ -1246,9 +1243,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 81
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-17.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-17.out
@@ -112,9 +112,8 @@ ORDER BY time, device_id;
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Filter: (device_id < 0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Filter: (device_id < 0)
-               Rows Removed by Filter: 18
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
 
@@ -245,9 +244,8 @@ ORDER BY time, device_id;
                Sort Method: quicksort 
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Filter: (device_id IS NULL)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Method: quicksort 
@@ -762,9 +760,9 @@ SET enable_seqscan TO FALSE;
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
@@ -1297,9 +1295,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 50
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=29)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 
@@ -1312,9 +1309,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.00 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 81
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 

--- a/tsl/test/shared/expected/transparent_decompress_chunk-18.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-18.out
@@ -112,9 +112,8 @@ ORDER BY time, device_id;
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Filter: (device_id < 0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-               Filter: (device_id < 0)
-               Rows Removed by Filter: 18
+         ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: (device_id < 0)
 
@@ -245,9 +244,8 @@ ORDER BY time, device_id;
                Sort Method: quicksort 
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
                      Filter: (device_id IS NULL)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
-                           Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
+                           Index Cond: (device_id IS NULL)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Method: quicksort 
@@ -762,9 +760,9 @@ SET enable_seqscan TO FALSE;
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
-         ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _timescaledb_internal._hyper_X_X_chunk (actual rows=1598.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
+               Index Cond: (_hyper_X_X_chunk.device_id = 1)
 
 -- globs should not plan IndexOnlyScans
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
@@ -1277,9 +1275,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.09 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 50
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.09 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.09 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.07 loops=29)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 
@@ -1292,9 +1289,8 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d':
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1 (actual rows=0.16 loops=32)
                      Filter: (("time" = g."time") AND (device_id = $1))
                      Rows Removed by Filter: 81
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
-                           Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time") AND (device_id = $1))
-                           Rows Removed by Filter: 16
+                     ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.16 loops=32)
+                           Index Cond: ((device_id = $1) AND (_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1 (actual rows=0.00 loops=27)
                      Index Cond: ((device_id = $1) AND ("time" = g."time"))
 

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -1,11 +1,9 @@
 set(TEST_FILES_SHARED
-    cagg_compression.sql
     chunkwise_agg_gather_sort.sql
     classify_relation.sql
     compat.sql
     compress_bloom_sparse_compat.sql
     compress_unique_index.sql
-    compression_dml.sql
     compression_nulls_not_distinct.sql
     constraint_aware_append.sql
     decompress_join.sql
@@ -26,7 +24,7 @@ set(TEST_TEMPLATES_SHARED
     space_constraint.sql.in
     transparent_decompress_chunk.sql.in)
 
-set(SOLO_TESTS merge_dml.sql)
+set(SOLO_TESTS cagg_compression.sql compression_dml.sql merge_dml.sql)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES_SHARED extension.sql timestamp_limits.sql
@@ -78,9 +76,7 @@ file(APPEND ${TEST_SCHEDULE_SHARED} "\n")
 set(GROUP_MEMBERS 0)
 foreach(TEST_FILE ${SOLO_TESTS})
   string(REGEX REPLACE "(.+)\.sql" "\\1" TESTS_TO_RUN ${TEST_FILE})
-  if(GROUP_MEMBERS EQUAL 0)
-    file(APPEND ${TEST_SCHEDULE_SHARED} "\ntest: ")
-  endif()
+  file(APPEND ${TEST_SCHEDULE_SHARED} "\ntest: ")
   file(APPEND ${TEST_SCHEDULE_SHARED} "${TESTS_TO_RUN} ")
   math(EXPR GROUP_MEMBERS "(${GROUP_MEMBERS}+1)%${PARALLEL_GROUP_SIZE}")
 endforeach(TEST_FILE)


### PR DESCRIPTION
Hypertables with caggs have direct batch delete optimization disabled
so when the cagg test that was creating addition caggs was running
at the same time as the compression dml tests certain optimizations
would be skipped leading to flaky tests.
