### PR TITLE
Add in-memory recompression for unordered chunks

### DIFF
--- a/.unreleased/pr_9032
+++ b/.unreleased/pr_9032
@@ -1,0 +1,1 @@
+Implements: #9032 Add in-memory recompression for unordered chunks

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -689,7 +689,7 @@ recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
 	/*
 	 * Choose recompression strategy based on chunk state and settings:
 	 * 1. Segmentwise recompression: For partial chunks
-	 * 2. In-memory recompression: For fully compressed chunks with matching settings
+	 * 2. In-memory recompression: For other compressed chunks with matching settings
 	 * 3. Fallback to decompress/compress: When neither strategy is applicable
 	 */
 
@@ -708,7 +708,7 @@ recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
 		recompressed = true;
 	}
 	/* TODO: optimize cases where settings differ but recompression is still possible */
-	else if (recompress && ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings))
+	else if (ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings))
 	{
 		if (!ts_guc_enable_in_memory_recompression)
 		{

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -761,7 +761,7 @@ perform_recompression(RecompressContext *recompress_ctx, Relation compressed_chu
  * Perform per segment in-memory recompression of a compressed chunk.
  *
  * Note: This function will early return if the chunk is not suitable for
- * recompression (e.g., partial, unordered, frozen).
+ * recompression (e.g., partial, frozen).
  */
 bool
 recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
@@ -771,16 +771,8 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 
 	Ensure(ts_guc_enable_in_memory_recompression, "in-memory recompression functionality disabled");
 
-	/*
-	 * Only proceed if chunk is in compressed state without partial or unordered status
-	 * Status meanings:
-	 * 1: compressed
-	 * 2: compressed_unordered TODO: add support
-	 * 4: frozen
-	 * 8: compressed_partial
-	 */
 	if (!ts_chunk_is_compressed(uncompressed_chunk) || ts_chunk_is_partial(uncompressed_chunk) ||
-		ts_chunk_is_unordered(uncompressed_chunk) || ts_chunk_is_frozen(uncompressed_chunk))
+		ts_chunk_is_frozen(uncompressed_chunk))
 		return false;
 
 	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
@@ -865,6 +857,11 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	LockRelationOid(uncompressed_chunk->table_id, AccessExclusiveLock);
 	LockRelationOid(compressed_chunk->table_id, AccessExclusiveLock);
 	ts_chunk_drop(compressed_chunk, DROP_RESTRICT, -1);
+	if (ts_chunk_clear_status(uncompressed_chunk, CHUNK_STATUS_COMPRESSED_UNORDERED))
+		ereport(DEBUG1,
+				(errmsg("cleared chunk status for recompression: \"%s.%s\"",
+						NameStr(uncompressed_chunk->fd.schema_name),
+						NameStr(uncompressed_chunk->fd.table_name))));
 	ts_chunk_set_compressed_chunk(uncompressed_chunk, new_compressed_chunk->fd.id);
 
 	/* recompress successful */

--- a/tsl/test/expected/recompression_integrity_tests.out
+++ b/tsl/test/expected/recompression_integrity_tests.out
@@ -2,8 +2,11 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Set path to check data intergrity after in-memory recompression
+\set TEST_BASE_NAME recompression_intergrity_tests
+-- requires TEST_BASE_NAME, TEST_TABLE_NAME, BATCH_METADATA_QUERY, ORDER_BY_CLAUSE
 \set RECOMPRESSION_INTEGRITY_CHECK_RELPATH 'include/recompression_integrity_check.sql'
 \set BATCH_METADATA_QUERY ''
+\set ORDER_BY_CLAUSE ''
 -- Test Case 1: Basic segmentby configuration
 DROP TABLE IF EXISTS recomp_segmentby_test CASCADE;
 NOTICE:  table "recomp_segmentby_test" does not exist, skipping
@@ -31,24 +34,21 @@ INSERT INTO recomp_segmentby_test VALUES
   ('2001-01-01 00:00:00', 'device1', 'room1', 25.0, 70.0),
   ('2001-01-01 01:00:00', 'device2', 'room2', 23.5, 68.5);
 \set TEST_TABLE_NAME 'recomp_segmentby_test'
-\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set TEST_BASE_NAME recompression_intergrity_check
-SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
-       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
-\gset
-SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
-\gset
--- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_2_chunk
 
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
         compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
@@ -65,7 +65,7 @@ LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
 :BATCH_METADATA_QUERY
 \set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
 \o :TEST_RESULTS_COMPRESS
 :QUERY1
 :QUERY2
@@ -139,24 +139,21 @@ INSERT INTO recomp_multi_segmentby_test VALUES
   ('2001-01-01', 'device1', 'room1', 'temp', 22.1),
   ('2001-01-01', 'device2', 'room1', 'humidity', 63.0);
 \set TEST_TABLE_NAME 'recomp_multi_segmentby_test'
-\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set TEST_BASE_NAME recompression_intergrity_check
-SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
-       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
-\gset
-SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
-\gset
--- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_3_6_chunk
  _timescaledb_internal._hyper_3_7_chunk
 
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
         compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
@@ -173,7 +170,7 @@ LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
 :BATCH_METADATA_QUERY
 \set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
 \o :TEST_RESULTS_COMPRESS
 :QUERY1
 :QUERY2
@@ -249,23 +246,20 @@ SELECT x, md5(x::text),
     '2022-01-01'::timestamp + (interval '1 hour') * x
 FROM generate_series(1, 10000) x;
 \set TEST_TABLE_NAME 'recomp_index_test'
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_11_chunk
+
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\set TEST_BASE_NAME recompression_intergrity_check
 SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
        format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
 \gset
 SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
 \gset
--- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_5_11_chunk
-
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
         compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
@@ -282,7 +276,7 @@ LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
 :BATCH_METADATA_QUERY
 \set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
 \o :TEST_RESULTS_COMPRESS
 :QUERY1
 :QUERY2
@@ -357,24 +351,22 @@ SELECT x, md5(x::text),
     '2022-01-01'::timestamp + (interval '1 second') * x
 FROM generate_series(1, 10000) x;
 \set TEST_TABLE_NAME 'recomp_large_data_test'
-\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set TEST_BASE_NAME recompression_intergrity_check
-SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
-       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
-\gset
-SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
-\gset
 -- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_7_14_chunk
  _timescaledb_internal._hyper_7_15_chunk
 
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
         compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
@@ -391,7 +383,7 @@ LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
 :BATCH_METADATA_QUERY
 \set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
 \o :TEST_RESULTS_COMPRESS
 :QUERY1
 :QUERY2
@@ -443,105 +435,8 @@ DROP TABLE recomp_large_data_test CASCADE;
 \set BATCH_METADATA_QUERY 'SELECT _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;'
 SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_sort_batches = true;
-SET timescaledb.enable_direct_compress_insert_client_sorted = false;
--- Test Case 5: Unordered chunk
-DROP TABLE IF EXISTS recomp_unordered CASCADE;
-NOTICE:  table "recomp_unordered" does not exist, skipping
-CREATE TABLE recomp_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
-NOTICE:  using column "time" as partitioning column
-INSERT INTO recomp_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
-INSERT INTO recomp_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(101,800) i;
--- Will not use in-memory recompression due to unordered
-\set TEST_TABLE_NAME 'recomp_unordered'
-\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-\set TEST_BASE_NAME recompression_intergrity_check
-SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
-       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
-\gset
-SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
-\gset
--- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_9_19_chunk
-
--- Store initial compressed chunk info before recompression
-SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
-FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
-WHERE uncompressed.hypertable_id = (
-          SELECT id
-          FROM _timescaledb_catalog.hypertable
-          WHERE table_name = :'TEST_TABLE_NAME'
-      )
-LIMIT 1 \gset
-\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
-:BATCH_METADATA_QUERY
- _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
-----------------+------------------------------+------------------------------
-            801 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
-
-\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
-\o :TEST_RESULTS_COMPRESS
-:QUERY1
-:QUERY2
-\o
--- Recompress the chunk in-memory
-SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_9_19_chunk
-
--- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
-FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
-WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
-LIMIT 1 \gset
-\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
-:BATCH_METADATA_QUERY
- _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
-----------------+------------------------------+------------------------------
-            801 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
-
--- Get data after in-memory recompression
-\o :TEST_RESULTS_RECOMPRESS
-:QUERY1
-:QUERY2
-\o
--- Check if a new chunk was created (this will show in the output)
-SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
-    'ERROR: Recompression did not create a new chunk'
-  ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
-  END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=21, new_chunk_id=22
-
--- Compare result using diff to validate integrity of recompressed data
-:DIFF_CMD
-SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
-                  relid                  |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
------------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
- recomp_unordered                        |                                                  |           | {time}  | {f}          | {f}                | 
- _timescaledb_internal._hyper_9_19_chunk | _timescaledb_internal.compress_hyper_10_22_chunk |           | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
-
-DROP TABLE IF EXISTS recomp_unordered CASCADE;
--- Test Case 5: Direct Compress Batches
 SET timescaledb.enable_direct_compress_insert_client_sorted = true;
+-- Test Case 5: Direct Compress Batches
 DROP TABLE IF EXISTS recomp_direct_compress CASCADE;
 NOTICE:  table "recomp_direct_compress" does not exist, skipping
 CREATE TABLE recomp_direct_compress (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
@@ -572,20 +467,11 @@ END $$;
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\set TEST_BASE_NAME recompression_intergrity_check
 SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
        format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
 \gset
 SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
 \gset
--- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
-psql:include/recompression_integrity_check.sql:14: NOTICE:  chunk "_hyper_11_23_chunk" is already converted to columnstore
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_23_chunk
-
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
         compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
@@ -610,16 +496,16 @@ LIMIT 1 \gset
             180 | Wed Jan 01 10:21:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
 
 \set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
 \o :TEST_RESULTS_COMPRESS
 :QUERY1
 :QUERY2
 \o
 -- Recompress the chunk in-memory
 SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
-              compress_chunk              
-------------------------------------------
- _timescaledb_internal._hyper_11_23_chunk
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_19_chunk
 
 -- Get info for the new compressed chunk
 SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
@@ -649,15 +535,15 @@ SELECT
   END AS recompression_status;
                      recompression_status                     
 --------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=24, new_chunk_id=25
+ SUCCESS: New chunk created, old_chunk_id=20, new_chunk_id=21
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
-                  relid                   |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
-------------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
- recomp_direct_compress                   |                                                  |           | {time}  | {f}          | {f}                | 
- _timescaledb_internal._hyper_11_23_chunk | _timescaledb_internal.compress_hyper_12_25_chunk |           | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+                  relid                  |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+-----------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
+ recomp_direct_compress                  |                                                  |           | {time}  | {f}          | {f}                | 
+ _timescaledb_internal._hyper_9_19_chunk | _timescaledb_internal.compress_hyper_10_21_chunk |           | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 DROP TABLE IF EXISTS recomp_direct_compress CASCADE;
 RESET timescaledb.enable_direct_compress_insert;

--- a/tsl/test/expected/recompression_integrity_unordered.out
+++ b/tsl/test/expected/recompression_integrity_unordered.out
@@ -1,0 +1,502 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Set path to check data intergrity after in-memory recompression
+\set TEST_BASE_NAME recompression_intergrity_unordered
+-- requires TEST_BASE_NAME, TEST_TABLE_NAME, BATCH_METADATA_QUERY, ORDER_BY_CLAUSE
+\set RECOMPRESSION_INTEGRITY_CHECK_RELPATH 'include/recompression_integrity_check.sql'
+-- Setup Direct Compress
+-- Batches may be uneven with direct compress but should always be even after recompression.
+\set BATCH_METADATA_QUERY 'SELECT _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;'
+\set ORDER_BY_CLAUSE ''
+SET timescaledb.enable_direct_compress_insert = true;
+SET timescaledb.enable_direct_compress_insert_sort_batches = true;
+SET timescaledb.enable_direct_compress_insert_client_sorted = false;
+-- Test Case 1: Unordered chunk
+DROP TABLE IF EXISTS recomp_unordered CASCADE;
+NOTICE:  table "recomp_unordered" does not exist, skipping
+CREATE TABLE recomp_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+-- Insert uneven batches
+SELECT setseed(0.5);
+ setseed 
+---------
+ 
+
+DO $$
+DECLARE
+start_pos int := 0;
+batch_size int;
+i int;
+BEGIN
+FOR i IN 1..5 LOOP  -- 5 random batches
+    batch_size := (random() * 200 + 50)::int;  -- Random size 50-250
+    EXECUTE format('INSERT INTO recomp_unordered SELECT ''2025-01-01''::timestamptz + (i || '' minute'')::interval, ''d1'', i::float FROM generate_series(%s,%s) i',
+                    start_pos, start_pos + batch_size - 1);
+
+    start_pos := start_pos + batch_size;
+END LOOP;
+END $$;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered') chunk;
+                 chunk                  |   chunk_status_text    
+----------------------------------------+------------------------
+ _timescaledb_internal._hyper_1_1_chunk | {COMPRESSED,UNORDERED}
+
+\set TEST_TABLE_NAME 'recomp_unordered'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            247 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 04:06:00 2025 PST
+            215 | Wed Jan 01 04:07:00 2025 PST | Wed Jan 01 07:41:00 2025 PST
+             76 | Wed Jan 01 07:42:00 2025 PST | Wed Jan 01 08:57:00 2025 PST
+             83 | Wed Jan 01 08:58:00 2025 PST | Wed Jan 01 10:20:00 2025 PST
+            180 | Wed Jan 01 10:21:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            801 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                    recompression_status                    
+------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=2, new_chunk_id=3
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered') chunk;
+                 chunk                  | chunk_status_text 
+----------------------------------------+-------------------
+ _timescaledb_internal._hyper_1_1_chunk | {COMPRESSED}
+
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
+ recomp_unordered                       |                                                |           | {time}  | {f}          | {f}                | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_3_chunk |           | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+DROP TABLE IF EXISTS recomp_unordered CASCADE;
+-- Test Case 2: Unordered chunk with segmentby
+DROP TABLE IF EXISTS recomp_unordered_segmentby CASCADE;
+NOTICE:  table "recomp_unordered_segmentby" does not exist, skipping
+CREATE TABLE recomp_unordered_segmentby (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- Insert uneven batches with multiple devices
+SELECT setseed(0.5);
+ setseed 
+---------
+ 
+
+DO $$
+DECLARE
+start_pos int := 0;
+batch_size int;
+i int;
+device_id int;
+BEGIN
+FOR i IN 1..5 LOOP  -- 5 random batches
+    batch_size := (random() * 200 + 50)::int;  -- Random size 50-250
+    device_id := (i % 3) + 1;  -- Rotate between 3 devices
+    EXECUTE format('INSERT INTO recomp_unordered_segmentby SELECT ''2025-01-01''::timestamptz + (i || '' minute'')::interval, ''d%s'', i::float FROM generate_series(%s,%s) i',
+                    device_id, start_pos, start_pos + batch_size - 1);
+
+    start_pos := start_pos + batch_size;
+END LOOP;
+END $$;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_segmentby') chunk;
+                 chunk                  |   chunk_status_text    
+----------------------------------------+------------------------
+ _timescaledb_internal._hyper_3_4_chunk | {COMPRESSED,UNORDERED}
+
+\set TEST_TABLE_NAME 'recomp_unordered_segmentby'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            247 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 04:06:00 2025 PST
+            215 | Wed Jan 01 04:07:00 2025 PST | Wed Jan 01 07:41:00 2025 PST
+             76 | Wed Jan 01 07:42:00 2025 PST | Wed Jan 01 08:57:00 2025 PST
+             83 | Wed Jan 01 08:58:00 2025 PST | Wed Jan 01 10:20:00 2025 PST
+            180 | Wed Jan 01 10:21:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+             76 | Wed Jan 01 07:42:00 2025 PST | Wed Jan 01 08:57:00 2025 PST
+            330 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 10:20:00 2025 PST
+            395 | Wed Jan 01 04:07:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                    recompression_status                    
+------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=5, new_chunk_id=6
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_segmentby') chunk;
+                 chunk                  | chunk_status_text 
+----------------------------------------+-------------------
+ _timescaledb_internal._hyper_3_4_chunk | {COMPRESSED}
+
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
+ recomp_unordered_segmentby             |                                                | {device}  | {time}  | {f}          | {f}                | 
+ _timescaledb_internal._hyper_3_4_chunk | _timescaledb_internal.compress_hyper_4_6_chunk | {device}  | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+DROP TABLE IF EXISTS recomp_unordered_segmentby CASCADE;
+-- Test Case 3: Unordered chunk with segmentby and multiple orderbys
+DROP TABLE IF EXISTS recomp_unordered_multi_orderby CASCADE;
+NOTICE:  table "recomp_unordered_multi_orderby" does not exist, skipping
+CREATE TABLE recomp_unordered_multi_orderby (time TIMESTAMPTZ NOT NULL, device TEXT, sensor_id INT, value float) WITH (tsdb.hypertable, tsdb.orderby='time,sensor_id', tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- Insert uneven batches with multiple devices and sensor_ids
+SELECT setseed(0.5);
+ setseed 
+---------
+ 
+
+DO $$
+DECLARE
+start_pos int := 0;
+batch_size int;
+i int;
+device_id int;
+sensor_id int;
+BEGIN
+FOR i IN 1..5 LOOP  -- 5 random batches
+    batch_size := (random() * 200 + 50)::int;  -- Random size 50-250
+    device_id := (i % 3) + 1;  -- Rotate between 3 devices
+    sensor_id := (i % 2) + 1;  -- Rotate between 2 sensors
+    EXECUTE format('INSERT INTO recomp_unordered_multi_orderby SELECT ''2025-01-01''::timestamptz + (i || '' minute'')::interval, ''d%s'', %s, i::float FROM generate_series(%s,%s) i',
+                    device_id, sensor_id, start_pos, start_pos + batch_size - 1);
+
+    start_pos := start_pos + batch_size;
+END LOOP;
+END $$;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_multi_orderby') chunk;
+                 chunk                  |   chunk_status_text    
+----------------------------------------+------------------------
+ _timescaledb_internal._hyper_5_7_chunk | {COMPRESSED,UNORDERED}
+
+\set TEST_TABLE_NAME 'recomp_unordered_multi_orderby'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time, sensor_id'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            247 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 04:06:00 2025 PST
+            215 | Wed Jan 01 04:07:00 2025 PST | Wed Jan 01 07:41:00 2025 PST
+             76 | Wed Jan 01 07:42:00 2025 PST | Wed Jan 01 08:57:00 2025 PST
+             83 | Wed Jan 01 08:58:00 2025 PST | Wed Jan 01 10:20:00 2025 PST
+            180 | Wed Jan 01 10:21:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+             76 | Wed Jan 01 07:42:00 2025 PST | Wed Jan 01 08:57:00 2025 PST
+            330 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 10:20:00 2025 PST
+            395 | Wed Jan 01 04:07:00 2025 PST | Wed Jan 01 13:20:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                    recompression_status                    
+------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=8, new_chunk_id=9
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_multi_orderby') chunk;
+                 chunk                  | chunk_status_text 
+----------------------------------------+-------------------
+ _timescaledb_internal._hyper_5_7_chunk | {COMPRESSED}
+
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                 relid                  |                 compress_relid                 | segmentby |     orderby      | orderby_desc | orderby_nullsfirst |                                                            index                                                            
+----------------------------------------+------------------------------------------------+-----------+------------------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------
+ recomp_unordered_multi_orderby         |                                                | {device}  | {time,sensor_id} | {f,f}        | {f,f}              | 
+ _timescaledb_internal._hyper_5_7_chunk | _timescaledb_internal.compress_hyper_6_9_chunk | {device}  | {time,sensor_id} | {f,f}        | {f,f}              | [{"type": "minmax", "column": "time", "source": "orderby"}, {"type": "minmax", "column": "sensor_id", "source": "orderby"}]
+
+DROP TABLE IF EXISTS recomp_unordered_multi_orderby CASCADE;
+-- Test Case 4: Orderby is not necessarily increasing every insert
+DROP TABLE IF EXISTS recomp_truly_unordered CASCADE;
+NOTICE:  table "recomp_truly_unordered" does not exist, skipping
+CREATE TABLE recomp_truly_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.segmentby='device', tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(50,200) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(50,200) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,100) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(150,700) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(150,700) i;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_truly_unordered') chunk;
+                  chunk                  |   chunk_status_text    
+-----------------------------------------+------------------------
+ _timescaledb_internal._hyper_7_10_chunk | {COMPRESSED,UNORDERED}
+
+\set TEST_TABLE_NAME 'recomp_truly_unordered'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            151 | Wed Jan 01 00:50:00 2025 PST | Wed Jan 01 03:20:00 2025 PST
+            151 | Wed Jan 01 00:50:00 2025 PST | Wed Jan 01 03:20:00 2025 PST
+            101 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 01:40:00 2025 PST
+            101 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 01:40:00 2025 PST
+            551 | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+            551 | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_10_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            803 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+            803 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                     recompression_status                     
+--------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=11, new_chunk_id=12
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_truly_unordered') chunk;
+                  chunk                  | chunk_status_text 
+-----------------------------------------+-------------------
+ _timescaledb_internal._hyper_7_10_chunk | {COMPRESSED}
+
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                  relid                  |                 compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+-----------------------------------------+-------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
+ recomp_truly_unordered                  |                                                 | {device}  | {time}  | {f}          | {f}                | 
+ _timescaledb_internal._hyper_7_10_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {device}  | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+DROP TABLE IF EXISTS recomp_truly_unordered CASCADE;
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_direct_compress_insert_sort_batches;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TEST_FILES
     plan_skip_scan_notnull.sql
     policy_generalization.sql
     recompression_integrity_tests.sql
+    recompression_integrity_unordered.sql
     reorder.sql
     size_utils_tsl.sql
     skip_scan.sql

--- a/tsl/test/sql/include/recompression_integrity_check.sql
+++ b/tsl/test/sql/include/recompression_integrity_check.sql
@@ -2,16 +2,11 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-\set TEST_BASE_NAME recompression_intergrity_check
 SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
        format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
 \gset
 SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
 \gset
-
--- Compress all uncompressed chunks
-SELECT compress_chunk(ch)
-FROM show_chunks(:'TEST_TABLE_NAME') ch;
 
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
@@ -31,8 +26,7 @@ LIMIT 1 \gset
 :BATCH_METADATA_QUERY
 
 \set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
-\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME ';'
-
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
 \o :TEST_RESULTS_COMPRESS
 :QUERY1
 :QUERY2

--- a/tsl/test/sql/recompression_integrity_tests.sql
+++ b/tsl/test/sql/recompression_integrity_tests.sql
@@ -3,8 +3,11 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 -- Set path to check data intergrity after in-memory recompression
+\set TEST_BASE_NAME recompression_intergrity_tests
+-- requires TEST_BASE_NAME, TEST_TABLE_NAME, BATCH_METADATA_QUERY, ORDER_BY_CLAUSE
 \set RECOMPRESSION_INTEGRITY_CHECK_RELPATH 'include/recompression_integrity_check.sql'
 \set BATCH_METADATA_QUERY ''
+\set ORDER_BY_CLAUSE ''
 
 -- Test Case 1: Basic segmentby configuration
 DROP TABLE IF EXISTS recomp_segmentby_test CASCADE;
@@ -35,6 +38,7 @@ INSERT INTO recomp_segmentby_test VALUES
   ('2001-01-01 01:00:00', 'device2', 'room2', 23.5, 68.5);
 
 \set TEST_TABLE_NAME 'recomp_segmentby_test'
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
@@ -69,6 +73,7 @@ INSERT INTO recomp_multi_segmentby_test VALUES
   ('2001-01-01', 'device2', 'room1', 'humidity', 63.0);
 
 \set TEST_TABLE_NAME 'recomp_multi_segmentby_test'
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
@@ -105,6 +110,7 @@ SELECT x, md5(x::text),
 FROM generate_series(1, 10000) x;
 
 \set TEST_TABLE_NAME 'recomp_index_test'
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
@@ -141,6 +147,8 @@ SELECT x, md5(x::text),
 FROM generate_series(1, 10000) x;
 
 \set TEST_TABLE_NAME 'recomp_large_data_test'
+-- Compress all uncompressed chunks
+SELECT compress_chunk(ch) FROM show_chunks(:'TEST_TABLE_NAME') ch;
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
@@ -151,23 +159,9 @@ DROP TABLE recomp_large_data_test CASCADE;
 \set BATCH_METADATA_QUERY 'SELECT _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;'
 SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_sort_batches = true;
-SET timescaledb.enable_direct_compress_insert_client_sorted = false;
-
--- Test Case 5: Unordered chunk
-DROP TABLE IF EXISTS recomp_unordered CASCADE;
-CREATE TABLE recomp_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
-INSERT INTO recomp_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
-INSERT INTO recomp_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(101,800) i;
-
--- Will not use in-memory recompression due to unordered
-\set TEST_TABLE_NAME 'recomp_unordered'
-\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
-SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
-DROP TABLE IF EXISTS recomp_unordered CASCADE;
-
--- Test Case 5: Direct Compress Batches
 SET timescaledb.enable_direct_compress_insert_client_sorted = true;
 
+-- Test Case 5: Direct Compress Batches
 DROP TABLE IF EXISTS recomp_direct_compress CASCADE;
 CREATE TABLE recomp_direct_compress (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
 

--- a/tsl/test/sql/recompression_integrity_unordered.sql
+++ b/tsl/test/sql/recompression_integrity_unordered.sql
@@ -1,0 +1,134 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Set path to check data intergrity after in-memory recompression
+\set TEST_BASE_NAME recompression_intergrity_unordered
+-- requires TEST_BASE_NAME, TEST_TABLE_NAME, BATCH_METADATA_QUERY, ORDER_BY_CLAUSE
+\set RECOMPRESSION_INTEGRITY_CHECK_RELPATH 'include/recompression_integrity_check.sql'
+
+-- Setup Direct Compress
+-- Batches may be uneven with direct compress but should always be even after recompression.
+\set BATCH_METADATA_QUERY 'SELECT _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;'
+\set ORDER_BY_CLAUSE ''
+SET timescaledb.enable_direct_compress_insert = true;
+SET timescaledb.enable_direct_compress_insert_sort_batches = true;
+SET timescaledb.enable_direct_compress_insert_client_sorted = false;
+
+-- Test Case 1: Unordered chunk
+DROP TABLE IF EXISTS recomp_unordered CASCADE;
+CREATE TABLE recomp_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
+-- Insert uneven batches
+SELECT setseed(0.5);
+DO $$
+DECLARE
+start_pos int := 0;
+batch_size int;
+i int;
+BEGIN
+FOR i IN 1..5 LOOP  -- 5 random batches
+    batch_size := (random() * 200 + 50)::int;  -- Random size 50-250
+    EXECUTE format('INSERT INTO recomp_unordered SELECT ''2025-01-01''::timestamptz + (i || '' minute'')::interval, ''d1'', i::float FROM generate_series(%s,%s) i',
+                    start_pos, start_pos + batch_size - 1);
+
+    start_pos := start_pos + batch_size;
+END LOOP;
+END $$;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered') chunk;
+\set TEST_TABLE_NAME 'recomp_unordered'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered') chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+DROP TABLE IF EXISTS recomp_unordered CASCADE;
+
+-- Test Case 2: Unordered chunk with segmentby
+DROP TABLE IF EXISTS recomp_unordered_segmentby CASCADE;
+CREATE TABLE recomp_unordered_segmentby (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+-- Insert uneven batches with multiple devices
+SELECT setseed(0.5);
+DO $$
+DECLARE
+start_pos int := 0;
+batch_size int;
+i int;
+device_id int;
+BEGIN
+FOR i IN 1..5 LOOP  -- 5 random batches
+    batch_size := (random() * 200 + 50)::int;  -- Random size 50-250
+    device_id := (i % 3) + 1;  -- Rotate between 3 devices
+    EXECUTE format('INSERT INTO recomp_unordered_segmentby SELECT ''2025-01-01''::timestamptz + (i || '' minute'')::interval, ''d%s'', i::float FROM generate_series(%s,%s) i',
+                    device_id, start_pos, start_pos + batch_size - 1);
+
+    start_pos := start_pos + batch_size;
+END LOOP;
+END $$;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_segmentby') chunk;
+\set TEST_TABLE_NAME 'recomp_unordered_segmentby'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_segmentby') chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+DROP TABLE IF EXISTS recomp_unordered_segmentby CASCADE;
+
+-- Test Case 3: Unordered chunk with segmentby and multiple orderbys
+DROP TABLE IF EXISTS recomp_unordered_multi_orderby CASCADE;
+CREATE TABLE recomp_unordered_multi_orderby (time TIMESTAMPTZ NOT NULL, device TEXT, sensor_id INT, value float) WITH (tsdb.hypertable, tsdb.orderby='time,sensor_id', tsdb.segmentby='device');
+-- Insert uneven batches with multiple devices and sensor_ids
+SELECT setseed(0.5);
+DO $$
+DECLARE
+start_pos int := 0;
+batch_size int;
+i int;
+device_id int;
+sensor_id int;
+BEGIN
+FOR i IN 1..5 LOOP  -- 5 random batches
+    batch_size := (random() * 200 + 50)::int;  -- Random size 50-250
+    device_id := (i % 3) + 1;  -- Rotate between 3 devices
+    sensor_id := (i % 2) + 1;  -- Rotate between 2 sensors
+    EXECUTE format('INSERT INTO recomp_unordered_multi_orderby SELECT ''2025-01-01''::timestamptz + (i || '' minute'')::interval, ''d%s'', %s, i::float FROM generate_series(%s,%s) i',
+                    device_id, sensor_id, start_pos, start_pos + batch_size - 1);
+
+    start_pos := start_pos + batch_size;
+END LOOP;
+END $$;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_multi_orderby') chunk;
+\set TEST_TABLE_NAME 'recomp_unordered_multi_orderby'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time, sensor_id'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_unordered_multi_orderby') chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+DROP TABLE IF EXISTS recomp_unordered_multi_orderby CASCADE;
+
+-- Test Case 4: Orderby is not necessarily increasing every insert
+DROP TABLE IF EXISTS recomp_truly_unordered CASCADE;
+CREATE TABLE recomp_truly_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.segmentby='device', tsdb.orderby='time');
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(50,200) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(50,200) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,100) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(150,700) i;
+INSERT INTO recomp_truly_unordered SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(150,700) i;
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_truly_unordered') chunk;
+\set TEST_TABLE_NAME 'recomp_truly_unordered'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_truly_unordered') chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+DROP TABLE IF EXISTS recomp_truly_unordered CASCADE;
+
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_direct_compress_insert_sort_batches;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+
+
+


### PR DESCRIPTION
Unordered chunks can now be recompressed in-memory without materializing data to disk. This improves performance and simplifies the recompression workflow.


Since in-memory recompression currently does a segment wise sort before compress, the current in-memory recompress  is compatible for ordering unordered chunks