### PR TITLE
Prevent `drop_chunks` from dropping unrefreshed data

### DIFF
--- a/.unreleased/pr_9006
+++ b/.unreleased/pr_9006
@@ -1,0 +1,1 @@
+Implements: #9006 Prevent drop_chunks from dropping CAgg-dependent chunks

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -104,7 +104,8 @@ CREATE OR REPLACE FUNCTION @extschema@.drop_chunks(
     newer_than             "any" = NULL,
     verbose                BOOLEAN = FALSE,
     created_before         "any" = NULL,
-    created_after          "any" = NULL
+    created_after          "any" = NULL,
+    force                   BOOLEAN = FALSE
 ) RETURNS SETOF TEXT AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
 LANGUAGE C VOLATILE PARALLEL UNSAFE;
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -205,3 +205,5 @@ DROP PROCEDURE IF EXISTS _timescaledb_functions.process_hypertable_invalidations
 -- Remove orphaned entries in materialization ranges table
 DELETE FROM _timescaledb_catalog.continuous_aggs_materialization_ranges
 WHERE NOT EXISTS (SELECT FROM _timescaledb_catalog.continuous_agg WHERE mat_hypertable_id = materialization_id);
+
+DROP FUNCTION IF EXISTS @extschema@.drop_chunks;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -107,3 +107,5 @@ ALTER TABLE _timescaledb_catalog.bgw_job SET SCHEMA _timescaledb_config;
 DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_compressed_batch_size(REGCLASS);
 DROP PROCEDURE IF EXISTS _timescaledb_functions.rebuild_columnstore(REGCLASS);
 DROP FUNCTION IF EXISTS _timescaledb_functions.cagg_get_grouping_columns;
+
+DROP FUNCTION IF EXISTS @extschema@.drop_chunks;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -21,7 +21,7 @@
 
 /* Should match definitions in ddl_api.sql */
 #define DROP_CHUNKS_FUNCNAME "drop_chunks"
-#define DROP_CHUNKS_NARGS 6
+#define DROP_CHUNKS_NARGS 7
 #define COMPRESS_CHUNK_FUNCNAME "compress_chunk"
 #define COMPRESS_CHUNK_NARGS 2
 #define DECOMPRESS_CHUNK_FUNCNAME "decompress_chunk"
@@ -218,7 +218,7 @@ extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(const Chunk *chunk,
 														   DropBehavior behavior, int32 log_level);
 extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than,
 												 int32 log_level, Oid time_type, Oid arg_type,
-												 bool older_newer);
+												 bool older_newer, bool force);
 extern TSDLLEXPORT Chunk *
 ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc, const char *schema_name,
 									 const char *table_name, Oid chunk_table_relid, bool *created);

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -198,3 +198,4 @@ ts_continuous_agg_fixed_bucket_width(const ContinuousAggBucketFunction *bucket_f
 extern TSDLLEXPORT int64
 ts_continuous_agg_bucket_width(const ContinuousAggBucketFunction *bucket_function);
 extern TSDLLEXPORT void ts_get_invalidation_replication_slot_name(char *slotname, Size szslot);
+extern TSDLLEXPORT int64 ts_get_earliest_watermark_on_hypertable(int32 hypertable_id);

--- a/test/sql/update.sql
+++ b/test/sql/update.sql
@@ -57,4 +57,3 @@ UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 minute' RETURNING *;
 UPDATE :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
 UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
 \set ON_ERROR_STOP 1
-

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -130,8 +130,11 @@ chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type, boo
 										 TypeNullCons,
 										 castNode(Const, makeBoolConst(false, true)),
 										 TypeNullCons,
-										 TypeNullCons };
-	Oid type_id[DROP_CHUNKS_NARGS] = { REGCLASSOID, ANYOID, ANYOID, BOOLOID, ANYOID, ANYOID };
+										 TypeNullCons,
+										 castNode(Const, makeBoolConst(false, true)) };
+	Oid type_id[DROP_CHUNKS_NARGS] = {
+		REGCLASSOID, ANYOID, ANYOID, BOOLOID, ANYOID, ANYOID, BOOLOID
+	};
 	char *const schema_name = ts_extension_schema_name();
 	List *const fqn = list_make2(makeString(schema_name), makeString(DROP_CHUNKS_FUNCNAME));
 

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -1525,6 +1525,10 @@ SELECT * from _timescaledb_internal.bgw_job_stat;
 SELECT show_chunks('test_table_scheduler');
               show_chunks               
 ----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
  _timescaledb_internal._hyper_1_5_chunk
  _timescaledb_internal._hyper_1_6_chunk
  _timescaledb_internal._hyper_1_7_chunk
@@ -1533,11 +1537,15 @@ SELECT show_chunks('test_table_scheduler');
 select hypertable_schema, hypertable_name, chunk_schema, chunk_name, is_compressed from timescaledb_information.chunks ;
    hypertable_schema   |      hypertable_name       |     chunk_schema      |    chunk_name     | is_compressed 
 -----------------------+----------------------------+-----------------------+-------------------+---------------
+ public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_1_chunk  | t
+ public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_2_chunk  | t
+ public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_3_chunk  | t
+ public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_4_chunk  | t
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_5_chunk  | t
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_6_chunk  | f
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_7_chunk  | f
  public                | test_table_scheduler       | _timescaledb_internal | _hyper_1_8_chunk  | f
- _timescaledb_internal | _materialized_hypertable_2 | _timescaledb_internal | _hyper_2_10_chunk | f
+ _timescaledb_internal | _materialized_hypertable_2 | _timescaledb_internal | _hyper_2_14_chunk | f
 
 select avg_a from cagg_scheduler ORDER BY 1;
        avg_a        

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -472,8 +472,20 @@ AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1 WITH NO DATA;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
---dropping chunks will process the invalidations
+-- chunks that contain data that hasn't been refreshed yet i.e. after the watermark will not be dropped unless force is specified
+-- drop_chunks does not process invalidations on drop
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
+NOTICE:  skipping _timescaledb_internal._hyper_10_13_chunk, chunk contains data required for a continuous aggregate refresh
+ drop_chunks 
+-------------
+
+SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
+ time | data 
+------+------
+    0 |    0
+
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), force => true);
+WARNING:  _timescaledb_internal._hyper_10_13_chunk contained data required for continuous aggregate refresh
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_10_13_chunk
@@ -485,10 +497,8 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 CALL refresh_continuous_aggregate('drop_chunks_view', 10, 40);
---this will be seen after the drop its within the invalidation window and will be dropped
 INSERT INTO drop_chunks_table VALUES (26, 100);
---this will not be processed by the drop since chunk 30-39 is not dropped but will be seen after refresh
---shows that the drop doesn't do more work than necessary
+-- Invalidation on 31 will not be seen in the CAgg after the drop
 INSERT INTO drop_chunks_table VALUES (31, 200);
 --move the time up to 39
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(35, 39) AS i;
@@ -513,7 +523,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
           15 |  19
           10 |  14
 
---refresh to process the invalidations and then drop
+--refresh to process the invalidations till 30 and then drop
 CALL refresh_continuous_aggregate('drop_chunks_view', NULL, (integer_now_test2()-9));
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
                drop_chunks                
@@ -521,7 +531,7 @@ SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
  _timescaledb_internal._hyper_10_14_chunk
  _timescaledb_internal._hyper_10_15_chunk
 
---new values on 25 now seen in view
+--new values on 25 are seen because of the refresh, but new value on 31 is not
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
  time_bucket | max 
 -------------+-----

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -472,8 +472,20 @@ AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1 WITH NO DATA;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
---dropping chunks will process the invalidations
+-- chunks that contain data that hasn't been refreshed yet i.e. after the watermark will not be dropped unless force is specified
+-- drop_chunks does not process invalidations on drop
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
+NOTICE:  skipping _timescaledb_internal._hyper_10_13_chunk, chunk contains data required for a continuous aggregate refresh
+ drop_chunks 
+-------------
+
+SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
+ time | data 
+------+------
+    0 |    0
+
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), force => true);
+WARNING:  _timescaledb_internal._hyper_10_13_chunk contained data required for continuous aggregate refresh
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_10_13_chunk
@@ -485,10 +497,8 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 CALL refresh_continuous_aggregate('drop_chunks_view', 10, 40);
---this will be seen after the drop its within the invalidation window and will be dropped
 INSERT INTO drop_chunks_table VALUES (26, 100);
---this will not be processed by the drop since chunk 30-39 is not dropped but will be seen after refresh
---shows that the drop doesn't do more work than necessary
+-- Invalidation on 31 will not be seen in the CAgg after the drop
 INSERT INTO drop_chunks_table VALUES (31, 200);
 --move the time up to 39
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(35, 39) AS i;
@@ -513,7 +523,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
           15 |  19
           10 |  14
 
---refresh to process the invalidations and then drop
+--refresh to process the invalidations till 30 and then drop
 CALL refresh_continuous_aggregate('drop_chunks_view', NULL, (integer_now_test2()-9));
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
                drop_chunks                
@@ -521,7 +531,7 @@ SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
  _timescaledb_internal._hyper_10_14_chunk
  _timescaledb_internal._hyper_10_15_chunk
 
---new values on 25 now seen in view
+--new values on 25 are seen because of the refresh, but new value on 31 is not
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
  time_bucket | max 
 -------------+-----

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -472,8 +472,20 @@ AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1 WITH NO DATA;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
---dropping chunks will process the invalidations
+-- chunks that contain data that hasn't been refreshed yet i.e. after the watermark will not be dropped unless force is specified
+-- drop_chunks does not process invalidations on drop
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
+NOTICE:  skipping _timescaledb_internal._hyper_10_13_chunk, chunk contains data required for a continuous aggregate refresh
+ drop_chunks 
+-------------
+
+SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
+ time | data 
+------+------
+    0 |    0
+
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), force => true);
+WARNING:  _timescaledb_internal._hyper_10_13_chunk contained data required for continuous aggregate refresh
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_10_13_chunk
@@ -485,10 +497,8 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 CALL refresh_continuous_aggregate('drop_chunks_view', 10, 40);
---this will be seen after the drop its within the invalidation window and will be dropped
 INSERT INTO drop_chunks_table VALUES (26, 100);
---this will not be processed by the drop since chunk 30-39 is not dropped but will be seen after refresh
---shows that the drop doesn't do more work than necessary
+-- Invalidation on 31 will not be seen in the CAgg after the drop
 INSERT INTO drop_chunks_table VALUES (31, 200);
 --move the time up to 39
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(35, 39) AS i;
@@ -513,7 +523,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
           15 |  19
           10 |  14
 
---refresh to process the invalidations and then drop
+--refresh to process the invalidations till 30 and then drop
 CALL refresh_continuous_aggregate('drop_chunks_view', NULL, (integer_now_test2()-9));
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
                drop_chunks                
@@ -521,7 +531,7 @@ SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
  _timescaledb_internal._hyper_10_14_chunk
  _timescaledb_internal._hyper_10_15_chunk
 
---new values on 25 now seen in view
+--new values on 25 are seen because of the refresh, but new value on 31 is not
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
  time_bucket | max 
 -------------+-----

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -472,8 +472,20 @@ AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1 WITH NO DATA;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
---dropping chunks will process the invalidations
+-- chunks that contain data that hasn't been refreshed yet i.e. after the watermark will not be dropped unless force is specified
+-- drop_chunks does not process invalidations on drop
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
+NOTICE:  skipping _timescaledb_internal._hyper_10_13_chunk, chunk contains data required for a continuous aggregate refresh
+ drop_chunks 
+-------------
+
+SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
+ time | data 
+------+------
+    0 |    0
+
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), force => true);
+WARNING:  _timescaledb_internal._hyper_10_13_chunk contained data required for continuous aggregate refresh
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_10_13_chunk
@@ -485,10 +497,8 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 CALL refresh_continuous_aggregate('drop_chunks_view', 10, 40);
---this will be seen after the drop its within the invalidation window and will be dropped
 INSERT INTO drop_chunks_table VALUES (26, 100);
---this will not be processed by the drop since chunk 30-39 is not dropped but will be seen after refresh
---shows that the drop doesn't do more work than necessary
+-- Invalidation on 31 will not be seen in the CAgg after the drop
 INSERT INTO drop_chunks_table VALUES (31, 200);
 --move the time up to 39
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(35, 39) AS i;
@@ -513,7 +523,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
           15 |  19
           10 |  14
 
---refresh to process the invalidations and then drop
+--refresh to process the invalidations till 30 and then drop
 CALL refresh_continuous_aggregate('drop_chunks_view', NULL, (integer_now_test2()-9));
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
                drop_chunks                
@@ -521,7 +531,7 @@ SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
  _timescaledb_internal._hyper_10_14_chunk
  _timescaledb_internal._hyper_10_15_chunk
 
---new values on 25 now seen in view
+--new values on 25 are seen because of the refresh, but new value on 31 is not
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
  time_bucket | max 
 -------------+-----

--- a/tsl/test/expected/cagg_drop_chunks.out
+++ b/tsl/test/expected/cagg_drop_chunks.out
@@ -281,3 +281,736 @@ SELECT * FROM conditions_2 ORDER BY bucket;
      18 |   5 |     2
 
 DROP PROCEDURE refresh_cagg_by_chunk_range(REGCLASS, REGCLASS, INTEGER);
