### PR TITLE
Add ColumnarIndexScan custom node

### DIFF
--- a/.unreleased/pr_9088
+++ b/.unreleased/pr_9088
@@ -1,0 +1,1 @@
+Implements: #9088 Add ColumnarIndexScan custom node

--- a/src/guc.c
+++ b/src/guc.c
@@ -126,6 +126,7 @@ TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings = true;
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
 TSDLLEXPORT bool ts_guc_enable_columnarscan = true;
+TSDLLEXPORT bool ts_guc_enable_columnarindexscan = false;
 TSDLLEXPORT int ts_guc_bgw_log_level = WARNING;
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 #if PG16_GE
@@ -1077,6 +1078,18 @@ _guc_init(void)
 							 "sequence scans.",
 							 &ts_guc_enable_columnarscan,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_columnarindexscan"),
+							 "Enable metadata-only optimization for ColumnarScans",
+							 "Enable returning results directly from compression "
+							 "metadata without decompression",
+							 &ts_guc_enable_columnarindexscan,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -108,6 +108,7 @@ extern TSDLLEXPORT bool ts_guc_auto_sparse_indexes;
 extern TSDLLEXPORT bool ts_guc_enable_sparse_index_bloom;
 extern TSDLLEXPORT bool ts_guc_read_legacy_bloom1_v1;
 extern TSDLLEXPORT bool ts_guc_enable_columnarscan;
