### PR TITLE
Add new chunks to hypertable publication

### DIFF
--- a/.unreleased/pr_9030
+++ b/.unreleased/pr_9030
@@ -1,0 +1,1 @@
+Implements: #9030 Add new chunks to hypertable publication

--- a/src/guc.c
+++ b/src/guc.c
@@ -118,6 +118,7 @@ TSDLLEXPORT int ts_guc_compression_batch_size_limit = 1000;
 TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
 bool ts_guc_enable_event_triggers = false;
+bool ts_guc_enable_chunk_auto_publication = false;
 bool ts_guc_debug_skip_scan_info = false;
 
 /* Only settable in debug mode for testing */
@@ -970,6 +971,18 @@ _guc_init(void)
 							 &ts_guc_enable_event_triggers,
 							 false,
 							 PGC_SUSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_chunk_auto_publication"),
+							 "Enable automatic chunk publication",
+							 "Enable automatically adding newly created chunks to the publication "
+							 "of their hypertable",
+							 &ts_guc_enable_chunk_auto_publication,
+							 false,
+							 PGC_USERSET,
 							 0,
 							 NULL,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -73,6 +73,7 @@ extern TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit;
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif
 extern bool ts_guc_enable_event_triggers;
+extern bool ts_guc_enable_chunk_auto_publication;
 extern TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan;
 extern TSDLLEXPORT bool ts_guc_enable_multikey_skip_scan;
 extern TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier;

