### PR TITLE
Add rebuild_columnstore function

### DIFF
--- a/.unreleased/pr_9033
+++ b/.unreleased/pr_9033
@@ -1,0 +1,1 @@
+Implements: #9033 Add rebuild_columnstore procedure

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -55,6 +55,10 @@ CREATE OR REPLACE PROCEDURE @extschema@.convert_to_rowstore(
     if_columnstore BOOLEAN = true
 ) AS '@MODULE_PATHNAME@', 'ts_decompress_chunk' LANGUAGE C;
 
+CREATE OR REPLACE PROCEDURE _timescaledb_functions.rebuild_columnstore(
+    chunk REGCLASS
+) AS '@MODULE_PATHNAME@', 'ts_rebuild_columnstore' LANGUAGE C;
+
 CREATE OR REPLACE PROCEDURE _timescaledb_functions.chunk_rewrite_cleanup()
 LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_chunk_rewrite_cleanup';
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -105,3 +105,5 @@ GRANT USAGE ON SCHEMA _timescaledb_config TO PUBLIC;
 ALTER TABLE _timescaledb_catalog.bgw_job SET SCHEMA _timescaledb_config;
 
 DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_compressed_batch_size(REGCLASS);
+-- remove rebuild_columnstore
+DROP PROCEDURE IF EXISTS _timescaledb_functions.rebuild_columnstore(REGCLASS);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -83,6 +83,7 @@ CROSSMODULE_WRAPPER(uuid_compressor_finish);
 CROSSMODULE_WRAPPER(create_compressed_chunk);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
+CROSSMODULE_WRAPPER(rebuild_columnstore);
 CROSSMODULE_WRAPPER(bloom1_contains);
 CROSSMODULE_WRAPPER(bloom1_contains_any);
 
@@ -351,6 +352,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.create_compressed_chunk = error_no_default_fn_pg_community,
 	.compress_chunk = error_no_default_fn_pg_community,
 	.decompress_chunk = error_no_default_fn_pg_community,
+	.rebuild_columnstore = error_no_default_fn_pg_community,
 	.compressed_data_decompress_forward = error_no_default_fn_pg_community,
 	.compressed_data_decompress_reverse = error_no_default_fn_pg_community,
 	.deltadelta_compressor_append = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -128,6 +128,7 @@ typedef struct CrossModuleFunctions
 	PGFunction create_compressed_chunk;
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
+	PGFunction rebuild_columnstore;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, TupleTableSlot *slot);
 	void (*init_decompress_state_for_insert)(ChunkInsertState *state, TupleTableSlot *slot);
 	bool (*decompress_target_segments)(ModifyHypertableState *ht_state);

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -14,6 +14,7 @@
 extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
