### PR TITLE
Can apply multikey sort for columnstore when one numeric key is pinned to a Const of different type

### DIFF
--- a/.unreleased/pr_9069
+++ b/.unreleased/pr_9069
@@ -1,0 +1,1 @@
+Fixes: #9069 Fix applying multikey sort for columnstore when one numeric key is pinned to a Const of different type

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -2587,7 +2587,41 @@ find_const_segmentby(RelOptInfo *chunk_rel, const CompressionInfo *info)
 					TypeCacheEntry *tce = lookup_type_cache(var->vartype, TYPECACHE_EQ_OPR);
 
 					if (op->opno != tce->eq_opr)
-						continue;
+					{
+						/* Issue #9066: check if our OpExpr is still an equality (Var = Const)
+						 * for Var and Const of different types
+						 */
+#if PG18_GE
+						List *opinfos = get_op_index_interpretation(op->opno);
+#else
+						List *opinfos = get_op_btree_interpretation(op->opno);
+#endif
+						ListCell *lc;
+						bool equality = false;
+						foreach (lc, opinfos)
+						{
+#if PG18_GE
+							OpIndexInterpretation *opinfo = (OpIndexInterpretation *) lfirst(lc);
+							if (opinfo->cmptype == COMPARE_EQ)
+#else
+							OpBtreeInterpretation *opinfo = (OpBtreeInterpretation *) lfirst(lc);
+							if (opinfo->strategy == BTEqualStrategyNumber)
+#endif
+							{
+								Oid mixed_type_eqop = get_opfamily_member(opinfo->opfamily_id,
+																		  var->vartype,
+																		  exprType((Node *) other),
+																		  BTEqualStrategyNumber);
+								if (op->opno == mixed_type_eqop)
+								{
+									equality = true;
+									break;
+								}
+							}
+						}
+						if (!equality)
+							continue;
+					}
 
 					if (bms_is_member(var->varattno, info->chunk_segmentby_attnos))
 						segmentby_columns = bms_add_member(segmentby_columns, var->varattno);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1869,34 +1869,22 @@ ORDER BY timestamp desc  LIMIT 1 ) a ON true;
                Runtime Exclusion: true
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_43_83_chunk
                      Output: _hyper_43_83_chunk."timestamp", _hyper_43_83_chunk.attr_id, _hyper_43_83_chunk.number_val
