### PR TITLE
Change default compression configuration for compressed continuous aggregates

### DIFF
--- a/.unreleased/pr_9038
+++ b/.unreleased/pr_9038
@@ -1,0 +1,1 @@
+Implements: #9038 Change default configuration for compressed continuous aggregates

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -22,12 +22,14 @@
 #include "hypertable_cache.h"
 #include "options.h"
 #include "scan_iterator.h"
+#include "ts_catalog/array_utils.h"
 #include "ts_catalog/continuous_agg.h"
 #include "with_clause/alter_table_with_clause.h"
 #include "with_clause/create_materialized_view_with_clause.h"
 
 static void cagg_update_materialized_only(ContinuousAgg *agg, bool materialized_only);
-static List *cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht);
+static List *cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht,
+										 WithClauseResult *with_clause_options);
 static void cagg_alter_compression(ContinuousAgg *agg, Hypertable *mat_ht, List *compress_defelems);
 
 static void
@@ -76,51 +78,54 @@ cagg_update_materialized_only(ContinuousAgg *agg, bool materialized_only)
 /* get the compression parameters for cagg. The parameters are
  * derived from the cagg view definition.
  * Computes:
- * compress_segmentby = GROUP BY columns from cagg query
- * compress_orderby = time_bucket column from cagg query
+ * compress_orderby = time_bucket column from cagg query followed by remaining grouping columns
  */
 static List *
-cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht)
+cagg_get_compression_params(ContinuousAgg *agg, Hypertable *mat_ht,
+							WithClauseResult *with_clause_options)
 {
-	List *defelems = NIL;
 	const Dimension *mat_ht_dim = hyperspace_get_open_dimension(mat_ht->space, 0);
-	const char *mat_ht_timecolname = quote_identifier(NameStr(mat_ht_dim->fd.column_name));
-	DefElem *ordby = makeDefElemExtended(EXTENSION_NAMESPACE,
-										 "compress_orderby",
-										 (Node *) makeString((char *) mat_ht_timecolname),
-										 DEFELEM_UNSPEC,
-										 -1);
-	defelems = lappend(defelems, ordby);
+	StringInfoData info;
+	initStringInfo(&info);
+	ArrayType *segmentby_columns = NULL;
+
+	/* add time column as first entry */
+	appendStringInfoString(&info, quote_identifier(NameStr(mat_ht_dim->fd.column_name)));
+
+	if (with_clause_options[AlterTableFlagSegmentBy].parsed)
+	{
+		segmentby_columns =
+			ts_compress_hypertable_parse_segment_by(with_clause_options[AlterTableFlagSegmentBy],
+													mat_ht);
+	}
+
 	List *grp_colnames = cagg_find_groupingcols(agg, mat_ht);
 	if (grp_colnames)
 	{
-		StringInfoData info;
-		initStringInfo(&info);
 		ListCell *lc;
 		foreach (lc, grp_colnames)
 		{
 			char *grpcol = (char *) lfirst(lc);
-			/* skip time dimension col if it appears in group-by list */
+			/* skip time dimension since we put it as first entry */
 			if (namestrcmp((Name) & (mat_ht_dim->fd.column_name), grpcol) == 0)
 				continue;
+
+			if (segmentby_columns && ts_array_is_member(segmentby_columns, grpcol))
+				continue;
+
 			if (info.len > 0)
 				appendStringInfoString(&info, ",");
 			appendStringInfoString(&info, quote_identifier(grpcol));
 		}
-
-		if (info.len > 0)
-		{
-			DefElem *segby;
-			segby = makeDefElemExtended(EXTENSION_NAMESPACE,
-										"compress_segmentby",
-										(Node *) makeString(info.data),
-										DEFELEM_UNSPEC,
-										-1);
-			defelems = lappend(defelems, segby);
-		}
 	}
 
-	return defelems;
+	DefElem *ordby = makeDefElemExtended(EXTENSION_NAMESPACE,
+										 "compress_orderby",
+										 (Node *) makeString(info.data),
+										 DEFELEM_UNSPEC,
+										 -1);
+
+	return list_make1(ordby);
 }
 
 /* forwards compression related changes via an alter statement to the underlying HT */
