### PR TITLE
Fix missing case for UUID partitioned hypertables with compression policy

### DIFF
--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -240,7 +240,7 @@ BEGIN
 
   -- execute the properly type casts for the lag value
   CASE dimtype
-    WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype, 'DATE'::regtype, 'INTERVAL' ::regtype, 'UUID' ::regtype  THEN
+    WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype, 'DATE'::regtype, 'INTERVAL'::regtype, 'UUID'::regtype  THEN
       CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time);
     WHEN 'BIGINT'::regtype THEN
       CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::BIGINT, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time);


### PR DESCRIPTION
Hi.

As per the documentation at https://www.tigerdata.com/docs/api/latest/hypertable/create_table it is possible to partition hypertables by using uuidv7. 

However any compression policy run on hypertables partitioned by uuidv7 will fail with the error

```
ERROR","sql_state_code":"20000","message":"case not found","hint":"CASE statement is missing ELSE part.","context":"PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 60 at CASE","backend_type":"Columnstore Policy [1019]
```

This is btw the same issue as people have experienced with other special partitioning types in https://github.com/timescale/timescaledb/issues/6537 . However I believe when uuid partitioning is shown in the official docs, this should work out of the box.

This change fixes this issue, and compression is running as expected now. The only sideeffect I can see of this change is for databases with other uuid versions than v7 as partitioning key. But compression policies already do not support that use case, as seen in the linked issue.