### PR TITLE
Use latest github release to determine current expected version

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Add repositories
       run: |
         apt-get update
-        apt-get install -y wget lsb-release gnupg sudo postgresql-common git cmake
+        apt-get install -y wget lsb-release gnupg sudo postgresql-common git cmake jq
         yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         image_type=$(lsb_release -i -s | tr '[:upper:]' '[:lower:]')
         echo "deb https://packagecloud.io/timescale/timescaledb/${image_type}/ $(lsb_release -c -s) main" \
@@ -59,17 +59,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Read versions
+    - name: Get version of latest release
       id: versions
       run: |
-        # read expected version from version.config
-        # version will only be a proper version in a release branch so we use previous_version
-        # as fallback for main
-        if grep '^version = [0-9.]\+$' version.config; then
-          version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
-        else
-          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
-        fi
+        version=$(wget -q https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
+        echo "version=${version}"
         echo "version=${version}" >>$GITHUB_OUTPUT
 
         grep PRETTY_NAME /etc/os-release >> $GITHUB_OUTPUT

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Add repositories
       run: |
         apt-get update
-        apt-get install -y wget lsb-release gnupg apt-transport-https sudo postgresql-common
+        apt-get install -y wget lsb-release gnupg apt-transport-https sudo postgresql-common jq
         yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         image_type=$(lsb_release -i -s | tr '[:upper:]' '[:lower:]')
         echo "deb https://packagecloud.io/timescale/timescaledb/${image_type}/ $(lsb_release -c -s) main" \
@@ -74,17 +74,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Read versions
+    - name: Get version of latest release
       id: versions
       run: |
-        # read expected version from version.config
-        # version will only be a proper version in a release branch so we use previous_version
-        # as fallback for main
-        if grep '^version = [0-9.]\+$' version.config; then
-          version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
-        else
-          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
-        fi
+        version=$(wget -q https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
+        echo "version=${version}"
         echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Test Installation

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -51,17 +51,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Read versions
+    - name: Get version of latest release
       id: versions
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        # read expected version from version.config
-        # version will only be a proper version in a release branch so we use previous_version
-        # as fallback for main
-        if grep '^version = [0-9.]\+$' version.config; then
-          version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
-        else
-          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
-        fi
+        version=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName')
         echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Wait for services to start

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -48,15 +48,12 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Test Installation
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         psql -X -c "CREATE EXTENSION timescaledb;" postgres
         psql -X -c "SELECT extname,extversion,version() FROM pg_extension WHERE extname='timescaledb';" postgres
-        # read expected version from version.config
-        if grep '^version = [0-9.]\+$' version.config; then
-          version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
-        else
-          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
-        fi
+        version=$(gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName')
         installed_version=$(psql -X -t \
             -c "SELECT extversion FROM pg_extension WHERE extname='timescaledb';" \
             postgres | sed -e 's! !!g')

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -56,7 +56,7 @@ jobs:
       run: |
         yum update -y
         if [[ "$(rpm -E %{rhel})" -eq "8" ]]; then dnf -qy module disable postgresql; fi
-        yum install -y timescaledb-2${{ matrix.pkg_suffix }}-postgresql-${{ matrix.pg }} sudo wget
+        yum install -y timescaledb-2${{ matrix.pkg_suffix }}-postgresql-${{ matrix.pg }} sudo wget jq
         sudo -u postgres /usr/pgsql-${{ matrix.pg }}/bin/initdb -D /var/lib/pgsql/${{ matrix.pg }}/data
         timescaledb-tune --quiet --yes --pg-config /usr/pgsql-${{ matrix.pg }}/bin/pg_config
 
@@ -70,17 +70,11 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Read versions
+    - name: Get version of latest release
       id: versions
       run: |
-        # read expected version from version.config
-        # version will only be a proper version in a release branch so we use previous_version
-        # as fallback for main
-        if grep '^version = [0-9.]\+$' version.config; then
-          version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
-        else
-          version=$(grep '^previous_version = ' version.config | sed -e 's!^previous_version = !!')
-        fi
+        version=$(wget -q https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
+        echo "version=${version}"
         echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Test Installation

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -34,16 +34,10 @@ jobs:
 
     - name: Get version
       id: version
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        # version will only be a proper version in a release branch so we use previous_version
-        # as fallback for main
-        if (grep '^version = [0-9.]\+$' version.config)
-        {
-          $version=sed -n 's!^version = !!p' version.config
-        } else {
-          $version=sed -n 's!^previous_version = !!p' version.config
-        }
-        cat version.config
+        $version=gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | .tagName'
         echo "Determined version: "
         echo "version=$version"
         echo "version=$version" >>$env:GITHUB_OUTPUT


### PR DESCRIPTION
The workflows verifying packages used version.config to determine
most recent version which required the forward PR to be merged to
main branch. This change uses github releases instead which means
workflow will use the new version as soon as it is released.
