### PR TITLE
Allow configuring work_mem for bgw jobs

### DIFF
--- a/.unreleased/pr_9059
+++ b/.unreleased/pr_9059
@@ -1,0 +1,1 @@
+Implements: #9059 Allow configuring work_mem for bgw jobs

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -716,6 +716,16 @@ job_execute(BgwJob *job)
 	StringInfoData query;
 	Portal portal = ActivePortal;
 
+	/* Check for work_mem setting in config and apply it */
+	if (job->fd.config)
+	{
+		char *work_mem_setting = ts_jsonb_get_str_field(job->fd.config, "work_mem");
+		if (work_mem_setting != NULL)
+		{
+			SetConfigOption("work_mem", work_mem_setting, PGC_USERSET, PGC_S_SESSION);
+		}
+	}
+
 	if (job->fd.config)
 		elog(DEBUG1,
 			 "Executing %s with parameters %s",

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -1099,3 +1099,29 @@ SELECT delete_job(:job_proc);
 ------------
  
 
+-- Test work_mem config option in job execution
+CREATE TABLE work_mem_log(job_id int, work_mem_value text);
+CREATE OR REPLACE PROCEDURE log_work_mem(job_id int, config jsonb) LANGUAGE PLPGSQL AS
+$$
+BEGIN
+    INSERT INTO work_mem_log VALUES(job_id, current_setting('work_mem'));
+END
+$$;
+-- Add job with work_mem in config
+SELECT add_job('log_work_mem', '1h', config => '{"work_mem": "123MB"}'::jsonb) AS job_work_mem \gset
+-- Run the job - work_mem should be set to 123MB before execution
+CALL run_job(:job_work_mem);
+-- Verify work_mem was set during job execution
+SELECT * FROM work_mem_log;
+ job_id | work_mem_value 
+--------+----------------
+   1022 | 123MB
+
+-- Cleanup
+SELECT delete_job(:job_work_mem);
+ delete_job 
+------------
+ 
+
+DROP TABLE work_mem_log;
+DROP PROCEDURE log_work_mem;


### PR DESCRIPTION
Jobs can now have a `work_mem` config key to configure the work_mem
setting for that job.

You can now set work_mem for a job by including it in the config JSONB:

SELECT add_job('my_proc', '1 hour', config => '{"work_mem": "256MB"}'::jsonb);
-- or update existing job:
SELECT alter_job(id,config:=jsonb_set(config,'{work_mem}','"256M"')) FROM _timescaledb_catalog.bgw_job WHERE id = <job_id>;

