### PR TITLE
Use UTF-8 encoding for make installcheck for APT packages

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -1,6 +1,9 @@
 # Test running make installcheck on our APT packages.
 name: "Packaging tests: Installcheck for APT"
 "on":
+  schedule:
+    # run daily 0:00 on main branch
+    - cron: '0 0 * * *'
   pull_request:
     paths: .github/workflows/apt-installcheck.yaml
   push:


### PR DESCRIPTION
Otherwise there are no collations available to run some of our collation tests.

Also enable scheduled runs on main now that it passes.