### PR TITLE
Add validation for compression index key limits

### DIFF
--- a/.unreleased/pr_9007
+++ b/.unreleased/pr_9007
@@ -1,0 +1,1 @@
+Fixes: #9007 Add validation for compression index key limits

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -386,3 +386,70 @@ SELECT * FROM settings;
 ----------+----------------+-----------+--------------------+--------------+--------------------+-------
  metrics2 |                |           | {d1,d2,value,time} | {t,f,t,f}    | {f,t,t,t}          | 
 
+-- Test column limits for orderby and segmentby
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+-- Test CREATE TABLE syntax
+CREATE TABLE test_column_limit_create (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT,
+    col1 DOUBLE PRECISION,
+    col2 DOUBLE PRECISION,
+    col3 DOUBLE PRECISION,
+    col4 DOUBLE PRECISION,
+    col5 DOUBLE PRECISION,
+    col6 DOUBLE PRECISION,
+    col7 DOUBLE PRECISION,
+    col8 DOUBLE PRECISION,
+    col9 DOUBLE PRECISION,
+    col10 DOUBLE PRECISION,
+    col11 DOUBLE PRECISION,
+    col12 DOUBLE PRECISION,
+    col13 DOUBLE PRECISION,
+    col14 DOUBLE PRECISION,
+    col15 DOUBLE PRECISION
+) WITH (
+    tsdb.hypertable,
+    tsdb.partition_column='time',
+    tsdb.segmentby='device_id',
+    tsdb.orderby= 'col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15'
+);
+ERROR:  too many segmentby and orderby columns
+DETAIL:  Combined segmentby keys (1) and orderby keys (32) cannot exceed 32
+-- Test ALTER TABLE syntax
+CREATE TABLE test_column_limit_alter (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT,
+    col1 DOUBLE PRECISION,
+    col2 DOUBLE PRECISION,
+    col3 DOUBLE PRECISION,
+    col4 DOUBLE PRECISION,
+    col5 DOUBLE PRECISION,
+    col6 DOUBLE PRECISION,
+    col7 DOUBLE PRECISION,
+    col8 DOUBLE PRECISION,
+    col9 DOUBLE PRECISION,
+    col10 DOUBLE PRECISION,
+    col11 DOUBLE PRECISION,
+    col12 DOUBLE PRECISION,
+    col13 DOUBLE PRECISION,
+    col14 DOUBLE PRECISION,
+    col15 DOUBLE PRECISION,
+    col16 DOUBLE PRECISION
+);
+-- Create hypertable
+SELECT create_hypertable('test_column_limit_alter', 'time');
+          create_hypertable           
+--------------------------------------
+ (8,public,test_column_limit_alter,t)
+
+-- Enable compression with 1 segmentby and 20 orderby columns (1 + 40 = 41 keys)
+ALTER TABLE test_column_limit_alter SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15'
+);
+ERROR:  too many segmentby and orderby columns
+DETAIL:  Combined segmentby keys (1) and orderby keys (32) cannot exceed 32
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -147,3 +147,67 @@ SELECT * FROM settings;
 -- hypertable so needs to be tested separately.
 DROP TABLE metrics CASCADE;
 SELECT * FROM settings;
+
+-- Test column limits for orderby and segmentby
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+-- Test CREATE TABLE syntax
+CREATE TABLE test_column_limit_create (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT,
+    col1 DOUBLE PRECISION,
+    col2 DOUBLE PRECISION,
+    col3 DOUBLE PRECISION,
+    col4 DOUBLE PRECISION,
+    col5 DOUBLE PRECISION,
+    col6 DOUBLE PRECISION,
+    col7 DOUBLE PRECISION,
+    col8 DOUBLE PRECISION,
+    col9 DOUBLE PRECISION,
+    col10 DOUBLE PRECISION,
+    col11 DOUBLE PRECISION,
+    col12 DOUBLE PRECISION,
+    col13 DOUBLE PRECISION,
+    col14 DOUBLE PRECISION,
+    col15 DOUBLE PRECISION
+) WITH (
+    tsdb.hypertable,
+    tsdb.partition_column='time',
+    tsdb.segmentby='device_id',
+    tsdb.orderby= 'col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15'
+);
+
+-- Test ALTER TABLE syntax
+CREATE TABLE test_column_limit_alter (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT,
+    col1 DOUBLE PRECISION,
+    col2 DOUBLE PRECISION,
+    col3 DOUBLE PRECISION,
+    col4 DOUBLE PRECISION,
+    col5 DOUBLE PRECISION,
+    col6 DOUBLE PRECISION,
+    col7 DOUBLE PRECISION,
+    col8 DOUBLE PRECISION,
+    col9 DOUBLE PRECISION,
+    col10 DOUBLE PRECISION,
+    col11 DOUBLE PRECISION,
+    col12 DOUBLE PRECISION,
+    col13 DOUBLE PRECISION,
+    col14 DOUBLE PRECISION,
+    col15 DOUBLE PRECISION,
+    col16 DOUBLE PRECISION
+);
+
+-- Create hypertable
+SELECT create_hypertable('test_column_limit_alter', 'time');
+
+-- Enable compression with 1 segmentby and 20 orderby columns (1 + 40 = 41 keys)
+ALTER TABLE test_column_limit_alter SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'col1, col2, col3, col4, col5, col6, col7, col8, col9, col10, col11, col12, col13, col14, col15'
+);
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse


### PR DESCRIPTION
Compression creates implicit indexes on compressed chunks using segmentby and orderby columns. Each segmentby column contributes 1 index key, and each orderby column contributes 2 keys (for min and max metadata). This can exceed PostgreSQL's INDEX_MAX_KEYS limit of 32.

Add validate_compression_index_key_limit() to check that the total number of index keys doesn't exceed INDEX_MAX_KEYS when setting up compression.

Fixes #8218