### PR TITLE
Remove _timescaledb_debug schema

### DIFF
--- a/.unreleased/pr_9016
+++ b/.unreleased/pr_9016
@@ -1,0 +1,1 @@
+Implements: #9016 Remove _timescaledb_debug schema

--- a/sql/debug_utils.sql
+++ b/sql/debug_utils.sql
@@ -6,6 +6,6 @@
 -- debugging in release builds. These are all placed in the schema
 -- _timescaledb_debug.
 
-CREATE OR REPLACE FUNCTION _timescaledb_debug.extension_state() RETURNS TEXT
+CREATE OR REPLACE FUNCTION _timescaledb_functions.extension_state() RETURNS TEXT
 AS '@MODULE_PATHNAME@', 'ts_extension_get_state' LANGUAGE C;
 

--- a/sql/pre_install/schemas.sql
+++ b/sql/pre_install/schemas.sql
@@ -11,13 +11,11 @@ CREATE SCHEMA _timescaledb_cache;
 CREATE SCHEMA _timescaledb_config;
 CREATE SCHEMA timescaledb_experimental;
 CREATE SCHEMA timescaledb_information;
-CREATE SCHEMA _timescaledb_debug;
 
 GRANT USAGE ON SCHEMA
       _timescaledb_cache,
       _timescaledb_catalog,
       _timescaledb_config,
-      _timescaledb_debug,
       _timescaledb_functions,
       _timescaledb_internal,
       timescaledb_experimental,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -145,3 +145,8 @@ ANALYZE _timescaledb_catalog.continuous_agg;
 --
 -- END Rebuild the catalog table `_timescaledb_catalog.continuous_agg`
 --
+
+DROP FUNCTION IF EXISTS _timescaledb_debug.extension_state();
+DROP SCHEMA IF EXISTS _timescaledb_debug;
+
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -94,3 +94,8 @@ ANALYZE _timescaledb_catalog.continuous_agg;
 --
 -- END Rebuild the catalog table `_timescaledb_catalog.continuous_agg`
 --
+
+DROP FUNCTION IF EXISTS _timescaledb_functions.extension_state();
+CREATE SCHEMA _timescaledb_debug;
+GRANT USAGE ON SCHEMA _timescaledb_debug TO PUBLIC;
+

--- a/test/expected/debug_utils.out
+++ b/test/expected/debug_utils.out
@@ -3,7 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SELECT _timescaledb_debug.extension_state();
+SELECT _timescaledb_functions.extension_state();
  extension_state 
 -----------------
  created
@@ -13,7 +13,7 @@ DO $$
 DECLARE
     module text;
 BEGIN
-    SELECT probin INTO module FROM pg_proc WHERE proname = 'extension_state' AND pronamespace = '_timescaledb_debug'::regnamespace;
+    SELECT probin INTO module FROM pg_proc WHERE proname = 'extension_state' AND pronamespace = '_timescaledb_functions'::regnamespace;
     EXECUTE format('CREATE FUNCTION extension_state() RETURNS TEXT AS ''%s'', ''ts_extension_get_state'' LANGUAGE C', module);
 END
 $$;

--- a/test/sql/debug_utils.sql
+++ b/test/sql/debug_utils.sql
@@ -5,7 +5,7 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-SELECT _timescaledb_debug.extension_state();
+SELECT _timescaledb_functions.extension_state();
 
 RESET ROLE;
 
@@ -13,7 +13,7 @@ DO $$
 DECLARE
     module text;
 BEGIN
-    SELECT probin INTO module FROM pg_proc WHERE proname = 'extension_state' AND pronamespace = '_timescaledb_debug'::regnamespace;
+    SELECT probin INTO module FROM pg_proc WHERE proname = 'extension_state' AND pronamespace = '_timescaledb_functions'::regnamespace;
     EXECUTE format('CREATE FUNCTION extension_state() RETURNS TEXT AS ''%s'', ''ts_extension_get_state'' LANGUAGE C', module);
 END
 $$;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -19,7 +19,6 @@ FROM pg_proc p
     e.oid = d.refobjid
 WHERE proname <> 'get_telemetry_report'
 ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text COLLATE "C";
- _timescaledb_debug.extension_state()
  _timescaledb_functions.accept_hypertable_invalidations(regclass,text)
  _timescaledb_functions.add_materialization_invalidations(regclass,tsrange)
  _timescaledb_functions.add_materialization_invalidations(regclass,tstzrange)
@@ -61,6 +60,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.dimension_info_out(_timescaledb_internal.dimension_info)
  _timescaledb_functions.drop_chunk(regclass)
  _timescaledb_functions.drop_osm_chunk(regclass)
+ _timescaledb_functions.extension_state()
  _timescaledb_functions.finalize_agg(text,name,name,name[],bytea,anyelement)
  _timescaledb_functions.finalize_agg_ffunc(internal,text,name,name,name[],bytea,anyelement)
  _timescaledb_functions.finalize_agg_sfunc(internal,text,name,name,name[],bytea,anyelement)


### PR DESCRIPTION
To reduce the amount of schemas we have drop the _timescaledb_debug
schema since it only had 1 function and move the function to
_timescaledb_functions schema.