+extern TSDLLEXPORT bool ts_guc_enable_columnarindexscan;
 extern TSDLLEXPORT int ts_guc_bgw_log_level;
 
 /*

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -38,6 +38,7 @@
 #include "export.h"
 #include "hypertable.h"
 #include "license_guc.h"
+#include "nodes/columnar_index_scan/columnar_index_scan.h"
 #include "nodes/columnar_scan/planner.h"
 #include "nodes/gapfill/gapfill_functions.h"
 #include "nodes/skip_scan/skip_scan.h"
@@ -214,6 +215,7 @@ ts_module_init(PG_FUNCTION_ARGS)
 	ts_cm_functions = &tsl_cm_functions;
 
 	_continuous_aggs_cache_inval_init();
+	_columnar_index_scan_init();
 	_columnar_scan_init();
 	_skip_scan_init();
 	_vector_agg_init();

--- a/tsl/src/nodes/CMakeLists.txt
+++ b/tsl/src/nodes/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})
+add_subdirectory(columnar_index_scan)
 add_subdirectory(columnar_scan)
 add_subdirectory(gapfill)
 add_subdirectory(skip_scan)

--- a/tsl/src/nodes/columnar_index_scan/CMakeLists.txt
+++ b/tsl/src/nodes/columnar_index_scan/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Add all *.c to sources in upperlevel directory
+set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/columnar_index_scan.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/columnar_index_scan_exec.c)
+target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
@@ -1,0 +1,429 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include <nodes/bitmapset.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <nodes/pathnodes.h>
+#include <optimizer/optimizer.h>
+#include <parser/parsetree.h>
+
+#include "compression/create.h"
+#include "debug_assert.h"
+#include "guc.h"
+#include "nodes/columnar_index_scan/columnar_index_scan.h"
+
+static CustomPathMethods columnar_index_scan_path_methods = {
+	.CustomName = "ColumnarIndexScanPath",
+	.PlanCustomPath = columnar_index_scan_plan_create,
+};
+
+static CustomScanMethods columnar_index_scan_plan_methods = {
+	.CustomName = "ColumnarIndexScan",
+	.CreateCustomScanState = columnar_index_scan_state_create,
+};
+
+bool
+ts_is_columnar_index_scan_path(Path *path)
+{
+	return IsA(path, CustomPath) &&
+		   castNode(CustomPath, path)->methods == &columnar_index_scan_path_methods;
+}
+
+bool
+ts_is_columnar_index_scan_plan(Plan *plan)
+{
+	return IsA(plan, CustomScan) &&
+		   castNode(CustomScan, plan)->methods == &columnar_index_scan_plan_methods;
+}
+
+void
+_columnar_index_scan_init(void)
+{
+	TryRegisterCustomScanMethods(&columnar_index_scan_plan_methods);
+}
+
+/*
+ * Check if an aggregate function can use compressed chunk sparse index.
+ *
+ * Currently supported aggregates are min and max
+ */
+static bool
+is_supported_aggregate(const CompressionInfo *info, Aggref *aggref, AttrNumber *aggregate_attno,
+					   AttrNumber *metadata_attno)
+{
+	/* No DISTINCT, ORDER BY, or FILTER */
+	if (aggref->args == NIL || aggref->aggdistinct != NIL || aggref->aggorder != NIL ||
+		aggref->aggfilter != NULL)
+		return false;
+
+	/* Get the argument - must be a Var referencing orderby column */
+	TargetEntry *arg_te = linitial_node(TargetEntry, aggref->args);
+
+	Node *arg_expr = strip_implicit_coercions((Node *) arg_te->expr);
+	if (!IsA(arg_expr, Var))
+		return false;
+
+	Var *var = castNode(Var, arg_expr);
+
+	/* Reject any system columns */
+	if (var->varattno <= 0)
+		return false;
+
+	/* var references hypertable attnums so we have to use hypertable relid for column name lookup
+	 */
+	AttrNumber chunk_attno =
+		ts_map_attno(info->ht_rte->relid, info->chunk_rte->relid, var->varattno);
+	AttrNumber meta_attno;
+
+	switch (aggref->aggfnoid)
+	{
+		case F_MIN_ANYARRAY:
+		case F_MIN_ANYENUM:
+		case F_MIN_BPCHAR:
+#if PG18_GE
+		case F_MIN_BYTEA:
+#endif
+		case F_MIN_DATE:
+		case F_MIN_FLOAT4:
+		case F_MIN_FLOAT8:
+		case F_MIN_INET:
+		case F_MIN_INT2:
+		case F_MIN_INT4:
+		case F_MIN_INT8:
+		case F_MIN_INTERVAL:
+		case F_MIN_MONEY:
+		case F_MIN_NUMERIC:
+		case F_MIN_OID:
+		case F_MIN_PG_LSN:
+#if PG18_GE
+		case F_MIN_RECORD:
+#endif
+		case F_MIN_SCALE:
+		case F_MIN_TEXT:
+		case F_MIN_TID:
+		case F_MIN_TIME:
+		case F_MIN_TIMESTAMP:
+		case F_MIN_TIMESTAMPTZ:
+		case F_MIN_TIMETZ:
+		case F_MIN_XID8:
+			meta_attno = compressed_column_metadata_attno(info->settings,
+														  info->chunk_rte->relid,
+														  chunk_attno,
+														  info->compressed_rte->relid,
+														  "min");
+			if (meta_attno)
+			{
+				*aggregate_attno = chunk_attno;
+				*metadata_attno = meta_attno;
+				return true;
+			}
+			break;
+		case F_MAX_ANYARRAY:
+		case F_MAX_ANYENUM:
+		case F_MAX_BPCHAR:
+#if PG18_GE
+		case F_MAX_BYTEA:
+#endif
+		case F_MAX_DATE:
+		case F_MAX_FLOAT4:
+		case F_MAX_FLOAT8:
+		case F_MAX_INET:
+		case F_MAX_INT2:
+		case F_MAX_INT4:
+		case F_MAX_INT8:
+		case F_MAX_INTERVAL:
+		case F_MAX_MONEY:
+		case F_MAX_NUMERIC:
+		case F_MAX_OID:
+		case F_MAX_PG_LSN:
+#if PG18_GE
+		case F_MAX_RECORD:
+#endif
+		case F_MAX_TEXT:
+		case F_MAX_TID:
+		case F_MAX_TIME:
+		case F_MAX_TIMESTAMP:
+		case F_MAX_TIMESTAMPTZ:
+		case F_MAX_TIMETZ:
+		case F_MAX_XID8:
+			meta_attno = compressed_column_metadata_attno(info->settings,
+														  info->chunk_rte->relid,
+														  chunk_attno,
+														  info->compressed_rte->relid,
+														  "max");
+			if (meta_attno)
+			{
+				*aggregate_attno = chunk_attno;
+				*metadata_attno = meta_attno;
+				return true;
+			}
+			break;
+	}
+	return false;
+}
+
+/*
+ * Check if we can use a ColumnarIndexScan for the given query.
+ *
+ * Requirements:
+ * - Query has eligible aggregate on any column with metadata
+ * - GROUP BY has only segmentby columns
+ * - WHERE clause can be fully pushed down to compressed chunk
+ * - No HAVING clause
+ */
+static bool
+can_use_columnar_index_scan(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
+							const CompressionInfo *info, AttrNumber *aggregate_attno,
+							AttrNumber *metadata_attno)
+{
+	Assert(ts_guc_enable_columnarindexscan);
+
+	Query *parse = root->parse;
+	ListCell *lc;
+	bool found_aggregate = false;
+
+	/* Must have aggregates */
+	if (!parse->hasAggs)
+		return false;
+
+	/* Punt on ordered output for now until we add proper support for ordered append */
+	if (root->sort_pathkeys != NIL)
+		return false;
+
+	/*
+	 * Only quals on non-segmentby constraints should be left in chunk_rel.
+	 * Segmentby constraints should be pushed into compressed chunk.
+	 */
+	if (chunk_rel->baserestrictinfo != NIL)
+		return false;
+
+	/* No HAVING clause allowed */
+	if (parse->havingQual != NULL)
+		return false;
+
+	/*
+	 * Check that only segmentby columns are in GROUP BY columns
+	 */
+	foreach (lc, parse->groupClause)
+	{
+		SortGroupClause *sgc = (SortGroupClause *) lfirst(lc);
+		TargetEntry *tle = get_sortgroupclause_tle(sgc, parse->targetList);
+
+		/* Must be a simple Var */
+		Node *node = strip_implicit_coercions((Node *) tle->expr);
+		if (!IsA(node, Var))
+			return false;
+
+		Var *var = castNode(Var, node);
+		if (var->varattno <= 0)
+		{
+			/* Reject any system columns except tableoid */
+			if (var->varattno != TableOidAttributeNumber)
+				return false;
+		}
+		else
+		{
+			/* GROUP BY references hypertable attnums so we have to translate to chunk */
+			AttrNumber chunk_attno =
+				ts_map_attno(info->ht_rte->relid, info->chunk_rte->relid, var->varattno);
+			if (!bms_is_member(chunk_attno, info->chunk_segmentby_attnos))
+				return false;
+		}
+	}
+
+	/*
+	 * Check target list.
+	 * The target list should contain:
+	 * - A single eligible aggregate on a column with min/max index
+	 * - Any segmentby columns
+	 */
+	foreach (lc, parse->targetList)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+
+		if (tle->resjunk)
+			continue;
+
+		if (IsA(tle->expr, Aggref))
+		{
+			/* Only one aggregate allowed */
+			if (found_aggregate)
+				return false;
+
+			if (!is_supported_aggregate(info,
+										castNode(Aggref, tle->expr),
+										aggregate_attno,
+										metadata_attno))
+				return false;
+
+			found_aggregate = true;
+		}
+		else
+		{
+			/* Non-aggregate must be a segmentby column (for GROUP BY) */
+			Node *expr = strip_implicit_coercions((Node *) tle->expr);
+			if (!IsA(expr, Var))
+				return false;
+
+			Var *var = castNode(Var, expr);
+			if (var->varattno <= 0)
+			{
+				if (var->varattno != TableOidAttributeNumber)
+					return false;
+			}
+			else if (!bms_is_member(var->varattno, info->chunk_segmentby_attnos))
+			{
+				return false;
+			}
+		}
+	}
+
+	return found_aggregate;
+}
+
+/*
+ * Calculate cost for ColumnarIndexScan.
+ */
+static void
+cost_columnar_index_scan(ColumnarIndexScanPath *path, Path *compressed_path)
+{
+	/* We return one row per compressed batch (same as compressed path rows) */
+	path->custom_path.path.rows = compressed_path->rows;
+	path->custom_path.path.startup_cost = compressed_path->startup_cost;
+	path->custom_path.path.total_cost = compressed_path->total_cost;
+
+#if PG18_GE
+	path->custom_path.path.disabled_nodes = compressed_path->disabled_nodes;
+#endif
+}
+
+ColumnarIndexScanPath *
+ts_columnar_index_scan_path_create(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
+								   const CompressionInfo *info, Path *compressed_path)
+{
+	if (!ts_guc_enable_columnarindexscan)
+		return NULL;
+
+	AttrNumber aggregate_attno = InvalidAttrNumber;
+	AttrNumber metadata_attno = InvalidAttrNumber;
+	if (!can_use_columnar_index_scan(root,
+									 chunk,
+									 chunk_rel,
+									 info,
+									 &aggregate_attno,
+									 &metadata_attno))
+		return NULL;
+
+	ColumnarIndexScanPath *path =
+		(ColumnarIndexScanPath *) newNode(sizeof(ColumnarIndexScanPath), T_CustomPath);
+
+	path->custom_path.path.pathtype = T_CustomScan;
+	path->custom_path.path.parent = chunk_rel;
+	path->custom_path.path.pathtarget = chunk_rel->reltarget;
+	path->custom_path.path.param_info = NULL;
+	path->custom_path.path.parallel_aware = false;
+	path->custom_path.path.parallel_safe = compressed_path->parallel_safe;
+	path->custom_path.path.parallel_workers = compressed_path->parallel_workers;
+	path->custom_path.path.pathkeys = NIL;
+	path->custom_path.flags = 0;
+	path->custom_path.custom_paths = list_make1(compressed_path);
+	path->custom_path.methods = &columnar_index_scan_path_methods;
+
+	path->info = info;
+	path->aggregate_attno = aggregate_attno;
+	path->metadata_attno = metadata_attno;
+
+	cost_columnar_index_scan(path, compressed_path);
+
+	return path;
+}
+
+/*
+ * Build a physical targetlist for a relation.
+ *
+ * This is similar to build_physical_tlist in plancat.c, but
+ * we do not punt on dropped columns or columns with missing values,
+ * since the columns we are interested in should not be dropped or missing.
+ */
+static List *
+build_tlist(PlannerInfo *root, RelOptInfo *rel)
+{
+	List *tlist = NIL;
+	Index varno = rel->relid;
+	RangeTblEntry *rte = planner_rt_fetch(varno, root);
+	Var *var;
+
+	/* Assume we already have adequate lock */
+	Relation relation = table_open(rte->relid, NoLock);
+
+	int numattrs = RelationGetNumberOfAttributes(relation);
+	for (int attrno = 1; attrno <= numattrs; attrno++)
+	{
+		Form_pg_attribute att_tup = TupleDescAttr(relation->rd_att, attrno - 1);
+
+		var =
+			makeVar(varno, attrno, att_tup->atttypid, att_tup->atttypmod, att_tup->attcollation, 0);
+
+		tlist = lappend(tlist, makeTargetEntry((Expr *) var, attrno, NULL, false));
+	}
+
+	table_close(relation, NoLock);
+
+	return tlist;
+}
+
+Plan *
+columnar_index_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
+								List *output_targetlist, List *clauses, List *custom_plans)
+{
+	ColumnarIndexScanPath *cispath = (ColumnarIndexScanPath *) path;
+	CustomScan *cscan = makeNode(CustomScan);
+	Scan *compressed_scan = linitial(custom_plans);
+
+	cscan->flags = path->flags;
+	cscan->methods = &columnar_index_scan_plan_methods;
+	cscan->scan.scanrelid = rel->relid;
+	cscan->custom_plans = custom_plans;
+
+	compressed_scan->plan.targetlist = build_tlist(root, cispath->info->compressed_rel);
+
+	ListCell *lc;
+	List *output_map = NIL;
+
+	foreach (lc, output_targetlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+		Ensure(IsA(tle->expr, Var), "output targetlist entries must be Vars");
+
+		Var *var = castNode(Var, tle->expr);
+		Assert((Index) var->varno == rel->relid);
+
+		if (var->varattno == cispath->aggregate_attno)
+		{
+			/* Aggregate column */
+			output_map = lappend_int(output_map, cispath->metadata_attno);
+		}
+		else
+		{
+			/* Segmentby column */
+			AttrNumber compressed_attno = ts_map_attno(cispath->info->chunk_rte->relid,
+													   cispath->info->compressed_rte->relid,
+													   var->varattno);
+			Ensure(compressed_attno != InvalidAttrNumber,
+				   "could not map chunk attno to compressed attno");
+			output_map = lappend_int(output_map, compressed_attno);
+		}
+	}
+
+	cscan->custom_private = list_make1(output_map);
+	cscan->custom_scan_tlist = output_targetlist;
+	cscan->scan.plan.targetlist = output_targetlist;
+
+	return &cscan->scan.plan;
+}

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+#include <nodes/extensible.h>
+
+#include "nodes/columnar_scan/columnar_scan.h"
+
+typedef struct ColumnarIndexScanPath
+{
+	CustomPath custom_path;
+	const CompressionInfo *info;
+	AttrNumber aggregate_attno; /* Chunk attno of the aggregate column */
+	AttrNumber metadata_attno;	/* Compressed chunk attno for metadata */
+} ColumnarIndexScanPath;
+
+extern void _columnar_index_scan_init(void);
+extern bool ts_is_columnar_index_scan_path(Path *path);
+extern bool ts_is_columnar_index_scan_plan(Plan *plan);
+
+extern ColumnarIndexScanPath *
+ts_columnar_index_scan_path_create(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
+								   const CompressionInfo *info, Path *compressed_path);
+extern Plan *columnar_index_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
+											 List *output_targetlist, List *clauses,
+											 List *custom_plans);
+extern Node *columnar_index_scan_state_create(CustomScan *cscan);

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan_exec.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan_exec.c
@@ -1,0 +1,106 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <executor/executor.h>
+#include <nodes/extensible.h>
+
+typedef struct ColumnarIndexScanState
+{
+	CustomScanState csstate;
+
+	List *output_map;
+
+	/* Custom scan tuple slot */
+	TupleTableSlot *custom_scan_slot;
+} ColumnarIndexScanState;
+
+extern Node *columnar_index_scan_state_create(CustomScan *cscan);
+static void columnar_index_scan_begin(CustomScanState *node, EState *estate, int eflags);
+static TupleTableSlot *columnar_index_scan_exec(CustomScanState *node);
+static void columnar_index_scan_end(CustomScanState *node);
+static void columnar_index_scan_rescan(CustomScanState *node);
+
+static CustomExecMethods columnar_index_scan_state_methods = {
+	.CustomName = "ColumnarIndexScanState",
+	.BeginCustomScan = columnar_index_scan_begin,
+	.ExecCustomScan = columnar_index_scan_exec,
+	.EndCustomScan = columnar_index_scan_end,
+	.ReScanCustomScan = columnar_index_scan_rescan,
+};
+
+Node *
+columnar_index_scan_state_create(CustomScan *cscan)
+{
+	ColumnarIndexScanState *state =
+		(ColumnarIndexScanState *) newNode(sizeof(ColumnarIndexScanState), T_CustomScanState);
+
+	state->csstate.methods = &columnar_index_scan_state_methods;
+	state->output_map = linitial(cscan->custom_private);
+
+	return (Node *) state;
+}
+
+static void
+columnar_index_scan_begin(CustomScanState *node, EState *estate, int eflags)
+{
+	ColumnarIndexScanState *state = (ColumnarIndexScanState *) node;
+	CustomScan *cscan = castNode(CustomScan, node->ss.ps.plan);
+	Plan *compressed_scan = linitial(cscan->custom_plans);
+
+	/* Initialize child plan */
+	PlanState *child_state = ExecInitNode(compressed_scan, estate, eflags);
+	node->custom_ps = list_make1(child_state);
+
+	/* Use the scan tuple slot set up by PostgreSQL */
+	state->custom_scan_slot = node->ss.ss_ScanTupleSlot;
+}
+
+static TupleTableSlot *
+columnar_index_scan_exec(CustomScanState *node)
+{
+	ColumnarIndexScanState *state = (ColumnarIndexScanState *) node;
+
+	for (;;)
+	{
+		TupleTableSlot *compressed_slot = ExecProcNode(linitial(node->custom_ps));
+
+		if (TupIsNull(compressed_slot))
+			return NULL;
+
+		/* Build output tuple */
+		TupleTableSlot *result_slot = state->custom_scan_slot;
+		ExecClearTuple(result_slot);
+
+		ListCell *lc;
+		int i = 0;
+		foreach (lc, state->output_map)
+		{
+			bool isnull;
+			AttrNumber attno = lfirst_int(lc);
+			Datum value = slot_getattr(compressed_slot, attno, &isnull);
+			result_slot->tts_values[i] = isnull ? (Datum) 0 : value;
+			result_slot->tts_isnull[i] = isnull;
+			i++;
+		}
+
+		ExecStoreVirtualTuple(result_slot);
+
+		return result_slot;
+	}
+}
+
+static void
+columnar_index_scan_end(CustomScanState *node)
+{
+	ExecEndNode(linitial(node->custom_ps));
+}
+
+static void
+columnar_index_scan_rescan(CustomScanState *node)
+{
+	ExecReScan(linitial(node->custom_ps));
+}

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -35,6 +35,7 @@
 #include "debug_assert.h"
 #include "import/allpaths.h"
 #include "import/planner.h"