-                     Filter: ((_hyper_43_83_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_83_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
-                     Batch Sorted Merge: true
-                     ->  Sort
+                     Vectorized Filter: ((_hyper_43_83_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_83_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
+                     ->  Index Scan using compress_hyper_44_86_chunk_attr_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_44_86_chunk
                            Output: compress_hyper_44_86_chunk._ts_meta_count, compress_hyper_44_86_chunk.attr_id, compress_hyper_44_86_chunk._ts_meta_min_1, compress_hyper_44_86_chunk._ts_meta_max_1, compress_hyper_44_86_chunk."timestamp", compress_hyper_44_86_chunk.number_val
-                           Sort Key: compress_hyper_44_86_chunk._ts_meta_max_1 DESC
-                           ->  Index Scan using compress_hyper_44_86_chunk_attr_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_44_86_chunk
-                                 Output: compress_hyper_44_86_chunk._ts_meta_count, compress_hyper_44_86_chunk.attr_id, compress_hyper_44_86_chunk._ts_meta_min_1, compress_hyper_44_86_chunk._ts_meta_max_1, compress_hyper_44_86_chunk."timestamp", compress_hyper_44_86_chunk.number_val
-                                 Index Cond: ((compress_hyper_44_86_chunk.attr_id = "*VALUES*".column1) AND (compress_hyper_44_86_chunk._ts_meta_min_1 < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone) AND (compress_hyper_44_86_chunk._ts_meta_max_1 > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone))
+                           Index Cond: ((compress_hyper_44_86_chunk.attr_id = "*VALUES*".column1) AND (compress_hyper_44_86_chunk._ts_meta_min_1 < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone) AND (compress_hyper_44_86_chunk._ts_meta_max_1 > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone))
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_43_82_chunk
                      Output: _hyper_43_82_chunk."timestamp", _hyper_43_82_chunk.attr_id, _hyper_43_82_chunk.number_val
-                     Filter: ((_hyper_43_82_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_82_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
-                     Batch Sorted Merge: true
-                     ->  Sort
+                     Vectorized Filter: ((_hyper_43_82_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_82_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
+                     ->  Index Scan using compress_hyper_44_85_chunk_attr_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_44_85_chunk
                            Output: compress_hyper_44_85_chunk._ts_meta_count, compress_hyper_44_85_chunk.attr_id, compress_hyper_44_85_chunk._ts_meta_min_1, compress_hyper_44_85_chunk._ts_meta_max_1, compress_hyper_44_85_chunk."timestamp", compress_hyper_44_85_chunk.number_val
-                           Sort Key: compress_hyper_44_85_chunk._ts_meta_max_1 DESC
-                           ->  Index Scan using compress_hyper_44_85_chunk_attr_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_44_85_chunk
-                                 Output: compress_hyper_44_85_chunk._ts_meta_count, compress_hyper_44_85_chunk.attr_id, compress_hyper_44_85_chunk._ts_meta_min_1, compress_hyper_44_85_chunk._ts_meta_max_1, compress_hyper_44_85_chunk."timestamp", compress_hyper_44_85_chunk.number_val
-                                 Index Cond: ((compress_hyper_44_85_chunk.attr_id = "*VALUES*".column1) AND (compress_hyper_44_85_chunk._ts_meta_min_1 < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone) AND (compress_hyper_44_85_chunk._ts_meta_max_1 > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone))
+                           Index Cond: ((compress_hyper_44_85_chunk.attr_id = "*VALUES*".column1) AND (compress_hyper_44_85_chunk._ts_meta_min_1 < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone) AND (compress_hyper_44_85_chunk._ts_meta_max_1 > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone))
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_43_81_chunk
                      Output: _hyper_43_81_chunk."timestamp", _hyper_43_81_chunk.attr_id, _hyper_43_81_chunk.number_val
-                     Filter: ((_hyper_43_81_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_81_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
-                     Batch Sorted Merge: true
-                     ->  Sort
+                     Vectorized Filter: ((_hyper_43_81_chunk."timestamp" > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone) AND (_hyper_43_81_chunk."timestamp" < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone))
+                     ->  Index Scan using compress_hyper_44_84_chunk_attr_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_44_84_chunk
                            Output: compress_hyper_44_84_chunk._ts_meta_count, compress_hyper_44_84_chunk.attr_id, compress_hyper_44_84_chunk._ts_meta_min_1, compress_hyper_44_84_chunk._ts_meta_max_1, compress_hyper_44_84_chunk."timestamp", compress_hyper_44_84_chunk.number_val
-                           Sort Key: compress_hyper_44_84_chunk._ts_meta_max_1 DESC
-                           ->  Index Scan using compress_hyper_44_84_chunk_attr_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_44_84_chunk
-                                 Output: compress_hyper_44_84_chunk._ts_meta_count, compress_hyper_44_84_chunk.attr_id, compress_hyper_44_84_chunk._ts_meta_min_1, compress_hyper_44_84_chunk._ts_meta_max_1, compress_hyper_44_84_chunk."timestamp", compress_hyper_44_84_chunk.number_val
-                                 Index Cond: ((compress_hyper_44_84_chunk.attr_id = "*VALUES*".column1) AND (compress_hyper_44_84_chunk._ts_meta_min_1 < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone) AND (compress_hyper_44_84_chunk._ts_meta_max_1 > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone))
+                           Index Cond: ((compress_hyper_44_84_chunk.attr_id = "*VALUES*".column1) AND (compress_hyper_44_84_chunk._ts_meta_min_1 < 'Thu Jul 06 00:00:00 2023'::timestamp without time zone) AND (compress_hyper_44_84_chunk._ts_meta_max_1 > 'Fri Jun 30 00:00:00 2023'::timestamp without time zone))
 
 SELECT * FROM ( VALUES(1),(2),(3),(4),(5),(6),(7),(8),(9),(10) ) AS attr_ids(attr_id)
 INNER JOIN LATERAL (

--- a/tsl/test/expected/decompress_index.out
+++ b/tsl/test/expected/decompress_index.out
@@ -145,3 +145,65 @@ explain (buffers off, costs off) SELECT * FROM record WHERE 'Yes' <= data ORDER 
          Index Cond: ((data)::text >= 'Yes'::text)
 
 drop table record cascade;
+-- Fix for issue #9066: IndexScan is not chosen for columnstore segmented on several keys
+-- for a query sorted on columnstore keys
+-- but where one numeric key is pinned to a Const of different but compatible type.
+-- We should chose IndexScan now, and use SkipScan as well.
+CREATE TABLE log_numeric(
+	"time"       timestamp with time zone NOT NULL,
+	device_id    integer                  NOT NULL,
+	parameter_id smallint                 NOT NULL,
+	value        double precision
+);
+SELECT create_hypertable('log_numeric', 'time', chunk_time_interval => interval '1 days', create_default_indexes => false);
+    create_hypertable     
+--------------------------
+ (5,public,log_numeric,t)
+
+ALTER TABLE log_numeric SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, parameter_id', timescaledb.compress_orderby='"time" DESC');
+INSERT INTO log_numeric
+SELECT time, device_id, parameter_id, device_id*parameter_id
+FROM generate_series('2000-01-01'::timestamptz,'2000-01-03'::timestamptz, '10 minute'::interval) AS g1(time),
+generate_series(1,4) device_id, generate_series(1,4) parameter_id;
+select compress_chunk(ch) from show_chunks('log_numeric') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+ _timescaledb_internal._hyper_5_8_chunk
+ _timescaledb_internal._hyper_5_9_chunk
+
+-- enable_seqscan is OFF, should see IndexScan
+explain (buffers off, costs off) SELECT * FROM log_numeric WHERE parameter_id = 1 ORDER BY device_id, parameter_id, time DESC;
+--- QUERY PLAN ---
+ Merge Append
+   Sort Key: log_numeric.device_id, log_numeric."time" DESC
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_10_chunk_device_id_parameter_id__ts_meta_m_idx on compress_hyper_6_10_chunk
+               Index Cond: (parameter_id = 1)
+   ->  Custom Scan (ColumnarScan) on _hyper_5_8_chunk
+         ->  Index Scan using compress_hyper_6_11_chunk_device_id_parameter_id__ts_meta_m_idx on compress_hyper_6_11_chunk
+               Index Cond: (parameter_id = 1)
+   ->  Custom Scan (ColumnarScan) on _hyper_5_9_chunk
+         ->  Index Scan using compress_hyper_6_12_chunk_device_id_parameter_id__ts_meta_m_idx on compress_hyper_6_12_chunk
+               Index Cond: (parameter_id = 1)
+
+-- SkipScan is chosen because IndexScan is chosen
+explain (buffers off, costs off) SELECT DISTINCT ON(device_id, parameter_id) * FROM log_numeric WHERE parameter_id = 1 ORDER BY device_id, parameter_id, time DESC;
+--- QUERY PLAN ---
+ Unique
+   ->  Merge Append
+         Sort Key: log_numeric.device_id, log_numeric."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_5_7_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+                     ->  Index Scan using compress_hyper_6_10_chunk_device_id_parameter_id__ts_meta_m_idx on compress_hyper_6_10_chunk
+                           Index Cond: (parameter_id = 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_8_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_5_8_chunk
+                     ->  Index Scan using compress_hyper_6_11_chunk_device_id_parameter_id__ts_meta_m_idx on compress_hyper_6_11_chunk
+                           Index Cond: (parameter_id = 1)
+         ->  Custom Scan (SkipScan) on _hyper_5_9_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_5_9_chunk
+                     ->  Index Scan using compress_hyper_6_12_chunk_device_id_parameter_id__ts_meta_m_idx on compress_hyper_6_12_chunk
+                           Index Cond: (parameter_id = 1)
+
+drop table log_numeric cascade;


### PR DESCRIPTION
Fixes #9066.

When we have a columnstore with multiple segmentby keys and we have a query ordered on columnstore keys where one segmentby key is pinned to a Const `(key = Const)`, we failed to to treat this key as Const segmentby when both key and Const were numeric compatible but different types like int4 and int32.

The issue is fixed by properly checking that OpExpr `(key = Const)` really is an equality operator comparing compatible types. 