+--
+-- Test drop_chunks with continuous aggregates and watermark protection
+--
+CREATE TABLE sensor_data (
+    time TIMESTAMPTZ NOT NULL,
+    sensor_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    pressure DOUBLE PRECISION
+);
+SELECT create_hypertable('sensor_data', 'time',
+    chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable     
+--------------------------
+ (5,public,sensor_data,t)
+
+INSERT INTO sensor_data
+SELECT
+    timestamp '2024-01-01' + (i * INTERVAL '4 hours') AS time,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(0, 25) AS i;
+CREATE MATERIALIZED VIEW sensor_hourly_avg
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 hour', time) AS bucket,
+    sensor_id,
+    AVG(temperature) AS avg_temperature,
+    AVG(humidity) AS avg_humidity,
+    AVG(pressure) AS avg_pressure,
+    COUNT(*) AS reading_count
+FROM sensor_data
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+-- Checks range start and end for chunks
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_71_chunk | Sun Dec 31 16:00:00 2023 PST | Mon Jan 01 16:00:00 2024 PST
+ _hyper_5_72_chunk | Mon Jan 01 16:00:00 2024 PST | Tue Jan 02 16:00:00 2024 PST
+ _hyper_5_73_chunk | Tue Jan 02 16:00:00 2024 PST | Wed Jan 03 16:00:00 2024 PST
+ _hyper_5_74_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+
+-- Completely refresh the aggregate
+CALL refresh_continuous_aggregate('sensor_hourly_avg', NULL, NULL);
+SELECT count(*) AS ht_before FROM show_chunks('sensor_data');
+ ht_before 
+-----------
+         5
+
+-- Insert more data after the CAgg watermark
+INSERT INTO sensor_data
+SELECT
+    timestamp '2024-02-01' + (i * INTERVAL '4 hours') AS time,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(0, 25) AS i;
+-- View ranges before drop chunks
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_71_chunk | Sun Dec 31 16:00:00 2023 PST | Mon Jan 01 16:00:00 2024 PST
+ _hyper_5_72_chunk | Mon Jan 01 16:00:00 2024 PST | Tue Jan 02 16:00:00 2024 PST
+ _hyper_5_73_chunk | Tue Jan 02 16:00:00 2024 PST | Wed Jan 03 16:00:00 2024 PST
+ _hyper_5_74_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+-- Verify watermark
+SELECT h.id AS mat_hypertable_id
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_hourly_avg' \gset
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id));
+         to_timestamp         
+------------------------------
+ Fri Jan 05 05:00:00 2024 PST
+
+\set VERBOSITY terse
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2023-12-31 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_79_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_80_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_81_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             4
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+-- Chunk with unrefreshed data can be dropped directly using DROP TABLE ...
+BEGIN;
+SELECT format('%I.%I', chunk_schema, chunk_name) AS chunk_to_drop
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start LIMIT 1 \gset
+SELECT :'chunk_to_drop' AS dropped_chunk;
+              dropped_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_71_chunk
+
+DROP TABLE :chunk_to_drop;
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_72_chunk | Mon Jan 01 16:00:00 2024 PST | Tue Jan 02 16:00:00 2024 PST
+ _hyper_5_73_chunk | Tue Jan 02 16:00:00 2024 PST | Wed Jan 03 16:00:00 2024 PST
+ _hyper_5_74_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', older_than => '2024-02-05 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_79_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_80_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_81_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             4
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-02 17:00:00-07'::timestamp with time zone, older_than => '2024-02-02 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             2
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_71_chunk | Sun Dec 31 16:00:00 2023 PST | Mon Jan 01 16:00:00 2024 PST
+ _hyper_5_72_chunk | Mon Jan 01 16:00:00 2024 PST | Tue Jan 02 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+-- Test force option
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2023-01-05 17:00:00-07'::timestamp with time zone, force => true);
+WARNING:  _timescaledb_internal._hyper_5_75_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_77_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_78_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_79_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_80_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_81_chunk contained data required for continuous aggregate refresh
+ dropped_count 
+---------------
+            10
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ chunk_name | range_start | range_end 
+------------+-------------+-----------
+
+ROLLBACK;
+\set VERBOSITY default
+--
+-- Test with multiple continuous aggregates to verify earliest watermark is used
+--
+-- Create a second continuous aggregate on the same hypertable (NOT hierarchical cagg)
+CREATE MATERIALIZED VIEW sensor_daily_avg
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    sensor_id,
+    AVG(temperature) AS avg_temperature,
+    AVG(humidity) AS avg_humidity,
+    AVG(pressure) AS avg_pressure,
+    COUNT(*) AS reading_count
+FROM sensor_data
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+-- Refresh the second aggregate partially to a different point
+CALL refresh_continuous_aggregate('sensor_daily_avg', '2024-01-01', '2024-01-03');
+SELECT h.id AS mat_hypertable_id_daily
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_daily_avg' \gset
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS hourly_watermark;
+       hourly_watermark       
+------------------------------
+ Fri Jan 05 05:00:00 2024 PST
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily)) AS daily_watermark;
+       daily_watermark        
+------------------------------
+ Tue Jan 02 16:00:00 2024 PST
+
+\set VERBOSITY terse
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', older_than => '2024-02-05 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_73_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_74_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_79_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_80_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_81_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             2
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_73_chunk | Tue Jan 02 16:00:00 2024 PST | Wed Jan 03 16:00:00 2024 PST
+ _hyper_5_74_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-01 17:00:00-07'::timestamp with time zone, older_than => '2024-02-02 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_73_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_74_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             1
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_71_chunk | Sun Dec 31 16:00:00 2023 PST | Mon Jan 01 16:00:00 2024 PST
+ _hyper_5_73_chunk | Tue Jan 02 16:00:00 2024 PST | Wed Jan 03 16:00:00 2024 PST
+ _hyper_5_74_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+\set VERBOSITY default
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-05 17:00:00-07'::timestamp with time zone, force => true);
+WARNING:  _timescaledb_internal._hyper_5_77_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_78_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_79_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_80_chunk contained data required for continuous aggregate refresh
+WARNING:  _timescaledb_internal._hyper_5_81_chunk contained data required for continuous aggregate refresh
+ dropped_count 
+---------------
+             5
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_71_chunk | Sun Dec 31 16:00:00 2023 PST | Mon Jan 01 16:00:00 2024 PST
+ _hyper_5_72_chunk | Mon Jan 01 16:00:00 2024 PST | Tue Jan 02 16:00:00 2024 PST
+ _hyper_5_73_chunk | Tue Jan 02 16:00:00 2024 PST | Wed Jan 03 16:00:00 2024 PST
+ _hyper_5_74_chunk | Wed Jan 03 16:00:00 2024 PST | Thu Jan 04 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+
+ROLLBACK;
+\set VERBOSITY default
+DROP MATERIALIZED VIEW sensor_daily_avg;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_7_82_chunk
+--
+-- Test with hierarchical continuous aggregate
+--
+-- Create hierarchical cagg
+CREATE MATERIALIZED VIEW sensor_daily_avg_hier
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', bucket) AS bucket,
+    sensor_id,
+    AVG(avg_temperature) AS avg_temperature,
+    AVG(avg_humidity) AS avg_humidity,
+    AVG(avg_pressure) AS avg_pressure,
+    SUM(reading_count) AS reading_count
+FROM sensor_hourly_avg
+GROUP BY time_bucket('1 day', bucket), sensor_id
+WITH NO DATA;
+-- Refresh the hierarchical aggregate partially
+CALL refresh_continuous_aggregate('sensor_daily_avg_hier', NULL, '2024-01-03');
+-- Verify watermarks
+SELECT h.id AS mat_hypertable_id_daily_hier
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_daily_avg_hier' \gset
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS hourly_watermark;
+       hourly_watermark       
+------------------------------
+ Fri Jan 05 05:00:00 2024 PST
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily_hier)) AS daily_hierarchical_watermark;
+ daily_hierarchical_watermark 
+------------------------------
+ Tue Jan 02 16:00:00 2024 PST
+
+\set VERBOSITY terse
+BEGIN;
+-- With hierarchical cagg, drop_chunks should still use the earliest watermark from the raw hypertable's caggs
+-- The hierarchical cagg watermark should not affect raw hypertable chunk retention
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', older_than => '2024-02-05 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_79_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_80_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_81_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             4
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-01 17:00:00-07'::timestamp with time zone, older_than => '2024-02-02 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_5_75_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_77_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_5_78_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             3
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_5_71_chunk | Sun Dec 31 16:00:00 2023 PST | Mon Jan 01 16:00:00 2024 PST
+ _hyper_5_75_chunk | Thu Jan 04 16:00:00 2024 PST | Fri Jan 05 16:00:00 2024 PST
+ _hyper_5_77_chunk | Wed Jan 31 16:00:00 2024 PST | Thu Feb 01 16:00:00 2024 PST
+ _hyper_5_78_chunk | Thu Feb 01 16:00:00 2024 PST | Fri Feb 02 16:00:00 2024 PST
+ _hyper_5_79_chunk | Fri Feb 02 16:00:00 2024 PST | Sat Feb 03 16:00:00 2024 PST
+ _hyper_5_80_chunk | Sat Feb 03 16:00:00 2024 PST | Sun Feb 04 16:00:00 2024 PST
+ _hyper_5_81_chunk | Sun Feb 04 16:00:00 2024 PST | Mon Feb 05 16:00:00 2024 PST
+
+ROLLBACK;
+\set VERBOSITY default
+-- Try drop_chunks on base cagg in the case of hierarchical caggs
+-- Here, the watermark of the hierarchical CAgg matters but the base CAgg watermark shouldn't affect it
+CALL refresh_continuous_aggregate('sensor_hourly_avg', NULL, NULL);
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS hourly_watermark;
+       hourly_watermark       
+------------------------------
+ Mon Feb 05 05:00:00 2024 PST
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily_hier)) AS daily_hierarchical_watermark;
+ daily_hierarchical_watermark 
+------------------------------
+ Tue Jan 02 16:00:00 2024 PST
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_hourly_avg', older_than => '2024-01-10 17:00:00-07'::timestamp with time zone);
+NOTICE:  skipping _timescaledb_internal._hyper_6_76_chunk, chunk contains data required for a continuous aggregate refresh
+HINT:  To drop this chunk, refresh all continuous aggregates on this hypertable till Sun Jan 07 16:00:00 2024 PST, or specify force=>true
+ dropped_count 
+---------------
+             0
+
+ SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = (
+      SELECT h.table_name
+      FROM _timescaledb_catalog.continuous_agg ca
+      JOIN _timescaledb_catalog.hypertable h ON
+  h.id = ca.mat_hypertable_id
+      WHERE ca.user_view_name = 'sensor_hourly_avg'
+  )
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_6_76_chunk | Thu Dec 28 16:00:00 2023 PST | Sun Jan 07 16:00:00 2024 PST
+ _hyper_6_84_chunk | Sat Jan 27 16:00:00 2024 PST | Tue Feb 06 16:00:00 2024 PST
+
+ROLLBACK;
+-- Test force option
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_hourly_avg', older_than => '2024-01-10 17:00:00-07'::timestamp with time zone, force => true);
+WARNING:  _timescaledb_internal._hyper_6_76_chunk contained data required for continuous aggregate refresh
+ dropped_count 
+---------------
+             1
+
+ SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = (
+      SELECT h.table_name
+      FROM _timescaledb_catalog.continuous_agg ca
+      JOIN _timescaledb_catalog.hypertable h ON
+  h.id = ca.mat_hypertable_id
+      WHERE ca.user_view_name = 'sensor_hourly_avg'
+  )
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_6_84_chunk | Sat Jan 27 16:00:00 2024 PST | Tue Feb 06 16:00:00 2024 PST
+
+ROLLBACK;
+-- Refresh hierarchical cagg completely
+CALL refresh_continuous_aggregate('sensor_daily_avg_hier', NULL, NULL);
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily_hier)) AS daily_hierarchical_watermark;
+ daily_hierarchical_watermark 
+------------------------------
+ Mon Feb 05 16:00:00 2024 PST
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_hourly_avg', older_than => '2024-01-10 17:00:00-07'::timestamp with time zone);
+ dropped_count 
+---------------
+             1
+
+ SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = (
+      SELECT h.table_name
+      FROM _timescaledb_catalog.continuous_agg ca
+      JOIN _timescaledb_catalog.hypertable h ON
+  h.id = ca.mat_hypertable_id
+      WHERE ca.user_view_name = 'sensor_hourly_avg'
+  )
+  ORDER BY range_start;
+    chunk_name     |         range_start          |          range_end           
+-------------------+------------------------------+------------------------------
+ _hyper_6_84_chunk | Sat Jan 27 16:00:00 2024 PST | Tue Feb 06 16:00:00 2024 PST
+
+ROLLBACK;
+DROP MATERIALIZED VIEW sensor_daily_avg_hier;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_8_83_chunk
+drop cascades to table _timescaledb_internal._hyper_8_85_chunk
+DROP MATERIALIZED VIEW sensor_hourly_avg;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_6_76_chunk
+drop cascades to table _timescaledb_internal._hyper_6_84_chunk
+DROP TABLE sensor_data;
+--
+-- Test drop_chunks with integer time continuous aggregates
+--
+CREATE OR REPLACE FUNCTION integer_now_sensor_data() returns INT LANGUAGE SQL STABLE as
+    $$ SELECT 150 $$;
+CREATE TABLE sensor_data_int (
+    time_int INT NOT NULL,
+    sensor_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    pressure DOUBLE PRECISION
+);
+SELECT create_hypertable('sensor_data_int', 'time_int',
+    chunk_time_interval => 10
+);
+      create_hypertable       
+------------------------------
+ (9,public,sensor_data_int,t)
+
+SELECT set_integer_now_func('sensor_data_int', 'integer_now_sensor_data');
+ set_integer_now_func 
+----------------------
+ 
+
+INSERT INTO sensor_data_int
+SELECT
+    i AS time_int,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(0, 99, 4) AS i;
+CREATE MATERIALIZED VIEW sensor_hourly_avg_int
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket(5, time_int) AS bucket,
+    sensor_id,
+    AVG(temperature) AS avg_temperature,
+    AVG(humidity) AS avg_humidity,
+    AVG(pressure) AS avg_pressure,
+    COUNT(*) AS reading_count
+FROM sensor_data_int
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+-- Check range start and end for chunks
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+    chunk_name     | range_start_integer | range_end_integer 
+-------------------+---------------------+-------------------
+ _hyper_9_86_chunk |                   0 |                10
+ _hyper_9_87_chunk |                  10 |                20
+ _hyper_9_88_chunk |                  20 |                30
+ _hyper_9_89_chunk |                  30 |                40
+ _hyper_9_90_chunk |                  40 |                50
+ _hyper_9_91_chunk |                  50 |                60
+ _hyper_9_92_chunk |                  60 |                70
+ _hyper_9_93_chunk |                  70 |                80
+ _hyper_9_94_chunk |                  80 |                90
+ _hyper_9_95_chunk |                  90 |               100
+
+-- Refresh the aggregate completely
+CALL refresh_continuous_aggregate('sensor_hourly_avg_int', NULL, NULL);
+SELECT count(*) AS ht_before FROM show_chunks('sensor_data_int');
+ ht_before 
+-----------
+        10
+
+-- Insert more data after the CAgg watermark
+INSERT INTO sensor_data_int
+SELECT
+    i AS time_int,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(100, 199, 4) AS i;
+-- View ranges before drop chunks
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+     chunk_name     | range_start_integer | range_end_integer 
+--------------------+---------------------+-------------------
+ _hyper_9_86_chunk  |                   0 |                10
+ _hyper_9_87_chunk  |                  10 |                20
+ _hyper_9_88_chunk  |                  20 |                30
+ _hyper_9_89_chunk  |                  30 |                40
+ _hyper_9_90_chunk  |                  40 |                50
+ _hyper_9_91_chunk  |                  50 |                60
+ _hyper_9_92_chunk  |                  60 |                70
+ _hyper_9_93_chunk  |                  70 |                80
+ _hyper_9_94_chunk  |                  80 |                90
+ _hyper_9_95_chunk  |                  90 |               100
+ _hyper_9_97_chunk  |                 100 |               110
+ _hyper_9_98_chunk  |                 110 |               120
+ _hyper_9_99_chunk  |                 120 |               130
+ _hyper_9_100_chunk |                 130 |               140
+ _hyper_9_101_chunk |                 140 |               150
+ _hyper_9_102_chunk |                 150 |               160
+ _hyper_9_103_chunk |                 160 |               170
+ _hyper_9_104_chunk |                 170 |               180
+ _hyper_9_105_chunk |                 180 |               190
+ _hyper_9_106_chunk |                 190 |               200
+
+-- Verify watermark
+SELECT h.id AS mat_hypertable_id_int
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_hourly_avg_int' \gset
+SELECT _timescaledb_functions.cagg_watermark(:mat_hypertable_id_int);
+ cagg_watermark 
+----------------
+            100
+
+\set VERBOSITY terse
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data_int', newer_than => 0);
+NOTICE:  skipping _timescaledb_internal._hyper_9_97_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_98_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_99_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_100_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_101_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_102_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_103_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_104_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_105_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_106_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+            10
+
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+     chunk_name     | range_start_integer | range_end_integer 
+--------------------+---------------------+-------------------
+ _hyper_9_97_chunk  |                 100 |               110
+ _hyper_9_98_chunk  |                 110 |               120
+ _hyper_9_99_chunk  |                 120 |               130
+ _hyper_9_100_chunk |                 130 |               140
+ _hyper_9_101_chunk |                 140 |               150
+ _hyper_9_102_chunk |                 150 |               160
+ _hyper_9_103_chunk |                 160 |               170
+ _hyper_9_104_chunk |                 170 |               180
+ _hyper_9_105_chunk |                 180 |               190
+ _hyper_9_106_chunk |                 190 |               200
+
+ROLLBACK;
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data_int', older_than => 120);
+NOTICE:  skipping _timescaledb_internal._hyper_9_97_chunk, chunk contains data required for a continuous aggregate refresh
+NOTICE:  skipping _timescaledb_internal._hyper_9_98_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+            10
+
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+     chunk_name     | range_start_integer | range_end_integer 
+--------------------+---------------------+-------------------
+ _hyper_9_97_chunk  |                 100 |               110
+ _hyper_9_98_chunk  |                 110 |               120
+ _hyper_9_99_chunk  |                 120 |               130
+ _hyper_9_100_chunk |                 130 |               140
+ _hyper_9_101_chunk |                 140 |               150
+ _hyper_9_102_chunk |                 150 |               160
+ _hyper_9_103_chunk |                 160 |               170
+ _hyper_9_104_chunk |                 170 |               180
+ _hyper_9_105_chunk |                 180 |               190
+ _hyper_9_106_chunk |                 190 |               200
+
+ROLLBACK;
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data_int', newer_than => 10, older_than => 110);
+NOTICE:  skipping _timescaledb_internal._hyper_9_97_chunk, chunk contains data required for a continuous aggregate refresh
+ dropped_count 
+---------------
+             9
+
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+     chunk_name     | range_start_integer | range_end_integer 
+--------------------+---------------------+-------------------
+ _hyper_9_86_chunk  |                   0 |                10
+ _hyper_9_97_chunk  |                 100 |               110
+ _hyper_9_98_chunk  |                 110 |               120
+ _hyper_9_99_chunk  |                 120 |               130
+ _hyper_9_100_chunk |                 130 |               140
+ _hyper_9_101_chunk |                 140 |               150
+ _hyper_9_102_chunk |                 150 |               160
+ _hyper_9_103_chunk |                 160 |               170
+ _hyper_9_104_chunk |                 170 |               180
+ _hyper_9_105_chunk |                 180 |               190
+ _hyper_9_106_chunk |                 190 |               200
+
+ROLLBACK;
+\set VERBOSITY default
+DROP MATERIALIZED VIEW sensor_hourly_avg_int;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_96_chunk
+DROP TABLE sensor_data_int;

