### PR TITLE
Convert tabs to spaces to make the workflow a valid YAML file

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -339,7 +339,7 @@ jobs:
         path: db/corpus-${{ matrix.case.bulk && 'bulk' || 'rowbyrow' }}
         key: "${{ format('{0}-{1}-{2}-{3}',
             steps.config.outputs.cache_prefix,
-			matrix.case.bulk && 'bulk' || 'rowbyrow',
+            matrix.case.bulk && 'bulk' || 'rowbyrow',
             github.run_id, github.run_attempt) }}"
 
     - name: Stack trace


### PR DESCRIPTION
While trying to run zizmor on the codebase, I was getting errors on `libfuzzer.yaml` workflow not being a valid YAML file. I validated the YAML file and found out that there is a mixed set of tabs and spaces on line 342. So, I fixed it.

CC @svenklemm