@@ -132,7 +137,8 @@ cagg_alter_compression(ContinuousAgg *agg, Hypertable *mat_ht, List *compress_de
 
 	if (with_clause_options[AlterTableFlagColumnstore].parsed)
 	{
-		List *default_compress_defelems = cagg_get_compression_params(agg, mat_ht);
+		List *default_compress_defelems =
+			cagg_get_compression_params(agg, mat_ht, with_clause_options);
 		WithClauseResult *default_with_clause_options =
 			ts_alter_table_with_clause_parse(default_compress_defelems);
 		/* Merge defaults if there's any. */

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -45,8 +45,7 @@ SELECT count(*) FROM _timescaledb_catalog.bgw_job;
 \set VERBOSITY default
 -- Test 1 step policy for integer type buckets
 ALTER materialized view mat_m1 set (timescaledb.compress = true);
-NOTICE:  defaulting compress_segmentby to a
-NOTICE:  defaulting compress_orderby to time_partition_col
+NOTICE:  defaulting compress_orderby to time_partition_col,a
 -- No policy is added if one errors out
 SELECT timescaledb_experimental.add_policies('mat_m1', refresh_start_offset => 1, refresh_end_offset => 10, compress_after => 11, drop_after => 20);
 ERROR:  policy refresh window too small
@@ -1103,8 +1102,7 @@ SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
 ERROR:  columnstore not enabled on continuous aggregate "metrics_cagg"
 ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
-NOTICE:  defaulting compress_segmentby to device_id
-NOTICE:  defaulting compress_orderby to dayb
+NOTICE:  defaulting compress_orderby to dayb,device_id
 --cannot use compress_created_before with cagg
 SELECT add_compression_policy('metrics_cagg', compress_created_before => '8 day'::interval) AS "COMP_JOB" ;
 ERROR:  cannot use "compress_created_before" with continuous aggregate "metrics_cagg" 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1217,8 +1217,7 @@ FROM public."tEst2"
 GROUP BY "Idd", "bUcket";
 NOTICE:  continuous aggregate "tEst2_mv" is already up-to-date
 ALTER MATERIALIZED VIEW "tEst2_mv" SET (timescaledb.compress = true);
-NOTICE:  defaulting compress_segmentby to "Idd"
-NOTICE:  defaulting compress_orderby to "bUcket"
+NOTICE:  defaulting compress_orderby to "bUcket","Idd"
 -- #5161 segmentby param
 CREATE MATERIALIZED VIEW test1_cont_view2
 WITH (timescaledb.continuous,
@@ -1232,14 +1231,12 @@ ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress = true,
   timescaledb.compress_segmentby = 'invalid_column'
 );
-NOTICE:  defaulting compress_orderby to t
 ERROR:  column "invalid_column" does not exist
 \set ON_ERROR_STOP 1
 ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress = true
 );
-NOTICE:  defaulting compress_segmentby to "iDeA"
-NOTICE:  defaulting compress_orderby to t
+NOTICE:  defaulting compress_orderby to t,"iDeA"
 ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress = true,
   timescaledb.compress_segmentby = '"iDeA"'
@@ -1250,7 +1247,6 @@ ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress = true,
   timescaledb.compress_orderby = '"iDeA"'
 );
-NOTICE:  defaulting compress_segmentby to "iDeA"
 ERROR:  cannot use column "iDeA" for both ordering and segmenting
 \set ON_ERROR_STOP 1
 ALTER MATERIALIZED VIEW test1_cont_view2 SET (

--- a/tsl/test/expected/continuous_aggs-15.out
+++ b/tsl/test/expected/continuous_aggs-15.out
@@ -1391,8 +1391,7 @@ SELECT mat_htid AS "MAT_HTID"
 FROM cagg_compression_status
 WHERE cagg_name = 'search_query_count_3' \gset
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'true');
-NOTICE:  defaulting compress_segmentby to search_query
-NOTICE:  defaulting compress_orderby to bucket
+NOTICE:  defaulting compress_orderby to bucket,search_query
 SELECT cagg_name, mat_table_name
 FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
@@ -1405,17 +1404,17 @@ WHERE hypertable_name = :'MAT_TABLE_NAME';
 -[ RECORD 1 ]----------+----------------------------
 hypertable_schema      | _timescaledb_internal
 hypertable_name        | _materialized_hypertable_41
-attname                | search_query
-segmentby_column_index | 1
-orderby_column_index   | 
-orderby_asc            | 
-orderby_nullsfirst     | 
--[ RECORD 2 ]----------+----------------------------
-hypertable_schema      | _timescaledb_internal
-hypertable_name        | _materialized_hypertable_41
 attname                | bucket
 segmentby_column_index | 
 orderby_column_index   | 1
