### PR TITLE
Test recompress with convert_to_columnstore

### DIFF
--- a/tsl/test/expected/recompression_integrity_tests.out
+++ b/tsl/test/expected/recompression_integrity_tests.out
@@ -678,17 +678,9 @@ ALTER TABLE recomp_guc_test SET (
 SET timescaledb.enable_in_memory_recompression = off;
 -- Insert test data
 INSERT INTO recomp_guc_test VALUES ('2000-01-01 00:00:00', 'device1', 20.5);
--- Compress all chunks
-SELECT compress_chunk(ch) FROM show_chunks('recomp_guc_test') ch;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_13_26_chunk
-
-SELECT compress_chunk(ch, recompress := true) FROM show_chunks('recomp_guc_test') ch LIMIT 1;
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_13_26_chunk
-
+SELECT ch AS chunk FROM show_chunks('recomp_guc_test') ch ORDER BY ch LIMIT 1 \gset
+CALL convert_to_columnstore(:'chunk');
+CALL convert_to_columnstore(:'chunk', recompress := true);
 -- Verify data integrity after fallback recompression
 SELECT COUNT(*) FROM recomp_guc_test;
  count 

--- a/tsl/test/sql/recompression_integrity_tests.sql
+++ b/tsl/test/sql/recompression_integrity_tests.sql
@@ -216,9 +216,9 @@ SET timescaledb.enable_in_memory_recompression = off;
 -- Insert test data
 INSERT INTO recomp_guc_test VALUES ('2000-01-01 00:00:00', 'device1', 20.5);
 
--- Compress all chunks
-SELECT compress_chunk(ch) FROM show_chunks('recomp_guc_test') ch;
-SELECT compress_chunk(ch, recompress := true) FROM show_chunks('recomp_guc_test') ch LIMIT 1;
+SELECT ch AS chunk FROM show_chunks('recomp_guc_test') ch ORDER BY ch LIMIT 1 \gset
+CALL convert_to_columnstore(:'chunk');
+CALL convert_to_columnstore(:'chunk', recompress := true);
 
 -- Verify data integrity after fallback recompression
 SELECT COUNT(*) FROM recomp_guc_test;


### PR DESCRIPTION
convert_to_columnstore() is a procedure and should work the same as compress_chunk().

Disable-check: force-changelog-file