### PR TITLE
Improve approximate row count on compressed chunks

### DIFF
--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -104,3 +104,4 @@ GRANT USAGE ON SCHEMA _timescaledb_config TO PUBLIC;
 
 ALTER TABLE _timescaledb_catalog.bgw_job SET SCHEMA _timescaledb_config;
 
+DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_compressed_batch_size(REGCLASS);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -104,6 +104,8 @@ CROSSMODULE_WRAPPER(split_chunk);
 CROSSMODULE_WRAPPER(detach_chunk);
 CROSSMODULE_WRAPPER(attach_chunk);
 
+CROSSMODULE_WRAPPER(estimate_compressed_batch_size);
+
 /*
  * casting a function pointer to a pointer of another type is undefined
  * behavior, so we need one of these for every function type we have

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -179,6 +179,8 @@ typedef struct CrossModuleFunctions
 
 	PGFunction detach_chunk;
 	PGFunction attach_chunk;
+
+	PGFunction estimate_compressed_batch_size;
 } CrossModuleFunctions;
 
 extern TSDLLEXPORT CrossModuleFunctions *ts_cm_functions;

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -47,6 +47,7 @@
 #include "hypercube.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
+#include "nodes/columnar_scan/columnar_scan.h"
 #include "recompress.h"
 #include "scan_iterator.h"
 #include "scanner.h"
@@ -945,4 +946,16 @@ tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk)
 {
 	/* Create a new compressed chunk */
 	return create_compress_chunk(compressed_ht, src_chunk, InvalidOid);
+}
+
+Datum
+tsl_estimate_compressed_batch_size(PG_FUNCTION_ARGS)
+{
+	Oid relid = PG_GETARG_OID(0);
+
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
+
+	float8 approx_batch_size = (float8) ts_columnar_estimate_compressed_batch_size(relid);
+
+	PG_RETURN_FLOAT8(approx_batch_size);
 }

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -26,3 +26,4 @@ extern void compression_chunk_size_catalog_insert(int32 src_chunk_id, const Rela
 												  int64 rowcnt_pre_compression,
 												  int64 rowcnt_post_compression,
 												  int64 rowcnt_frozen);
+extern Datum tsl_estimate_compressed_batch_size(PG_FUNCTION_ARGS);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -190,6 +190,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.split_chunk = chunk_split_chunk,
 	.detach_chunk = chunk_detach,
 	.attach_chunk = chunk_attach,
+	.estimate_compressed_batch_size = tsl_estimate_compressed_batch_size,
 };
 
 static void

--- a/tsl/src/nodes/columnar_scan/columnar_scan.h
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.h
@@ -66,4 +66,6 @@ void ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *rel, const H
 extern bool ts_is_columnar_scan_path(Path *path);
 extern bool ts_is_columnar_scan_plan(Plan *plan);
 
+extern double ts_columnar_estimate_compressed_batch_size(const Oid relid);
+
 ColumnarScanPath *copy_columnar_scan_path(ColumnarScanPath *src);

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -56,6 +56,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.dimension_info_out(_timescaledb_internal.dimension_info)
  _timescaledb_functions.drop_chunk(regclass)
  _timescaledb_functions.drop_osm_chunk(regclass)
+ _timescaledb_functions.estimate_compressed_batch_size(regclass)
  _timescaledb_functions.extension_state()
  _timescaledb_functions.first_combinefunc(internal,internal)
  _timescaledb_functions.first_sfunc(internal,anyelement,"any")


### PR DESCRIPTION
In #8654 we fixed the `approximate_row_count` for compressed chunks to use Postgres statistics doing the math `pg_class.reltuples * 1000`.

This is not very accurate since we can have less than 1000 rows per segment leading to bad information, so exposed the internal compressed batch size estimation in an SQL function to be used to properly calculate the approximate row count.

Disable-check: force-changelog-file
