### PR TITLE
Generalize the per-aggregate filters in vectorized aggregation

### DIFF
--- a/tsl/src/compression/arrow_c_data_interface.h
+++ b/tsl/src/compression/arrow_c_data_interface.h
@@ -184,12 +184,18 @@ arrow_set_row_validity(uint64 *bitmap, size_t row_number, bool value)
 }
 
 /*
- * Combine the validity bitmaps into the given storage.
+ * Combine the validity bitmaps into the given storage. Can return one of the
+ * input filters if the others are NULL.
  */
-static inline const uint64 *
+static inline pg_nodiscard const uint64 *
 arrow_combine_validity(size_t num_words, uint64 *restrict storage, const uint64 *filter1,
 					   const uint64 *filter2, const uint64 *filter3)
 {
+	Assert(num_words != 0);
+	Assert(storage != filter1);
+	Assert(storage != filter2);
+	Assert(storage != filter3);
+
 	/*
 	 * Any and all of the filters can be null. For simplicity, move the non-null
 	 * filters to the leading positions.
@@ -257,6 +263,23 @@ arrow_combine_validity(size_t num_words, uint64 *restrict storage, const uint64 
 }
 
 /*
+ * Do the &= operation on bitmaps. The right argument can be NULL.
+ */
+static inline void
+arrow_validity_and(int num_words, uint64 *restrict left, const uint64 *right)
+{
+	if (right == NULL)
+	{
+		return;
+	}
+
+	for (int i = 0; i < num_words; i++)
+	{
+		left[i] &= right[i];
+	}
+}
+
+/*
  * Increase the `source_value` to be an even multiple of `pad_to`.
  */
 static inline uint64
@@ -268,6 +291,8 @@ pad_to_multiple(uint64 pad_to, uint64 source_value)
 static inline int
 arrow_num_valid(const uint64 *bitmap, size_t total_rows)
 {
+	Assert(total_rows != 0);
+
 	if (bitmap == NULL)
 	{
 		return total_rows;

--- a/tsl/src/nodes/vector_agg/exec.c
+++ b/tsl/src/nodes/vector_agg/exec.c
@@ -437,15 +437,30 @@ vector_agg_exec(CustomScanState *node)
 		for (int i = 0; i < naggs; i++)
 		{
 			VectorAggDef *agg_def = &vector_agg_state->agg_defs[i];
-			if (agg_def->filter_clauses == NIL)
+			uint64 *filter_clause_result = NULL;
+			if (agg_def->filter_clauses != NIL)
 			{
-				continue;
+				VectorQualState *vqstate =
+					vector_agg_state->init_vector_quals(vector_agg_state, agg_def, slot);
+				if (vector_qual_compute(vqstate) != AllRowsPass)
+				{
+					filter_clause_result = vqstate->vector_qual_result;
+				}
 			}
 
-			VectorQualState *vqstate =
-				vector_agg_state->init_vector_quals(vector_agg_state, agg_def, slot);
-			vector_qual_compute(vqstate);
-			agg_def->filter_result = vqstate->vector_qual_result;
+			DecompressBatchState *batch_state = (DecompressBatchState *) slot;
+			if (filter_clause_result != NULL)
+			{
+				const int num_validity_words = (batch_state->total_batch_rows + 63) / 64;
+				arrow_validity_and(num_validity_words,
+								   filter_clause_result,
+								   batch_state->vector_qual_result);
+				agg_def->effective_batch_filter = filter_clause_result;
+			}
+			else
+			{
+				agg_def->effective_batch_filter = batch_state->vector_qual_result;
+			}
 		}
 
 		/*

--- a/tsl/src/nodes/vector_agg/exec.h
+++ b/tsl/src/nodes/vector_agg/exec.h
@@ -20,7 +20,12 @@ typedef struct VectorAggDef
 	int input_offset;
 	int output_offset;
 	List *filter_clauses;
-	uint64 *filter_result;
+
+	/*
+	 * This filter bitmap ANDs the batch filter and the aggregate function
+	 * FILTER clause, if present.
+	 */
+	uint64 const *effective_batch_filter;
 } VectorAggDef;
 
 typedef struct GroupingColumn

--- a/tsl/src/nodes/vector_agg/grouping_policy_batch.c
+++ b/tsl/src/nodes/vector_agg/grouping_policy_batch.c
@@ -117,12 +117,16 @@ static void
 compute_single_aggregate(GroupingPolicyBatch *policy, TupleTableSlot *vector_slot,
 						 VectorAggDef *agg_def, void *agg_state, MemoryContext agg_extra_mctx)
 {
+	/*
+	 * We have functions with one argument, and one function with no arguments
+	 * (count(*)). Collect the arguments.
+	 */
 	const ArrowArray *arg_arrow = NULL;
 	const uint64 *arg_validity_bitmap = NULL;
 	Datum arg_datum = 0;
 	bool arg_isnull = true;
 	uint16 total_batch_rows = 0;
-	const uint64 *vector_qual_result = vector_slot_get_qual_result(vector_slot, &total_batch_rows);
+	vector_slot_get_qual_result(vector_slot, &total_batch_rows);
 
 	/*
 	 * We have functions with one argument, and one function with no arguments
@@ -153,14 +157,15 @@ compute_single_aggregate(GroupingPolicyBatch *policy, TupleTableSlot *vector_slo
 	}
 
 	/*
-	 * Compute the unified validity bitmap.
+	 * Compute the combined validity bitmap that includes the argument validity.
 	 */
-	const size_t num_words = (total_batch_rows + 63) / 64;
-	const uint64 *filter = arrow_combine_validity(num_words,
-												  policy->tmp_filter,
-												  vector_qual_result,
-												  agg_def->filter_result,
-												  arg_validity_bitmap);
+	DecompressBatchState *batch_state = (DecompressBatchState *) vector_slot;
+	const size_t num_words = (batch_state->total_batch_rows + 63) / 64;
+	const uint64 *combined_validity = arrow_combine_validity(num_words,
+															 policy->tmp_filter,
+															 agg_def->effective_batch_filter,
+															 arg_validity_bitmap,
+															 NULL);
 
 	/*
 	 * Now call the function.
@@ -168,7 +173,7 @@ compute_single_aggregate(GroupingPolicyBatch *policy, TupleTableSlot *vector_slo
 	if (arg_arrow != NULL)
 	{
 		/* Arrow argument. */
-		agg_def->func.agg_vector(agg_state, arg_arrow, filter, agg_extra_mctx);
+		agg_def->func.agg_vector(agg_state, arg_arrow, combined_validity, agg_extra_mctx);
 	}
 	else
 	{
@@ -180,7 +185,7 @@ compute_single_aggregate(GroupingPolicyBatch *policy, TupleTableSlot *vector_slo
 		 * have been skipped by the caller, but we also have to check for the
 		 * case when no rows match the aggregate FILTER clause.
 		 */
-		const int n = arrow_num_valid(filter, total_batch_rows);
+		const int n = arrow_num_valid(combined_validity, batch_state->total_batch_rows);
 		if (n > 0)
 		{
 			agg_def->func.agg_scalar(agg_state, arg_datum, arg_isnull, n, agg_extra_mctx);


### PR DESCRIPTION
Keep a resulting filter bitmap that includes the argument nullability, batch filter and aggregate filter. This will be used for optionally computing the vectorized expressions.

In contrast, the current code only computes this resulting bitmap just before we compute the aggregate function itself.

Disable-check: force-changelog-file