### PR TITLE
Fix sort limiting for direct compress

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -904,7 +904,7 @@ tsl_compressor_add_slot(RowCompressor *compressor, BulkWriter *bulk_writer, Tupl
 		compressor->tuples_to_sort++;
 
 		if (compressor->tuple_sort_limit &&
-			compressor->tuples_to_sort > compressor->tuple_sort_limit)
+			compressor->tuples_to_sort >= compressor->tuple_sort_limit)
 			tsl_compressor_flush(compressor, bulk_writer);
 	}
 	else

--- a/tsl/test/expected/direct_compress_copy.out
+++ b/tsl/test/expected/direct_compress_copy.out
@@ -325,21 +325,19 @@ SELECT _timescaledb_functions.chunk_status_text(:'CHUNK'::regclass);
 ROLLBACK;
 -- simple test with compressed copy enabled and sorting limited to 500
 -- batches should be limited to that amount so we have more compressed batches
+-- dataset is tweaked to fall into a single chunk with exactly 3 batches
 BEGIN;
 SET timescaledb.enable_direct_compress_copy = true;
-SET timescaledb.direct_compress_copy_tuple_sort_limit = 500;
-COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-01 + I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
+SET timescaledb.direct_compress_copy_tuple_sort_limit = 1000;
+COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-02 + I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
- Append (actual rows=3000.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_38_chunk (actual rows=959.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_39_chunk (actual rows=2.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_40_chunk (actual rows=2041.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_41_chunk (actual rows=5.00 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_1_38_chunk (actual rows=3000.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_39_chunk (actual rows=3.00 loops=1)
 
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
             first             |             last             
 ------------------------------+------------------------------
- Wed Jan 01 00:01:00 2025 PST | Fri Jan 03 02:00:00 2025 PST
+ Thu Jan 02 00:01:00 2025 PST | Sat Jan 04 02:00:00 2025 PST
 
 ROLLBACK;

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -604,22 +604,20 @@ SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics
 ROLLBACK;
 -- simple test with compressed insert enabled and sorting limited to 500
 -- batches should be limited to that amount so we have more compressed batches
+-- dataset is tweaked to fall into single chunk with exactly 3 batches
 BEGIN;
 SET timescaledb.enable_direct_compress_insert = true;
-SET timescaledb.direct_compress_insert_tuple_sort_limit = 500;
-INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+SET timescaledb.direct_compress_insert_tuple_sort_limit = 1000;
+INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(1,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
- Append (actual rows=3001.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_59_chunk (actual rows=960.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_60_chunk (actual rows=2.00 loops=1)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_61_chunk (actual rows=2041.00 loops=1)
-         ->  Seq Scan on compress_hyper_2_62_chunk (actual rows=5.00 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_1_59_chunk (actual rows=3000.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_60_chunk (actual rows=3.00 loops=1)
 
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
             first             |             last             
 ------------------------------+------------------------------
- Wed Jan 01 00:00:00 2025 PST | Fri Jan 03 02:00:00 2025 PST
+ Thu Jan 02 00:01:00 2025 PST | Sat Jan 04 02:00:00 2025 PST
 
 -- since the chunks are new status should be COMPRESSED, UNORDERED
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;

--- a/tsl/test/sql/direct_compress_copy.sql
+++ b/tsl/test/sql/direct_compress_copy.sql
@@ -228,10 +228,11 @@ ROLLBACK;
 
 -- simple test with compressed copy enabled and sorting limited to 500
 -- batches should be limited to that amount so we have more compressed batches
+-- dataset is tweaked to fall into a single chunk with exactly 3 batches
 BEGIN;
 SET timescaledb.enable_direct_compress_copy = true;
-SET timescaledb.direct_compress_copy_tuple_sort_limit = 500;
-COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-01 + I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
+SET timescaledb.direct_compress_copy_tuple_sort_limit = 1000;
+COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-02 + I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
 ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -316,10 +316,11 @@ ROLLBACK;
 
 -- simple test with compressed insert enabled and sorting limited to 500
 -- batches should be limited to that amount so we have more compressed batches
+-- dataset is tweaked to fall into single chunk with exactly 3 batches
 BEGIN;
 SET timescaledb.enable_direct_compress_insert = true;
-SET timescaledb.direct_compress_insert_tuple_sort_limit = 500;
-INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+SET timescaledb.direct_compress_insert_tuple_sort_limit = 1000;
+INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(1,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
 -- since the chunks are new status should be COMPRESSED, UNORDERED


### PR DESCRIPTION
Previous limit introduced an off-by-one bug where you would flush limit+1 tuples and thus potentially creating single tuple batch. This would negatively affect compression ratio and ingest speed of direct compress.

Disable-check: force-changelog-file