+orderby_asc            | t
+orderby_nullsfirst     | f
+-[ RECORD 2 ]----------+----------------------------
+hypertable_schema      | _timescaledb_internal
+hypertable_name        | _materialized_hypertable_41
+attname                | search_query
+segmentby_column_index | 
+orderby_column_index   | 2
 orderby_asc            | t
 orderby_nullsfirst     | f
 

--- a/tsl/test/expected/continuous_aggs-16.out
+++ b/tsl/test/expected/continuous_aggs-16.out
@@ -1391,8 +1391,7 @@ SELECT mat_htid AS "MAT_HTID"
 FROM cagg_compression_status
 WHERE cagg_name = 'search_query_count_3' \gset
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'true');
-NOTICE:  defaulting compress_segmentby to search_query
-NOTICE:  defaulting compress_orderby to bucket
+NOTICE:  defaulting compress_orderby to bucket,search_query
 SELECT cagg_name, mat_table_name
 FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
@@ -1405,17 +1404,17 @@ WHERE hypertable_name = :'MAT_TABLE_NAME';
 -[ RECORD 1 ]----------+----------------------------
 hypertable_schema      | _timescaledb_internal
 hypertable_name        | _materialized_hypertable_41
-attname                | search_query
-segmentby_column_index | 1
-orderby_column_index   | 
-orderby_asc            | 
-orderby_nullsfirst     | 
--[ RECORD 2 ]----------+----------------------------
-hypertable_schema      | _timescaledb_internal
-hypertable_name        | _materialized_hypertable_41
 attname                | bucket
 segmentby_column_index | 
 orderby_column_index   | 1
+orderby_asc            | t
+orderby_nullsfirst     | f
+-[ RECORD 2 ]----------+----------------------------
+hypertable_schema      | _timescaledb_internal
+hypertable_name        | _materialized_hypertable_41
+attname                | search_query
+segmentby_column_index | 
+orderby_column_index   | 2
 orderby_asc            | t
 orderby_nullsfirst     | f
 

--- a/tsl/test/expected/continuous_aggs-17.out
+++ b/tsl/test/expected/continuous_aggs-17.out
@@ -1391,8 +1391,7 @@ SELECT mat_htid AS "MAT_HTID"
 FROM cagg_compression_status
 WHERE cagg_name = 'search_query_count_3' \gset
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'true');
-NOTICE:  defaulting compress_segmentby to search_query
-NOTICE:  defaulting compress_orderby to bucket
+NOTICE:  defaulting compress_orderby to bucket,search_query
 SELECT cagg_name, mat_table_name
 FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
@@ -1405,17 +1404,17 @@ WHERE hypertable_name = :'MAT_TABLE_NAME';
 -[ RECORD 1 ]----------+----------------------------
 hypertable_schema      | _timescaledb_internal
 hypertable_name        | _materialized_hypertable_41
-attname                | search_query
-segmentby_column_index | 1
-orderby_column_index   | 
-orderby_asc            | 
-orderby_nullsfirst     | 
--[ RECORD 2 ]----------+----------------------------
-hypertable_schema      | _timescaledb_internal
-hypertable_name        | _materialized_hypertable_41
 attname                | bucket
 segmentby_column_index | 
 orderby_column_index   | 1
+orderby_asc            | t
+orderby_nullsfirst     | f
+-[ RECORD 2 ]----------+----------------------------
+hypertable_schema      | _timescaledb_internal
+hypertable_name        | _materialized_hypertable_41
+attname                | search_query
+segmentby_column_index | 
+orderby_column_index   | 2
 orderby_asc            | t
 orderby_nullsfirst     | f
 

--- a/tsl/test/expected/continuous_aggs-18.out
+++ b/tsl/test/expected/continuous_aggs-18.out
@@ -1391,8 +1391,7 @@ SELECT mat_htid AS "MAT_HTID"
 FROM cagg_compression_status
 WHERE cagg_name = 'search_query_count_3' \gset
 ALTER MATERIALIZED VIEW search_query_count_3 SET (timescaledb.compress = 'true');
-NOTICE:  defaulting compress_segmentby to search_query
-NOTICE:  defaulting compress_orderby to bucket
+NOTICE:  defaulting compress_orderby to bucket,search_query
 SELECT cagg_name, mat_table_name
 FROM cagg_compression_status where cagg_name = 'search_query_count_3';
       cagg_name       |       mat_table_name        