--- a/tsl/test/expected/cagg_migrate.out
+++ b/tsl/test/expected/cagg_migrate.out
@@ -1,0 +1,3092 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- ########################################################
+-- ## INTEGER data type tests
+-- ########################################################
+\set IS_TIME_DIMENSION FALSE
+\set TIME_DIMENSION_DATATYPE INTEGER
+\ir include/cagg_migrate_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Setup some variables
+SELECT
+    format('../data/cagg_migrate_%1$s.sql', lower(:'TIME_DIMENSION_DATATYPE')) AS "TEST_SCHEMA_FILE"
+\gset
+-- restore dump
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+
+\ir :TEST_SCHEMA_FILE
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE public.conditions (
+    "time" integer NOT NULL,
+    temperature numeric
+);
+CREATE VIEW _timescaledb_internal._direct_view_2 AS
+ SELECT public.time_bucket(24, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket(24, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_3 AS
+ SELECT public.time_bucket(24, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket(24, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_4 AS
+ SELECT public.time_bucket(168, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket(168, "time"));
+CREATE TABLE _timescaledb_internal._materialized_hypertable_2 (
+    bucket integer NOT NULL,
+    min numeric,
+    max numeric,
+    avg numeric,
+    sum numeric
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_3 (
+    bucket integer NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_4 (
+    bucket integer NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE VIEW _timescaledb_internal._partial_view_2 AS
+ SELECT public.time_bucket(24, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket(24, "time"));
+CREATE VIEW _timescaledb_internal._partial_view_3 AS
+ SELECT public.time_bucket(24, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket(24, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW _timescaledb_internal._partial_view_4 AS
+ SELECT public.time_bucket(168, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket(168, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW public.conditions_summary_daily AS
+ SELECT _materialized_hypertable_3.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_3
+  WHERE (_materialized_hypertable_3.bucket < COALESCE((_timescaledb_functions.cagg_watermark(3))::integer, '-2147483648'::integer))
+  GROUP BY _materialized_hypertable_3.bucket
+UNION ALL
+ SELECT public.time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE((_timescaledb_functions.cagg_watermark(3))::integer, '-2147483648'::integer))
+  GROUP BY (public.time_bucket(24, conditions."time"));
+CREATE VIEW public.conditions_summary_daily_new AS
+ SELECT _materialized_hypertable_2.bucket,
+    _materialized_hypertable_2.min,
+    _materialized_hypertable_2.max,
+    _materialized_hypertable_2.avg,
+    _materialized_hypertable_2.sum
+   FROM _timescaledb_internal._materialized_hypertable_2
+  WHERE (_materialized_hypertable_2.bucket < COALESCE((_timescaledb_functions.cagg_watermark(2))::integer, '-2147483648'::integer))
+UNION ALL
+ SELECT public.time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE((_timescaledb_functions.cagg_watermark(2))::integer, '-2147483648'::integer))
+  GROUP BY (public.time_bucket(24, conditions."time"));
+CREATE VIEW public.conditions_summary_weekly AS
+ SELECT _materialized_hypertable_4.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_4.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_4.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE (_materialized_hypertable_4.bucket < COALESCE((_timescaledb_functions.cagg_watermark(4))::integer, '-2147483648'::integer))
+  GROUP BY _materialized_hypertable_4.bucket
+UNION ALL
+ SELECT public.time_bucket(168, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE((_timescaledb_functions.cagg_watermark(4))::integer, '-2147483648'::integer))
+  GROUP BY (public.time_bucket(168, conditions."time"));
+COPY _timescaledb_catalog.hypertable (id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name, chunk_target_size, compression_state, compressed_hypertable_id, status) FROM stdin;
+COPY _timescaledb_catalog.dimension (id, hypertable_id, column_name, column_type, aligned, num_slices, partitioning_func_schema, partitioning_func, interval_length, compress_interval_length, integer_now_func_schema, integer_now_func) FROM stdin;
+COPY _timescaledb_catalog.continuous_agg (mat_hypertable_id, raw_hypertable_id, parent_mat_hypertable_id, user_view_schema, user_view_name, partial_view_schema, partial_view_name, direct_view_schema, direct_view_name, materialized_only, finalized) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_bucket_function (mat_hypertable_id, bucket_func, bucket_width, bucket_fixed_width) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_invalidation_threshold (hypertable_id, watermark) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value, greatest_modified_value) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark) FROM stdin;
+SELECT pg_catalog.setval('_timescaledb_catalog.dimension_id_seq', 4, true);
+ setval 
+--------
+      4
+
+SELECT pg_catalog.setval('_timescaledb_catalog.hypertable_id_seq', 4, true);
+ setval 
+--------
+      4
+
+CREATE INDEX _materialized_hypertable_2_bucket_idx ON _timescaledb_internal._materialized_hypertable_2 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_3_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_4_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING btree (bucket DESC);
+CREATE INDEX conditions_time_idx ON public.conditions USING btree ("time" DESC);
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+
+-- Make sure no scheduled job will be executed during the regression tests
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+
+\if :IS_TIME_DIMENSION
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series('2022-01-01 00:00:00-00'::timestamptz, '2022-12-31 23:59:59-00'::timestamptz, '1 hour'),
+        0.25;
+\else
+    CREATE OR REPLACE FUNCTION integer_now()
+    RETURNS :TIME_DIMENSION_DATATYPE LANGUAGE SQL STABLE AS
+    $$
+        SELECT coalesce(max(time), 0)
+        FROM public.conditions
+    $$;
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series(1, 1000, 1),
+        0.25;
+\endif
+CALL refresh_continuous_aggregate('conditions_summary_daily', NULL, NULL);
+CALL refresh_continuous_aggregate('conditions_summary_weekly', NULL, NULL);
+\set ON_ERROR_STOP 0
+-- should fail because we don't need to migrate finalized caggs
+CALL cagg_migrate('conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:42: ERROR:  continuous aggregate "public.conditions_summary_daily_new" does not require any migration
+-- should fail relation does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+psql:include/cagg_migrate_common.sql:45: ERROR:  relation "conditions_summary_not_cagg" does not exist at character 19
+CREATE TABLE conditions_summary_not_cagg();
+-- should fail continuous agg does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+psql:include/cagg_migrate_common.sql:50: ERROR:  continuous aggregate "public.conditions_summary_not_cagg" does not exist
+\set ON_ERROR_STOP 1
+DROP TABLE conditions_summary_not_cagg;
+SELECT
+    ca.raw_hypertable_id AS "RAW_HYPERTABLE_ID",
+    h.schema_name AS "MAT_SCHEMA_NAME",
+    h.table_name AS "MAT_TABLE_NAME",
+    partial_view_name AS "PART_VIEW_NAME",
+    partial_view_schema AS "PART_VIEW_SCHEMA",
+    direct_view_name AS "DIR_VIEW_NAME",
+    direct_view_schema AS "DIR_VIEW_SCHEMA",
+    user_view_name AS "USER_VIEW_NAME",
+    user_view_schema AS "USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily'
+\gset
+\set ON_ERROR_STOP 0
+-- should fail because the new cagg with suffix '_new' already exists
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:74: ERROR:  continuous aggregate "public.conditions_summary_daily_new" already exists
+\set ON_ERROR_STOP 1
+-- remove the new cagg to execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+-- get and set all the cagg data
+SELECT
+    _timescaledb_functions.cagg_migrate_pre_validation(
+        'public',
+        'conditions_summary_daily',
+        'conditions_summary_daily_new'
+    ) AS "CAGG_DATA"
+\gset
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+\x on
+SELECT mat_hypertable_id, user_view_definition FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+-[ RECORD 1 ]--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+mat_hypertable_id    | 3
+user_view_definition |  SELECT _materialized_hypertable_3.bucket,                                                                                                                                                   +
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::numeric) AS min,+
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::numeric) AS max,+
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::numeric) AS avg,+
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::numeric) AS sum +
+                     |    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                     +
+                     |   WHERE (_materialized_hypertable_3.bucket < COALESCE((_timescaledb_functions.cagg_watermark(3))::integer, '-2147483648'::integer))                                                          +
+                     |   GROUP BY _materialized_hypertable_3.bucket                                                                                                                                                 +
+                     | UNION ALL                                                                                                                                                                                    +
+                     |  SELECT public.time_bucket(24, conditions."time") AS bucket,                                                                                                                                 +
+                     |     min(conditions.temperature) AS min,                                                                                                                                                      +
+                     |     max(conditions.temperature) AS max,                                                                                                                                                      +
+                     |     avg(conditions.temperature) AS avg,                                                                                                                                                      +
+                     |     sum(conditions.temperature) AS sum                                                                                                                                                       +
+                     |    FROM public.conditions                                                                                                                                                                    +
+                     |   WHERE (conditions."time" >= COALESCE((_timescaledb_functions.cagg_watermark(3))::integer, '-2147483648'::integer))                                                                         +
+                     |   GROUP BY (public.time_bucket(24, conditions."time"));
+
+\x off
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |   status    |       type       |                                                                         config                                                                          
+-------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | NOT STARTED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | NOT STARTED | DISABLE POLICIES | {"policies": null}
+                 3 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | NOT STARTED | COPY DATA        | {"end_ts": "240", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | NOT STARTED | COPY DATA        | {"end_ts": "480", "start_ts": "240", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | NOT STARTED | COPY DATA        | {"end_ts": "720", "start_ts": "480", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | NOT STARTED | COPY DATA        | {"end_ts": "960", "start_ts": "720", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | NOT STARTED | COPY DATA        | {"end_ts": "1200", "start_ts": "960", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | NOT STARTED | ENABLE POLICIES  | 
+
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:96: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:96: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('1008' AS integer), NULL);"
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "240", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "480", "start_ts": "240", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "720", "start_ts": "480", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "960", "start_ts": "720", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "1200", "start_ts": "960", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | ENABLE POLICIES  | 
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:101: ERROR:  plan already exists for materialized hypertable 3
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:102: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
+-- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+psql:include/cagg_migrate_common.sql:106: NOTICE:  defaulting compress_orderby to bucket
+\if :IS_TIME_DIMENSION
+SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
+\else
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
+ add_retention_policy 
+----------------------
+                 1000
+
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1001
+
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
+ add_compression_policy 
+------------------------
+                   1002
+
+\endif
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'USER_VIEW_SCHEMA'
+AND hypertable_name = :'USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule |                            config                             | next_start | initial_start | hypertable_schema |     hypertable_name      |      check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------------------------------------------------------+------------+---------------+-------------------+--------------------------+------------------------+-------------------------------------------
+   1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              | {"drop_after": 400, "hypertable_id": 3}                       |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_retention_check
+   1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_refresh_continuous_aggregate_check
+   1002 | Columnstore Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              | {"hypertable_id": 3, "compress_after": 100}                   |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_compression_check
+
+-- execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:125: NOTICE:  drop cascades to 10 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:126: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:127: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:127: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('1008' AS integer), NULL);"
+SELECT
+    ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
+    h.schema_name AS "NEW_MAT_SCHEMA_NAME",
+    h.table_name AS "NEW_MAT_TABLE_NAME",
+    partial_view_name AS "NEW_PART_VIEW_NAME",
+    partial_view_schema AS "NEW_PART_VIEW_SCHEMA",
+    direct_view_name AS "NEW_DIR_VIEW_NAME",
+    direct_view_schema AS "NEW_DIR_VIEW_SCHEMA",
+    user_view_name AS "NEW_USER_VIEW_NAME",
+    user_view_schema AS "NEW_USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily_new'
+\gset
+\d+ conditions_summary_daily_new
+                View "public.conditions_summary_daily_new"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ bucket | integer |           |          |         | plain   | 
+ min    | numeric |           |          |         | main    | 
+ max    | numeric |           |          |         | main    | 
+ avg    | numeric |           |          |         | main    | 
+ sum    | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _materialized_hypertable_7.min,
+    _materialized_hypertable_7.max,
+    _materialized_hypertable_7.avg,
+    _materialized_hypertable_7.sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_functions.cagg_watermark(7)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.cagg_watermark(7)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(24, conditions."time"));
+
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_USER_VIEW_SCHEMA'
+AND hypertable_name = :'NEW_USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule |                            config                             | next_start | initial_start | hypertable_schema |       hypertable_name        |      check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------------------------------------------------------+------------+---------------+-------------------+------------------------------+------------------------+-------------------------------------------
+   1003 | Retention Policy [1003]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              | {"drop_after": 400, "hypertable_id": 7}                       |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_retention_check
+   1004 | Refresh Continuous Aggregate Policy [1004] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 7} |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_refresh_continuous_aggregate_check
+   1005 | Columnstore Policy [1005]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              | {"hypertable_id": 7, "compress_after": 100}                   |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_compression_check
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1000, 1002]}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "240", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "480", "start_ts": "240", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "720", "start_ts": "480", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "960", "start_ts": "720", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "1200", "start_ts": "960", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | FINISHED | COPY POLICIES    | {"policies": [1000, 1001, 1002], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005, 1000, 1001, 1002]}
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_3_102_chunk
+ _timescaledb_internal._hyper_3_103_chunk
+ _timescaledb_internal._hyper_3_104_chunk
+ _timescaledb_internal._hyper_3_105_chunk
+ _timescaledb_internal._hyper_3_106_chunk
+ _timescaledb_internal._hyper_3_107_chunk
+ _timescaledb_internal._hyper_3_108_chunk
+ _timescaledb_internal._hyper_3_109_chunk
+ _timescaledb_internal._hyper_3_110_chunk
+ _timescaledb_internal._hyper_3_111_chunk
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_7_128_chunk
+ _timescaledb_internal._hyper_7_129_chunk
+ _timescaledb_internal._hyper_7_130_chunk
+ _timescaledb_internal._hyper_7_131_chunk
+ _timescaledb_internal._hyper_7_132_chunk
+ _timescaledb_internal._hyper_7_133_chunk
+ _timescaledb_internal._hyper_7_134_chunk
+ _timescaledb_internal._hyper_7_135_chunk
+ _timescaledb_internal._hyper_7_136_chunk
+ _timescaledb_internal._hyper_7_137_chunk
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+CREATE OR REPLACE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:177: NOTICE:  drop cascades to 10 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:178: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Columnstore Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_functions | policy_compression_check                  | 
+
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:181: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:181: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily', CAST('1008' AS integer), NULL);"
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                  View "public.conditions_summary_daily"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ bucket | integer |           |          |         | plain   | 
+ min    | numeric |           |          |         | main    | 
+ max    | numeric |           |          |         | main    | 
+ avg    | numeric |           |          |         | main    | 
+ sum    | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.min,
+    _materialized_hypertable_9.max,
+    _materialized_hypertable_9.avg,
+    _materialized_hypertable_9.sum
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_functions.cagg_watermark(9)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.cagg_watermark(9)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(24, conditions."time"));
+
+-- cagg with the old format because it was overriden
+\d+ conditions_summary_daily_old
+                View "public.conditions_summary_daily_old"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ bucket | integer |           |          |         | plain   | 
+ min    | numeric |           |          |         | main    | 
+ max    | numeric |           |          |         | main    | 
+ avg    | numeric |           |          |         | main    | 
+ sum    | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_3.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_3
+  WHERE _materialized_hypertable_3.bucket < COALESCE(_timescaledb_functions.cagg_watermark(3)::integer, '-2147483648'::integer)
+  GROUP BY _materialized_hypertable_3.bucket
+UNION ALL
+ SELECT time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.cagg_watermark(3)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(24, conditions."time"));
+
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:188: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1006 | Retention Policy [1006]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             9 | {"drop_after": 400, "hypertable_id": 9}                       | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1007 | Refresh Continuous Aggregate Policy [1007] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             9 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 9} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1008 | Columnstore Policy [1008]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             9 | {"hypertable_id": 9, "compress_after": 100}                   | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |      check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1002 | Columnstore Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- test migration overriding the new cagg and removing the old
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:198: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+psql:include/cagg_migrate_common.sql:199: NOTICE:  drop cascades to 10 other objects
+ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Columnstore Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_functions | policy_compression_check                  | 
+
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
+psql:include/cagg_migrate_common.sql:203: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:203: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily', CAST('1008' AS integer), NULL);"
+psql:include/cagg_migrate_common.sql:203: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1000 not found, skipping
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1001 not found, skipping
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1002 not found, skipping
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                  View "public.conditions_summary_daily"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ bucket | integer |           |          |         | plain   | 
+ min    | numeric |           |          |         | main    | 
+ max    | numeric |           |          |         | main    | 
+ avg    | numeric |           |          |         | main    | 
+ sum    | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_11.bucket,
+    _materialized_hypertable_11.min,
+    _materialized_hypertable_11.max,
+    _materialized_hypertable_11.avg,
+    _materialized_hypertable_11.sum
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE _materialized_hypertable_11.bucket < COALESCE(_timescaledb_functions.cagg_watermark(11)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.cagg_watermark(11)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(24, conditions."time"));
+
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:208: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+-- should fail because the old cagg was removed
+SELECT * FROM conditions_summary_daily_old;
+psql:include/cagg_migrate_common.sql:210: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                             config                             |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+----------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1009 | Retention Policy [1009]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            11 | {"drop_after": 400, "hypertable_id": 11}                       | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1010 | Refresh Continuous Aggregate Policy [1010] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            11 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 11} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1011 | Columnstore Policy [1011]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            11 | {"hypertable_id": 11, "compress_after": 100}                   | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- permission tests
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:220: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
+ALTER MATERIALIZED VIEW conditions_summary_weekly OWNER TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:227: ERROR:  permission denied for table continuous_agg_migrate_plan
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:237: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:247: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- all necessary permissions granted
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:256: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_weekly_new', CAST('1008' AS integer), NULL);"
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_weekly
+EXCEPT
+SELECT * FROM conditions_summary_weekly_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                         
+-------------------+---------+----------+------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------
+                 4 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 4 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_weekly_new"}
+                 4 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 4 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_weekly_new", "window_start_type": "integer"}
+                 4 |       5 | FINISHED | COPY DATA        | {"end_ts": "1680", "start_ts": "0", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 4 |       6 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_weekly_new"}
+                 4 |       7 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_weekly_new"}
+                 4 |       8 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_weekly_new"}
+                 4 |       9 | FINISHED | ENABLE POLICIES  | 
+
+RESET ROLE;
+-- according to the official documentation trying to execute a procedure with
+-- transaction control statements inside an explicit transaction should fail:
+-- https://www.postgresql.org/docs/current/sql-call.html
+-- `If CALL is executed in a transaction block, then the called procedure cannot
+--  execute transaction control statements. Transaction control statements are only
+--  allowed if CALL is executed in its own transaction.`
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:273: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_weekly_new;
+psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other objects
+\set ON_ERROR_STOP 0
+BEGIN;
+-- should fail with `invalid transaction termination`
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:279: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+CREATE FUNCTION execute_migration() RETURNS void AS
+$$
+BEGIN
+    CALL cagg_migrate('conditions_summary_weekly');
+    RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+\set ON_ERROR_STOP 0
+-- execute migration inside a plpgsql function
+BEGIN;
+-- should fail with `invalid transaction termination`
+SELECT execute_migration();
+psql:include/cagg_migrate_common.sql:296: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+--
+-- test dropping chunks
+--
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+ chunk_name | dropped 
+------------+---------
+
+-- drop 1 chunk
+\if :IS_TIME_DIMENSION
+    SELECT drop_chunks('conditions', older_than => CAST('2022-01-08 00:00:00-00' AS :TIME_DIMENSION_DATATYPE), force=>true);
+\else
+    SELECT drop_chunks('conditions', older_than => 10, force=>true);
+psql:include/cagg_migrate_common.sql:316: WARNING:  _timescaledb_internal._hyper_1_1_chunk contained data required for continuous aggregate refresh
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+\endif
+-- now he have one chunk marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+    chunk_name    | dropped 
+------------------+---------
+ _hyper_1_1_chunk | t
+
+-- this migration should remove the chunk metadata marked as dropped
+CALL cagg_migrate('conditions_summary_weekly', override => TRUE, drop_old => TRUE);
+psql:include/cagg_migrate_common.sql:328: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_weekly', CAST('1008' AS integer), NULL);"
+psql:include/cagg_migrate_common.sql:328: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:328: INFO:  Removing metadata of chunk 1 from hypertable 1
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+ chunk_name | dropped 
+------------+---------
+
+-- cleanup
+DROP FUNCTION execute_migration();
+REVOKE SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan FROM :ROLE_DEFAULT_PERM_USER;
+REVOKE USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq FROM :ROLE_DEFAULT_PERM_USER;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:342: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+psql:include/cagg_migrate_common.sql:343: NOTICE:  drop cascades to 10 other objects
+DROP MATERIALIZED VIEW conditions_summary_weekly;
+psql:include/cagg_migrate_common.sql:344: NOTICE:  drop cascades to 6 other objects
+DROP TABLE conditions;
+SELECT _timescaledb_functions.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+
+-- ########################################################
+-- ## TIMESTAMP data type tests
+-- ########################################################
+\set IS_TIME_DIMENSION TRUE
+\set TIME_DIMENSION_DATATYPE TIMESTAMP
+\ir include/cagg_migrate_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Setup some variables
+SELECT
+    format('../data/cagg_migrate_%1$s.sql', lower(:'TIME_DIMENSION_DATATYPE')) AS "TEST_SCHEMA_FILE"
+\gset
+-- restore dump
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+
+\ir :TEST_SCHEMA_FILE
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE public.conditions (
+    "time" timestamp without time zone NOT NULL,
+    temperature numeric
+);
+CREATE VIEW _timescaledb_internal._direct_view_6 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_7 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_8 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time"));
+CREATE TABLE _timescaledb_internal._materialized_hypertable_6 (
+    bucket timestamp without time zone NOT NULL,
+    min numeric,
+    max numeric,
+    avg numeric,
+    sum numeric
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_7 (
+    bucket timestamp without time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_8 (
+    bucket timestamp without time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE VIEW _timescaledb_internal._partial_view_6 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._partial_view_7 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW _timescaledb_internal._partial_view_8 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW public.conditions_summary_daily AS
+ SELECT _materialized_hypertable_7.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE (_materialized_hypertable_7.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone))
+  GROUP BY _materialized_hypertable_7.bucket
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_daily_new AS
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.min,
+    _materialized_hypertable_6.max,
+    _materialized_hypertable_6.avg,
+    _materialized_hypertable_6.sum
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE (_materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp without time zone))
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp without time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_weekly AS
+ SELECT _materialized_hypertable_8.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_8
+  WHERE (_materialized_hypertable_8.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp without time zone))
+  GROUP BY _materialized_hypertable_8.bucket
+UNION ALL
+ SELECT public.time_bucket('7 days'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp without time zone))
+  GROUP BY (public.time_bucket('7 days'::interval, conditions."time"));
+COPY _timescaledb_catalog.hypertable (id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name, chunk_target_size, compression_state, compressed_hypertable_id, status) FROM stdin;
+COPY _timescaledb_catalog.dimension (id, hypertable_id, column_name, column_type, aligned, num_slices, partitioning_func_schema, partitioning_func, interval_length, compress_interval_length, integer_now_func_schema, integer_now_func) FROM stdin;
+COPY _timescaledb_catalog.continuous_agg (mat_hypertable_id, raw_hypertable_id, parent_mat_hypertable_id, user_view_schema, user_view_name, partial_view_schema, partial_view_name, direct_view_schema, direct_view_name, materialized_only, finalized) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_bucket_function (mat_hypertable_id, bucket_func, bucket_width, bucket_fixed_width) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_invalidation_threshold (hypertable_id, watermark) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value, greatest_modified_value) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark) FROM stdin;
+SELECT pg_catalog.setval('_timescaledb_catalog.dimension_id_seq', 8, true);
+ setval 
+--------
+      8
+
+SELECT pg_catalog.setval('_timescaledb_catalog.hypertable_id_seq', 8, true);
+ setval 
+--------
+      8
+
+CREATE INDEX _materialized_hypertable_6_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_7_bucket_idx ON _timescaledb_internal._materialized_hypertable_7 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_8_bucket_idx ON _timescaledb_internal._materialized_hypertable_8 USING btree (bucket DESC);
+CREATE INDEX conditions_time_idx ON public.conditions USING btree ("time" DESC);
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+
+-- Make sure no scheduled job will be executed during the regression tests
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+
+\if :IS_TIME_DIMENSION
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series('2022-01-01 00:00:00-00'::timestamptz, '2022-12-31 23:59:59-00'::timestamptz, '1 hour'),
+        0.25;
+\else
+    CREATE OR REPLACE FUNCTION integer_now()
+    RETURNS :TIME_DIMENSION_DATATYPE LANGUAGE SQL STABLE AS
+    $$
+        SELECT coalesce(max(time), 0)
+        FROM public.conditions
+    $$;
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series(1, 1000, 1),
+        0.25;
+\endif
+CALL refresh_continuous_aggregate('conditions_summary_daily', NULL, NULL);
+CALL refresh_continuous_aggregate('conditions_summary_weekly', NULL, NULL);
+\set ON_ERROR_STOP 0
+-- should fail because we don't need to migrate finalized caggs
+CALL cagg_migrate('conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:42: ERROR:  continuous aggregate "public.conditions_summary_daily_new" does not require any migration
+-- should fail relation does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+psql:include/cagg_migrate_common.sql:45: ERROR:  relation "conditions_summary_not_cagg" does not exist at character 19
+CREATE TABLE conditions_summary_not_cagg();
+-- should fail continuous agg does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+psql:include/cagg_migrate_common.sql:50: ERROR:  continuous aggregate "public.conditions_summary_not_cagg" does not exist
+\set ON_ERROR_STOP 1
+DROP TABLE conditions_summary_not_cagg;
+SELECT
+    ca.raw_hypertable_id AS "RAW_HYPERTABLE_ID",
+    h.schema_name AS "MAT_SCHEMA_NAME",
+    h.table_name AS "MAT_TABLE_NAME",
+    partial_view_name AS "PART_VIEW_NAME",
+    partial_view_schema AS "PART_VIEW_SCHEMA",
+    direct_view_name AS "DIR_VIEW_NAME",
+    direct_view_schema AS "DIR_VIEW_SCHEMA",
+    user_view_name AS "USER_VIEW_NAME",
+    user_view_schema AS "USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily'
+\gset
+\set ON_ERROR_STOP 0
+-- should fail because the new cagg with suffix '_new' already exists
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:74: ERROR:  continuous aggregate "public.conditions_summary_daily_new" already exists
+\set ON_ERROR_STOP 1
+-- remove the new cagg to execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+-- get and set all the cagg data
+SELECT
+    _timescaledb_functions.cagg_migrate_pre_validation(
+        'public',
+        'conditions_summary_daily',
+        'conditions_summary_daily_new'
+    ) AS "CAGG_DATA"
+\gset
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+\x on
+SELECT mat_hypertable_id, user_view_definition FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+-[ RECORD 1 ]--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+mat_hypertable_id    | 7
+user_view_definition |  SELECT _materialized_hypertable_7.bucket,                                                                                                                                                      +
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_2_2, NULL::numeric) AS min,   +
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_3_3, NULL::numeric) AS max,   +
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_4_4, NULL::numeric) AS avg,   +
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_5_5, NULL::numeric) AS sum    +
+                     |    FROM _timescaledb_internal._materialized_hypertable_7                                                                                                                                        +
+                     |   WHERE (_materialized_hypertable_7.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone))+
+                     |   GROUP BY _materialized_hypertable_7.bucket                                                                                                                                                    +
+                     | UNION ALL                                                                                                                                                                                       +
+                     |  SELECT public.time_bucket('@ 1 day'::interval, conditions."time") AS bucket,                                                                                                                   +
+                     |     min(conditions.temperature) AS min,                                                                                                                                                         +
+                     |     max(conditions.temperature) AS max,                                                                                                                                                         +
+                     |     avg(conditions.temperature) AS avg,                                                                                                                                                         +
+                     |     sum(conditions.temperature) AS sum                                                                                                                                                          +
+                     |    FROM public.conditions                                                                                                                                                                       +
+                     |   WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone))               +
+                     |   GROUP BY (public.time_bucket('@ 1 day'::interval, conditions."time"));
+
+\x off
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |   status    |       type       |                                                                                                   config                                                                                                   
+-------------------+---------+-------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 7 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "2023-01-01 00:00:00"}
+                 7 |       2 | NOT STARTED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 7 |       3 | NOT STARTED | DISABLE POLICIES | {"policies": null}
+                 7 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "2023-01-01 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp without time zone"}
+                 7 |       5 | NOT STARTED | COPY DATA        | {"end_ts": "2022-01-10 00:00:00", "start_ts": "2021-12-31 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       6 | NOT STARTED | COPY DATA        | {"end_ts": "2022-01-20 00:00:00", "start_ts": "2022-01-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       7 | NOT STARTED | COPY DATA        | {"end_ts": "2022-01-30 00:00:00", "start_ts": "2022-01-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       8 | NOT STARTED | COPY DATA        | {"end_ts": "2022-02-09 00:00:00", "start_ts": "2022-01-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       9 | NOT STARTED | COPY DATA        | {"end_ts": "2022-02-19 00:00:00", "start_ts": "2022-02-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      10 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-01 00:00:00", "start_ts": "2022-02-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      11 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-11 00:00:00", "start_ts": "2022-03-01 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      12 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-21 00:00:00", "start_ts": "2022-03-11 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      13 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-31 00:00:00", "start_ts": "2022-03-21 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      14 | NOT STARTED | COPY DATA        | {"end_ts": "2022-04-10 00:00:00", "start_ts": "2022-03-31 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      15 | NOT STARTED | COPY DATA        | {"end_ts": "2022-04-20 00:00:00", "start_ts": "2022-04-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      16 | NOT STARTED | COPY DATA        | {"end_ts": "2022-04-30 00:00:00", "start_ts": "2022-04-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      17 | NOT STARTED | COPY DATA        | {"end_ts": "2022-05-10 00:00:00", "start_ts": "2022-04-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      18 | NOT STARTED | COPY DATA        | {"end_ts": "2022-05-20 00:00:00", "start_ts": "2022-05-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      19 | NOT STARTED | COPY DATA        | {"end_ts": "2022-05-30 00:00:00", "start_ts": "2022-05-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      20 | NOT STARTED | COPY DATA        | {"end_ts": "2022-06-09 00:00:00", "start_ts": "2022-05-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      21 | NOT STARTED | COPY DATA        | {"end_ts": "2022-06-19 00:00:00", "start_ts": "2022-06-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      22 | NOT STARTED | COPY DATA        | {"end_ts": "2022-06-29 00:00:00", "start_ts": "2022-06-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      23 | NOT STARTED | COPY DATA        | {"end_ts": "2022-07-09 00:00:00", "start_ts": "2022-06-29 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      24 | NOT STARTED | COPY DATA        | {"end_ts": "2022-07-19 00:00:00", "start_ts": "2022-07-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      25 | NOT STARTED | COPY DATA        | {"end_ts": "2022-07-29 00:00:00", "start_ts": "2022-07-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      26 | NOT STARTED | COPY DATA        | {"end_ts": "2022-08-08 00:00:00", "start_ts": "2022-07-29 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      27 | NOT STARTED | COPY DATA        | {"end_ts": "2022-08-18 00:00:00", "start_ts": "2022-08-08 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      28 | NOT STARTED | COPY DATA        | {"end_ts": "2022-08-28 00:00:00", "start_ts": "2022-08-18 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      29 | NOT STARTED | COPY DATA        | {"end_ts": "2022-09-07 00:00:00", "start_ts": "2022-08-28 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      30 | NOT STARTED | COPY DATA        | {"end_ts": "2022-09-17 00:00:00", "start_ts": "2022-09-07 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      31 | NOT STARTED | COPY DATA        | {"end_ts": "2022-09-27 00:00:00", "start_ts": "2022-09-17 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      32 | NOT STARTED | COPY DATA        | {"end_ts": "2022-10-07 00:00:00", "start_ts": "2022-09-27 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      33 | NOT STARTED | COPY DATA        | {"end_ts": "2022-10-17 00:00:00", "start_ts": "2022-10-07 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      34 | NOT STARTED | COPY DATA        | {"end_ts": "2022-10-27 00:00:00", "start_ts": "2022-10-17 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      35 | NOT STARTED | COPY DATA        | {"end_ts": "2022-11-06 00:00:00", "start_ts": "2022-10-27 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      36 | NOT STARTED | COPY DATA        | {"end_ts": "2022-11-16 00:00:00", "start_ts": "2022-11-06 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      37 | NOT STARTED | COPY DATA        | {"end_ts": "2022-11-26 00:00:00", "start_ts": "2022-11-16 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      38 | NOT STARTED | COPY DATA        | {"end_ts": "2022-12-06 00:00:00", "start_ts": "2022-11-26 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      39 | NOT STARTED | COPY DATA        | {"end_ts": "2022-12-16 00:00:00", "start_ts": "2022-12-06 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      40 | NOT STARTED | COPY DATA        | {"end_ts": "2022-12-26 00:00:00", "start_ts": "2022-12-16 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      41 | NOT STARTED | COPY DATA        | {"end_ts": "2023-01-05 00:00:00", "start_ts": "2022-12-26 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      42 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      43 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      44 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      45 | NOT STARTED | ENABLE POLICIES  | 
+
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:96: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:96: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('2023-01-01 00:00:00' AS timestamp without time zone), NULL);"
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                   config                                                                                                   
+-------------------+---------+----------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 7 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "2023-01-01 00:00:00"}
+                 7 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 7 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 7 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "2023-01-01 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp without time zone"}
+                 7 |       5 | FINISHED | COPY DATA        | {"end_ts": "2022-01-10 00:00:00", "start_ts": "2021-12-31 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       6 | FINISHED | COPY DATA        | {"end_ts": "2022-01-20 00:00:00", "start_ts": "2022-01-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       7 | FINISHED | COPY DATA        | {"end_ts": "2022-01-30 00:00:00", "start_ts": "2022-01-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       8 | FINISHED | COPY DATA        | {"end_ts": "2022-02-09 00:00:00", "start_ts": "2022-01-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       9 | FINISHED | COPY DATA        | {"end_ts": "2022-02-19 00:00:00", "start_ts": "2022-02-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      10 | FINISHED | COPY DATA        | {"end_ts": "2022-03-01 00:00:00", "start_ts": "2022-02-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      11 | FINISHED | COPY DATA        | {"end_ts": "2022-03-11 00:00:00", "start_ts": "2022-03-01 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      12 | FINISHED | COPY DATA        | {"end_ts": "2022-03-21 00:00:00", "start_ts": "2022-03-11 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      13 | FINISHED | COPY DATA        | {"end_ts": "2022-03-31 00:00:00", "start_ts": "2022-03-21 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      14 | FINISHED | COPY DATA        | {"end_ts": "2022-04-10 00:00:00", "start_ts": "2022-03-31 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      15 | FINISHED | COPY DATA        | {"end_ts": "2022-04-20 00:00:00", "start_ts": "2022-04-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      16 | FINISHED | COPY DATA        | {"end_ts": "2022-04-30 00:00:00", "start_ts": "2022-04-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      17 | FINISHED | COPY DATA        | {"end_ts": "2022-05-10 00:00:00", "start_ts": "2022-04-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      18 | FINISHED | COPY DATA        | {"end_ts": "2022-05-20 00:00:00", "start_ts": "2022-05-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      19 | FINISHED | COPY DATA        | {"end_ts": "2022-05-30 00:00:00", "start_ts": "2022-05-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      20 | FINISHED | COPY DATA        | {"end_ts": "2022-06-09 00:00:00", "start_ts": "2022-05-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      21 | FINISHED | COPY DATA        | {"end_ts": "2022-06-19 00:00:00", "start_ts": "2022-06-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      22 | FINISHED | COPY DATA        | {"end_ts": "2022-06-29 00:00:00", "start_ts": "2022-06-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      23 | FINISHED | COPY DATA        | {"end_ts": "2022-07-09 00:00:00", "start_ts": "2022-06-29 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      24 | FINISHED | COPY DATA        | {"end_ts": "2022-07-19 00:00:00", "start_ts": "2022-07-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      25 | FINISHED | COPY DATA        | {"end_ts": "2022-07-29 00:00:00", "start_ts": "2022-07-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      26 | FINISHED | COPY DATA        | {"end_ts": "2022-08-08 00:00:00", "start_ts": "2022-07-29 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      27 | FINISHED | COPY DATA        | {"end_ts": "2022-08-18 00:00:00", "start_ts": "2022-08-08 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      28 | FINISHED | COPY DATA        | {"end_ts": "2022-08-28 00:00:00", "start_ts": "2022-08-18 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      29 | FINISHED | COPY DATA        | {"end_ts": "2022-09-07 00:00:00", "start_ts": "2022-08-28 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      30 | FINISHED | COPY DATA        | {"end_ts": "2022-09-17 00:00:00", "start_ts": "2022-09-07 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      31 | FINISHED | COPY DATA        | {"end_ts": "2022-09-27 00:00:00", "start_ts": "2022-09-17 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      32 | FINISHED | COPY DATA        | {"end_ts": "2022-10-07 00:00:00", "start_ts": "2022-09-27 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      33 | FINISHED | COPY DATA        | {"end_ts": "2022-10-17 00:00:00", "start_ts": "2022-10-07 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      34 | FINISHED | COPY DATA        | {"end_ts": "2022-10-27 00:00:00", "start_ts": "2022-10-17 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      35 | FINISHED | COPY DATA        | {"end_ts": "2022-11-06 00:00:00", "start_ts": "2022-10-27 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      36 | FINISHED | COPY DATA        | {"end_ts": "2022-11-16 00:00:00", "start_ts": "2022-11-06 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      37 | FINISHED | COPY DATA        | {"end_ts": "2022-11-26 00:00:00", "start_ts": "2022-11-16 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      38 | FINISHED | COPY DATA        | {"end_ts": "2022-12-06 00:00:00", "start_ts": "2022-11-26 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      39 | FINISHED | COPY DATA        | {"end_ts": "2022-12-16 00:00:00", "start_ts": "2022-12-06 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      40 | FINISHED | COPY DATA        | {"end_ts": "2022-12-26 00:00:00", "start_ts": "2022-12-16 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      41 | FINISHED | COPY DATA        | {"end_ts": "2023-01-05 00:00:00", "start_ts": "2022-12-26 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      42 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      43 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      44 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      45 | FINISHED | ENABLE POLICIES  | 
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:101: ERROR:  plan already exists for materialized hypertable 7
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:102: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
+-- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+psql:include/cagg_migrate_common.sql:106: NOTICE:  defaulting compress_orderby to bucket
+\if :IS_TIME_DIMENSION
+SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
+ add_retention_policy 
+----------------------
+                 1012
+
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1013
+
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
+ add_compression_policy 
+------------------------
+                   1014
+
+\else
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
+\endif
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'USER_VIEW_SCHEMA'
+AND hypertable_name = :'USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule |                                     config                                     | next_start | initial_start | hypertable_schema |     hypertable_name      |      check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+--------------------------------------------------------------------------------+------------+---------------+-------------------+--------------------------+------------------------+-------------------------------------------
+   1012 | Retention Policy [1012]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 7}                                |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_retention_check
+   1013 | Refresh Continuous Aggregate Policy [1013] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 7} |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_refresh_continuous_aggregate_check
+   1014 | Columnstore Policy [1014]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              | {"hypertable_id": 7, "compress_after": "@ 45 days"}                            |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_compression_check
+
+-- execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:125: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:126: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:127: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:127: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('2023-01-01 00:00:00' AS timestamp without time zone), NULL);"
+SELECT
+    ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
+    h.schema_name AS "NEW_MAT_SCHEMA_NAME",
+    h.table_name AS "NEW_MAT_TABLE_NAME",
+    partial_view_name AS "NEW_PART_VIEW_NAME",
+    partial_view_schema AS "NEW_PART_VIEW_SCHEMA",
+    direct_view_name AS "NEW_DIR_VIEW_NAME",
+    direct_view_schema AS "NEW_DIR_VIEW_SCHEMA",
+    user_view_name AS "NEW_USER_VIEW_NAME",
+    user_view_schema AS "NEW_USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily_new'
+\gset
+\d+ conditions_summary_daily_new
+                          View "public.conditions_summary_daily_new"
+ Column |            Type             | Collation | Nullable | Default | Storage | Description 
+--------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp without time zone |           |          |         | plain   | 
+ min    | numeric                     |           |          |         | main    | 
+ max    | numeric                     |           |          |         | main    | 
+ avg    | numeric                     |           |          |         | main    | 
+ sum    | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_11.bucket,
+    _materialized_hypertable_11.min,
+    _materialized_hypertable_11.max,
+    _materialized_hypertable_11.avg,
+    _materialized_hypertable_11.sum
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE _materialized_hypertable_11.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_USER_VIEW_SCHEMA'
+AND hypertable_name = :'NEW_USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule |                                     config                                      | next_start | initial_start | hypertable_schema |       hypertable_name        |      check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------------------------------------------------------------------------+------------+---------------+-------------------+------------------------------+------------------------+-------------------------------------------
+   1015 | Retention Policy [1015]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 11}                                |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_retention_check
+   1016 | Refresh Continuous Aggregate Policy [1016] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 11} |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_refresh_continuous_aggregate_check
+   1017 | Columnstore Policy [1017]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              | {"hypertable_id": 11, "compress_after": "@ 45 days"}                            |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_compression_check
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                   config                                                                                                   
+-------------------+---------+----------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 7 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "2023-01-01 00:00:00"}
+                 7 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 7 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1012, 1014]}
+                 7 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "2023-01-01 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp without time zone"}
+                 7 |       5 | FINISHED | COPY DATA        | {"end_ts": "2022-01-10 00:00:00", "start_ts": "2021-12-31 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       6 | FINISHED | COPY DATA        | {"end_ts": "2022-01-20 00:00:00", "start_ts": "2022-01-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       7 | FINISHED | COPY DATA        | {"end_ts": "2022-01-30 00:00:00", "start_ts": "2022-01-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       8 | FINISHED | COPY DATA        | {"end_ts": "2022-02-09 00:00:00", "start_ts": "2022-01-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |       9 | FINISHED | COPY DATA        | {"end_ts": "2022-02-19 00:00:00", "start_ts": "2022-02-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      10 | FINISHED | COPY DATA        | {"end_ts": "2022-03-01 00:00:00", "start_ts": "2022-02-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      11 | FINISHED | COPY DATA        | {"end_ts": "2022-03-11 00:00:00", "start_ts": "2022-03-01 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      12 | FINISHED | COPY DATA        | {"end_ts": "2022-03-21 00:00:00", "start_ts": "2022-03-11 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      13 | FINISHED | COPY DATA        | {"end_ts": "2022-03-31 00:00:00", "start_ts": "2022-03-21 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      14 | FINISHED | COPY DATA        | {"end_ts": "2022-04-10 00:00:00", "start_ts": "2022-03-31 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      15 | FINISHED | COPY DATA        | {"end_ts": "2022-04-20 00:00:00", "start_ts": "2022-04-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      16 | FINISHED | COPY DATA        | {"end_ts": "2022-04-30 00:00:00", "start_ts": "2022-04-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      17 | FINISHED | COPY DATA        | {"end_ts": "2022-05-10 00:00:00", "start_ts": "2022-04-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      18 | FINISHED | COPY DATA        | {"end_ts": "2022-05-20 00:00:00", "start_ts": "2022-05-10 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      19 | FINISHED | COPY DATA        | {"end_ts": "2022-05-30 00:00:00", "start_ts": "2022-05-20 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      20 | FINISHED | COPY DATA        | {"end_ts": "2022-06-09 00:00:00", "start_ts": "2022-05-30 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      21 | FINISHED | COPY DATA        | {"end_ts": "2022-06-19 00:00:00", "start_ts": "2022-06-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      22 | FINISHED | COPY DATA        | {"end_ts": "2022-06-29 00:00:00", "start_ts": "2022-06-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      23 | FINISHED | COPY DATA        | {"end_ts": "2022-07-09 00:00:00", "start_ts": "2022-06-29 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      24 | FINISHED | COPY DATA        | {"end_ts": "2022-07-19 00:00:00", "start_ts": "2022-07-09 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      25 | FINISHED | COPY DATA        | {"end_ts": "2022-07-29 00:00:00", "start_ts": "2022-07-19 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      26 | FINISHED | COPY DATA        | {"end_ts": "2022-08-08 00:00:00", "start_ts": "2022-07-29 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      27 | FINISHED | COPY DATA        | {"end_ts": "2022-08-18 00:00:00", "start_ts": "2022-08-08 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      28 | FINISHED | COPY DATA        | {"end_ts": "2022-08-28 00:00:00", "start_ts": "2022-08-18 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      29 | FINISHED | COPY DATA        | {"end_ts": "2022-09-07 00:00:00", "start_ts": "2022-08-28 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      30 | FINISHED | COPY DATA        | {"end_ts": "2022-09-17 00:00:00", "start_ts": "2022-09-07 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      31 | FINISHED | COPY DATA        | {"end_ts": "2022-09-27 00:00:00", "start_ts": "2022-09-17 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      32 | FINISHED | COPY DATA        | {"end_ts": "2022-10-07 00:00:00", "start_ts": "2022-09-27 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      33 | FINISHED | COPY DATA        | {"end_ts": "2022-10-17 00:00:00", "start_ts": "2022-10-07 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      34 | FINISHED | COPY DATA        | {"end_ts": "2022-10-27 00:00:00", "start_ts": "2022-10-17 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      35 | FINISHED | COPY DATA        | {"end_ts": "2022-11-06 00:00:00", "start_ts": "2022-10-27 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      36 | FINISHED | COPY DATA        | {"end_ts": "2022-11-16 00:00:00", "start_ts": "2022-11-06 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      37 | FINISHED | COPY DATA        | {"end_ts": "2022-11-26 00:00:00", "start_ts": "2022-11-16 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      38 | FINISHED | COPY DATA        | {"end_ts": "2022-12-06 00:00:00", "start_ts": "2022-11-26 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      39 | FINISHED | COPY DATA        | {"end_ts": "2022-12-16 00:00:00", "start_ts": "2022-12-06 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      40 | FINISHED | COPY DATA        | {"end_ts": "2022-12-26 00:00:00", "start_ts": "2022-12-16 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      41 | FINISHED | COPY DATA        | {"end_ts": "2023-01-05 00:00:00", "start_ts": "2022-12-26 00:00:00", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 7 |      42 | FINISHED | COPY POLICIES    | {"policies": [1012, 1013, 1014], "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      43 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      44 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 7 |      45 | FINISHED | ENABLE POLICIES  | {"policies": [1015, 1016, 1017, 1012, 1013, 1014]}
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_7_243_chunk
+ _timescaledb_internal._hyper_7_244_chunk
+ _timescaledb_internal._hyper_7_245_chunk
+ _timescaledb_internal._hyper_7_246_chunk
+ _timescaledb_internal._hyper_7_247_chunk
+ _timescaledb_internal._hyper_7_248_chunk
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+ _timescaledb_internal._hyper_11_263_chunk
+ _timescaledb_internal._hyper_11_264_chunk
+ _timescaledb_internal._hyper_11_265_chunk
+ _timescaledb_internal._hyper_11_266_chunk
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+CREATE OR REPLACE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:177: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:178: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1012 | Retention Policy [1012]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             7 | {"drop_after": "@ 30 days", "hypertable_id": 7}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1013 | Refresh Continuous Aggregate Policy [1013] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             7 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 7} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1014 | Columnstore Policy [1014]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             7 | {"hypertable_id": 7, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:181: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:181: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily', CAST('2023-01-01 00:00:00' AS timestamp without time zone), NULL);"
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                            View "public.conditions_summary_daily"
+ Column |            Type             | Collation | Nullable | Default | Storage | Description 
+--------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp without time zone |           |          |         | plain   | 
+ min    | numeric                     |           |          |         | main    | 
+ max    | numeric                     |           |          |         | main    | 
+ avg    | numeric                     |           |          |         | main    | 
+ sum    | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_13.bucket,
+    _materialized_hypertable_13.min,
+    _materialized_hypertable_13.max,
+    _materialized_hypertable_13.avg,
+    _materialized_hypertable_13.sum
+   FROM _timescaledb_internal._materialized_hypertable_13
+  WHERE _materialized_hypertable_13.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(13)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(13)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+-- cagg with the old format because it was overriden
+\d+ conditions_summary_daily_old
+                          View "public.conditions_summary_daily_old"
+ Column |            Type             | Collation | Nullable | Default | Storage | Description 
+--------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp without time zone |           |          |         | plain   | 
+ min    | numeric                     |           |          |         | main    | 
+ max    | numeric                     |           |          |         | main    | 
+ avg    | numeric                     |           |          |         | main    | 
+ sum    | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone)
+  GROUP BY _materialized_hypertable_7.bucket
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:188: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1018 | Retention Policy [1018]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            13 | {"drop_after": "@ 30 days", "hypertable_id": 13}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1019 | Refresh Continuous Aggregate Policy [1019] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            13 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 13} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1020 | Columnstore Policy [1020]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            13 | {"hypertable_id": 13, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |      check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1012 | Retention Policy [1012]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             7 | {"drop_after": "@ 30 days", "hypertable_id": 7}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1013 | Refresh Continuous Aggregate Policy [1013] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             7 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 7} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1014 | Columnstore Policy [1014]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             7 | {"hypertable_id": 7, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- test migration overriding the new cagg and removing the old
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:198: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+psql:include/cagg_migrate_common.sql:199: NOTICE:  drop cascades to 6 other objects
+ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1012 | Retention Policy [1012]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |             7 | {"drop_after": "@ 30 days", "hypertable_id": 7}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1013 | Refresh Continuous Aggregate Policy [1013] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |             7 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 7} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1014 | Columnstore Policy [1014]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |             7 | {"hypertable_id": 7, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
+psql:include/cagg_migrate_common.sql:203: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:203: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily', CAST('2023-01-01 00:00:00' AS timestamp without time zone), NULL);"
+psql:include/cagg_migrate_common.sql:203: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1012 not found, skipping
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1013 not found, skipping
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1014 not found, skipping
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                            View "public.conditions_summary_daily"
+ Column |            Type             | Collation | Nullable | Default | Storage | Description 
+--------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp without time zone |           |          |         | plain   | 
+ min    | numeric                     |           |          |         | main    | 
+ max    | numeric                     |           |          |         | main    | 
+ avg    | numeric                     |           |          |         | main    | 
+ sum    | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_15.bucket,
+    _materialized_hypertable_15.min,
+    _materialized_hypertable_15.max,
+    _materialized_hypertable_15.avg,
+    _materialized_hypertable_15.sum
+   FROM _timescaledb_internal._materialized_hypertable_15
+  WHERE _materialized_hypertable_15.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(15)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(15)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:208: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+-- should fail because the old cagg was removed
+SELECT * FROM conditions_summary_daily_old;
+psql:include/cagg_migrate_common.sql:210: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1021 | Retention Policy [1021]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            15 | {"drop_after": "@ 30 days", "hypertable_id": 15}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1022 | Refresh Continuous Aggregate Policy [1022] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            15 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 15} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1023 | Columnstore Policy [1023]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            15 | {"hypertable_id": 15, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- permission tests
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:220: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
+ALTER MATERIALIZED VIEW conditions_summary_weekly OWNER TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:227: ERROR:  permission denied for table continuous_agg_migrate_plan
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:237: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:247: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- all necessary permissions granted
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:256: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_weekly_new', CAST('2023-01-02 00:00:00' AS timestamp without time zone), NULL);"
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_weekly
+EXCEPT
+SELECT * FROM conditions_summary_weekly_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                   config                                                                                                    
+-------------------+---------+----------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 8 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "2023-01-02 00:00:00"}
+                 8 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_weekly_new"}
+                 8 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 8 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "2023-01-02 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "window_start_type": "timestamp without time zone"}
+                 8 |       5 | FINISHED | COPY DATA        | {"end_ts": "2022-03-07 00:00:00", "start_ts": "2021-12-27 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 8 |       6 | FINISHED | COPY DATA        | {"end_ts": "2022-05-16 00:00:00", "start_ts": "2022-03-07 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 8 |       7 | FINISHED | COPY DATA        | {"end_ts": "2022-07-25 00:00:00", "start_ts": "2022-05-16 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 8 |       8 | FINISHED | COPY DATA        | {"end_ts": "2022-10-03 00:00:00", "start_ts": "2022-07-25 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 8 |       9 | FINISHED | COPY DATA        | {"end_ts": "2022-12-12 00:00:00", "start_ts": "2022-10-03 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 8 |      10 | FINISHED | COPY DATA        | {"end_ts": "2023-02-20 00:00:00", "start_ts": "2022-12-12 00:00:00", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp without time zone"}
+                 8 |      11 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_weekly_new"}
+                 8 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_weekly_new"}
+                 8 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_weekly_new"}
+                 8 |      14 | FINISHED | ENABLE POLICIES  | 
+
+RESET ROLE;
+-- according to the official documentation trying to execute a procedure with
+-- transaction control statements inside an explicit transaction should fail:
+-- https://www.postgresql.org/docs/current/sql-call.html
+-- `If CALL is executed in a transaction block, then the called procedure cannot
+--  execute transaction control statements. Transaction control statements are only
+--  allowed if CALL is executed in its own transaction.`
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:273: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_weekly_new;
+psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other objects
+\set ON_ERROR_STOP 0
+BEGIN;
+-- should fail with `invalid transaction termination`
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:279: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+CREATE FUNCTION execute_migration() RETURNS void AS
+$$
+BEGIN
+    CALL cagg_migrate('conditions_summary_weekly');
+    RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+\set ON_ERROR_STOP 0
+-- execute migration inside a plpgsql function
+BEGIN;
+-- should fail with `invalid transaction termination`
+SELECT execute_migration();
+psql:include/cagg_migrate_common.sql:296: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+--
+-- test dropping chunks
+--
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+ chunk_name | dropped 
+------------+---------
+
+-- drop 1 chunk
+\if :IS_TIME_DIMENSION
+    SELECT drop_chunks('conditions', older_than => CAST('2022-01-08 00:00:00-00' AS :TIME_DIMENSION_DATATYPE), force=>true);
+psql:include/cagg_migrate_common.sql:314: WARNING:  _timescaledb_internal._hyper_5_190_chunk contained data required for continuous aggregate refresh
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_5_190_chunk
+
+\else
+    SELECT drop_chunks('conditions', older_than => 10, force=>true);
+\endif
+-- now he have one chunk marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+     chunk_name     | dropped 
+--------------------+---------
+ _hyper_5_190_chunk | t
+
+-- this migration should remove the chunk metadata marked as dropped
+CALL cagg_migrate('conditions_summary_weekly', override => TRUE, drop_old => TRUE);
+psql:include/cagg_migrate_common.sql:328: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_weekly', CAST('2023-01-02 00:00:00' AS timestamp without time zone), NULL);"
+psql:include/cagg_migrate_common.sql:328: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:328: INFO:  Removing metadata of chunk 190 from hypertable 5
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+ chunk_name | dropped 
+------------+---------
+
+-- cleanup
+DROP FUNCTION execute_migration();
+REVOKE SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan FROM :ROLE_DEFAULT_PERM_USER;
+REVOKE USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq FROM :ROLE_DEFAULT_PERM_USER;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:342: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+psql:include/cagg_migrate_common.sql:343: NOTICE:  drop cascades to 6 other objects
+DROP MATERIALIZED VIEW conditions_summary_weekly;
+psql:include/cagg_migrate_common.sql:344: NOTICE:  drop cascades to 6 other objects
+DROP TABLE conditions;
+SELECT _timescaledb_functions.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+
+-- ########################################################
+-- ## TIMESTAMPTZ data type tests
+-- ########################################################
+\set IS_TIME_DIMENSION TRUE
+\set TIME_DIMENSION_DATATYPE TIMESTAMPTZ
+\ir include/cagg_migrate_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Setup some variables
+SELECT
+    format('../data/cagg_migrate_%1$s.sql', lower(:'TIME_DIMENSION_DATATYPE')) AS "TEST_SCHEMA_FILE"
+\gset
+-- restore dump
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+
+\ir :TEST_SCHEMA_FILE
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE public.conditions (
+    "time" timestamp with time zone NOT NULL,
+    temperature numeric
+);
+CREATE VIEW _timescaledb_internal._direct_view_10 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_11 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_12 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time"));
+CREATE TABLE _timescaledb_internal._materialized_hypertable_10 (
+    bucket timestamp with time zone NOT NULL,
+    min numeric,
+    max numeric,
+    avg numeric,
+    sum numeric
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_11 (
+    bucket timestamp with time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_12 (
+    bucket timestamp with time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE VIEW _timescaledb_internal._partial_view_10 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._partial_view_11 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW _timescaledb_internal._partial_view_12 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW public.conditions_summary_daily AS
+ SELECT _materialized_hypertable_11.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE (_materialized_hypertable_11.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone))
+  GROUP BY _materialized_hypertable_11.bucket
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_daily_new AS
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.min,
+    _materialized_hypertable_10.max,
+    _materialized_hypertable_10.avg,
+    _materialized_hypertable_10.sum
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE (_materialized_hypertable_10.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(10)), '-infinity'::timestamp with time zone))
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(10)), '-infinity'::timestamp with time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_weekly AS
+ SELECT _materialized_hypertable_12.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_12
+  WHERE (_materialized_hypertable_12.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(12)), '-infinity'::timestamp with time zone))
+  GROUP BY _materialized_hypertable_12.bucket
+UNION ALL
+ SELECT public.time_bucket('7 days'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(12)), '-infinity'::timestamp with time zone))
+  GROUP BY (public.time_bucket('7 days'::interval, conditions."time"));
+COPY _timescaledb_catalog.hypertable (id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name, chunk_target_size, compression_state, compressed_hypertable_id, status) FROM stdin;
+COPY _timescaledb_catalog.dimension (id, hypertable_id, column_name, column_type, aligned, num_slices, partitioning_func_schema, partitioning_func, interval_length, compress_interval_length, integer_now_func_schema, integer_now_func) FROM stdin;
+COPY _timescaledb_catalog.continuous_agg (mat_hypertable_id, raw_hypertable_id, parent_mat_hypertable_id, user_view_schema, user_view_name, partial_view_schema, partial_view_name, direct_view_schema, direct_view_name, materialized_only, finalized) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_bucket_function (mat_hypertable_id, bucket_func, bucket_width, bucket_fixed_width) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_invalidation_threshold (hypertable_id, watermark) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value, greatest_modified_value) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark) FROM stdin;
+SELECT pg_catalog.setval('_timescaledb_catalog.dimension_id_seq', 12, true);
+ setval 
+--------
+     12
+
+CREATE INDEX _materialized_hypertable_10_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_11_bucket_idx ON _timescaledb_internal._materialized_hypertable_11 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_12_bucket_idx ON _timescaledb_internal._materialized_hypertable_12 USING btree (bucket DESC);
+CREATE INDEX conditions_time_idx ON public.conditions USING btree ("time" DESC);
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+
+-- Make sure no scheduled job will be executed during the regression tests
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+
+\if :IS_TIME_DIMENSION
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series('2022-01-01 00:00:00-00'::timestamptz, '2022-12-31 23:59:59-00'::timestamptz, '1 hour'),
+        0.25;
+\else
+    CREATE OR REPLACE FUNCTION integer_now()
+    RETURNS :TIME_DIMENSION_DATATYPE LANGUAGE SQL STABLE AS
+    $$
+        SELECT coalesce(max(time), 0)
+        FROM public.conditions
+    $$;
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series(1, 1000, 1),
+        0.25;
+\endif
+CALL refresh_continuous_aggregate('conditions_summary_daily', NULL, NULL);
+CALL refresh_continuous_aggregate('conditions_summary_weekly', NULL, NULL);
+\set ON_ERROR_STOP 0
+-- should fail because we don't need to migrate finalized caggs
+CALL cagg_migrate('conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:42: ERROR:  continuous aggregate "public.conditions_summary_daily_new" does not require any migration
+-- should fail relation does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+psql:include/cagg_migrate_common.sql:45: ERROR:  relation "conditions_summary_not_cagg" does not exist at character 19
+CREATE TABLE conditions_summary_not_cagg();
+-- should fail continuous agg does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+psql:include/cagg_migrate_common.sql:50: ERROR:  continuous aggregate "public.conditions_summary_not_cagg" does not exist
+\set ON_ERROR_STOP 1
+DROP TABLE conditions_summary_not_cagg;
+SELECT
+    ca.raw_hypertable_id AS "RAW_HYPERTABLE_ID",
+    h.schema_name AS "MAT_SCHEMA_NAME",
+    h.table_name AS "MAT_TABLE_NAME",
+    partial_view_name AS "PART_VIEW_NAME",
+    partial_view_schema AS "PART_VIEW_SCHEMA",
+    direct_view_name AS "DIR_VIEW_NAME",
+    direct_view_schema AS "DIR_VIEW_SCHEMA",
+    user_view_name AS "USER_VIEW_NAME",
+    user_view_schema AS "USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily'
+\gset
+\set ON_ERROR_STOP 0
+-- should fail because the new cagg with suffix '_new' already exists
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:74: ERROR:  continuous aggregate "public.conditions_summary_daily_new" already exists
+\set ON_ERROR_STOP 1
+-- remove the new cagg to execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+-- get and set all the cagg data
+SELECT
+    _timescaledb_functions.cagg_migrate_pre_validation(
+        'public',
+        'conditions_summary_daily',
+        'conditions_summary_daily_new'
+    ) AS "CAGG_DATA"
+\gset
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+\x on
+SELECT mat_hypertable_id, user_view_definition FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+-[ RECORD 1 ]--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+mat_hypertable_id    | 11
+user_view_definition |  SELECT _materialized_hypertable_11.bucket,                                                                                                                                                   +
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_2_2, NULL::numeric) AS min,+
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_3_3, NULL::numeric) AS max,+
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_4_4, NULL::numeric) AS avg,+
+                     |     _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_5_5, NULL::numeric) AS sum +
+                     |    FROM _timescaledb_internal._materialized_hypertable_11                                                                                                                                     +
+                     |   WHERE (_materialized_hypertable_11.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone))                +
+                     |   GROUP BY _materialized_hypertable_11.bucket                                                                                                                                                 +
+                     | UNION ALL                                                                                                                                                                                     +
+                     |  SELECT public.time_bucket('@ 1 day'::interval, conditions."time") AS bucket,                                                                                                                 +
+                     |     min(conditions.temperature) AS min,                                                                                                                                                       +
+                     |     max(conditions.temperature) AS max,                                                                                                                                                       +
+                     |     avg(conditions.temperature) AS avg,                                                                                                                                                       +
+                     |     sum(conditions.temperature) AS sum                                                                                                                                                        +
+                     |    FROM public.conditions                                                                                                                                                                     +
+                     |   WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone))                                +
+                     |   GROUP BY (public.time_bucket('@ 1 day'::interval, conditions."time"));
+
+\x off
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |   status    |       type       |                                                                                                    config                                                                                                     
+-------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                11 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "2022-12-31 16:00:00-08"}
+                11 |       2 | NOT STARTED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | NOT STARTED | DISABLE POLICIES | {"policies": null}
+                11 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "2022-12-31 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                11 |       5 | NOT STARTED | COPY DATA        | {"end_ts": "2022-01-10 16:00:00-08", "start_ts": "2021-12-31 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       6 | NOT STARTED | COPY DATA        | {"end_ts": "2022-01-20 16:00:00-08", "start_ts": "2022-01-10 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       7 | NOT STARTED | COPY DATA        | {"end_ts": "2022-01-30 16:00:00-08", "start_ts": "2022-01-20 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       8 | NOT STARTED | COPY DATA        | {"end_ts": "2022-02-09 16:00:00-08", "start_ts": "2022-01-30 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       9 | NOT STARTED | COPY DATA        | {"end_ts": "2022-02-19 16:00:00-08", "start_ts": "2022-02-09 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      10 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-01 16:00:00-08", "start_ts": "2022-02-19 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      11 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-11 16:00:00-08", "start_ts": "2022-03-01 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      12 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-21 16:00:00-07", "start_ts": "2022-03-11 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      13 | NOT STARTED | COPY DATA        | {"end_ts": "2022-03-31 16:00:00-07", "start_ts": "2022-03-21 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      14 | NOT STARTED | COPY DATA        | {"end_ts": "2022-04-10 16:00:00-07", "start_ts": "2022-03-31 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      15 | NOT STARTED | COPY DATA        | {"end_ts": "2022-04-20 16:00:00-07", "start_ts": "2022-04-10 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      16 | NOT STARTED | COPY DATA        | {"end_ts": "2022-04-30 16:00:00-07", "start_ts": "2022-04-20 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      17 | NOT STARTED | COPY DATA        | {"end_ts": "2022-05-10 16:00:00-07", "start_ts": "2022-04-30 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      18 | NOT STARTED | COPY DATA        | {"end_ts": "2022-05-20 16:00:00-07", "start_ts": "2022-05-10 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      19 | NOT STARTED | COPY DATA        | {"end_ts": "2022-05-30 16:00:00-07", "start_ts": "2022-05-20 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      20 | NOT STARTED | COPY DATA        | {"end_ts": "2022-06-09 16:00:00-07", "start_ts": "2022-05-30 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      21 | NOT STARTED | COPY DATA        | {"end_ts": "2022-06-19 16:00:00-07", "start_ts": "2022-06-09 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      22 | NOT STARTED | COPY DATA        | {"end_ts": "2022-06-29 16:00:00-07", "start_ts": "2022-06-19 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      23 | NOT STARTED | COPY DATA        | {"end_ts": "2022-07-09 16:00:00-07", "start_ts": "2022-06-29 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      24 | NOT STARTED | COPY DATA        | {"end_ts": "2022-07-19 16:00:00-07", "start_ts": "2022-07-09 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      25 | NOT STARTED | COPY DATA        | {"end_ts": "2022-07-29 16:00:00-07", "start_ts": "2022-07-19 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      26 | NOT STARTED | COPY DATA        | {"end_ts": "2022-08-08 16:00:00-07", "start_ts": "2022-07-29 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      27 | NOT STARTED | COPY DATA        | {"end_ts": "2022-08-18 16:00:00-07", "start_ts": "2022-08-08 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      28 | NOT STARTED | COPY DATA        | {"end_ts": "2022-08-28 16:00:00-07", "start_ts": "2022-08-18 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      29 | NOT STARTED | COPY DATA        | {"end_ts": "2022-09-07 16:00:00-07", "start_ts": "2022-08-28 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      30 | NOT STARTED | COPY DATA        | {"end_ts": "2022-09-17 16:00:00-07", "start_ts": "2022-09-07 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      31 | NOT STARTED | COPY DATA        | {"end_ts": "2022-09-27 16:00:00-07", "start_ts": "2022-09-17 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      32 | NOT STARTED | COPY DATA        | {"end_ts": "2022-10-07 16:00:00-07", "start_ts": "2022-09-27 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      33 | NOT STARTED | COPY DATA        | {"end_ts": "2022-10-17 16:00:00-07", "start_ts": "2022-10-07 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      34 | NOT STARTED | COPY DATA        | {"end_ts": "2022-10-27 16:00:00-07", "start_ts": "2022-10-17 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      35 | NOT STARTED | COPY DATA        | {"end_ts": "2022-11-06 16:00:00-08", "start_ts": "2022-10-27 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      36 | NOT STARTED | COPY DATA        | {"end_ts": "2022-11-16 16:00:00-08", "start_ts": "2022-11-06 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      37 | NOT STARTED | COPY DATA        | {"end_ts": "2022-11-26 16:00:00-08", "start_ts": "2022-11-16 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      38 | NOT STARTED | COPY DATA        | {"end_ts": "2022-12-06 16:00:00-08", "start_ts": "2022-11-26 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      39 | NOT STARTED | COPY DATA        | {"end_ts": "2022-12-16 16:00:00-08", "start_ts": "2022-12-06 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      40 | NOT STARTED | COPY DATA        | {"end_ts": "2022-12-26 16:00:00-08", "start_ts": "2022-12-16 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      41 | NOT STARTED | COPY DATA        | {"end_ts": "2023-01-05 16:00:00-08", "start_ts": "2022-12-26 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      42 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      43 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      44 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      45 | NOT STARTED | ENABLE POLICIES  | 
+
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:96: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:96: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('2022-12-31 16:00:00-08' AS timestamp with time zone), NULL);"
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                    config                                                                                                     
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "2022-12-31 16:00:00-08"}
+                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "2022-12-31 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "2022-01-10 16:00:00-08", "start_ts": "2021-12-31 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "2022-01-20 16:00:00-08", "start_ts": "2022-01-10 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "2022-01-30 16:00:00-08", "start_ts": "2022-01-20 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "2022-02-09 16:00:00-08", "start_ts": "2022-01-30 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "2022-02-19 16:00:00-08", "start_ts": "2022-02-09 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "2022-03-01 16:00:00-08", "start_ts": "2022-02-19 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      11 | FINISHED | COPY DATA        | {"end_ts": "2022-03-11 16:00:00-08", "start_ts": "2022-03-01 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      12 | FINISHED | COPY DATA        | {"end_ts": "2022-03-21 16:00:00-07", "start_ts": "2022-03-11 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      13 | FINISHED | COPY DATA        | {"end_ts": "2022-03-31 16:00:00-07", "start_ts": "2022-03-21 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      14 | FINISHED | COPY DATA        | {"end_ts": "2022-04-10 16:00:00-07", "start_ts": "2022-03-31 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      15 | FINISHED | COPY DATA        | {"end_ts": "2022-04-20 16:00:00-07", "start_ts": "2022-04-10 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      16 | FINISHED | COPY DATA        | {"end_ts": "2022-04-30 16:00:00-07", "start_ts": "2022-04-20 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      17 | FINISHED | COPY DATA        | {"end_ts": "2022-05-10 16:00:00-07", "start_ts": "2022-04-30 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      18 | FINISHED | COPY DATA        | {"end_ts": "2022-05-20 16:00:00-07", "start_ts": "2022-05-10 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      19 | FINISHED | COPY DATA        | {"end_ts": "2022-05-30 16:00:00-07", "start_ts": "2022-05-20 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      20 | FINISHED | COPY DATA        | {"end_ts": "2022-06-09 16:00:00-07", "start_ts": "2022-05-30 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      21 | FINISHED | COPY DATA        | {"end_ts": "2022-06-19 16:00:00-07", "start_ts": "2022-06-09 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      22 | FINISHED | COPY DATA        | {"end_ts": "2022-06-29 16:00:00-07", "start_ts": "2022-06-19 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      23 | FINISHED | COPY DATA        | {"end_ts": "2022-07-09 16:00:00-07", "start_ts": "2022-06-29 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      24 | FINISHED | COPY DATA        | {"end_ts": "2022-07-19 16:00:00-07", "start_ts": "2022-07-09 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      25 | FINISHED | COPY DATA        | {"end_ts": "2022-07-29 16:00:00-07", "start_ts": "2022-07-19 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      26 | FINISHED | COPY DATA        | {"end_ts": "2022-08-08 16:00:00-07", "start_ts": "2022-07-29 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      27 | FINISHED | COPY DATA        | {"end_ts": "2022-08-18 16:00:00-07", "start_ts": "2022-08-08 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      28 | FINISHED | COPY DATA        | {"end_ts": "2022-08-28 16:00:00-07", "start_ts": "2022-08-18 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      29 | FINISHED | COPY DATA        | {"end_ts": "2022-09-07 16:00:00-07", "start_ts": "2022-08-28 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      30 | FINISHED | COPY DATA        | {"end_ts": "2022-09-17 16:00:00-07", "start_ts": "2022-09-07 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      31 | FINISHED | COPY DATA        | {"end_ts": "2022-09-27 16:00:00-07", "start_ts": "2022-09-17 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      32 | FINISHED | COPY DATA        | {"end_ts": "2022-10-07 16:00:00-07", "start_ts": "2022-09-27 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      33 | FINISHED | COPY DATA        | {"end_ts": "2022-10-17 16:00:00-07", "start_ts": "2022-10-07 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      34 | FINISHED | COPY DATA        | {"end_ts": "2022-10-27 16:00:00-07", "start_ts": "2022-10-17 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      35 | FINISHED | COPY DATA        | {"end_ts": "2022-11-06 16:00:00-08", "start_ts": "2022-10-27 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      36 | FINISHED | COPY DATA        | {"end_ts": "2022-11-16 16:00:00-08", "start_ts": "2022-11-06 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      37 | FINISHED | COPY DATA        | {"end_ts": "2022-11-26 16:00:00-08", "start_ts": "2022-11-16 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      38 | FINISHED | COPY DATA        | {"end_ts": "2022-12-06 16:00:00-08", "start_ts": "2022-11-26 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      39 | FINISHED | COPY DATA        | {"end_ts": "2022-12-16 16:00:00-08", "start_ts": "2022-12-06 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      40 | FINISHED | COPY DATA        | {"end_ts": "2022-12-26 16:00:00-08", "start_ts": "2022-12-16 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      41 | FINISHED | COPY DATA        | {"end_ts": "2023-01-05 16:00:00-08", "start_ts": "2022-12-26 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      42 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      43 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      44 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      45 | FINISHED | ENABLE POLICIES  | 
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:101: ERROR:  plan already exists for materialized hypertable 11
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:102: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
+-- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+psql:include/cagg_migrate_common.sql:106: NOTICE:  defaulting compress_orderby to bucket
+\if :IS_TIME_DIMENSION
+SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
+ add_retention_policy 
+----------------------
+                 1024
+
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1025
+
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
+ add_compression_policy 
+------------------------
+                   1026
+
+\else
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
+\endif
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'USER_VIEW_SCHEMA'
+AND hypertable_name = :'USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule |                                     config                                      | next_start | initial_start | hypertable_schema |     hypertable_name      |      check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------------------------------------------------------------------------+------------+---------------+-------------------+--------------------------+------------------------+-------------------------------------------
+   1024 | Retention Policy [1024]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 11}                                |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_retention_check
+   1025 | Refresh Continuous Aggregate Policy [1025] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 11} |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_refresh_continuous_aggregate_check
+   1026 | Columnstore Policy [1026]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              | {"hypertable_id": 11, "compress_after": "@ 45 days"}                            |            |               | public            | conditions_summary_daily | _timescaledb_functions | policy_compression_check
+
+-- execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:125: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:126: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:127: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:127: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('2022-12-31 16:00:00-08' AS timestamp with time zone), NULL);"
+SELECT
+    ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
+    h.schema_name AS "NEW_MAT_SCHEMA_NAME",
+    h.table_name AS "NEW_MAT_TABLE_NAME",
+    partial_view_name AS "NEW_PART_VIEW_NAME",
+    partial_view_schema AS "NEW_PART_VIEW_SCHEMA",
+    direct_view_name AS "NEW_DIR_VIEW_NAME",
+    direct_view_schema AS "NEW_DIR_VIEW_SCHEMA",
+    user_view_name AS "NEW_USER_VIEW_NAME",
+    user_view_schema AS "NEW_USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily_new'
+\gset
+\d+ conditions_summary_daily_new
+                         View "public.conditions_summary_daily_new"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+ min    | numeric                  |           |          |         | main    | 
+ max    | numeric                  |           |          |         | main    | 
+ avg    | numeric                  |           |          |         | main    | 
+ sum    | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_21.bucket,
+    _materialized_hypertable_21.min,
+    _materialized_hypertable_21.max,
+    _materialized_hypertable_21.avg,
+    _materialized_hypertable_21.sum
+   FROM _timescaledb_internal._materialized_hypertable_21
+  WHERE _materialized_hypertable_21.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(21)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(21)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_USER_VIEW_SCHEMA'
+AND hypertable_name = :'NEW_USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule |                                     config                                      | next_start | initial_start | hypertable_schema |       hypertable_name        |      check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------------------------------------------------------------------------+------------+---------------+-------------------+------------------------------+------------------------+-------------------------------------------
+   1027 | Retention Policy [1027]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 21}                                |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_retention_check
+   1028 | Refresh Continuous Aggregate Policy [1028] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 21} |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_refresh_continuous_aggregate_check
+   1029 | Columnstore Policy [1029]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              | {"hypertable_id": 21, "compress_after": "@ 45 days"}                            |            |               | public            | conditions_summary_daily_new | _timescaledb_functions | policy_compression_check
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                    config                                                                                                     
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "2022-12-31 16:00:00-08"}
+                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1024, 1026]}
+                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "2022-12-31 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "2022-01-10 16:00:00-08", "start_ts": "2021-12-31 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "2022-01-20 16:00:00-08", "start_ts": "2022-01-10 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "2022-01-30 16:00:00-08", "start_ts": "2022-01-20 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "2022-02-09 16:00:00-08", "start_ts": "2022-01-30 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "2022-02-19 16:00:00-08", "start_ts": "2022-02-09 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "2022-03-01 16:00:00-08", "start_ts": "2022-02-19 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      11 | FINISHED | COPY DATA        | {"end_ts": "2022-03-11 16:00:00-08", "start_ts": "2022-03-01 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      12 | FINISHED | COPY DATA        | {"end_ts": "2022-03-21 16:00:00-07", "start_ts": "2022-03-11 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      13 | FINISHED | COPY DATA        | {"end_ts": "2022-03-31 16:00:00-07", "start_ts": "2022-03-21 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      14 | FINISHED | COPY DATA        | {"end_ts": "2022-04-10 16:00:00-07", "start_ts": "2022-03-31 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      15 | FINISHED | COPY DATA        | {"end_ts": "2022-04-20 16:00:00-07", "start_ts": "2022-04-10 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      16 | FINISHED | COPY DATA        | {"end_ts": "2022-04-30 16:00:00-07", "start_ts": "2022-04-20 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      17 | FINISHED | COPY DATA        | {"end_ts": "2022-05-10 16:00:00-07", "start_ts": "2022-04-30 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      18 | FINISHED | COPY DATA        | {"end_ts": "2022-05-20 16:00:00-07", "start_ts": "2022-05-10 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      19 | FINISHED | COPY DATA        | {"end_ts": "2022-05-30 16:00:00-07", "start_ts": "2022-05-20 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      20 | FINISHED | COPY DATA        | {"end_ts": "2022-06-09 16:00:00-07", "start_ts": "2022-05-30 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      21 | FINISHED | COPY DATA        | {"end_ts": "2022-06-19 16:00:00-07", "start_ts": "2022-06-09 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      22 | FINISHED | COPY DATA        | {"end_ts": "2022-06-29 16:00:00-07", "start_ts": "2022-06-19 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      23 | FINISHED | COPY DATA        | {"end_ts": "2022-07-09 16:00:00-07", "start_ts": "2022-06-29 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      24 | FINISHED | COPY DATA        | {"end_ts": "2022-07-19 16:00:00-07", "start_ts": "2022-07-09 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      25 | FINISHED | COPY DATA        | {"end_ts": "2022-07-29 16:00:00-07", "start_ts": "2022-07-19 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      26 | FINISHED | COPY DATA        | {"end_ts": "2022-08-08 16:00:00-07", "start_ts": "2022-07-29 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      27 | FINISHED | COPY DATA        | {"end_ts": "2022-08-18 16:00:00-07", "start_ts": "2022-08-08 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      28 | FINISHED | COPY DATA        | {"end_ts": "2022-08-28 16:00:00-07", "start_ts": "2022-08-18 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      29 | FINISHED | COPY DATA        | {"end_ts": "2022-09-07 16:00:00-07", "start_ts": "2022-08-28 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      30 | FINISHED | COPY DATA        | {"end_ts": "2022-09-17 16:00:00-07", "start_ts": "2022-09-07 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      31 | FINISHED | COPY DATA        | {"end_ts": "2022-09-27 16:00:00-07", "start_ts": "2022-09-17 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      32 | FINISHED | COPY DATA        | {"end_ts": "2022-10-07 16:00:00-07", "start_ts": "2022-09-27 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      33 | FINISHED | COPY DATA        | {"end_ts": "2022-10-17 16:00:00-07", "start_ts": "2022-10-07 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      34 | FINISHED | COPY DATA        | {"end_ts": "2022-10-27 16:00:00-07", "start_ts": "2022-10-17 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      35 | FINISHED | COPY DATA        | {"end_ts": "2022-11-06 16:00:00-08", "start_ts": "2022-10-27 16:00:00-07", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      36 | FINISHED | COPY DATA        | {"end_ts": "2022-11-16 16:00:00-08", "start_ts": "2022-11-06 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      37 | FINISHED | COPY DATA        | {"end_ts": "2022-11-26 16:00:00-08", "start_ts": "2022-11-16 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      38 | FINISHED | COPY DATA        | {"end_ts": "2022-12-06 16:00:00-08", "start_ts": "2022-11-26 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      39 | FINISHED | COPY DATA        | {"end_ts": "2022-12-16 16:00:00-08", "start_ts": "2022-12-06 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      40 | FINISHED | COPY DATA        | {"end_ts": "2022-12-26 16:00:00-08", "start_ts": "2022-12-16 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      41 | FINISHED | COPY DATA        | {"end_ts": "2023-01-05 16:00:00-08", "start_ts": "2022-12-26 16:00:00-08", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      42 | FINISHED | COPY POLICIES    | {"policies": [1024, 1025, 1026], "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      43 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      44 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      45 | FINISHED | ENABLE POLICIES  | {"policies": [1027, 1028, 1029, 1024, 1025, 1026]}
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_11_356_chunk
+ _timescaledb_internal._hyper_11_357_chunk
+ _timescaledb_internal._hyper_11_358_chunk
+ _timescaledb_internal._hyper_11_359_chunk
+ _timescaledb_internal._hyper_11_360_chunk
+ _timescaledb_internal._hyper_11_361_chunk
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_21_374_chunk
+ _timescaledb_internal._hyper_21_375_chunk
+ _timescaledb_internal._hyper_21_376_chunk
+ _timescaledb_internal._hyper_21_377_chunk
+ _timescaledb_internal._hyper_21_378_chunk
+ _timescaledb_internal._hyper_21_379_chunk
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+CREATE OR REPLACE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:177: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:178: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1024 | Retention Policy [1024]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            11 | {"drop_after": "@ 30 days", "hypertable_id": 11}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1025 | Refresh Continuous Aggregate Policy [1025] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            11 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 11} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1026 | Columnstore Policy [1026]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            11 | {"hypertable_id": 11, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:181: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:181: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily', CAST('2022-12-31 16:00:00-08' AS timestamp with time zone), NULL);"
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                           View "public.conditions_summary_daily"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+ min    | numeric                  |           |          |         | main    | 
+ max    | numeric                  |           |          |         | main    | 
+ avg    | numeric                  |           |          |         | main    | 
+ sum    | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_23.bucket,
+    _materialized_hypertable_23.min,
+    _materialized_hypertable_23.max,
+    _materialized_hypertable_23.avg,
+    _materialized_hypertable_23.sum
+   FROM _timescaledb_internal._materialized_hypertable_23
+  WHERE _materialized_hypertable_23.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(23)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(23)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+-- cagg with the old format because it was overriden
+\d+ conditions_summary_daily_old
+                         View "public.conditions_summary_daily_old"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+ min    | numeric                  |           |          |         | main    | 
+ max    | numeric                  |           |          |         | main    | 
+ avg    | numeric                  |           |          |         | main    | 
+ sum    | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_11.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE _materialized_hypertable_11.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone)
+  GROUP BY _materialized_hypertable_11.bucket
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:188: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1030 | Retention Policy [1030]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            23 | {"drop_after": "@ 30 days", "hypertable_id": 23}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1031 | Refresh Continuous Aggregate Policy [1031] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            23 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 23} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1032 | Columnstore Policy [1032]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            23 | {"hypertable_id": 23, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1024 | Retention Policy [1024]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            11 | {"drop_after": "@ 30 days", "hypertable_id": 11}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1025 | Refresh Continuous Aggregate Policy [1025] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            11 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 11} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1026 | Columnstore Policy [1026]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            11 | {"hypertable_id": 11, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- test migration overriding the new cagg and removing the old
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:198: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+psql:include/cagg_migrate_common.sql:199: NOTICE:  drop cascades to 6 other objects
+ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1024 | Retention Policy [1024]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            11 | {"drop_after": "@ 30 days", "hypertable_id": 11}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1025 | Refresh Continuous Aggregate Policy [1025] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            11 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 11} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1026 | Columnstore Policy [1026]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            11 | {"hypertable_id": 11, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
+psql:include/cagg_migrate_common.sql:203: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_migrate_common.sql:203: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily', CAST('2022-12-31 16:00:00-08' AS timestamp with time zone), NULL);"
+psql:include/cagg_migrate_common.sql:203: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1024 not found, skipping
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1025 not found, skipping
+psql:include/cagg_migrate_common.sql:203: NOTICE:  job 1026 not found, skipping
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                           View "public.conditions_summary_daily"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+ min    | numeric                  |           |          |         | main    | 
+ max    | numeric                  |           |          |         | main    | 
+ avg    | numeric                  |           |          |         | main    | 
+ sum    | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_25.bucket,
+    _materialized_hypertable_25.min,
+    _materialized_hypertable_25.max,
+    _materialized_hypertable_25.avg,
+    _materialized_hypertable_25.sum
+   FROM _timescaledb_internal._materialized_hypertable_25
+  WHERE _materialized_hypertable_25.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(25)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(25)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:208: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+-- should fail because the old cagg was removed
+SELECT * FROM conditions_summary_daily_old;
+psql:include/cagg_migrate_common.sql:210: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema       |              proc_name              |   owner    | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |      check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+------------------------+-------------------------------------+------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+------------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1033 | Retention Policy [1033]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_functions | policy_retention                    | super_user | t         | f              |               |            25 | {"drop_after": "@ 30 days", "hypertable_id": 25}                                | _timescaledb_functions | policy_retention_check                    | 
+ public | conditions_summary_daily | 1034 | Refresh Continuous Aggregate Policy [1034] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_refresh_continuous_aggregate | super_user | t         | f              |               |            25 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 25} | _timescaledb_functions | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1035 | Columnstore Policy [1035]                  | @ 12 hours        | @ 0         |          -1 | @ 1 hour     | _timescaledb_functions | policy_compression                  | super_user | t         | f              |               |            25 | {"hypertable_id": 25, "compress_after": "@ 45 days"}                            | _timescaledb_functions | policy_compression_check                  | 
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+
+-- permission tests
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:220: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
+ALTER MATERIALIZED VIEW conditions_summary_weekly OWNER TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:227: ERROR:  permission denied for table continuous_agg_migrate_plan
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:237: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:247: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+\set ON_ERROR_STOP 1
+RESET ROLE;
+GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- all necessary permissions granted
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:256: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_weekly_new', CAST('2023-01-01 16:00:00-08' AS timestamp with time zone), NULL);"
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_weekly
+EXCEPT
+SELECT * FROM conditions_summary_weekly_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                     config                                                                                                     
+-------------------+---------+----------+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "2023-01-01 16:00:00-08"}
+                12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_weekly_new"}
+                12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "2023-01-01 16:00:00-08", "cagg_name_new": "conditions_summary_weekly_new", "window_start_type": "timestamp with time zone"}
+                12 |       5 | FINISHED | COPY DATA        | {"end_ts": "2022-03-06 16:00:00-08", "start_ts": "2021-12-26 16:00:00-08", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       6 | FINISHED | COPY DATA        | {"end_ts": "2022-05-15 16:00:00-07", "start_ts": "2022-03-06 16:00:00-08", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       7 | FINISHED | COPY DATA        | {"end_ts": "2022-07-24 16:00:00-07", "start_ts": "2022-05-15 16:00:00-07", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       8 | FINISHED | COPY DATA        | {"end_ts": "2022-10-02 16:00:00-07", "start_ts": "2022-07-24 16:00:00-07", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       9 | FINISHED | COPY DATA        | {"end_ts": "2022-12-11 16:00:00-08", "start_ts": "2022-10-02 16:00:00-07", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |      10 | FINISHED | COPY DATA        | {"end_ts": "2023-02-19 16:00:00-08", "start_ts": "2022-12-11 16:00:00-08", "cagg_name_new": "conditions_summary_weekly_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |      11 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_weekly_new"}
+                12 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_weekly_new"}
+                12 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_weekly_new"}
+                12 |      14 | FINISHED | ENABLE POLICIES  | 
+
+RESET ROLE;
+-- according to the official documentation trying to execute a procedure with
+-- transaction control statements inside an explicit transaction should fail:
+-- https://www.postgresql.org/docs/current/sql-call.html
+-- `If CALL is executed in a transaction block, then the called procedure cannot
+--  execute transaction control statements. Transaction control statements are only
+--  allowed if CALL is executed in its own transaction.`
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:273: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_weekly_new;
+psql:include/cagg_migrate_common.sql:274: NOTICE:  drop cascades to 6 other objects
+\set ON_ERROR_STOP 0
+BEGIN;
+-- should fail with `invalid transaction termination`
+CALL cagg_migrate('conditions_summary_weekly');
+psql:include/cagg_migrate_common.sql:279: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+CREATE FUNCTION execute_migration() RETURNS void AS
+$$
+BEGIN
+    CALL cagg_migrate('conditions_summary_weekly');
+    RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+\set ON_ERROR_STOP 0
+-- execute migration inside a plpgsql function
+BEGIN;
+-- should fail with `invalid transaction termination`
+SELECT execute_migration();
+psql:include/cagg_migrate_common.sql:296: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+--
+-- test dropping chunks
+--
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+ chunk_name | dropped 
+------------+---------
+
+-- drop 1 chunk
+\if :IS_TIME_DIMENSION
+    SELECT drop_chunks('conditions', older_than => CAST('2022-01-08 00:00:00-00' AS :TIME_DIMENSION_DATATYPE), force=>true);
+psql:include/cagg_migrate_common.sql:314: WARNING:  _timescaledb_internal._hyper_9_303_chunk contained data required for continuous aggregate refresh
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_9_303_chunk
+
+\else
+    SELECT drop_chunks('conditions', older_than => 10, force=>true);
+\endif
+-- now he have one chunk marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+     chunk_name     | dropped 
+--------------------+---------
+ _hyper_9_303_chunk | t
+
+-- this migration should remove the chunk metadata marked as dropped
+CALL cagg_migrate('conditions_summary_weekly', override => TRUE, drop_old => TRUE);
+psql:include/cagg_migrate_common.sql:328: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_weekly', CAST('2023-01-01 16:00:00-08' AS timestamp with time zone), NULL);"
+psql:include/cagg_migrate_common.sql:328: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:328: INFO:  Removing metadata of chunk 303 from hypertable 9
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+ chunk_name | dropped 
+------------+---------
+
+-- cleanup
+DROP FUNCTION execute_migration();
+REVOKE SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan FROM :ROLE_DEFAULT_PERM_USER;
+REVOKE USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq FROM :ROLE_DEFAULT_PERM_USER;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:342: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+psql:include/cagg_migrate_common.sql:343: NOTICE:  drop cascades to 6 other objects
+DROP MATERIALIZED VIEW conditions_summary_weekly;
+psql:include/cagg_migrate_common.sql:344: NOTICE:  drop cascades to 6 other objects
+DROP TABLE conditions;
+SELECT _timescaledb_functions.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+
+-- #########################################################
+-- Issue 5359 - custom timezones should not break the migration
+-- #########################################################
+SET timezone = 'Europe/Budapest';
+-- Test with timestamp
+\set TIME_DIMENSION_DATATYPE TIMESTAMP
+\ir include/cagg_migrate_custom_timezone.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT
+    format('../data/cagg_migrate_%1$s.sql', lower(:'TIME_DIMENSION_DATATYPE')) AS "TEST_SCHEMA_FILE"
+\gset
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+
+\ir :TEST_SCHEMA_FILE
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE public.conditions (
+    "time" timestamp without time zone NOT NULL,
+    temperature numeric
+);
+CREATE VIEW _timescaledb_internal._direct_view_6 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_7 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_8 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time"));
+CREATE TABLE _timescaledb_internal._materialized_hypertable_6 (
+    bucket timestamp without time zone NOT NULL,
+    min numeric,
+    max numeric,
+    avg numeric,
+    sum numeric
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_7 (
+    bucket timestamp without time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_8 (
+    bucket timestamp without time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE VIEW _timescaledb_internal._partial_view_6 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._partial_view_7 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW _timescaledb_internal._partial_view_8 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW public.conditions_summary_daily AS
+ SELECT _materialized_hypertable_7.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_7.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE (_materialized_hypertable_7.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone))
+  GROUP BY _materialized_hypertable_7.bucket
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(7)), '-infinity'::timestamp without time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_daily_new AS
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.min,
+    _materialized_hypertable_6.max,
+    _materialized_hypertable_6.avg,
+    _materialized_hypertable_6.sum
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE (_materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp without time zone))
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp without time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_weekly AS
+ SELECT _materialized_hypertable_8.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_8.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_8
+  WHERE (_materialized_hypertable_8.bucket < COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp without time zone))
+  GROUP BY _materialized_hypertable_8.bucket
+UNION ALL
+ SELECT public.time_bucket('7 days'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp_without_timezone(_timescaledb_functions.cagg_watermark(8)), '-infinity'::timestamp without time zone))
+  GROUP BY (public.time_bucket('7 days'::interval, conditions."time"));
+COPY _timescaledb_catalog.hypertable (id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name, chunk_target_size, compression_state, compressed_hypertable_id, status) FROM stdin;
+COPY _timescaledb_catalog.dimension (id, hypertable_id, column_name, column_type, aligned, num_slices, partitioning_func_schema, partitioning_func, interval_length, compress_interval_length, integer_now_func_schema, integer_now_func) FROM stdin;
+COPY _timescaledb_catalog.continuous_agg (mat_hypertable_id, raw_hypertable_id, parent_mat_hypertable_id, user_view_schema, user_view_name, partial_view_schema, partial_view_name, direct_view_schema, direct_view_name, materialized_only, finalized) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_bucket_function (mat_hypertable_id, bucket_func, bucket_width, bucket_fixed_width) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_invalidation_threshold (hypertable_id, watermark) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value, greatest_modified_value) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark) FROM stdin;
+SELECT pg_catalog.setval('_timescaledb_catalog.dimension_id_seq', 8, true);
+ setval 
+--------
+      8
+
+SELECT pg_catalog.setval('_timescaledb_catalog.hypertable_id_seq', 8, true);
+ setval 
+--------
+      8
+
+CREATE INDEX _materialized_hypertable_6_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_7_bucket_idx ON _timescaledb_internal._materialized_hypertable_7 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_8_bucket_idx ON _timescaledb_internal._materialized_hypertable_8 USING btree (bucket DESC);
+CREATE INDEX conditions_time_idx ON public.conditions USING btree ("time" DESC);
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+
+-- Check restored watermark values
+SELECT mat_hypertable_id, _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(mat_hypertable_id))
+   FROM _timescaledb_catalog.continuous_agg;
+ mat_hypertable_id |          to_timestamp           
+-------------------+---------------------------------
+                 6 | Mon Nov 24 01:16:20 4714 LMT BC
+                 7 | Mon Nov 24 01:16:20 4714 LMT BC
+                 8 | Mon Nov 24 01:16:20 4714 LMT BC
+
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_custom_timezone.sql:17: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('4714-11-24 00:00:00 BC' AS timestamp without time zone), NULL);"
+-- Cleanup
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_custom_timezone.sql:20: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+DROP MATERIALIZED VIEW conditions_summary_weekly;
+DROP TABLE conditions CASCADE;
+psql:include/cagg_migrate_custom_timezone.sql:23: NOTICE:  drop cascades to 3 other objects
+-- Test with timestamptz
+\set TIME_DIMENSION_DATATYPE TIMESTAMPTZ
+\ir include/cagg_migrate_custom_timezone.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT
+    format('../data/cagg_migrate_%1$s.sql', lower(:'TIME_DIMENSION_DATATYPE')) AS "TEST_SCHEMA_FILE"
+\gset
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+
+\ir :TEST_SCHEMA_FILE
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE public.conditions (
+    "time" timestamp with time zone NOT NULL,
+    temperature numeric
+);
+CREATE VIEW _timescaledb_internal._direct_view_10 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_11 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._direct_view_12 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time"));
+CREATE TABLE _timescaledb_internal._materialized_hypertable_10 (
+    bucket timestamp with time zone NOT NULL,
+    min numeric,
+    max numeric,
+    avg numeric,
+    sum numeric
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_11 (
+    bucket timestamp with time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE TABLE _timescaledb_internal._materialized_hypertable_12 (
+    bucket timestamp with time zone NOT NULL,
+    agg_2_2 bytea,
+    agg_3_3 bytea,
+    agg_4_4 bytea,
+    agg_5_5 bytea,
+    chunk_id integer
+);
+CREATE VIEW _timescaledb_internal._partial_view_10 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    min(temperature) AS min,
+    max(temperature) AS max,
+    avg(temperature) AS avg,
+    sum(temperature) AS sum
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time"));
+CREATE VIEW _timescaledb_internal._partial_view_11 AS
+ SELECT public.time_bucket('1 day'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('1 day'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW _timescaledb_internal._partial_view_12 AS
+ SELECT public.time_bucket('7 days'::interval, "time") AS bucket,
+    _timescaledb_functions.partialize_agg(min(temperature)) AS agg_2_2,
+    _timescaledb_functions.partialize_agg(max(temperature)) AS agg_3_3,
+    _timescaledb_functions.partialize_agg(avg(temperature)) AS agg_4_4,
+    _timescaledb_functions.partialize_agg(sum(temperature)) AS agg_5_5,
+    _timescaledb_functions.chunk_id_from_relid(tableoid) AS chunk_id
+   FROM public.conditions
+  GROUP BY (public.time_bucket('7 days'::interval, "time")), (_timescaledb_functions.chunk_id_from_relid(tableoid));
+CREATE VIEW public.conditions_summary_daily AS
+ SELECT _materialized_hypertable_11.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_11.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE (_materialized_hypertable_11.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone))
+  GROUP BY _materialized_hypertable_11.bucket
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(11)), '-infinity'::timestamp with time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_daily_new AS
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.min,
+    _materialized_hypertable_10.max,
+    _materialized_hypertable_10.avg,
+    _materialized_hypertable_10.sum
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE (_materialized_hypertable_10.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(10)), '-infinity'::timestamp with time zone))
+UNION ALL
+ SELECT public.time_bucket('1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(10)), '-infinity'::timestamp with time zone))
+  GROUP BY (public.time_bucket('1 day'::interval, conditions."time"));
+CREATE VIEW public.conditions_summary_weekly AS
+ SELECT _materialized_hypertable_12.bucket,
+    _timescaledb_functions.finalize_agg('pg_catalog.min(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_2_2, NULL::numeric) AS min,
+    _timescaledb_functions.finalize_agg('pg_catalog.max(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_3_3, NULL::numeric) AS max,
+    _timescaledb_functions.finalize_agg('pg_catalog.avg(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_4_4, NULL::numeric) AS avg,
+    _timescaledb_functions.finalize_agg('pg_catalog.sum(numeric)'::text, NULL::name, NULL::name, '{{pg_catalog,numeric}}'::name[], _materialized_hypertable_12.agg_5_5, NULL::numeric) AS sum
+   FROM _timescaledb_internal._materialized_hypertable_12
+  WHERE (_materialized_hypertable_12.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(12)), '-infinity'::timestamp with time zone))
+  GROUP BY _materialized_hypertable_12.bucket
+UNION ALL
+ SELECT public.time_bucket('7 days'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM public.conditions
+  WHERE (conditions."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(12)), '-infinity'::timestamp with time zone))
+  GROUP BY (public.time_bucket('7 days'::interval, conditions."time"));
+COPY _timescaledb_catalog.hypertable (id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name, chunk_target_size, compression_state, compressed_hypertable_id, status) FROM stdin;
+COPY _timescaledb_catalog.dimension (id, hypertable_id, column_name, column_type, aligned, num_slices, partitioning_func_schema, partitioning_func, interval_length, compress_interval_length, integer_now_func_schema, integer_now_func) FROM stdin;
+COPY _timescaledb_catalog.continuous_agg (mat_hypertable_id, raw_hypertable_id, parent_mat_hypertable_id, user_view_schema, user_view_name, partial_view_schema, partial_view_name, direct_view_schema, direct_view_name, materialized_only, finalized) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_bucket_function (mat_hypertable_id, bucket_func, bucket_width, bucket_fixed_width) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_invalidation_threshold (hypertable_id, watermark) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value, greatest_modified_value) FROM stdin;
+COPY _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark) FROM stdin;
+SELECT pg_catalog.setval('_timescaledb_catalog.dimension_id_seq', 12, true);
+ setval 
+--------
+     12
+
+CREATE INDEX _materialized_hypertable_10_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_11_bucket_idx ON _timescaledb_internal._materialized_hypertable_11 USING btree (bucket DESC);
+CREATE INDEX _materialized_hypertable_12_bucket_idx ON _timescaledb_internal._materialized_hypertable_12 USING btree (bucket DESC);
+CREATE INDEX conditions_time_idx ON public.conditions USING btree ("time" DESC);
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+
+-- Check restored watermark values
+SELECT mat_hypertable_id, _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(mat_hypertable_id))
+   FROM _timescaledb_catalog.continuous_agg;
+ mat_hypertable_id |          to_timestamp           
+-------------------+---------------------------------
+                10 | Mon Nov 24 01:16:20 4714 LMT BC
+                11 | Mon Nov 24 01:16:20 4714 LMT BC
+                12 | Mon Nov 24 01:16:20 4714 LMT BC
+
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_custom_timezone.sql:17: WARNING:  refresh the continuous aggregate after the migration executing this statement: "CALL public.refresh_continuous_aggregate('public.conditions_summary_daily_new', CAST('4714-11-24 01:16:20+01:16:20 BC' AS timestamp with time zone), NULL);"
+-- Cleanup
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_custom_timezone.sql:20: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+DROP MATERIALIZED VIEW conditions_summary_daily;
+DROP MATERIALIZED VIEW conditions_summary_weekly;
+DROP TABLE conditions CASCADE;
+psql:include/cagg_migrate_custom_timezone.sql:23: NOTICE:  drop cascades to 3 other objects
+-- #########################################################
+-- Issue 6976 - space partitioning should not cause catalog corruption
+-- #########################################################
+CREATE TABLE space_partitioning (
+	time timestamptz,
+	device_id integer,
+	value float
+);
+-- Updating sequence numbers so creating a hypertable doesn't mess with
+-- data imports used by migration tests
+SELECT setval('_timescaledb_catalog.hypertable_id_seq', 999, true);
+ setval 
+--------
+    999
+
+SELECT setval('_timescaledb_catalog.chunk_id_seq', 999, true);
+ setval 
+--------
+    999
+
+SELECT setval('_timescaledb_catalog.dimension_id_seq', 999, true);
+ setval 
+--------
+    999
+
+SELECT setval('_timescaledb_catalog.dimension_slice_id_seq', 999, true);
+ setval 
+--------
+    999
+
+SELECT create_hypertable('space_partitioning', 'time', chunk_time_interval=>'1 hour'::interval);
+         create_hypertable          
+------------------------------------
+ (1000,public,space_partitioning,t)
+
+SELECT add_dimension('space_partitioning', 'device_id', 3);
+                add_dimension                 
+----------------------------------------------
+ (1001,public,space_partitioning,device_id,t)
+
+INSERT INTO space_partitioning SELECT t, 1, 1.0 FROM generate_series('2024-01-01'::timestamptz, '2024-02-01'::timestamptz, '10 minutes'::interval) t;
+INSERT INTO space_partitioning SELECT t, 1000, 1.0 FROM generate_series('2024-01-01'::timestamptz, '2024-02-01'::timestamptz, '10 minutes'::interval) t;
+CREATE MATERIALIZED VIEW space_partitioning_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT
+    time_bucket(INTERVAL '1 week', "time") AS bucket,
+    device_id,
+    MIN(value),
+    MAX(value),
+    SUM(value)
+FROM
+    space_partitioning
+GROUP BY
+    1, 2
+WITH NO DATA;
+-- setting up the state so that remove_dropped_chunk_metadata
+-- would run on the hypertable and trigger the catalog corruption
+UPDATE _timescaledb_catalog.chunk
+SET dropped = TRUE
+FROM _timescaledb_catalog.hypertable
+WHERE  chunk.hypertable_id = hypertable.id
+AND hypertable.table_name = 'space_partitioning'
+AND chunk.id = 1000;
+UPDATE _timescaledb_catalog.continuous_agg
+SET finalized = true
+FROM _timescaledb_catalog.hypertable
+WHERE continuous_agg.raw_hypertable_id = hypertable.id
+AND hypertable.table_name = 'space_partitioning';
+SET timescaledb.restoring TO ON;
+DROP TABLE _timescaledb_internal._hyper_1000_1000_chunk;
+SET timescaledb.restoring TO OFF;
+SELECT _timescaledb_functions.remove_dropped_chunk_metadata(id)
+FROM _timescaledb_catalog.hypertable
+WHERE table_name = 'space_partitioning';
+INFO:  Removing metadata of chunk 1000 from hypertable 1000
+ remove_dropped_chunk_metadata 
+-------------------------------
+                             1
+
+-- check every chunk has as many chunk constraints as
+-- there are dimensions, should return empty result
+-- this ensures we have avoided catalog corruption
+WITH dimension_count as (
+SELECT ht.id, count(*)
+FROM _timescaledb_catalog.hypertable ht
+INNER JOIN _timescaledb_catalog.dimension d
+	ON d.hypertable_id = ht.id
+WHERE table_name = 'space_partitioning'
+GROUP BY 1),
+chunk_constraint_count AS (
+SELECT c.hypertable_id, cc.chunk_id, count(*)
+FROM _timescaledb_catalog.chunk_constraint cc
+INNER JOIN _timescaledb_catalog.chunk c
+	ON cc.chunk_id = c.id
+GROUP BY 1, 2
+)
+SELECT *
+FROM dimension_count dc
+INNER JOIN chunk_constraint_count ccc
+	ON ccc.hypertable_id = dc.id
+WHERE dc.count != ccc.count;
+ id | count | hypertable_id | chunk_id | count 
+----+-------+---------------+----------+-------
+

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1439,7 +1439,8 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 -------
      2
 
-SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
+SELECT drop_chunks('metrics', older_than=>'1 day'::interval, force=>true);
+WARNING:  _timescaledb_internal._hyper_13_34_chunk contained data required for continuous aggregate refresh
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_13_33_chunk

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -213,7 +213,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  detach_tablespace(name,regclass,boolean)
  detach_tablespaces(regclass)
  disable_chunk_skipping(regclass,name,boolean)
- drop_chunks(regclass,"any","any",boolean,"any","any")
+ drop_chunks(regclass,"any","any",boolean,"any","any",boolean)
  enable_chunk_skipping(regclass,name,boolean)
  first(anyelement,"any")
  generate_uuidv7()

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -359,17 +359,18 @@ AS SELECT time_bucket('5', time), max(data)
     GROUP BY 1 WITH NO DATA;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
---dropping chunks will process the invalidations
+-- chunks that contain data that hasn't been refreshed yet i.e. after the watermark will not be dropped unless force is specified
+-- drop_chunks does not process invalidations on drop
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
+SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), force => true);
 SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 CALL refresh_continuous_aggregate('drop_chunks_view', 10, 40);
 
---this will be seen after the drop its within the invalidation window and will be dropped
 INSERT INTO drop_chunks_table VALUES (26, 100);
---this will not be processed by the drop since chunk 30-39 is not dropped but will be seen after refresh
---shows that the drop doesn't do more work than necessary
+-- Invalidation on 31 will not be seen in the CAgg after the drop
 INSERT INTO drop_chunks_table VALUES (31, 200);
 --move the time up to 39
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(35, 39) AS i;
@@ -382,11 +383,11 @@ WHERE hypertable_name = 'drop_chunks_table';
 --the invalidation on 25 not yet seen
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 
---refresh to process the invalidations and then drop
+--refresh to process the invalidations till 30 and then drop
 CALL refresh_continuous_aggregate('drop_chunks_view', NULL, (integer_now_test2()-9));
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 
---new values on 25 now seen in view
+--new values on 25 are seen because of the refresh, but new value on 31 is not
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 --earliest datapoint now in table
 SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;

--- a/tsl/test/sql/cagg_drop_chunks.sql
+++ b/tsl/test/sql/cagg_drop_chunks.sql
@@ -127,3 +127,405 @@ CALL refresh_cagg_by_chunk_range('conditions_2', 'conditions', NULL);
 SELECT * FROM conditions_2 ORDER BY bucket;
 
 DROP PROCEDURE refresh_cagg_by_chunk_range(REGCLASS, REGCLASS, INTEGER);
+
+--
+-- Test drop_chunks with continuous aggregates and watermark protection
+--
+CREATE TABLE sensor_data (
+    time TIMESTAMPTZ NOT NULL,
+    sensor_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    pressure DOUBLE PRECISION
+);
+
+SELECT create_hypertable('sensor_data', 'time',
+    chunk_time_interval => INTERVAL '1 day'
+);
+
+INSERT INTO sensor_data
+SELECT
+    timestamp '2024-01-01' + (i * INTERVAL '4 hours') AS time,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(0, 25) AS i;
+
+CREATE MATERIALIZED VIEW sensor_hourly_avg
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 hour', time) AS bucket,
+    sensor_id,
+    AVG(temperature) AS avg_temperature,
+    AVG(humidity) AS avg_humidity,
+    AVG(pressure) AS avg_pressure,
+    COUNT(*) AS reading_count
+FROM sensor_data
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+
+-- Checks range start and end for chunks
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+
+-- Completely refresh the aggregate
+CALL refresh_continuous_aggregate('sensor_hourly_avg', NULL, NULL);
+
+SELECT count(*) AS ht_before FROM show_chunks('sensor_data');
+
+-- Insert more data after the CAgg watermark
+INSERT INTO sensor_data
+SELECT
+    timestamp '2024-02-01' + (i * INTERVAL '4 hours') AS time,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(0, 25) AS i;
+
+-- View ranges before drop chunks
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+
+-- Verify watermark
+SELECT h.id AS mat_hypertable_id
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_hourly_avg' \gset
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id));
+
+\set VERBOSITY terse
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2023-12-31 17:00:00-07'::timestamp with time zone);
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+
+ROLLBACK;
+
+-- Chunk with unrefreshed data can be dropped directly using DROP TABLE ...
+BEGIN;
+SELECT format('%I.%I', chunk_schema, chunk_name) AS chunk_to_drop
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start LIMIT 1 \gset
+
+SELECT :'chunk_to_drop' AS dropped_chunk;
+
+DROP TABLE :chunk_to_drop;
+
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', older_than => '2024-02-05 17:00:00-07'::timestamp with time zone);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-02 17:00:00-07'::timestamp with time zone, older_than => '2024-02-02 17:00:00-07'::timestamp with time zone);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+
+-- Test force option
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2023-01-05 17:00:00-07'::timestamp with time zone, force => true);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+
+\set VERBOSITY default
+
+--
+-- Test with multiple continuous aggregates to verify earliest watermark is used
+--
+-- Create a second continuous aggregate on the same hypertable (NOT hierarchical cagg)
+CREATE MATERIALIZED VIEW sensor_daily_avg
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', time) AS bucket,
+    sensor_id,
+    AVG(temperature) AS avg_temperature,
+    AVG(humidity) AS avg_humidity,
+    AVG(pressure) AS avg_pressure,
+    COUNT(*) AS reading_count
+FROM sensor_data
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+
+-- Refresh the second aggregate partially to a different point
+CALL refresh_continuous_aggregate('sensor_daily_avg', '2024-01-01', '2024-01-03');
+
+SELECT h.id AS mat_hypertable_id_daily
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_daily_avg' \gset
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS hourly_watermark;
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily)) AS daily_watermark;
+
+\set VERBOSITY terse
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', older_than => '2024-02-05 17:00:00-07'::timestamp with time zone);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-01 17:00:00-07'::timestamp with time zone, older_than => '2024-02-02 17:00:00-07'::timestamp with time zone);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+\set VERBOSITY default
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-05 17:00:00-07'::timestamp with time zone, force => true);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+\set VERBOSITY default
+
+DROP MATERIALIZED VIEW sensor_daily_avg;
+
+--
+-- Test with hierarchical continuous aggregate
+--
+-- Create hierarchical cagg
+CREATE MATERIALIZED VIEW sensor_daily_avg_hier
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day', bucket) AS bucket,
+    sensor_id,
+    AVG(avg_temperature) AS avg_temperature,
+    AVG(avg_humidity) AS avg_humidity,
+    AVG(avg_pressure) AS avg_pressure,
+    SUM(reading_count) AS reading_count
+FROM sensor_hourly_avg
+GROUP BY time_bucket('1 day', bucket), sensor_id
+WITH NO DATA;
+
+-- Refresh the hierarchical aggregate partially
+CALL refresh_continuous_aggregate('sensor_daily_avg_hier', NULL, '2024-01-03');
+
+-- Verify watermarks
+SELECT h.id AS mat_hypertable_id_daily_hier
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_daily_avg_hier' \gset
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS hourly_watermark;
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily_hier)) AS daily_hierarchical_watermark;
+
+\set VERBOSITY terse
+BEGIN;
+
+-- With hierarchical cagg, drop_chunks should still use the earliest watermark from the raw hypertable's caggs
+-- The hierarchical cagg watermark should not affect raw hypertable chunk retention
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', older_than => '2024-02-05 17:00:00-07'::timestamp with time zone);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data', newer_than => '2024-01-01 17:00:00-07'::timestamp with time zone, older_than => '2024-02-02 17:00:00-07'::timestamp with time zone);
+SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data'
+  ORDER BY range_start;
+ROLLBACK;
+\set VERBOSITY default
+
+-- Try drop_chunks on base cagg in the case of hierarchical caggs
+-- Here, the watermark of the hierarchical CAgg matters but the base CAgg watermark shouldn't affect it
+
+CALL refresh_continuous_aggregate('sensor_hourly_avg', NULL, NULL);
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id)) AS hourly_watermark;
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily_hier)) AS daily_hierarchical_watermark;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_hourly_avg', older_than => '2024-01-10 17:00:00-07'::timestamp with time zone);
+ SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = (
+      SELECT h.table_name
+      FROM _timescaledb_catalog.continuous_agg ca
+      JOIN _timescaledb_catalog.hypertable h ON
+  h.id = ca.mat_hypertable_id
+      WHERE ca.user_view_name = 'sensor_hourly_avg'
+  )
+  ORDER BY range_start;
+ROLLBACK;
+
+-- Test force option
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_hourly_avg', older_than => '2024-01-10 17:00:00-07'::timestamp with time zone, force => true);
+ SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = (
+      SELECT h.table_name
+      FROM _timescaledb_catalog.continuous_agg ca
+      JOIN _timescaledb_catalog.hypertable h ON
+  h.id = ca.mat_hypertable_id
+      WHERE ca.user_view_name = 'sensor_hourly_avg'
+  )
+  ORDER BY range_start;
+ROLLBACK;
+
+-- Refresh hierarchical cagg completely
+CALL refresh_continuous_aggregate('sensor_daily_avg_hier', NULL, NULL);
+
+SELECT _timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(:mat_hypertable_id_daily_hier)) AS daily_hierarchical_watermark;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_hourly_avg', older_than => '2024-01-10 17:00:00-07'::timestamp with time zone);
+ SELECT chunk_name, range_start, range_end
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = (
+      SELECT h.table_name
+      FROM _timescaledb_catalog.continuous_agg ca
+      JOIN _timescaledb_catalog.hypertable h ON
+  h.id = ca.mat_hypertable_id
+      WHERE ca.user_view_name = 'sensor_hourly_avg'
+  )
+  ORDER BY range_start;
+ROLLBACK;
+
+DROP MATERIALIZED VIEW sensor_daily_avg_hier;
+DROP MATERIALIZED VIEW sensor_hourly_avg;
+DROP TABLE sensor_data;
+
+--
+-- Test drop_chunks with integer time continuous aggregates
+--
+CREATE OR REPLACE FUNCTION integer_now_sensor_data() returns INT LANGUAGE SQL STABLE as
+    $$ SELECT 150 $$;
+
+CREATE TABLE sensor_data_int (
+    time_int INT NOT NULL,
+    sensor_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    pressure DOUBLE PRECISION
+);
+
+SELECT create_hypertable('sensor_data_int', 'time_int',
+    chunk_time_interval => 10
+);
+
+SELECT set_integer_now_func('sensor_data_int', 'integer_now_sensor_data');
+
+INSERT INTO sensor_data_int
+SELECT
+    i AS time_int,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(0, 99, 4) AS i;
+
+CREATE MATERIALIZED VIEW sensor_hourly_avg_int
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket(5, time_int) AS bucket,
+    sensor_id,
+    AVG(temperature) AS avg_temperature,
+    AVG(humidity) AS avg_humidity,
+    AVG(pressure) AS avg_pressure,
+    COUNT(*) AS reading_count
+FROM sensor_data_int
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+
+-- Check range start and end for chunks
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+
+-- Refresh the aggregate completely
+CALL refresh_continuous_aggregate('sensor_hourly_avg_int', NULL, NULL);
+
+SELECT count(*) AS ht_before FROM show_chunks('sensor_data_int');
+
+-- Insert more data after the CAgg watermark
+INSERT INTO sensor_data_int
+SELECT
+    i AS time_int,
+    (i % 5) + 1 AS sensor_id,
+    15 + 15 * random() AS temperature,
+    30 + 60 * random() AS humidity,
+    980 + 40 * random() AS pressure
+FROM generate_series(100, 199, 4) AS i;
+
+-- View ranges before drop chunks
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+
+-- Verify watermark
+SELECT h.id AS mat_hypertable_id_int
+  FROM _timescaledb_catalog.continuous_agg ca
+  JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'sensor_hourly_avg_int' \gset
+
+SELECT _timescaledb_functions.cagg_watermark(:mat_hypertable_id_int);
+
+\set VERBOSITY terse
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data_int', newer_than => 0);
+
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+
+ROLLBACK;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data_int', older_than => 120);
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+ROLLBACK;
+
+BEGIN;
+SELECT count(*) AS dropped_count FROM drop_chunks('sensor_data_int', newer_than => 10, older_than => 110);
+SELECT chunk_name, range_start_integer, range_end_integer
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_int'
+  ORDER BY range_start_integer;
+ROLLBACK;
+\set VERBOSITY default
+
+DROP MATERIALIZED VIEW sensor_hourly_avg_int;
+DROP TABLE sensor_data_int;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -681,7 +681,7 @@ DROP TABLE approx_count;
 --TEST drop_chunks from a compressed hypertable (that has caggs defined).
 -- chunk metadata is still retained. verify correct status for chunk
 SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
-SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
+SELECT drop_chunks('metrics', older_than=>'1 day'::interval, force=>true);
 SELECT
    c.table_name as chunk_name,
    c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id

--- a/tsl/test/sql/include/cagg_migrate_common.sql
+++ b/tsl/test/sql/include/cagg_migrate_common.sql
@@ -1,0 +1,347 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Setup some variables
+SELECT
+    format('../data/cagg_migrate_%1$s.sql', lower(:'TIME_DIMENSION_DATATYPE')) AS "TEST_SCHEMA_FILE"
+\gset
+
+-- restore dump
+SELECT timescaledb_pre_restore();
+\ir :TEST_SCHEMA_FILE
+SELECT timescaledb_post_restore();
+
+-- Make sure no scheduled job will be executed during the regression tests
+SELECT _timescaledb_functions.stop_background_workers();
+
+\if :IS_TIME_DIMENSION
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series('2022-01-01 00:00:00-00'::timestamptz, '2022-12-31 23:59:59-00'::timestamptz, '1 hour'),
+        0.25;
+\else
+    CREATE OR REPLACE FUNCTION integer_now()
+    RETURNS :TIME_DIMENSION_DATATYPE LANGUAGE SQL STABLE AS
+    $$
+        SELECT coalesce(max(time), 0)
+        FROM public.conditions
+    $$;
+
+    INSERT INTO conditions ("time", temperature)
+    SELECT
+        generate_series(1, 1000, 1),
+        0.25;
+\endif
+
+CALL refresh_continuous_aggregate('conditions_summary_daily', NULL, NULL);
+CALL refresh_continuous_aggregate('conditions_summary_weekly', NULL, NULL);
+
+\set ON_ERROR_STOP 0
+-- should fail because we don't need to migrate finalized caggs
+CALL cagg_migrate('conditions_summary_daily_new');
+
+-- should fail relation does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+
+CREATE TABLE conditions_summary_not_cagg();
+
+-- should fail continuous agg does not exist
+CALL cagg_migrate('conditions_summary_not_cagg');
+\set ON_ERROR_STOP 1
+
+DROP TABLE conditions_summary_not_cagg;
+
+SELECT
+    ca.raw_hypertable_id AS "RAW_HYPERTABLE_ID",
+    h.schema_name AS "MAT_SCHEMA_NAME",
+    h.table_name AS "MAT_TABLE_NAME",
+    partial_view_name AS "PART_VIEW_NAME",
+    partial_view_schema AS "PART_VIEW_SCHEMA",
+    direct_view_name AS "DIR_VIEW_NAME",
+    direct_view_schema AS "DIR_VIEW_SCHEMA",
+    user_view_name AS "USER_VIEW_NAME",
+    user_view_schema AS "USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily'
+\gset
+
+\set ON_ERROR_STOP 0
+-- should fail because the new cagg with suffix '_new' already exists
+CALL cagg_migrate('conditions_summary_daily');
+\set ON_ERROR_STOP 1
+
+-- remove the new cagg to execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+
+-- get and set all the cagg data
+SELECT
+    _timescaledb_functions.cagg_migrate_pre_validation(
+        'public',
+        'conditions_summary_daily',
+        'conditions_summary_daily_new'
+    ) AS "CAGG_DATA"
+\gset
+
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+\x on
+SELECT mat_hypertable_id, user_view_definition FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+\x off
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_functions.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+CALL cagg_migrate('conditions_summary_daily');
+\set ON_ERROR_STOP 1
+
+-- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+
+\if :IS_TIME_DIMENSION
+SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
+\else
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
+\endif
+
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'USER_VIEW_SCHEMA'
+AND hypertable_name = :'USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+
+-- execute the migration
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+CALL cagg_migrate('conditions_summary_daily');
+
+SELECT
+    ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
+    h.schema_name AS "NEW_MAT_SCHEMA_NAME",
+    h.table_name AS "NEW_MAT_TABLE_NAME",
+    partial_view_name AS "NEW_PART_VIEW_NAME",
+    partial_view_schema AS "NEW_PART_VIEW_SCHEMA",
+    direct_view_name AS "NEW_DIR_VIEW_NAME",
+    direct_view_schema AS "NEW_DIR_VIEW_SCHEMA",
+    user_view_name AS "NEW_USER_VIEW_NAME",
+    user_view_schema AS "NEW_USER_VIEW_SCHEMA"
+FROM
+    _timescaledb_catalog.continuous_agg ca
+    JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE
+    user_view_name = 'conditions_summary_daily_new'
+\gset
+
+\d+ conditions_summary_daily_new
+
+SELECT *
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_USER_VIEW_SCHEMA'
+AND hypertable_name = :'NEW_USER_VIEW_NAME'
+AND job_id >= 1000 ORDER BY job_id;
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+
+CREATE OR REPLACE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
+
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+-- cagg with the old format because it was overriden
+\d+ conditions_summary_daily_old
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+
+-- test migration overriding the new cagg and removing the old
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+DROP MATERIALIZED VIEW conditions_summary_daily;
+ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+\set ON_ERROR_STOP 0
+-- should fail because the cagg was overriden
+SELECT * FROM conditions_summary_daily_new;
+-- should fail because the old cagg was removed
+SELECT * FROM conditions_summary_daily_old;
+\set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+
+-- permission tests
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
+ALTER MATERIALIZED VIEW conditions_summary_weekly OWNER TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+\set ON_ERROR_STOP 1
+
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
+CALL cagg_migrate('conditions_summary_weekly');
+\set ON_ERROR_STOP 1
+
+RESET ROLE;
+GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+\set ON_ERROR_STOP 0
+-- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
+CALL cagg_migrate('conditions_summary_weekly');
+\set ON_ERROR_STOP 1
+
+RESET ROLE;
+GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+-- all necessary permissions granted
+CALL cagg_migrate('conditions_summary_weekly');
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_weekly
+EXCEPT
+SELECT * FROM conditions_summary_weekly_new;
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+
+RESET ROLE;
+
+-- according to the official documentation trying to execute a procedure with
+-- transaction control statements inside an explicit transaction should fail:
+-- https://www.postgresql.org/docs/current/sql-call.html
+-- `If CALL is executed in a transaction block, then the called procedure cannot
+--  execute transaction control statements. Transaction control statements are only
+--  allowed if CALL is executed in its own transaction.`
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+DROP MATERIALIZED VIEW conditions_summary_weekly_new;
+
+\set ON_ERROR_STOP 0
+BEGIN;
+-- should fail with `invalid transaction termination`
+CALL cagg_migrate('conditions_summary_weekly');
+ROLLBACK;
+\set ON_ERROR_STOP 1
+
+CREATE FUNCTION execute_migration() RETURNS void AS
+$$
+BEGIN
+    CALL cagg_migrate('conditions_summary_weekly');
+    RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+
+\set ON_ERROR_STOP 0
+-- execute migration inside a plpgsql function
+BEGIN;
+-- should fail with `invalid transaction termination`
+SELECT execute_migration();
+ROLLBACK;
+\set ON_ERROR_STOP 1
+
+--
+-- test dropping chunks
+--
+
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+
+-- drop 1 chunk
+\if :IS_TIME_DIMENSION
+    SELECT drop_chunks('conditions', older_than => CAST('2022-01-08 00:00:00-00' AS :TIME_DIMENSION_DATATYPE), force=>true);
+\else
+    SELECT drop_chunks('conditions', older_than => 10, force=>true);
+\endif
+
+-- now he have one chunk marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+
+-- this migration should remove the chunk metadata marked as dropped
+CALL cagg_migrate('conditions_summary_weekly', override => TRUE, drop_old => TRUE);
+
+-- no chunks marked as dropped
+SELECT
+   c.table_name as chunk_name,
+   c.dropped
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id AND h.table_name = 'conditions' AND c.dropped
+ORDER BY 1;
+
+-- cleanup
+DROP FUNCTION execute_migration();
+REVOKE SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan FROM :ROLE_DEFAULT_PERM_USER;
+REVOKE USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq FROM :ROLE_DEFAULT_PERM_USER;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+DROP MATERIALIZED VIEW conditions_summary_daily;
+DROP MATERIALIZED VIEW conditions_summary_weekly;
+DROP TABLE conditions;
+
+SELECT _timescaledb_functions.start_background_workers();


### PR DESCRIPTION
This PR changes `drop_chunks` behaviour to skip dropping chunks that contain unrefreshed data that is required for continuous aggregate refreshes. This is done by checking the CAgg watermark. A notice is emitted for each skipped chunk.

This is mainly to prevent data retention policies (which use drop_chunks under-the-hood) from dropping chunks which haven't been refreshed yet by a corresponding refresh policy.

This also introduces a 'force' option to `drop_chunks` to allow users to override the watermark-protection and drop chunks containing unrefreshed data. Using 'force' to drop a chunk containing unrefreshed CAgg data generates a warning for the user.

Note that invalidation logs are not checked. It is still possible to drop chunks containing unrefreshed data that was backfilled.