--- a/test/expected/chunk_publication.out
+++ b/test/expected/chunk_publication.out
@@ -1,0 +1,576 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test automatic addition of chunks to publications
+-- Publications require superuser privileges
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = WARNING;
+SET timescaledb.enable_chunk_auto_publication = true;
+-- Test 1: Basic single publication
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (1,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create publication and add hypertable
+CREATE PUBLICATION test_pub FOR TABLE test_hypertable;
+-- Verify initial state (1 chunk)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Insert to create 2 more chunks (total 3 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify state (3 chunks)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_2_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_3_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Insert to create 5 more chunks (total 8 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify final state (8 chunks)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_2_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_3_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_4_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_5_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_6_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_7_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_8_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Verify chunk removal via DROP TABLE
+SELECT chunk_schema || '.' || chunk_name as "CHUNK_TO_DROP"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_hypertable'
+ORDER BY chunk_schema, chunk_name LIMIT 1 \gset
+-- Verify chunk removal via DROP TABLE
+DROP TABLE :CHUNK_TO_DROP;
+-- Verify chunk was removed from publication (7 chunks remaining)
+SELECT chunk_schema, chunk_name
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_hypertable'
+ORDER BY chunk_schema, chunk_name;
+     chunk_schema      |    chunk_name    
+-----------------------+------------------
+ _timescaledb_internal | _hyper_1_2_chunk
+ _timescaledb_internal | _hyper_1_3_chunk
+ _timescaledb_internal | _hyper_1_4_chunk
+ _timescaledb_internal | _hyper_1_5_chunk
+ _timescaledb_internal | _hyper_1_6_chunk
+ _timescaledb_internal | _hyper_1_7_chunk
+ _timescaledb_internal | _hyper_1_8_chunk
+
+SELECT schemaname, tablename, attnames, rowfilter
+FROM pg_publication_tables
+WHERE pubname = 'test_pub'
+ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_2_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_3_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_4_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_5_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_6_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_7_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_8_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Verify chunk removal via drop_chunks()
+SELECT drop_chunks('test_hypertable', older_than => '2024-01-07 00:00:00+00'::timestamptz);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+
+-- Verify dropped chunks were removed from publication (2 chunks remaining: 2024-01-07 and 2024-01-08)
+SELECT chunk_schema, chunk_name
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_hypertable'
+ORDER BY chunk_schema, chunk_name;
+     chunk_schema      |    chunk_name    
+-----------------------+------------------
+ _timescaledb_internal | _hyper_1_7_chunk
+ _timescaledb_internal | _hyper_1_8_chunk
+
+SELECT schemaname, tablename, attnames, rowfilter
+FROM pg_publication_tables
+WHERE pubname = 'test_pub'
+ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_7_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_8_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Verify chunk removal via TRUNCATE
+TRUNCATE TABLE test_hypertable;
+-- Verify all chunks were removed from publication (0 chunks remaining)
+SELECT chunk_schema, chunk_name
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_hypertable'
+ORDER BY chunk_schema, chunk_name;
+ chunk_schema | chunk_name 
+--------------+------------
+
+SELECT schemaname, tablename, attnames, rowfilter
+FROM pg_publication_tables
+WHERE pubname = 'test_pub'
+ORDER BY schemaname, tablename;
+ schemaname |    tablename    |           attnames           | rowfilter 
+------------+-----------------+------------------------------+-----------
+ public     | test_hypertable | {time,device_id,value,extra} | 
+
+-- Cleanup
+DROP PUBLICATION test_pub CASCADE;
+DROP TABLE test_hypertable CASCADE;
+-- Test 2: Multiple publications
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (2,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create pub1 and add hypertable
+CREATE PUBLICATION test_pub1 FOR TABLE test_hypertable;
+-- Verify (1 chunk in pub1)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub1' ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_2_9_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Insert to create 2 more chunks (total 3 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify (3 chunks in pub1)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub1' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_2_10_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_11_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_9_chunk  | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Create pub2 and add hypertable
+CREATE PUBLICATION test_pub2 FOR TABLE test_hypertable;
+-- Verify (3 chunks in pub1, 3 chunks in pub2)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub1' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_2_10_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_11_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_9_chunk  | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub2' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_2_10_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_11_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_9_chunk  | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Insert to create 5 more chunks (total 8 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify (8 chunks in pub1, 8 chunks in pub2)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub1' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_2_10_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_11_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_12_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_13_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_14_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_15_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_16_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_9_chunk  | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub2' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_2_10_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_11_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_12_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_13_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_14_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_15_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_16_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_2_9_chunk  | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Cleanup
+DROP PUBLICATION test_pub1 CASCADE;
+DROP PUBLICATION test_pub2 CASCADE;
+DROP TABLE test_hypertable CASCADE;
+-- Test 3: Row filtering (WHERE clause with multiple conditions)
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (3,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create publication with row filter (multiple conditions)
+CREATE PUBLICATION test_pub_row_filter FOR TABLE test_hypertable WHERE (device_id > 10 AND value > 1000);
+-- Verify initial state (1 chunk with row filter)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_row_filter' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           |                         rowfilter                         
+-----------------------+-------------------+------------------------------+-----------------------------------------------------------
+ _timescaledb_internal | _hyper_3_17_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ public                | test_hypertable   | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+
+-- Insert to create 2 more chunks (total 3 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify state (3 chunks with row filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_row_filter' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           |                         rowfilter                         
+-----------------------+-------------------+------------------------------+-----------------------------------------------------------
+ _timescaledb_internal | _hyper_3_17_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_18_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_19_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ public                | test_hypertable   | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+
+-- Insert to create 5 more chunks (total 8 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify final state (8 chunks with row filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_row_filter' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           |                         rowfilter                         
+-----------------------+-------------------+------------------------------+-----------------------------------------------------------
+ _timescaledb_internal | _hyper_3_17_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_18_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_19_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_20_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_21_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_22_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_23_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ _timescaledb_internal | _hyper_3_24_chunk | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+ public                | test_hypertable   | {time,device_id,value,extra} | ((device_id > 10) AND (value > (1000)::double precision))
+
+-- Cleanup
+DROP PUBLICATION test_pub_row_filter CASCADE;
+DROP TABLE test_hypertable CASCADE;
+-- Test 4: Column filtering
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (4,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create publication with column filter
+CREATE PUBLICATION test_pub_col_filter FOR TABLE test_hypertable (time, device_id);
+-- Verify initial state (1 chunk with column filter)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_col_filter' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |     attnames     | rowfilter 
+-----------------------+-------------------+------------------+-----------
+ _timescaledb_internal | _hyper_4_25_chunk | {time,device_id} | 
+ public                | test_hypertable   | {time,device_id} | 
+
+-- Insert to create 2 more chunks (total 3 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify state (3 chunks with column filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_col_filter' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |     attnames     | rowfilter 
+-----------------------+-------------------+------------------+-----------
+ _timescaledb_internal | _hyper_4_25_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_26_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_27_chunk | {time,device_id} | 
+ public                | test_hypertable   | {time,device_id} | 
+
+-- Insert to create 5 more chunks (total 8 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify final state (8 chunks with column filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_col_filter' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |     attnames     | rowfilter 
+-----------------------+-------------------+------------------+-----------
+ _timescaledb_internal | _hyper_4_25_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_26_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_27_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_28_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_29_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_30_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_31_chunk | {time,device_id} | 
+ _timescaledb_internal | _hyper_4_32_chunk | {time,device_id} | 
+ public                | test_hypertable   | {time,device_id} | 
+
+-- Cleanup
+DROP PUBLICATION test_pub_col_filter CASCADE;
+DROP TABLE test_hypertable CASCADE;
+-- Test 5: Combined row + column filtering
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (5,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create publication with both row and column filters
+CREATE PUBLICATION test_pub_combined FOR TABLE test_hypertable (time, device_id) WHERE (device_id > 10);
+-- Verify initial state (1 chunk with both filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_combined' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |     attnames     |    rowfilter     
+-----------------------+-------------------+------------------+------------------
+ _timescaledb_internal | _hyper_5_33_chunk | {time,device_id} | (device_id > 10)
+ public                | test_hypertable   | {time,device_id} | (device_id > 10)
+
+-- Insert to create 2 more chunks (total 3 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify state (3 chunks with both filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_combined' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |     attnames     |    rowfilter     
+-----------------------+-------------------+------------------+------------------
+ _timescaledb_internal | _hyper_5_33_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_34_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_35_chunk | {time,device_id} | (device_id > 10)
+ public                | test_hypertable   | {time,device_id} | (device_id > 10)
+
+-- Insert to create 5 more chunks (total 8 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify final state (8 chunks with both filters)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_combined' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |     attnames     |    rowfilter     
+-----------------------+-------------------+------------------+------------------
+ _timescaledb_internal | _hyper_5_33_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_34_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_35_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_36_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_37_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_38_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_39_chunk | {time,device_id} | (device_id > 10)
+ _timescaledb_internal | _hyper_5_40_chunk | {time,device_id} | (device_id > 10)
+ public                | test_hypertable   | {time,device_id} | (device_id > 10)
+
+-- Cleanup
+DROP PUBLICATION test_pub_combined CASCADE;
+DROP TABLE test_hypertable CASCADE;
+-- Test 6: FOR ALL TABLES publication
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (6,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create FOR ALL TABLES publication
+CREATE PUBLICATION test_pub_all_tables FOR ALL TABLES;
+-- Verify initial state (1 chunk)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_all_tables' AND tablename LIKE '%test_hypertable%' OR tablename LIKE '_hyper_%' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_6_41_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Insert to create 2 more chunks (total 3 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify state (3 chunks)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_all_tables' AND tablename LIKE '%test_hypertable%' OR tablename LIKE '_hyper_%' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_6_41_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_42_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_43_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Insert to create 5 more chunks (total 8 chunks)
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify final state (8 chunks)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub_all_tables' AND tablename LIKE '%test_hypertable%' OR tablename LIKE '_hyper_%' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_6_41_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_42_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_43_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_44_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_45_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_46_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_47_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_6_48_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Cleanup
+DROP PUBLICATION test_pub_all_tables CASCADE;
+DROP TABLE test_hypertable CASCADE;
+-- Test 7: Edge case - Hypertable not in any publication
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (7,public,test_hypertable,t)
+
+-- Insert to create 8 chunks without any publication
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+INSERT INTO test_hypertable VALUES ('2024-01-05 00:00:00+00', 5, 5.0, 'data5');
+INSERT INTO test_hypertable VALUES ('2024-01-06 00:00:00+00', 6, 6.0, 'data6');
+INSERT INTO test_hypertable VALUES ('2024-01-07 00:00:00+00', 7, 7.0, 'data7');
+INSERT INTO test_hypertable VALUES ('2024-01-08 00:00:00+00', 8, 8.0, 'data8');
+-- Verify chunks were created successfully
+SELECT COUNT(*) as chunks_created FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_hypertable';
+ chunks_created 
+----------------
+              8
+
+-- Cleanup
+DROP TABLE test_hypertable CASCADE;
+-- Test 8: Edge case - Publication dropped before chunk creation
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (8,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create publication and add hypertable
+CREATE PUBLICATION test_pub FOR TABLE test_hypertable;
+-- Verify (1 chunk in publication)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     |           attnames           | rowfilter 
+-----------------------+-------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_8_57_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable   | {time,device_id,value,extra} | 
+
+-- Drop the publication
+DROP PUBLICATION test_pub;
+-- Insert to create 2 more chunks (total 3 chunks)
+-- Should succeed with WARNING, not error
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify chunks were created successfully despite missing publication
+SELECT COUNT(*) as chunks_after_pub_drop FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_hypertable';
+ chunks_after_pub_drop 
+-----------------------
+                     3
+
+-- Cleanup
+DROP TABLE test_hypertable CASCADE;
+-- Test 9: GUC control of chunk publication
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (9,public,test_hypertable,t)
+
+-- Insert to create first chunk
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+-- Create publication
+CREATE PUBLICATION test_pub_guc FOR TABLE test_hypertable;
+-- Verify initial state (1 chunk)
+SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'test_pub_guc' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_9_60_chunk
+ public                | test_hypertable
+
+-- Test Part 1: GUC enabled - chunks should be added to publication automatically
+-- Insert to create a new chunk - should be added to publication automatically
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+-- Verify (2 chunks in publication)
+SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'test_pub_guc' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_9_60_chunk
+ _timescaledb_internal | _hyper_9_61_chunk
+ public                | test_hypertable
+
+-- Test Part 2: Disable the GUC and create another chunk
+SET timescaledb.enable_chunk_auto_publication = false;
+-- Insert to create a new chunk - should NOT be added to publication
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Verify (still 2 chunks in publication, chunk 3 should not be there)
+SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'test_pub_guc' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_9_60_chunk
+ _timescaledb_internal | _hyper_9_61_chunk
+ public                | test_hypertable
+
+-- Verify that chunk 3 exists but is not in the publication
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks WHERE hypertable_name = 'test_hypertable';
+     chunk_schema      |    chunk_name     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_9_60_chunk
+ _timescaledb_internal | _hyper_9_61_chunk
+ _timescaledb_internal | _hyper_9_62_chunk
+
+-- Test Part 3: Re-enable the GUC and create another chunk
+SET timescaledb.enable_chunk_auto_publication = true;
+-- Insert to create a new chunk - should be added to publication again
+INSERT INTO test_hypertable VALUES ('2024-01-04 00:00:00+00', 4, 4.0, 'data4');
+-- Verify (3 chunks in publication: chunk 1, 2, and 4; chunk 3 still missing)
+SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'test_pub_guc' ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_9_60_chunk
+ _timescaledb_internal | _hyper_9_61_chunk
+ _timescaledb_internal | _hyper_9_63_chunk
+ public                | test_hypertable
+
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks WHERE hypertable_name = 'test_hypertable';
+     chunk_schema      |    chunk_name     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_9_60_chunk
+ _timescaledb_internal | _hyper_9_61_chunk
+ _timescaledb_internal | _hyper_9_62_chunk
+ _timescaledb_internal | _hyper_9_63_chunk
+
+-- Cleanup
+DROP PUBLICATION test_pub_guc CASCADE;
+DROP TABLE test_hypertable CASCADE;
+RESET client_min_messages;

--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -25,3 +25,6 @@ extra_float_digits=0
 
 timescaledb.license='apache'
 timescaledb.enable_compression_ratio_warnings=false
+
+# Some tests use logical entries in WAL
+wal_level = logical

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_FILES
     catalog_corruption.sql
     chunks.sql
     chunk_adaptive.sql
+    chunk_publication.sql
     chunk_utils.sql
     cluster.sql
     create_chunks.sql

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -346,3 +346,40 @@ SELECT txid_current_if_assigned() IS NULL;
  t
 
 COMMIT;
+-- Test that newly created chunks are automatically added to publications
+SET ROLE :ROLE_SUPERUSER;
+SET timescaledb.enable_chunk_auto_publication = true;
+CREATE PUBLICATION test_chunk_pub FOR TABLE chunkapi;
+-- Verify existing chunks are in the publication
+SELECT COUNT(*) as initial_chunk_count
+FROM pg_publication_tables
+WHERE pubname = 'test_chunk_pub'
+  AND tablename LIKE '%chunk%';
+ initial_chunk_count 
+---------------------
+                   4
+
+-- Create a new chunk via create_chunk API
+CREATE TABLE pub_test_chunk(time timestamptz not null, device int, temp float);
+INSERT INTO pub_test_chunk VALUES ('2018-01-22 05:00:00-8', 1, 26.7);
+SELECT table_name as new_chunk_name FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1516233600000000, 1516838400000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'pub_test_chunk') \gset
+-- Verify the new chunk was automatically added to the publication
+SELECT COUNT(*) as final_chunk_count
+FROM pg_publication_tables
+WHERE pubname = 'test_chunk_pub'
+  AND tablename LIKE '%chunk%';
+ final_chunk_count 
+-------------------
+                 5
+
+-- Show the new chunk in the publication (it should have the internal chunk name)
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_chunk_pub'
+  AND tablename = :'new_chunk_name';
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_3_16_chunk
+
+-- Cleanup
+DROP PUBLICATION test_chunk_pub CASCADE;

--- a/tsl/test/expected/chunk_publication_compression.out
+++ b/tsl/test/expected/chunk_publication_compression.out
@@ -1,0 +1,55 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test that compressed chunks are NOT automatically added to publications
+-- Publications require superuser privileges
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = WARNING;
+SET timescaledb.enable_chunk_auto_publication = true;
+SET timescaledb.enable_compression_ratio_warnings = false;
+-- Test 1: Basic publication with compression
+-- Compressed chunks should NOT be automatically added to publications
+CREATE TABLE test_hypertable (time timestamptz NOT NULL, device_id int, value float, extra text);
+SELECT create_hypertable('test_hypertable', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable       
+------------------------------
+ (1,public,test_hypertable,t)
+
+ALTER TABLE test_hypertable SET (timescaledb.compress, timescaledb.compress_segmentby='device_id');
+-- Insert to create 3 chunks
+INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
+INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
+INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
+-- Create publication and add hypertable
+CREATE PUBLICATION test_pub FOR TABLE test_hypertable;
+-- Verify initial state (3 uncompressed chunks)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_2_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_3_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Compress all chunks
+SELECT compress_chunk(show_chunks('test_hypertable'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- Verify after compression: should still have only 3 chunks, NO compressed chunk table
+-- (compressed chunk table should NOT be automatically added to publication)
+SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
+      schemaname       |    tablename     |           attnames           | rowfilter 
+-----------------------+------------------+------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_2_chunk | {time,device_id,value,extra} | 
+ _timescaledb_internal | _hyper_1_3_chunk | {time,device_id,value,extra} | 
+ public                | test_hypertable  | {time,device_id,value,extra} | 
+
+-- Cleanup
+DROP PUBLICATION test_pub CASCADE;
+DROP TABLE test_hypertable CASCADE;
+RESET client_min_messages;

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1760,6 +1760,89 @@ ERROR:  cannot modify compressed chunk belonging to a frozen chunk
 COPY :COMPRESSED_CHUNK FROM STDIN;
 ERROR:  cannot COPY into chunk belonging to a frozen chunk
 \set ON_ERROR_STOP 1
+-- TEST: OSM chunks should NOT be added to publications
+-- Create a new hypertable for publication testing
+\c :TEST_DBNAME :ROLE_4
+CREATE TABLE ht_pub_test(timec timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('ht_pub_test', 'timec', chunk_time_interval => interval '1 day');
+     create_hypertable     
+---------------------------
+ (29,public,ht_pub_test,t)
+
+-- Insert data to create first normal chunk
+INSERT INTO ht_pub_test VALUES ('2023-01-01 01:00', 1, 10.5);
+-- Create publication
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timescaledb.enable_chunk_auto_publication = true;
+CREATE PUBLICATION test_pub_osm FOR TABLE ht_pub_test;
+-- Verify: 1 normal chunk in publication
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_pub_osm'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename      
+-----------------------+--------------------
+ _timescaledb_internal | _hyper_29_46_chunk
+ public                | ht_pub_test
+
+-- Create a new foreign table for OSM testing
+\c :TEST_DBNAME :ROLE_4
+CREATE FOREIGN TABLE osm_chunk_pub_test
+(timec timestamptz NOT NULL, device_id int, value float)
+SERVER s3_server OPTIONS (schema_name 'public', table_name 'fdw_table');
+-- Attach OSM chunk
+SELECT _timescaledb_functions.attach_osm_table_chunk('ht_pub_test', 'osm_chunk_pub_test');
+ attach_osm_table_chunk 
+------------------------
+ t
+
+SELECT _timescaledb_functions.hypertable_osm_range_update('ht_pub_test', '2020-01-01'::timestamptz, '2020-01-02');
+ hypertable_osm_range_update 
+-----------------------------
+ f
+
+-- Check chunks also have OSM chunk
+SELECT schema_name, table_name, status, osm_chunk
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id IN (SELECT id from _timescaledb_catalog.hypertable
+                        WHERE table_name = 'ht_pub_test')
+ORDER BY table_name;
+      schema_name      |     table_name     | status | osm_chunk 
+-----------------------+--------------------+--------+-----------
+ _timescaledb_internal | _hyper_29_46_chunk |      0 | f
+ public                | osm_chunk_pub_test |      0 | t
+
+-- Verify: still only 1 normal chunk in publication (OSM chunk NOT added)
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_pub_osm'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename      
+-----------------------+--------------------
+ _timescaledb_internal | _hyper_29_46_chunk
+ public                | ht_pub_test
+
+-- Insert data to create second normal chunk
+\c :TEST_DBNAME :ROLE_4
+SET timescaledb.enable_chunk_auto_publication = true;
+INSERT INTO ht_pub_test VALUES ('2023-01-02 01:00', 2, 20.5);
+-- Verify: 2 normal chunks in publication (second chunk added, OSM still not)
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_pub_osm'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename      
+-----------------------+--------------------
+ _timescaledb_internal | _hyper_29_46_chunk
+ _timescaledb_internal | _hyper_29_48_chunk
+ public                | ht_pub_test
+
+-- Cleanup
+DROP PUBLICATION test_pub_osm CASCADE;
+\c :TEST_DBNAME :ROLE_4
+DROP TABLE ht_pub_test CASCADE;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- clean up databases created
 DROP DATABASE postgres_fdw_db WITH (FORCE);

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -903,3 +903,46 @@ drop table pre_cleaned_chunks;
 call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_4_chunk', concurrently => true);
 call merge_chunks_concurrently(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_12_chunk']);
 drop view chunks_being_merged;
+-- Test: Verify merged chunks remain in publication
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timescaledb.enable_chunk_auto_publication = true;
+CREATE TABLE pub_merge_test(time timestamptz not null, device int, temp float);
+SELECT create_hypertable('pub_merge_test', 'time', chunk_time_interval => interval '1 day');
+      create_hypertable      
+-----------------------------
+ (5,public,pub_merge_test,t)
+
+-- Insert data to create multiple chunks
+INSERT INTO pub_merge_test VALUES
+    ('2024-01-01 01:00', 1, 1.0),
+    ('2024-01-02 01:00', 2, 2.0);
+-- Create publication
+CREATE PUBLICATION test_merge_pub FOR TABLE pub_merge_test;
+-- Verify chunks before merge
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_merge_pub'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_5_20_chunk
+ _timescaledb_internal | _hyper_5_21_chunk
+ public                | pub_merge_test
+
+-- Merge chunks
+SELECT show_chunks('pub_merge_test') as chunk1 ORDER BY 1 LIMIT 1 OFFSET 0 \gset
+SELECT show_chunks('pub_merge_test') as chunk2 ORDER BY 1 LIMIT 1 OFFSET 1 \gset
+CALL merge_chunks(:'chunk1', :'chunk2');
+-- Verify merged chunk remains in publication
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_merge_pub'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_5_20_chunk
+ public                | pub_merge_test
+
+-- Cleanup
+DROP PUBLICATION test_merge_pub CASCADE;
+DROP TABLE pub_merge_test CASCADE;

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -1136,3 +1136,44 @@ select to_timestamp(time), * from :chunk3;
 ------------------------------+------------+------
  Thu Jan 09 03:00:00 2025 PST | 1736420400 |   12
 
+-- Test: Verify split chunks are added to publication
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timescaledb.enable_chunk_auto_publication = true;
+CREATE TABLE pub_split_test(time timestamptz not null, device int, temp float);
+SELECT create_hypertable('pub_split_test', 'time', chunk_time_interval => interval '1 month');
+      create_hypertable      
+-----------------------------
+ (7,public,pub_split_test,t)
+
+-- Create publication
+CREATE PUBLICATION test_split_pub FOR TABLE pub_split_test;
+-- Insert data to create a single chunk
+INSERT INTO pub_split_test VALUES
+    ('2024-01-03 01:00', 1, 1.0),
+    ('2024-01-09 01:00', 2, 2.0);
+-- Verify 1 chunk in publication
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_split_pub'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_7_34_chunk
+ public                | pub_split_test
+
+SELECT show_chunks('pub_split_test') chunk_to_split \gset
+CALL split_chunk(:'chunk_to_split', split_at => '2024-01-06 00:00');
+-- Verify both split chunks are in publication
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_split_pub'
+ORDER BY schemaname, tablename;
+      schemaname       |     tablename     
+-----------------------+-------------------
+ _timescaledb_internal | _hyper_7_34_chunk
+ _timescaledb_internal | _hyper_7_35_chunk
+ public                | pub_split_test
+
+-- Cleanup
+DROP PUBLICATION test_split_pub CASCADE;
+DROP TABLE pub_split_test CASCADE;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_FILES
     cagg_refresh_using_merge.sql
     cagg_utils.sql
     cagg_watermark.sql
+    chunk_publication_compression.sql
     columnar_scan_cost.sql
     columnstore_aliases.sql
     compress_auto_sparse_index.sql

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -240,3 +240,34 @@ SELECT txid_current_if_assigned() IS NULL;
 SELECT COUNT(*) FROM :chunk;
 SELECT txid_current_if_assigned() IS NULL;
 COMMIT;
+
+-- Test that newly created chunks are automatically added to publications
+SET ROLE :ROLE_SUPERUSER;
+SET timescaledb.enable_chunk_auto_publication = true;
+CREATE PUBLICATION test_chunk_pub FOR TABLE chunkapi;
+
+-- Verify existing chunks are in the publication
+SELECT COUNT(*) as initial_chunk_count
+FROM pg_publication_tables
+WHERE pubname = 'test_chunk_pub'
+  AND tablename LIKE '%chunk%';
+
+-- Create a new chunk via create_chunk API
+CREATE TABLE pub_test_chunk(time timestamptz not null, device int, temp float);
+INSERT INTO pub_test_chunk VALUES ('2018-01-22 05:00:00-8', 1, 26.7);
+SELECT table_name as new_chunk_name FROM _timescaledb_functions.create_chunk('chunkapi', '{"time": [1516233600000000, 1516838400000000], "device": [-9223372036854775808, 1073741823]}', NULL, NULL, 'pub_test_chunk') \gset
+
+-- Verify the new chunk was automatically added to the publication
+SELECT COUNT(*) as final_chunk_count
+FROM pg_publication_tables
+WHERE pubname = 'test_chunk_pub'
+  AND tablename LIKE '%chunk%';
+
+-- Show the new chunk in the publication (it should have the internal chunk name)
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_chunk_pub'
+  AND tablename = :'new_chunk_name';
+
+-- Cleanup
+DROP PUBLICATION test_chunk_pub CASCADE;

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -466,3 +466,39 @@ call merge_chunks('_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_intern
 call merge_chunks_concurrently(ARRAY['_timescaledb_internal._hyper_1_1_chunk', '_timescaledb_internal._hyper_1_5_chunk', '_timescaledb_internal._hyper_1_12_chunk']);
 
 drop view chunks_being_merged;
+
+-- Test: Verify merged chunks remain in publication
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timescaledb.enable_chunk_auto_publication = true;
+
+CREATE TABLE pub_merge_test(time timestamptz not null, device int, temp float);
+SELECT create_hypertable('pub_merge_test', 'time', chunk_time_interval => interval '1 day');
+
+-- Insert data to create multiple chunks
+INSERT INTO pub_merge_test VALUES
+    ('2024-01-01 01:00', 1, 1.0),
+    ('2024-01-02 01:00', 2, 2.0);
+
+-- Create publication
+CREATE PUBLICATION test_merge_pub FOR TABLE pub_merge_test;
+
+-- Verify chunks before merge
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_merge_pub'
+ORDER BY schemaname, tablename;
+
+-- Merge chunks
+SELECT show_chunks('pub_merge_test') as chunk1 ORDER BY 1 LIMIT 1 OFFSET 0 \gset
+SELECT show_chunks('pub_merge_test') as chunk2 ORDER BY 1 LIMIT 1 OFFSET 1 \gset
+CALL merge_chunks(:'chunk1', :'chunk2');
+
+-- Verify merged chunk remains in publication
+SELECT schemaname, tablename
+FROM pg_publication_tables
+WHERE pubname = 'test_merge_pub'
+ORDER BY schemaname, tablename;
+
+-- Cleanup
+DROP PUBLICATION test_merge_pub CASCADE;
+DROP TABLE pub_merge_test CASCADE;


### PR DESCRIPTION
Problem: Adding a hypertable to a publication automatically includes all existing chunks, but newly created chunks are not automatically added to the publication.

This commit fixes the problem by adding newly created chunks to all publications that the hypertable belongs to, while respecting the hypertable’s row and column filtering rules.

This ensures that logical replication works correctly for partitioned data without requiring manual chunk management.

Added a new GUC `timescaledb.enable_chunk_auto_publication` to control behaviour of this change.

By default `timescaledb.enable_chunk_auto_publication` is disabled, it could be modified without restarting the database. 