### PR TITLE
Proper error code in ts_get_internal_time_min()

### DIFF
--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -182,7 +182,10 @@ coerce_to_time_type(Oid type)
 	if (ts_type_is_int8_binary_compatible(type))
 		return INT8OID;
 
-	elog(ERROR, "unsupported time type \"%s\"", format_type_be(type));
+	ereport(ERROR,
+			errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			errmsg("unsupported time type \"%s\"",
+				   DatumGetPointer(DirectFunctionCall1(regtypeout, type))));
 	pg_unreachable();
 }
 

--- a/test/expected/util.out
+++ b/test/expected/util.out
@@ -59,9 +59,9 @@ SELECT typ,
 
 \set ON_ERROR_STOP 0
 SELECT _timescaledb_functions.get_internal_time_min(0);
-ERROR:  cache lookup failed for type 0
+ERROR:  unsupported time type "-"
 SELECT _timescaledb_functions.get_internal_time_max(0);
-ERROR:  cache lookup failed for type 0
+ERROR:  unsupported time type "-"
 \set ON_ERROR_STOP 1
 WITH
   tstzranges AS (


### PR DESCRIPTION
Change the error code and also switch to the regtype formatting function that handles invalid types gracefully.


Disable-check: force-changelog-file