### PR TITLE
Delete refresh pending ranges when dropping CAgg

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -202,3 +202,6 @@ DROP PROCEDURE IF EXISTS _timescaledb_functions.process_hypertable_invalidations
 DROP PROCEDURE IF EXISTS _timescaledb_functions.process_hypertable_invalidations(regclass);
 DROP PROCEDURE IF EXISTS _timescaledb_functions.process_hypertable_invalidations(regclass[]);
 
+-- Remove orphaned entries in materialization ranges table
+DELETE FROM _timescaledb_catalog.continuous_aggs_materialization_ranges
+WHERE NOT EXISTS (SELECT FROM _timescaledb_catalog.continuous_agg WHERE mat_hypertable_id = materialization_id);

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -153,8 +153,6 @@ extern TSDLLEXPORT ContinuousAggInfo ts_continuous_agg_get_all_caggs_info(int32 
 extern TSDLLEXPORT ContinuousAgg *
 ts_continuous_agg_find_by_mat_hypertable_id(int32 mat_hypertable_id, bool missing_ok);
 
-extern TSDLLEXPORT void ts_materialization_invalidation_log_delete_inner(int32 mat_hypertable_id);
-
 extern TSDLLEXPORT ContinuousAggHypertableStatus
 ts_continuous_agg_hypertable_status(int32 hypertable_id);
 extern TSDLLEXPORT List *ts_continuous_aggs_find_by_raw_table_id(int32 raw_hypertable_id);

--- a/tsl/test/isolation/expected/cagg_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_refresh.out
@@ -770,6 +770,62 @@ user_view_name|lowest_modified_value|greatest_modified_value
 --------------+---------------------+-----------------------
 
 
+starting permutation: WP_after_enable R6_pending_materialization_ranges R1_refresh K1_cancelpid R6_pending_materialization_ranges WP_after_release R1_drop R6_pending_materialization_ranges_orphan
+R5: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'DEBUG1';
+
+L1: WARNING:  there is already a transaction in progress
+L2: WARNING:  there is already a transaction in progress
+L3: WARNING:  there is already a transaction in progress
+step WP_after_enable: 
+    SELECT debug_waitpoint_enable('after_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+
+step R1_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 25, 70);
+ <waiting ...>
+step K1_cancelpid: 
+    CALL cancelpids();
+ <waiting ...>
+step R1_refresh: <... completed>
+ERROR:  canceling statement due to user request
+step R6_pending_materialization_ranges: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name = 'cond_10';
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+cond_10       |                   30|                     70
+
+step K1_cancelpid: <... completed>
+step WP_after_release: 
+    SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+R1: NOTICE:  drop cascades to table _timescaledb_internal._hyper_X_X_chunk
+step R1_drop: 
+    DROP MATERIALIZED VIEW cond_10;
+
+step R6_pending_materialization_ranges_orphan: 
+    SELECT * FROM pending_materialization_ranges WHERE user_view_name IS NULL;
+
+user_view_name|lowest_modified_value|greatest_modified_value
+--------------+---------------------+-----------------------
+
+
 starting permutation: WP_before_enable R1_refresh R3_refresh WP_before_release
 R5: LOG:  statement: 
     SET SESSION lock_timeout = '500ms';


### PR DESCRIPTION
When dropping a CAgg the potential pending ranges on the metadata table `continuous_aggs_materialization_ranges` aren't removed.

This is an oversight from #8514 when we introduced the new metadata table responsible for range locking when processing concurrent refreshes.

Fixed it by removing the entries when dropping CAgg.

Disable-check: force-changelog-file
