### PR TITLE
Fix check for pending ranges in CAgg refresh

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -904,6 +904,14 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 		ContinuousAggRefreshState refresh;
 		continuous_agg_refresh_init(&refresh, cagg, &refresh_window, bucketing_refresh_window);
 
+#ifdef TS_DEBUG
+		elog(NOTICE,
+			 "continuous aggregate \"%s\" has pending materializations in window [ %s, %s ]",
+			 NameStr(cagg->data.user_view_name),
+			 ts_internal_to_time_string(refresh_window.start, refresh_window.type),
+			 ts_internal_to_time_string(refresh_window.end, refresh_window.type));
+#endif
+
 		InternalTimeRange invalidation = {
 			.type = refresh_window.type,
 			.start = refresh_window.start,

--- a/tsl/test/isolation/expected/cagg_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_refresh.out
@@ -336,6 +336,7 @@ step L3_unlock_cagg_table:
     ROLLBACK;
 
 step R1_refresh: <... completed>
+R2: NOTICE:  continuous aggregate "cond_10" has pending materializations in window [ 35, 62 ]
 step R2_refresh: <... completed>
 step S1_select: 
     SELECT bucket, avg_temp
@@ -669,6 +670,7 @@ user_view_name|lowest_modified_value|greatest_modified_value
 --------------+---------------------+-----------------------
 cond_10       |                   30|                     70
 
+R13: NOTICE:  continuous aggregate "cond_10" has pending materializations in window [ 40, 100 ]
 step R13_refresh2: 
     -- the window start 40 is one bucket before the pending range start 30
     -- so in this case the left behind pending range will be processed
@@ -758,6 +760,7 @@ user_view_name|lowest_modified_value|greatest_modified_value
 --------------+---------------------+-----------------------
 cond_10       |                   30|                    120
 
+R13: NOTICE:  continuous aggregate "cond_10" has pending materializations in window [ 40, 110 ]
 step R13_refresh4: 
     -- the window end 110 is one bucket after the pending range end 120
     -- so in this case the left behind pending range will be processed


### PR DESCRIPTION
In https://github.com/timescale/timescaledb/pull/8607 we added an extra check for pending ranges after processing invalidations and materialize the data for self healing in case of interruped CAgg refresh left behind some pending ranges.

The problem is we're not using the latest snapshot to check for pending ranges leading to unecessary executing the check since the deleted pending range still visibile. Fixed it by pushing the latest snapshot and then don't see the deleted pending range.

Disable-check: force-changelog-file