+extern Datum tsl_rebuild_columnstore(PG_FUNCTION_ARGS);
 extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress);
 extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk);
 

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -759,9 +759,6 @@ perform_recompression(RecompressContext *recompress_ctx, Relation compressed_chu
 
 /*
  * Perform per segment in-memory recompression of a compressed chunk.
- *
- * Note: This function will early return if the chunk is not suitable for
- * recompression (e.g., partial, frozen).
  */
 bool
 recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
@@ -771,8 +768,7 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 
 	Ensure(ts_guc_enable_in_memory_recompression, "in-memory recompression functionality disabled");
 
-	if (!ts_chunk_is_compressed(uncompressed_chunk) || ts_chunk_is_partial(uncompressed_chunk) ||
-		ts_chunk_is_frozen(uncompressed_chunk))
+	if (!ts_chunk_is_compressed(uncompressed_chunk) || ts_chunk_is_frozen(uncompressed_chunk))
 		return false;
 
 	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -167,6 +167,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.process_rename_cmd = tsl_process_rename_cmd,
 	.compress_chunk = tsl_compress_chunk,
 	.decompress_chunk = tsl_decompress_chunk,
+	.rebuild_columnstore = tsl_rebuild_columnstore,
 	.decompress_batches_for_insert = decompress_batches_for_insert,
 	.init_decompress_state_for_insert = init_decompress_state_for_insert,
 	.decompress_target_segments = decompress_target_segments,

--- a/tsl/test/expected/rebuild_columnstore_tests.out
+++ b/tsl/test/expected/rebuild_columnstore_tests.out
@@ -1,0 +1,300 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test rebuild_columnstore function with various chunk states
+-- Helper view to show chunk and compressed chunk info
+CREATE VIEW chunk_status_view AS
+SELECT
+    h.table_name AS hypertable_name,
+    uc.schema_name || '.' || uc.table_name AS chunk,
+    cc.schema_name || '.' || cc.table_name AS compressed_chunk,
+    _timescaledb_functions.chunk_status_text((uc.schema_name || '.' || uc.table_name)::regclass) AS status
+FROM _timescaledb_catalog.chunk uc
+LEFT JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.hypertable h ON uc.hypertable_id = h.id;
+SET timescaledb.enable_direct_compress_insert = true;
+-- Test 1: Rebuild fully compressed (ordered) chunk
+SET timescaledb.enable_direct_compress_insert_client_sorted = true;
+CREATE TABLE rebuild_ordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO rebuild_ordered
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(101,750) i;
+-- should be compressed
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_ordered';
+ hypertable_name |                 chunk                  |                compressed_chunk                |    status    
+-----------------+----------------------------------------+------------------------------------------------+--------------
+ rebuild_ordered | _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_2_chunk | {COMPRESSED}
+
+SELECT chunk FROM show_chunks('rebuild_ordered') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+-- should be compressed
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_ordered';
+ hypertable_name |                 chunk                  |                compressed_chunk                |    status    
+-----------------+----------------------------------------+------------------------------------------------+--------------
+ rebuild_ordered | _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_3_chunk | {COMPRESSED}
+
+DROP TABLE rebuild_ordered CASCADE;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+-- Test 2: Rebuild unordered chunk (should order the chunk)
+CREATE TABLE rebuild_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO rebuild_unordered
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,100) i;
+INSERT INTO rebuild_unordered
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(101,750) i;
+-- should be compressed, unordered
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_unordered';
+  hypertable_name  |                 chunk                  |                compressed_chunk                |         status         
+-------------------+----------------------------------------+------------------------------------------------+------------------------
+ rebuild_unordered | _timescaledb_internal._hyper_3_4_chunk | _timescaledb_internal.compress_hyper_4_5_chunk | {COMPRESSED,UNORDERED}
+
+SELECT chunk FROM show_chunks('rebuild_unordered') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+-- should be compressed
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_unordered';
+  hypertable_name  |                 chunk                  |                compressed_chunk                |    status    
+-------------------+----------------------------------------+------------------------------------------------+--------------
+ rebuild_unordered | _timescaledb_internal._hyper_3_4_chunk | _timescaledb_internal.compress_hyper_4_6_chunk | {COMPRESSED}
+
+DROP TABLE rebuild_unordered CASCADE;
+-- Test 3: Rebuild partial chunk (should preserve partial state with in-memory)
+CREATE TABLE rebuild_partial (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO rebuild_partial
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,100) i;
+INSERT INTO rebuild_partial
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(101,750) i;
+-- Less than 10 tuples will not undergo direct compression
+INSERT INTO rebuild_partial
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(751,755) i;
+WARNING:  disabling direct compress because of too small batch size
+-- should be compressed, unordered, partial
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_partial';
+ hypertable_name |                 chunk                  |                compressed_chunk                |             status             
+-----------------+----------------------------------------+------------------------------------------------+--------------------------------
+ rebuild_partial | _timescaledb_internal._hyper_5_7_chunk | _timescaledb_internal.compress_hyper_6_8_chunk | {COMPRESSED,UNORDERED,PARTIAL}
+
+SELECT chunk FROM show_chunks('rebuild_partial') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+-- should be compressed, partial
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_partial';
+ hypertable_name |                 chunk                  |                compressed_chunk                |        status        
+-----------------+----------------------------------------+------------------------------------------------+----------------------
+ rebuild_partial | _timescaledb_internal._hyper_5_7_chunk | _timescaledb_internal.compress_hyper_6_9_chunk | {COMPRESSED,PARTIAL}
+
+-- Verify uncompressed row count
+SELECT chunk FROM show_chunks('rebuild_partial') AS chunk LIMIT 1 \gset
+SELECT COUNT(*) FROM ONLY :chunk;
+ count 
+-------
+     5
+
+SELECT COUNT(*) FROM rebuild_partial;
+ count 
+-------
+   756
+
+DROP TABLE rebuild_partial CASCADE;
+-- Test 4: Rebuild with segmentby
+CREATE TABLE rebuild_segmentby (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- Insert data for multiple devices creating unordered batches
+INSERT INTO rebuild_segmentby
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,250) i;
+INSERT INTO rebuild_segmentby
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
+FROM generate_series(251,500) i;
+INSERT INTO rebuild_segmentby
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(501,750) i;
+-- get meta data info before rebuild
+SELECT chunk AS "CHUNK_NAME", compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE hypertable_name = 'rebuild_segmentby'
+LIMIT 1 \gset
+SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+ _ts_meta_count | device |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+--------+------------------------------+------------------------------
+            251 | d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 04:10:00 2025 PST
+            250 | d2     | Wed Jan 01 04:11:00 2025 PST | Wed Jan 01 08:20:00 2025 PST
+            250 | d1     | Wed Jan 01 08:21:00 2025 PST | Wed Jan 01 12:30:00 2025 PST
+
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_segmentby';
+  hypertable_name  |                  chunk                  |                compressed_chunk                 |         status         
+-------------------+-----------------------------------------+-------------------------------------------------+------------------------
+ rebuild_segmentby | _timescaledb_internal._hyper_7_10_chunk | _timescaledb_internal.compress_hyper_8_11_chunk | {COMPRESSED,UNORDERED}
+
+CALL _timescaledb_functions.rebuild_columnstore(:'CHUNK_NAME'::regclass);
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_segmentby';
+  hypertable_name  |                  chunk                  |                compressed_chunk                 |    status    
+-------------------+-----------------------------------------+-------------------------------------------------+--------------
+ rebuild_segmentby | _timescaledb_internal._hyper_7_10_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {COMPRESSED}
+
+-- get meta data info after rebuild
+SELECT compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE chunk = :'CHUNK_NAME'
+LIMIT 1 \gset
+SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+ _ts_meta_count | device |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+--------+------------------------------+------------------------------
+            501 | d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 12:30:00 2025 PST
+            250 | d2     | Wed Jan 01 04:11:00 2025 PST | Wed Jan 01 08:20:00 2025 PST
+
+DROP TABLE rebuild_segmentby CASCADE;
+-- Test 5: Change compression settings
+CREATE TABLE rebuild_settings (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- Insert data for multiple devices creating unordered batches
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,250) i;
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
+FROM generate_series(251,500) i;
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(501,750) i;
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
+FROM generate_series(300,305) i;
+WARNING:  disabling direct compress because of too small batch size
+-- get meta data info before rebuild
+SELECT chunk AS "CHUNK_NAME", compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE hypertable_name = 'rebuild_settings'
+LIMIT 1 \gset
+SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+ _ts_meta_count | device |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+--------+------------------------------+------------------------------
+            251 | d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 04:10:00 2025 PST
+            250 | d2     | Wed Jan 01 04:11:00 2025 PST | Wed Jan 01 08:20:00 2025 PST
+            250 | d1     | Wed Jan 01 08:21:00 2025 PST | Wed Jan 01 12:30:00 2025 PST
+
+ALTER TABLE rebuild_settings SET (
+    timescaledb.compress_segmentby = ''
+);
+-- settings changed, decompress/compress fallback
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_settings';
+ hypertable_name  |                  chunk                  |                 compressed_chunk                 |             status             
+------------------+-----------------------------------------+--------------------------------------------------+--------------------------------
+ rebuild_settings | _timescaledb_internal._hyper_9_13_chunk | _timescaledb_internal.compress_hyper_10_14_chunk | {COMPRESSED,UNORDERED,PARTIAL}
+
+CALL _timescaledb_functions.rebuild_columnstore(:'CHUNK_NAME'::regclass);
+-- should be compressed, partial status cleared due to full recompression
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_settings';
+ hypertable_name  |                  chunk                  |                 compressed_chunk                 |    status    
+------------------+-----------------------------------------+--------------------------------------------------+--------------
+ rebuild_settings | _timescaledb_internal._hyper_9_13_chunk | _timescaledb_internal.compress_hyper_10_15_chunk | {COMPRESSED}
+
+-- get meta data info after rebuild
+SELECT compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE chunk = :'CHUNK_NAME'
+LIMIT 1 \gset
+SELECT _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            757 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 12:30:00 2025 PST
+
+DROP TABLE rebuild_settings CASCADE;
+-- Test 6: Edge cases handling
+\set ON_ERROR_STOP 0
+-- Invalid OID error handling
+CALL _timescaledb_functions.rebuild_columnstore(NULL);
+ERROR:  invalid chunk OID
+CALL _timescaledb_functions.rebuild_columnstore(0::OID);
+ERROR:  invalid chunk OID
+-- Invalid chunk_id
+CALL _timescaledb_functions.rebuild_columnstore(15000);
+ERROR:  chunk not found
+\set ON_ERROR_STOP 1
+CREATE TABLE rebuild_error (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO rebuild_error
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,5) i;
+WARNING:  disabling direct compress because of too small batch size
+-- uncompressed notice
+SELECT chunk FROM show_chunks('rebuild_error') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+NOTICE:  chunk "_timescaledb_internal._hyper_11_16_chunk" is uncompressed or frozen, skipping
+SELECT compress_chunk(chunk) FROM show_chunks('rebuild_error') AS chunk;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_16_chunk
+
+SELECT _timescaledb_functions.freeze_chunk(chunk) FROM show_chunks('rebuild_error') AS chunk;
+ freeze_chunk 
+--------------
+ t
+
+-- frozen notice
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+NOTICE:  chunk "_timescaledb_internal._hyper_11_16_chunk" is uncompressed or frozen, skipping
+SELECT _timescaledb_functions.unfreeze_chunk(chunk) FROM show_chunks('rebuild_error') AS chunk;
+ unfreeze_chunk 
+----------------
+ t
+
+SET timescaledb.enable_in_memory_recompression = false;
+-- guc disabled, decompress/compress fallback
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_error';
+ hypertable_name |                  chunk                   |                 compressed_chunk                 |    status    
+-----------------+------------------------------------------+--------------------------------------------------+--------------
+ rebuild_error   | _timescaledb_internal._hyper_11_16_chunk | _timescaledb_internal.compress_hyper_12_17_chunk | {COMPRESSED}
+
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_error';
+ hypertable_name |                  chunk                   |                 compressed_chunk                 |    status    
+-----------------+------------------------------------------+--------------------------------------------------+--------------
+ rebuild_error   | _timescaledb_internal._hyper_11_16_chunk | _timescaledb_internal.compress_hyper_12_18_chunk | {COMPRESSED}
+
+RESET timescaledb.enable_in_memory_recompression;
+DROP TABLE rebuild_error CASCADE;
+CREATE TABLE rebuild_no_orderby (col1 INT NOT NULL, device INT);
+SELECT create_hypertable('rebuild_no_orderby', 'col1', chunk_time_interval => 10);
+        create_hypertable         
+----------------------------------
+ (13,public,rebuild_no_orderby,t)
+
+ALTER TABLE rebuild_no_orderby SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'col1'
+);
+INSERT INTO rebuild_no_orderby VALUES (1, 2);
+WARNING:  disabling direct compress because of too small batch size
+SELECT compress_chunk(chunk) FROM show_chunks('rebuild_no_orderby') chunk;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_13_19_chunk
+
+-- no orderby, decompress/compress fallback
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_no_orderby';
+  hypertable_name   |                  chunk                   |                 compressed_chunk                 |    status    
+--------------------+------------------------------------------+--------------------------------------------------+--------------
+ rebuild_no_orderby | _timescaledb_internal._hyper_13_19_chunk | _timescaledb_internal.compress_hyper_14_20_chunk | {COMPRESSED}
+
+SELECT chunk FROM show_chunks('rebuild_no_orderby') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_no_orderby';
+  hypertable_name   |                  chunk                   |                 compressed_chunk                 |    status    
+--------------------+------------------------------------------+--------------------------------------------------+--------------
+ rebuild_no_orderby | _timescaledb_internal._hyper_13_19_chunk | _timescaledb_internal.compress_hyper_14_21_chunk | {COMPRESSED}
+
+DROP TABLE rebuild_no_orderby CASCADE;
+DROP VIEW chunk_status_view;
+RESET timescaledb.enable_direct_compress_insert;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -107,6 +107,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.policy_retention_check(jsonb)
  _timescaledb_functions.process_ddl_event()
  _timescaledb_functions.range_value_to_pretty(bigint,regtype)