+#include "nodes/columnar_index_scan/columnar_index_scan.h"
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/columnar_scan/planner.h"
 #include "nodes/columnar_scan/qual_pushdown.h"
@@ -1358,6 +1359,22 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("debug: batch sorted merge is required but not possible at planning "
 						"time")));
+	}
+
+	/*
+	 * Try to create a ColumnarIndexScan path for the metadata-only optimization.
+	 */
+	{
+		ColumnarIndexScanPath *index_scan_path =
+			ts_columnar_index_scan_path_create(root,
+											   chunk,
+											   chunk_rel,
+											   compression_info,
+											   compressed_path);
+		if (index_scan_path)
+		{
+			decompressed_paths = lappend(decompressed_paths, index_scan_path);
+		}
 	}
 
 	/*

--- a/tsl/test/expected/columnar_index_scan.out
+++ b/tsl/test/expected/columnar_index_scan.out
@@ -1,0 +1,232 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (costs off)'
+CREATE TABLE metrics(
+    time timestamptz NOT NULL,
+    device text,
+    sensor text,
+    value float,
+    value2 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics VALUES
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+-- Compress all chunks
+SELECT compress_chunk(c) FROM show_chunks('metrics') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET max_parallel_workers_per_gather = 0;
+SET timescaledb.enable_columnarindexscan = on;
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, max(time) FROM metrics GROUP BY device;
+ device |             max              
+--------+------------------------------
+ d1     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+ sensor |             min              
+--------+------------------------------
+ B      | Wed Jan 01 00:30:00 2025 PST
+ C      | Wed Jan 01 00:30:00 2025 PST
+ A      | Wed Jan 01 00:00:00 2025 PST
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+ sensor | min 
+--------+-----
+ B      |   5
+ C      |   5
+ A      |  10
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+ device | sensor |             max              
+--------+--------+------------------------------
+ d2     | A      | Wed Jan 01 02:00:00 2025 PST
+ d1     | A      | Wed Jan 01 02:00:00 2025 PST
+ d2     | C      | Wed Jan 01 02:30:00 2025 PST
+ d1     | B      | Wed Jan 01 02:30:00 2025 PST
+
+-- order by does currently prevent optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
+ device |             max              
+--------+------------------------------
+ d1     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- filter on non-segmentby prevents optimization
+:PREFIX SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Vectorized Filter: ("time" <> 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+ device |             max              
+--------+------------------------------
+ d1     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.value
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT max(time) FROM metrics GROUP BY value;
+             max              
+------------------------------
+ Wed Jan 01 01:00:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 00:00:00 2025 PST
+ Wed Jan 01 01:30:00 2025 PST
+ Wed Jan 01 02:00:00 2025 PST
+ Wed Jan 01 02:30:00 2025 PST
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, max(time) FROM metrics GROUP BY device,value;
+ device |             max              
+--------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST
+ d1     | Wed Jan 01 00:30:00 2025 PST
+ d1     | Wed Jan 01 02:00:00 2025 PST
+ d1     | Wed Jan 01 02:30:00 2025 PST
+ d1     | Wed Jan 01 01:30:00 2025 PST
+ d2     | Wed Jan 01 00:30:00 2025 PST
+ d2     | Wed Jan 01 02:00:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 01:30:00 2025 PST
+ d2     | Wed Jan 01 01:00:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST
+ d1     | Wed Jan 01 01:00:00 2025 PST
+
+-- no group by prevents optimization
+:PREFIX SELECT max(time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT max(time) FROM metrics;
+             max              
+------------------------------
+ Wed Jan 01 02:30:00 2025 PST
+
+-- multiple min/max prevent optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- aggregate on segmentby can use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- aggregate on column without metadata does not use optimization
+:PREFIX SELECT device, min(value2) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT device, min(value2) FROM metrics GROUP BY device;
+ device | min 
+--------+-----
+ d1     |   5
+ d2     |   5
+

--- a/tsl/test/expected/vector_agg_filter.out
+++ b/tsl/test/expected/vector_agg_filter.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timescaledb.enable_columnarindexscan = off;
 -- helper function: float -> pseudorandom float [-0.5..0.5]
 CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
     SELECT hashfloat8(x::float8) / pow(2, 32)

--- a/tsl/test/expected/vector_agg_functions.out
+++ b/tsl/test/expected/vector_agg_functions.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SET timescaledb.enable_columnarindexscan TO off;
 -- helper function: float -> pseudorandom float [-0.5..0.5]
 CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
     SELECT hashfloat8(x::float8) / pow(2, 32)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_FILES
     cagg_watermark.sql
     chunk_column_stats.sql
     columnar_scan_cost.sql
+    columnar_index_scan.sql
     columnstore_aliases.sql
     compress_auto_sparse_index.sql
     compress_bitmap_scan.sql

--- a/tsl/test/sql/vector_agg_filter.sql
+++ b/tsl/test/sql/vector_agg_filter.sql
@@ -4,6 +4,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+SET timescaledb.enable_columnarindexscan = off;
+
 -- helper function: float -> pseudorandom float [-0.5..0.5]
 CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
     SELECT hashfloat8(x::float8) / pow(2, 32)

--- a/tsl/test/sql/vector_agg_functions.sql
+++ b/tsl/test/sql/vector_agg_functions.sql
@@ -4,6 +4,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+SET timescaledb.enable_columnarindexscan TO off;
+
 -- helper function: float -> pseudorandom float [-0.5..0.5]
 CREATE OR REPLACE FUNCTION mix(x anyelement) RETURNS float8 AS $$
     SELECT hashfloat8(x::float8) / pow(2, 32)


### PR DESCRIPTION
This commit introduces a new PostgreSQL custom scan node called
ColumnarIndexScan that optimizes queries on compressed chunks by
leveraging sparse indexes (min/max metadata) to answer certain aggregate
queries without requiring decompression. Previously those sparse
indexes would only be used for batch filtering.

With this commit any min/max queries with optional groupings by any segmentby
columns will use the optimization.

Example plan:
```
EXPLAIN (costs off) SELECT device, max(time) from t GROUP BY device;
                               QUERY PLAN
------------------------------------------------------------------------
 Finalize HashAggregate
   Group Key: t.device
   ->  Append
         ->  Partial HashAggregate
               Group Key: _hyper_1_34_chunk.device
               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_34_chunk
                     ->  Seq Scan on compress_hyper_2_61_chunk
         ->  Partial HashAggregate
               Group Key: _hyper_1_35_chunk.device
               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_35_chunk
                     ->  Seq Scan on compress_hyper_2_62_chunk
(11 rows)
```