### PR TITLE
Reset the grouping policy after returning all partial results

### DIFF
--- a/tsl/src/nodes/vector_agg/exec.c
+++ b/tsl/src/nodes/vector_agg/exec.c
@@ -406,6 +406,12 @@ vector_agg_exec(CustomScanState *node)
 	}
 
 	/*
+	 * Have no more partial aggregation results but might still have input.
+	 * Reset the grouping policy and start a new cycle of partial aggregation.
+	 */
+	grouping->gp_reset(grouping);
+
+	/*
 	 * If the partial aggregation results have ended, and the input has ended,
 	 * we're done.
 	 */
@@ -413,12 +419,6 @@ vector_agg_exec(CustomScanState *node)
 	{
 		return NULL;
 	}
-
-	/*
-	 * Have no more partial aggregation results and still have input, have to
-	 * reset the grouping policy and start a new cycle of partial aggregation.
-	 */
-	grouping->gp_reset(grouping);
 
 	/*
 	 * Now we loop through the input compressed tuples, until they end or until


### PR DESCRIPTION
This leaves it in a reset state after the input is finished, which reduces per-chunk memory usage and can be important when we have a lot of chunks.

Disable-check: force-changelog-file