### PR TITLE
Don't register timescaledb-tune specific GUCs

### DIFF
--- a/.unreleased/pr_9085
+++ b/.unreleased/pr_9085
@@ -1,0 +1,1 @@
+Implements: #9085 Don't register timescaledb-tune specific GUCs

--- a/src/guc.c
+++ b/src/guc.c
@@ -155,8 +155,6 @@ char *ts_telemetry_cloud = NULL;
 #endif
 
 TSDLLEXPORT char *ts_guc_license = TS_LICENSE_DEFAULT;
-char *ts_last_tune_time = NULL;
-char *ts_last_tune_version = NULL;
 
 bool ts_guc_debug_allow_cagg_with_deprecated_funcs = false;
 
@@ -1234,28 +1232,6 @@ _guc_init(void)
 							   /* flags= */ 0,
 							   /* check_hook= */ ts_license_guc_check_hook,
 							   /* assign_hook= */ ts_license_guc_assign_hook,
-							   /* show_hook= */ NULL);
-
-	DefineCustomStringVariable(/* name= */ MAKE_EXTOPTION("last_tuned"),
-							   /* short_desc= */ "last tune run",
-							   /* long_desc= */ "records last time timescaledb-tune ran",
-							   /* valueAddr= */ &ts_last_tune_time,
-							   /* bootValue= */ NULL,
-							   /* context= */ PGC_SIGHUP,
-							   /* flags= */ 0,
-							   /* check_hook= */ NULL,
-							   /* assign_hook= */ NULL,
-							   /* show_hook= */ NULL);
-
-	DefineCustomStringVariable(/* name= */ MAKE_EXTOPTION("last_tuned_version"),
-							   /* short_desc= */ "version of timescaledb-tune",
-							   /* long_desc= */ "version of timescaledb-tune used to tune",
-							   /* valueAddr= */ &ts_last_tune_version,
-							   /* bootValue= */ NULL,
-							   /* context= */ PGC_SIGHUP,
-							   /* flags= */ 0,
-							   /* check_hook= */ NULL,
-							   /* assign_hook= */ NULL,
 							   /* show_hook= */ NULL);
 
 	DefineCustomEnumVariable(MAKE_EXTOPTION("bgw_log_level"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -103,8 +103,6 @@ extern char *ts_telemetry_cloud;
 #endif
 
 extern TSDLLEXPORT char *ts_guc_license;
-extern char *ts_last_tune_time;
-extern char *ts_last_tune_version;
 extern TSDLLEXPORT bool ts_guc_enable_compression_indexscan;
 extern TSDLLEXPORT bool ts_guc_enable_bulk_decompression;
 extern TSDLLEXPORT bool ts_guc_auto_sparse_indexes;

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -980,11 +980,13 @@ build_telemetry_report()
 	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
 
 	/* add tuned info, which is optional */
-	if (ts_last_tune_time != NULL)
-		ts_jsonb_add_str(parse_state, REQ_TS_LAST_TUNE_TIME, ts_last_tune_time);
+	char *last_tune_time = GetConfigOptionByName("timescaledb.last_tune_time", NULL, true);
+	if (last_tune_time != NULL)
+		ts_jsonb_add_str(parse_state, REQ_TS_LAST_TUNE_TIME, last_tune_time);
 
-	if (ts_last_tune_version != NULL)
-		ts_jsonb_add_str(parse_state, REQ_TS_LAST_TUNE_VERSION, ts_last_tune_version);
+	char *last_tune_version = GetConfigOptionByName("timescaledb.last_tune_version", NULL, true);
+	if (last_tune_version != NULL)
+		ts_jsonb_add_str(parse_state, REQ_TS_LAST_TUNE_VERSION, last_tune_version);
 
 	/* add cloud to telemetry when set */
 	if (ts_telemetry_cloud != NULL)

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -293,6 +293,8 @@ ERROR:  malformed telemetry response body
 SELECT test_check_version_response('{"is_up_to_date": false}');
 ERROR:  malformed telemetry response body
 \set ON_ERROR_STOP 1
+SET timescaledb.last_tune_time = '2024-01-01 00:00:00+00';
+SET timescaledb.last_tune_version = '1.2.3';
 SET timescaledb.telemetry_level=basic;
 -- Connect to a bogus host and path to test error handling in telemetry_main()
 SELECT _timescaledb_internal.test_telemetry_main_conn('noservice.timescale.com', 'path');

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -147,6 +147,9 @@ SELECT test_check_version_response('{"current_timescaledb_version": "1.6.1"}');
 SELECT test_check_version_response('{"is_up_to_date": false}');
 \set ON_ERROR_STOP 1
 
+SET timescaledb.last_tune_time = '2024-01-01 00:00:00+00';
+SET timescaledb.last_tune_version = '1.2.3';
+
 SET timescaledb.telemetry_level=basic;
 -- Connect to a bogus host and path to test error handling in telemetry_main()
 SELECT _timescaledb_internal.test_telemetry_main_conn('noservice.timescale.com', 'path');


### PR DESCRIPTION
These were not used as real GUCs but instead used as variable
for timescaledb-tune version and date it last run. For that
functionality they don't have to be registered as GUCs with timescaledb
as you can just set unregistered GUCs to any value.

Disable-check: approval-count