@@ -1405,17 +1404,17 @@ WHERE hypertable_name = :'MAT_TABLE_NAME';
 -[ RECORD 1 ]----------+----------------------------
 hypertable_schema      | _timescaledb_internal
 hypertable_name        | _materialized_hypertable_41
-attname                | search_query
-segmentby_column_index | 1
-orderby_column_index   | 
-orderby_asc            | 
-orderby_nullsfirst     | 
--[ RECORD 2 ]----------+----------------------------
-hypertable_schema      | _timescaledb_internal
-hypertable_name        | _materialized_hypertable_41
 attname                | bucket
 segmentby_column_index | 
 orderby_column_index   | 1
+orderby_asc            | t
+orderby_nullsfirst     | f
+-[ RECORD 2 ]----------+----------------------------
+hypertable_schema      | _timescaledb_internal
+hypertable_name        | _materialized_hypertable_41
+attname                | search_query
+segmentby_column_index | 
+orderby_column_index   | 2
 orderby_asc            | t
 orderby_nullsfirst     | f
 

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -271,8 +271,7 @@ FROM show_chunks('hyper') c ORDER BY c LIMIT 4;
  _timescaledb_internal._hyper_1_4_chunk
 
 ALTER MATERIALIZED VIEW contagg SET (timescaledb.compress);
-NOTICE:  defaulting compress_segmentby to device
-NOTICE:  defaulting compress_orderby to hour
+NOTICE:  defaulting compress_orderby to hour,device
 SELECT compress_chunk(c)
 FROM show_chunks('contagg') c ORDER BY c LIMIT 1;
              compress_chunk              
@@ -304,11 +303,11 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_reltuples": 697                             +
      },                                                   +
      "hypertables": {                                     +
-         "heap_size": 368640,                             +
+         "heap_size": 335872,                             +
          "toast_size": 40960,                             +
          "compression": {                                 +
-             "compressed_heap_size": 114688,              +
-             "compressed_row_count": 49,                  +
+             "compressed_heap_size": 81920,               +
+             "compressed_row_count": 40,                  +
              "compressed_toast_size": 40960,              +
              "num_compressed_chunks": 5,                  +
              "uncompressed_heap_size": 221184,            +
@@ -317,7 +316,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
              "uncompressed_toast_size": 0,                +
              "uncompressed_indexes_size": 131072,         +
              "num_compressed_hypertables": 2,             +
-             "compressed_row_count_frozen_immediately": 49+
+             "compressed_row_count_frozen_immediately": 40+
          },                                               +
          "indexes_size": 270336,                          +
          "num_children": 11,                              +

--- a/tsl/test/shared/expected/cagg_compression.out
+++ b/tsl/test/shared/expected/cagg_compression.out
@@ -53,8 +53,7 @@ WHERE
  
 
 ALTER MATERIALIZED VIEW metrics_compressed_summary SET (timescaledb.compress);
-psql:include/cagg_compression_setup.sql:42: NOTICE:  defaulting compress_segmentby to device_id
-psql:include/cagg_compression_setup.sql:42: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_compression_setup.sql:42: NOTICE:  defaulting compress_orderby to bucket,device_id
 CALL refresh_continuous_aggregate('metrics_compressed_summary', NULL, '2000-01-15 23:55:00+0');
 SELECT CASE WHEN res is NULL THEN NULL
             ELSE 'compressed'
@@ -115,8 +114,7 @@ WHERE
  
 
 ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.compress);
-psql:include/cagg_compression_setup.sql:94: NOTICE:  defaulting compress_segmentby to device_id
-psql:include/cagg_compression_setup.sql:94: NOTICE:  defaulting compress_orderby to bucket
+psql:include/cagg_compression_setup.sql:94: NOTICE:  defaulting compress_orderby to bucket,device_id
 CALL refresh_continuous_aggregate('metrics_summary', NULL, '2000-01-15 23:55:00+0');
 SELECT CASE WHEN res is NULL THEN NULL
             ELSE 'compressed'


### PR DESCRIPTION
This PR changes the default compression configuration to no longer
automatically assign segmentby columns. The new default for the
compression settings will be empty segmentby and orderby with the
bucketing column as first entry followed by any remaining grouping
columns.
