### PR TITLE
Fix update race with BGW jobs

### DIFF
--- a/.unreleased/pr_9061
+++ b/.unreleased/pr_9061
@@ -1,0 +1,1 @@
+Fixes: #9061 Fix update race with BGW jobs

--- a/src/scan_iterator.h
+++ b/src/scan_iterator.h
@@ -37,6 +37,24 @@ typedef struct ScanIterator
 		}, \
 	}
 
+#define ts_scan_iterator_create_with_catalog_snapshot(catalog_table_id, lock_mode, mctx)             \
+	(ScanIterator)                                                                                   \
+	{                                                                                                \
+		.ctx = {                                                                                   \
+			.internal = {													\
+				.ended = true,											\
+				.scan_mcxt = CurrentMemoryContext,						\
+			},															\
+			.table = catalog_get_table_id(ts_catalog_get(), catalog_table_id),                     \
+			.nkeys = 0,                                                                            \
+			.scandirection = ForwardScanDirection,                                                 \
+			.lockmode = lock_mode,                                                                 \
+			.result_mctx = mctx,                                                                   \
+			.flags = SCANNER_F_NOFLAGS,									\
+			.use_catalog_snapshot = true,						\
+		}, \
+	}
+
 static inline TupleInfo *
 ts_scan_iterator_tuple_info(const ScanIterator *iterator)
 {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -224,21 +224,29 @@ prepare_scan(ScannerCtx *ctx)
 		 * mode.
 		 */
 		MemoryContext oldmcxt = MemoryContextSwitchTo(ctx->internal.scan_mcxt);
-		ctx->snapshot = RegisterSnapshot(GetSnapshotData(SnapshotSelf));
-		/*
-		 * Invalidate the PG catalog snapshot to ensure it is refreshed and
-		 * up-to-date with the snapshot used to scan TimescaleDB
-		 * metadata. Since TimescaleDB metadata is often joined with PG
-		 * catalog data (e.g., calling get_relname_relid() to fill in chunk
-		 * table Oid), this avoids any potential problems where the different
-		 * snapshots used to scan TimescaleDB metadata and PG catalog metadata
-		 * aren't in sync.
-		 *
-		 * Ideally, a catalog snapshot would be used to scan TimescaleDB
-		 * metadata, but that will change the behavior of chunk creation in
-		 * SERIALIZED mode, as described above.
-		 */
-		InvalidateCatalogSnapshot();
+
+		if (ctx->use_catalog_snapshot)
+		{
+			ctx->snapshot = RegisterSnapshot(GetCatalogSnapshot(ctx->table));
+		}
+		else
+		{
+			ctx->snapshot = RegisterSnapshot(GetSnapshotData(SnapshotSelf));
+			/*
+			 * Invalidate the PG catalog snapshot to ensure it is refreshed and
+			 * up-to-date with the snapshot used to scan TimescaleDB
+			 * metadata. Since TimescaleDB metadata is often joined with PG
+			 * catalog data (e.g., calling get_relname_relid() to fill in chunk
+			 * table Oid), this avoids any potential problems where the different
+			 * snapshots used to scan TimescaleDB metadata and PG catalog metadata
+			 * aren't in sync.
+			 *
+			 * Ideally, a catalog snapshot would be used to scan TimescaleDB
+			 * metadata, but that will change the behavior of chunk creation in
+			 * SERIALIZED mode, as described above.
+			 */
+			InvalidateCatalogSnapshot();
+		}
 		ctx->internal.registered_snapshot = true;
 		MemoryContextSwitchTo(oldmcxt);
 	}

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -114,10 +114,12 @@ typedef struct ScannerCtx
 								* on */
 	const ScanTupLock *tuplock;
 	ScanDirection scandirection;
