### PR TITLE
Run Windows and 32bit tests on push to `trigger/regression`

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -11,6 +11,7 @@ name: Regression Linux i386
     branches:
       - main
       - ?.*.x
+      - trigger/regression
     paths-ignore:
       - '**.md'
       - 'LICENSE*'

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -9,6 +9,7 @@ name: Regression Windows
       - main
       - ?.*.x
       - trigger/windows_tests
+      - trigger/regression
     paths-ignore:
       - '**.md'
       - 'LICENSE*'


### PR DESCRIPTION
Currently there's no way to run all the regression tests together, I think we can use the `trigger/regression` branch for this. At the moment it triggers only the Linux and MacOS regression tests.