+ _timescaledb_functions.rebuild_columnstore(regclass)
  _timescaledb_functions.recompress_chunk_segmentwise(regclass,boolean)
  _timescaledb_functions.relation_approximate_size(regclass)
  _timescaledb_functions.relation_size(regclass)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TEST_FILES
     move.sql
     plan_skip_scan_notnull.sql
     policy_generalization.sql
+    rebuild_columnstore_tests.sql
     recompression_integrity_tests.sql
     recompression_integrity_unordered.sql
     reorder.sql

--- a/tsl/test/sql/rebuild_columnstore_tests.sql
+++ b/tsl/test/sql/rebuild_columnstore_tests.sql
@@ -1,0 +1,225 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test rebuild_columnstore function with various chunk states
+
+-- Helper view to show chunk and compressed chunk info
+CREATE VIEW chunk_status_view AS
+SELECT
+    h.table_name AS hypertable_name,
+    uc.schema_name || '.' || uc.table_name AS chunk,
+    cc.schema_name || '.' || cc.table_name AS compressed_chunk,
+    _timescaledb_functions.chunk_status_text((uc.schema_name || '.' || uc.table_name)::regclass) AS status
+FROM _timescaledb_catalog.chunk uc
+LEFT JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.hypertable h ON uc.hypertable_id = h.id;
+
+SET timescaledb.enable_direct_compress_insert = true;
+
+-- Test 1: Rebuild fully compressed (ordered) chunk
+SET timescaledb.enable_direct_compress_insert_client_sorted = true;
+
+CREATE TABLE rebuild_ordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+
+INSERT INTO rebuild_ordered
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(101,750) i;
+
+-- should be compressed
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_ordered';
+SELECT chunk FROM show_chunks('rebuild_ordered') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+
+-- should be compressed
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_ordered';
+
+DROP TABLE rebuild_ordered CASCADE;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+
+-- Test 2: Rebuild unordered chunk (should order the chunk)
+CREATE TABLE rebuild_unordered (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+
+INSERT INTO rebuild_unordered
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,100) i;
+
+INSERT INTO rebuild_unordered
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(101,750) i;
+
+-- should be compressed, unordered
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_unordered';
+SELECT chunk FROM show_chunks('rebuild_unordered') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+
+-- should be compressed
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_unordered';
+
+DROP TABLE rebuild_unordered CASCADE;
+
+-- Test 3: Rebuild partial chunk (should preserve partial state with in-memory)
+CREATE TABLE rebuild_partial (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+
+INSERT INTO rebuild_partial
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,100) i;
+
+INSERT INTO rebuild_partial
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(101,750) i;
+
+-- Less than 10 tuples will not undergo direct compression
+INSERT INTO rebuild_partial
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(751,755) i;
+
+-- should be compressed, unordered, partial
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_partial';
+SELECT chunk FROM show_chunks('rebuild_partial') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+
+-- should be compressed, partial
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_partial';
+
+-- Verify uncompressed row count
+SELECT chunk FROM show_chunks('rebuild_partial') AS chunk LIMIT 1 \gset
+SELECT COUNT(*) FROM ONLY :chunk;
+SELECT COUNT(*) FROM rebuild_partial;
+
+DROP TABLE rebuild_partial CASCADE;
+
+-- Test 4: Rebuild with segmentby
+CREATE TABLE rebuild_segmentby (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+
+-- Insert data for multiple devices creating unordered batches
+INSERT INTO rebuild_segmentby
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,250) i;
+
+INSERT INTO rebuild_segmentby
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
+FROM generate_series(251,500) i;
+
+INSERT INTO rebuild_segmentby
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(501,750) i;
+
+-- get meta data info before rebuild
+SELECT chunk AS "CHUNK_NAME", compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE hypertable_name = 'rebuild_segmentby'
+LIMIT 1 \gset
+SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_segmentby';
+CALL _timescaledb_functions.rebuild_columnstore(:'CHUNK_NAME'::regclass);
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_segmentby';
+
+-- get meta data info after rebuild
+SELECT compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE chunk = :'CHUNK_NAME'
+LIMIT 1 \gset
+SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+
+DROP TABLE rebuild_segmentby CASCADE;
+
+-- Test 5: Change compression settings
+CREATE TABLE rebuild_settings (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+
+-- Insert data for multiple devices creating unordered batches
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,250) i;
+
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
+FROM generate_series(251,500) i;
+
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(501,750) i;
+INSERT INTO rebuild_settings
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
+FROM generate_series(300,305) i;
+
+-- get meta data info before rebuild
+SELECT chunk AS "CHUNK_NAME", compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE hypertable_name = 'rebuild_settings'
+LIMIT 1 \gset
+SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+ALTER TABLE rebuild_settings SET (
+    timescaledb.compress_segmentby = ''
+);
+-- settings changed, decompress/compress fallback
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_settings';
+CALL _timescaledb_functions.rebuild_columnstore(:'CHUNK_NAME'::regclass);
+-- should be compressed, partial status cleared due to full recompression
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_settings';
+
+-- get meta data info after rebuild
+SELECT compressed_chunk AS "COMPRESSED_CHUNK_NAME"
+FROM chunk_status_view
+WHERE chunk = :'CHUNK_NAME'
+LIMIT 1 \gset
+SELECT _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_CHUNK_NAME;
+
+DROP TABLE rebuild_settings CASCADE;
+
+-- Test 6: Edge cases handling
+\set ON_ERROR_STOP 0
+
+-- Invalid OID error handling
+CALL _timescaledb_functions.rebuild_columnstore(NULL);
+CALL _timescaledb_functions.rebuild_columnstore(0::OID);
+
+-- Invalid chunk_id
+CALL _timescaledb_functions.rebuild_columnstore(15000);
+\set ON_ERROR_STOP 1
+
+CREATE TABLE rebuild_error (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+WITH (tsdb.hypertable, tsdb.orderby='time');
+INSERT INTO rebuild_error
+SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+FROM generate_series(0,5) i;
+-- uncompressed notice
+SELECT chunk FROM show_chunks('rebuild_error') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT compress_chunk(chunk) FROM show_chunks('rebuild_error') AS chunk;
+SELECT _timescaledb_functions.freeze_chunk(chunk) FROM show_chunks('rebuild_error') AS chunk;
+-- frozen notice
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT _timescaledb_functions.unfreeze_chunk(chunk) FROM show_chunks('rebuild_error') AS chunk;
+SET timescaledb.enable_in_memory_recompression = false;
+-- guc disabled, decompress/compress fallback
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_error';
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_error';
+RESET timescaledb.enable_in_memory_recompression;
+DROP TABLE rebuild_error CASCADE;
+
+CREATE TABLE rebuild_no_orderby (col1 INT NOT NULL, device INT);
+SELECT create_hypertable('rebuild_no_orderby', 'col1', chunk_time_interval => 10);
+ALTER TABLE rebuild_no_orderby SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'col1'
+);
+
+INSERT INTO rebuild_no_orderby VALUES (1, 2);
+SELECT compress_chunk(chunk) FROM show_chunks('rebuild_no_orderby') chunk;
+-- no orderby, decompress/compress fallback
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_no_orderby';
+SELECT chunk FROM show_chunks('rebuild_no_orderby') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_no_orderby';
+DROP TABLE rebuild_no_orderby CASCADE;
+
+DROP VIEW chunk_status_view;
+RESET timescaledb.enable_direct_compress_insert;


### PR DESCRIPTION
Rebuild columnstore of compressed chunks using in-memory
recompression when possible, with fallback to
decompress/compress.

For partial chunks, only the columnstore portion is rebuilt.
The function attempts in-memory recompression first,
preserving the partial chunk structure. If in-memory
recompression is unavailable or fails, it falls back to full
decompress/compress cycle making the partial chunk fully
compressed.

Adds cross-module function hooks and SQL interface.

** OLD **
When recompress=true, only the columnstore portion of partial chunks is recompressed in-memory, leaving rowstore data unchanged and the chunk's partial status is preserved.

Previously, recompress=true invoked recompress_chunk_segmentwise_impl, which did not optimize columnstore.

Needs #9032 to be merged first