-	Snapshot snapshot; /* Snapshot requested by the caller. Set automatically
-						* when NULL */
-	void *data;		   /* User-provided data passed on to filter()
-						* and tuple_found() */
+	Snapshot snapshot;		   /* Snapshot requested by the caller. Set automatically
+								* when NULL */
+	bool use_catalog_snapshot; /* If true, use a catalog snapshot to scan data, unless snapshot is
+								  already set */
+	void *data;				   /* User-provided data passed on to filter()
+								* and tuple_found() */
 
 	/*
 	 * Optional handler called before a scan starts, but relation locks are

--- a/tsl/test/isolation/expected/bgw_job_duplicate_race.out
+++ b/tsl/test/isolation/expected/bgw_job_duplicate_race.out
@@ -1,0 +1,38 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s3_enable_waitpoint s1_alter_job s2_direct_update s3_release_waitpoint
+?column?
+--------
+       1
+
+step s3_enable_waitpoint: 
+    SELECT debug_waitpoint_enable('bgw_job_find_during_scan');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_alter_job: 
+    SELECT count(*) FROM (
+        SELECT alter_job(job_id, scheduled => false)
+        FROM timescaledb_information.jobs
+        WHERE proc_name = 'test_job_proc_race'
+    ) x;
+ <waiting ...>
+step s2_direct_update: 
+    UPDATE _timescaledb_catalog.bgw_job
+    SET scheduled = NOT scheduled
+    WHERE proc_name = 'test_job_proc_race';
+
+step s3_release_waitpoint: 
+    SELECT debug_waitpoint_release('bgw_job_find_during_scan');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_alter_job: <... completed>
+count
+-----
+    1
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(
     APPEND
     TEST_FILES
+    bgw_job_duplicate_race.spec
     cagg_concurrent_move.spec
     cagg_concurrent_invalidation.spec
     cagg_concurrent_refresh.spec

--- a/tsl/test/isolation/specs/bgw_job_duplicate_race.spec
+++ b/tsl/test/isolation/specs/bgw_job_duplicate_race.spec
@@ -1,0 +1,99 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+###
+# Test for the race condition that can cause duplicate job rows to be visible
+# during concurrent job scanning and updating (issue #4863).
+#
+# The bug occurs when:
+# 1. One transaction scans the bgw_job table using SnapshotSelf
+# 2. Another transaction updates the same job row concurrently (bypassing advisory locks)
+# 3. Due to SnapshotSelf visibility semantics, both old and new tuple versions
+#    may become visible, triggering the assertion at job.c:
+#    Assert(num_found == 0)
+#
+# This test demonstrates the vulnerability when direct table updates bypass the
+# advisory lock mechanism used by the job API functions. The test is expected to
+# crash with an assertion failure if SnapshotSelf is used, proving the race
+# condition exists. With the fix to use a transaction snapshot, the crash
+# does not occur.
+#
+# Test flow:
+# 1. Session s3 enables the debug waitpoint inside the scan loop
+# 2. Session s1 starts alter_job which pauses at the waitpoint DURING scanning
+#    (after reading the first tuple but before the loop continues)
+# 3. Session s2 directly updates the job row (bypassing advisory locks)
+# 4. Session s3 releases the waitpoint
+# 5. Session s1 continues scanning and sees the updated tuple as a duplicate,
+#    triggering the assertion failure
+###
+
+setup {
+    CREATE OR REPLACE FUNCTION test_job_proc_race(job_id int, config jsonb)
+    RETURNS void LANGUAGE plpgsql AS $$
+    BEGIN
+        -- no-op job for testing
+        PERFORM pg_sleep(0.1);
+    END;
+    $$;
+
+    -- Create a test job with a far-future initial_start so it doesn't auto-run
+    -- Do not output job_id in order to avoid flakes
+    SELECT 1 FROM add_job('test_job_proc_race', '1 hour', initial_start => '2100-01-01'::timestamptz);
+}
+
+teardown {
+    -- Clean up all test jobs
+    SELECT delete_job(job_id) FROM timescaledb_information.jobs WHERE proc_name = 'test_job_proc_race';
+    DROP FUNCTION IF EXISTS test_job_proc_race(int, jsonb);
+}
+
+# Session s1 performs alter_job which scans the job table
+session "s1"
+setup {
+    SET client_min_messages = WARNING;
+}
+
+# alter_job internally calls ts_bgw_job_find which uses the scanner with SnapshotSelf
+# This will hit the waitpoint during the job lookup scan (after reading first tuple)
+step "s1_alter_job" {
+    SELECT count(*) FROM (
+        SELECT alter_job(job_id, scheduled => false)
+        FROM timescaledb_information.jobs
+        WHERE proc_name = 'test_job_proc_race'
+    ) x;
+}
+
+# Session s2 performs concurrent modifications bypassing advisory locks
+session "s2"
+setup {
+    SET client_min_messages = WARNING;
+}
+
+# Directly update the job row - this bypasses the advisory lock mechanism
+# that alter_job uses, creating the race condition
+step "s2_direct_update" {
+    UPDATE _timescaledb_catalog.bgw_job
+    SET scheduled = NOT scheduled
+    WHERE proc_name = 'test_job_proc_race';
+}
+
+# Session s3 controls the debug waitpoint
+session "s3"
+setup {
+    SET client_min_messages = WARNING;
+}
+
+step "s3_enable_waitpoint" {
+    SELECT debug_waitpoint_enable('bgw_job_find_during_scan');
+}
+
+step "s3_release_waitpoint" {
+    SELECT debug_waitpoint_release('bgw_job_find_during_scan');
+}
+
+# This permutation triggers the race condition:
+# s1 pauses mid-scan, s2 updates the row, s1 resumes and sees duplicate tuple
+# Expected result: server crash due to assertion failure
+permutation "s3_enable_waitpoint" "s1_alter_job" "s2_direct_update" "s3_release_waitpoint"


### PR DESCRIPTION
There are re-occurring crashes in background worker (BGW) tests caused by an assertion that checks for duplicate jobs with the same primary key ID. Since it is a primary key, such duplicate jobs should not exist. However, the BGW code scans its metadata tables with the default Scanner SnapshotSelf snapshot. Under this snapshot, it is possible to read both current tuples and new versions of the tuples that are in progress of being updated by another process but are not yet committed.

The code to handle job metadata should really use a MVCC-compatible snapshot in order to ensure proper visibility.  Therefore, this fix changes the job code to use a catalog snapshot.

In summary, the following changes are made:

- Use a catalog snapshot to read job metadata
- Add a test that triggers the duplicate row assertion when an MVCC-compatible snapshots is _not_ used.