### PR TITLE
Display unordered chunk status in explain

### DIFF
--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -627,6 +627,8 @@ build_compressioninfo(PlannerInfo *root, const Hypertable *ht, const Chunk *chun
 		info->parent_relids = find_childrel_parents(root, chunk_rel);
 	}
 
+	info->chunk_status = chunk->fd.status;
+
 	return info;
 }
 
@@ -2369,6 +2371,7 @@ columnar_scan_path_create(PlannerInfo *root, const CompressionInfo *compression_
 
 	path->custom_path.custom_paths = list_make1(compressed_path);
 	path->reverse = false;
+	path->chunk_status = compression_info->chunk_status;
 	path->required_compressed_pathkeys = NIL;
 	cost_columnar_scan(root, compression_info, &path->custom_path.path, compressed_path);
 

--- a/tsl/src/nodes/columnar_scan/columnar_scan.h
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.h
@@ -47,6 +47,8 @@ typedef struct CompressionInfo
 
 	/* Compressed batch size estimated from statistics. */
 	double compressed_batch_size;
+
+	int32 chunk_status;
 } CompressionInfo;
 
 typedef struct ColumnarScanPath
@@ -58,6 +60,7 @@ typedef struct ColumnarScanPath
 	bool needs_sequence_num;
 	bool reverse;
 	bool batch_sorted_merge;
+	int32 chunk_status;
 } ColumnarScanPath;
 
 void ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *rel, const Hypertable *ht,

--- a/tsl/src/nodes/columnar_scan/decompress_context.h
+++ b/tsl/src/nodes/columnar_scan/decompress_context.h
@@ -95,6 +95,9 @@ typedef struct DecompressContext
 	PlanState *ps; /* Set for filtering and instrumentation */
 
 	Detoaster detoaster;
+
+	int32 chunk_status;
+
 } DecompressContext;
 
 #endif /* TIMESCALEDB_DECOMPRESS_CONTEXT_H */

--- a/tsl/src/nodes/columnar_scan/planner.c
+++ b/tsl/src/nodes/columnar_scan/planner.c
@@ -1449,6 +1449,7 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 	lfirst_int(list_nth_cell(settings, DCS_BatchSortedMerge)) = dcpath->batch_sorted_merge;
 	lfirst_int(list_nth_cell(settings, DCS_EnableBulkDecompression)) = enable_bulk_decompression;
 	lfirst_int(list_nth_cell(settings, DCS_HasRowMarks)) = root->parse->rowMarks != NIL;
+	lfirst_int(list_nth_cell(settings, DCS_ChunkStatus)) = dcpath->chunk_status;
 
 	/*
 	 * Vectorized quals must go into custom_exprs, because Postgres has to see

--- a/tsl/src/nodes/columnar_scan/planner.h
+++ b/tsl/src/nodes/columnar_scan/planner.h
@@ -15,6 +15,7 @@ typedef enum
 	DCS_BatchSortedMerge = 3,
 	DCS_EnableBulkDecompression = 4,
 	DCS_HasRowMarks = 5,
+	DCS_ChunkStatus = 6,
 	DCS_Count
 } ColumnarScanSettingsIndex;
 

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -78,6 +78,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=25.00 loops=1)
                      Output: _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                      Vectorized Filter: ((_hyper_1_1_chunk."time" >= 'Fri Dec 31 16:00:00 1999 PST'::timestamp with time zone) AND (_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone))
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.filter_1, compress_hyper_2_3_chunk.filler_2, compress_hyper_2_3_chunk.filler_3, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1, compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.v0, compress_hyper_2_3_chunk.v1, compress_hyper_2_3_chunk.v2, compress_hyper_2_3_chunk.v3
@@ -93,6 +94,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_2_chunk (actual rows=25.00 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Vectorized Filter: ((_hyper_1_2_chunk."time" >= 'Fri Dec 31 16:00:00 1999 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone))
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3
@@ -125,6 +127,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=25.00 loops=1)
                      Output: _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                      Vectorized Filter: ((_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_1_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.filter_1, compress_hyper_2_3_chunk.filler_2, compress_hyper_2_3_chunk.filler_3, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1, compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.v0, compress_hyper_2_3_chunk.v1, compress_hyper_2_3_chunk.v2, compress_hyper_2_3_chunk.v3
@@ -140,6 +143,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_2_chunk (actual rows=25.00 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Vectorized Filter: ((_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3
@@ -168,6 +172,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Vectorized Filter: ((_hyper_1_2_chunk."time" >= ('2000-01-09 00:00:00+0'::cstring)::timestamp with time zone) AND (_hyper_1_2_chunk."time" <= ('2000-02-01 00:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 15
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3
@@ -202,6 +207,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=25.00 loops=1)
                      Output: _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                      Vectorized Filter: ((_hyper_1_1_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_1_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_3_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_3_chunk._ts_meta_count, compress_hyper_2_3_chunk.device_id, compress_hyper_2_3_chunk.filter_1, compress_hyper_2_3_chunk.filler_2, compress_hyper_2_3_chunk.filler_3, compress_hyper_2_3_chunk._ts_meta_min_1, compress_hyper_2_3_chunk._ts_meta_max_1, compress_hyper_2_3_chunk."time", compress_hyper_2_3_chunk.v0, compress_hyper_2_3_chunk.v1, compress_hyper_2_3_chunk.v2, compress_hyper_2_3_chunk.v3
@@ -217,6 +223,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_2_chunk (actual rows=25.00 loops=1)
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Vectorized Filter: ((_hyper_1_2_chunk."time" <= 'Mon Jan 31 16:00:00 2000 PST'::timestamp with time zone) AND (_hyper_1_2_chunk."time" >= ('2000-01-01 00:00:00+0'::cstring)::timestamp with time zone))
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3
@@ -252,6 +259,7 @@ SELECT count(*), sum(v0), sum(v1), sum(v2), sum(v3) FROM testtable WHERE time >=
                      Output: _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                      Vectorized Filter: ((_hyper_1_2_chunk."time" >= ('2000-01-09 00:00:00+0'::cstring)::timestamp with time zone) AND (_hyper_1_2_chunk."time" <= ('2000-02-01 00:00:00+0'::cstring)::timestamp with time zone))
                      Rows Removed by Filter: 15
+                     Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Index Scan using compress_hyper_2_4_chunk_device_id__ts_meta_min_1__ts_meta__idx on _timescaledb_internal.compress_hyper_2_4_chunk (actual rows=5.00 loops=1)
                            Output: compress_hyper_2_4_chunk._ts_meta_count, compress_hyper_2_4_chunk.device_id, compress_hyper_2_4_chunk.filter_1, compress_hyper_2_4_chunk.filler_2, compress_hyper_2_4_chunk.filler_3, compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1, compress_hyper_2_4_chunk."time", compress_hyper_2_4_chunk.v0, compress_hyper_2_4_chunk.v1, compress_hyper_2_4_chunk.v2, compress_hyper_2_4_chunk.v3

--- a/tsl/test/expected/compress_explain.out
+++ b/tsl/test/expected/compress_explain.out
@@ -1,0 +1,280 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Display extra statuses of compressed chunks in "explain verbose"
+\set PREFIX 'EXPLAIN (verbose, analyze, buffers off, costs off, timing off, summary off)'
+CREATE TABLE metrics (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time desc', tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- uncompressed data: no explain extras
+BEGIN;
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_1_chunk.device
+   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_2_chunk.device
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+ chunk_status_text 
+-------------------
+ {}
+
+ROLLBACK;
+SET timescaledb.enable_direct_compress_insert = false;
+BEGIN;
+-- basic compressed chunks: no explain extras
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_3_chunk.device
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_5_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_5_chunk._ts_meta_count, compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1, compress_hyper_2_5_chunk."time", compress_hyper_2_5_chunk.value
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_4_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_4_chunk.device
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_6_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_6_chunk._ts_meta_count, compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1, compress_hyper_2_6_chunk."time", compress_hyper_2_6_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ freeze_chunk 
+--------------
+ t
+ t
+
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_3_chunk.device
+         Chunk Status: FROZEN
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_5_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_5_chunk._ts_meta_count, compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1, compress_hyper_2_5_chunk."time", compress_hyper_2_5_chunk.value
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_4_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_4_chunk.device
+         Chunk Status: FROZEN
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_6_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_6_chunk._ts_meta_count, compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1, compress_hyper_2_6_chunk."time", compress_hyper_2_6_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+  chunk_status_text  
+---------------------
+ {COMPRESSED,FROZEN}
+
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ unfreeze_chunk 
+----------------
+ t
+ t
+
+-- Partial chunk
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,10) i;
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3012.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_3_chunk.device
+         Chunk Status: PARTIAL
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_5_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_5_chunk._ts_meta_count, compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1, compress_hyper_2_5_chunk."time", compress_hyper_2_5_chunk.value
+   ->  Seq Scan on _timescaledb_internal._hyper_1_3_chunk (actual rows=11.00 loops=1)
+         Output: _hyper_1_3_chunk.device
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_4_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_4_chunk.device
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_6_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_6_chunk._ts_meta_count, compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1, compress_hyper_2_6_chunk."time", compress_hyper_2_6_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+  chunk_status_text   
+----------------------
+ {COMPRESSED,PARTIAL}
+ {COMPRESSED}
+
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ freeze_chunk 
+--------------
+ t
+ t
+
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3012.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_3_chunk.device
+         Chunk Status: FROZEN, PARTIAL
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_5_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_5_chunk._ts_meta_count, compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1, compress_hyper_2_5_chunk."time", compress_hyper_2_5_chunk.value
+   ->  Seq Scan on _timescaledb_internal._hyper_1_3_chunk (actual rows=11.00 loops=1)
+         Output: _hyper_1_3_chunk.device
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_4_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_4_chunk.device
+         Chunk Status: FROZEN
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_6_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_6_chunk._ts_meta_count, compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1, compress_hyper_2_6_chunk."time", compress_hyper_2_6_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+      chunk_status_text      
+-----------------------------
+ {COMPRESSED,FROZEN,PARTIAL}
+ {COMPRESSED,FROZEN}
+
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ unfreeze_chunk 
+----------------
+ t
+ t
+
+ROLLBACK;
+SET timescaledb.enable_direct_compress_insert = true;
+SET timescaledb.enable_direct_compress_insert_sort_batches = true;
+SET timescaledb.enable_direct_compress_insert_client_sorted = false;
+BEGIN;
+-- direct insert producing UNORDERED chunks
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_7_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_7_chunk.device
+         Chunk Status: UNORDERED
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_8_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_8_chunk._ts_meta_count, compress_hyper_2_8_chunk.device, compress_hyper_2_8_chunk._ts_meta_min_1, compress_hyper_2_8_chunk._ts_meta_max_1, compress_hyper_2_8_chunk."time", compress_hyper_2_8_chunk.value
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_9_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_9_chunk.device
+         Chunk Status: UNORDERED
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_10_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_10_chunk._ts_meta_count, compress_hyper_2_10_chunk.device, compress_hyper_2_10_chunk._ts_meta_min_1, compress_hyper_2_10_chunk._ts_meta_max_1, compress_hyper_2_10_chunk."time", compress_hyper_2_10_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ freeze_chunk 
+--------------
+ t
+ t
+
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_7_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_7_chunk.device
+         Chunk Status: UNORDERED, FROZEN
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_8_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_8_chunk._ts_meta_count, compress_hyper_2_8_chunk.device, compress_hyper_2_8_chunk._ts_meta_min_1, compress_hyper_2_8_chunk._ts_meta_max_1, compress_hyper_2_8_chunk."time", compress_hyper_2_8_chunk.value
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_9_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_9_chunk.device
+         Chunk Status: UNORDERED, FROZEN
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_10_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_10_chunk._ts_meta_count, compress_hyper_2_10_chunk.device, compress_hyper_2_10_chunk._ts_meta_min_1, compress_hyper_2_10_chunk._ts_meta_max_1, compress_hyper_2_10_chunk."time", compress_hyper_2_10_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+       chunk_status_text       
+-------------------------------
+ {COMPRESSED,UNORDERED,FROZEN}
+
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ unfreeze_chunk 
+----------------
+ t
+ t
+
+-- Partial chunk
+SET timescaledb.enable_direct_compress_insert = false;
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,10) i;
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3012.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_7_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_7_chunk.device
+         Chunk Status: UNORDERED, PARTIAL
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_8_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_8_chunk._ts_meta_count, compress_hyper_2_8_chunk.device, compress_hyper_2_8_chunk._ts_meta_min_1, compress_hyper_2_8_chunk._ts_meta_max_1, compress_hyper_2_8_chunk."time", compress_hyper_2_8_chunk.value
+   ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk (actual rows=11.00 loops=1)
+         Output: _hyper_1_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_9_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_9_chunk.device
+         Chunk Status: UNORDERED
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_10_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_10_chunk._ts_meta_count, compress_hyper_2_10_chunk.device, compress_hyper_2_10_chunk._ts_meta_min_1, compress_hyper_2_10_chunk._ts_meta_max_1, compress_hyper_2_10_chunk."time", compress_hyper_2_10_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+       chunk_status_text        
+--------------------------------
+ {COMPRESSED,UNORDERED,PARTIAL}
+ {COMPRESSED,UNORDERED}
+
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ freeze_chunk 
+--------------
+ t
+ t
+
+:PREFIX SELECT device FROM metrics;
+--- QUERY PLAN ---
+ Append (actual rows=3012.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_7_chunk (actual rows=960.00 loops=1)
+         Output: _hyper_1_7_chunk.device
+         Chunk Status: UNORDERED, FROZEN, PARTIAL
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_8_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_8_chunk._ts_meta_count, compress_hyper_2_8_chunk.device, compress_hyper_2_8_chunk._ts_meta_min_1, compress_hyper_2_8_chunk._ts_meta_max_1, compress_hyper_2_8_chunk."time", compress_hyper_2_8_chunk.value
+   ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk (actual rows=11.00 loops=1)
+         Output: _hyper_1_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_9_chunk (actual rows=2041.00 loops=1)
+         Output: _hyper_1_9_chunk.device
+         Chunk Status: UNORDERED, FROZEN
+         Bulk Decompression: false
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_10_chunk (actual rows=3.00 loops=1)
+               Output: compress_hyper_2_10_chunk._ts_meta_count, compress_hyper_2_10_chunk.device, compress_hyper_2_10_chunk._ts_meta_min_1, compress_hyper_2_10_chunk._ts_meta_max_1, compress_hyper_2_10_chunk."time", compress_hyper_2_10_chunk.value
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+           chunk_status_text           
+---------------------------------------
+ {COMPRESSED,UNORDERED,FROZEN,PARTIAL}
+ {COMPRESSED,UNORDERED,FROZEN}
+
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ unfreeze_chunk 
+----------------
+ t
+ t
+
+ROLLBACK;
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_direct_compress_insert_sort_batches;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+drop table metrics cascade;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1655,6 +1655,7 @@ SELECT sum(cpu) FROM f_sensor_data;
                      Grouping Policy: all compressed batches
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_37_73_chunk
                            Output: _hyper_37_73_chunk.cpu
+                           Chunk Status: PARTIAL
                            ->  Parallel Seq Scan on _timescaledb_internal.compress_hyper_38_74_chunk
                                  Output: compress_hyper_38_74_chunk._ts_meta_count, compress_hyper_38_74_chunk.sensor_id, compress_hyper_38_74_chunk._ts_meta_min_1, compress_hyper_38_74_chunk._ts_meta_max_1, compress_hyper_38_74_chunk."time", compress_hyper_38_74_chunk.cpu, compress_hyper_38_74_chunk.temperature
                ->  Partial Aggregate
@@ -1672,6 +1673,7 @@ SELECT * FROM f_sensor_data WHERE sensor_id > 1000;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_37_73_chunk
                Output: _hyper_37_73_chunk."time", _hyper_37_73_chunk.sensor_id, _hyper_37_73_chunk.cpu, _hyper_37_73_chunk.temperature
                Filter: (_hyper_37_73_chunk.sensor_id > 1000)
+               Chunk Status: PARTIAL
                ->  Parallel Index Scan using compress_hyper_38_74_chunk_sensor_id__ts_meta_min_1__ts_met_idx on _timescaledb_internal.compress_hyper_38_74_chunk
                      Output: compress_hyper_38_74_chunk._ts_meta_count, compress_hyper_38_74_chunk.sensor_id, compress_hyper_38_74_chunk._ts_meta_min_1, compress_hyper_38_74_chunk._ts_meta_max_1, compress_hyper_38_74_chunk."time", compress_hyper_38_74_chunk.cpu, compress_hyper_38_74_chunk.temperature
                      Index Cond: (compress_hyper_38_74_chunk.sensor_id > 1000)
@@ -1770,6 +1772,7 @@ SELECT * FROM ht_metrics_partially_compressed ORDER BY time DESC, device LIMIT 1
                      Sort Key: _hyper_41_77_chunk."time" DESC, _hyper_41_77_chunk.device
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_41_77_chunk
                            Output: _hyper_41_77_chunk."time", _hyper_41_77_chunk.device, _hyper_41_77_chunk.value
+                           Chunk Status: PARTIAL
                            ->  Seq Scan on _timescaledb_internal.compress_hyper_42_79_chunk
                                  Output: compress_hyper_42_79_chunk._ts_meta_count, compress_hyper_42_79_chunk.device, compress_hyper_42_79_chunk._ts_meta_min_1, compress_hyper_42_79_chunk._ts_meta_max_1, compress_hyper_42_79_chunk."time", compress_hyper_42_79_chunk.value
                ->  Sort
@@ -2297,6 +2300,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                Sort Key: sensor_data_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_45_87_chunk (never executed)
                      Output: _hyper_45_87_chunk."time", _hyper_45_87_chunk.sensor_id, _hyper_45_87_chunk.cpu, _hyper_45_87_chunk.temperature
+                     Chunk Status: PARTIAL
                      Batch Sorted Merge: true
                      Bulk Decompression: false
                      ->  Sort (never executed)
@@ -2377,6 +2381,7 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
                      Sort Key: _hyper_45_87_chunk."time" DESC
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_45_87_chunk (never executed)
                            Output: _hyper_45_87_chunk."time", _hyper_45_87_chunk.sensor_id, _hyper_45_87_chunk.cpu, _hyper_45_87_chunk.temperature
+                           Chunk Status: PARTIAL
                            Bulk Decompression: true
                            ->  Seq Scan on _timescaledb_internal.compress_hyper_46_94_chunk (never executed)
                                  Output: compress_hyper_46_94_chunk._ts_meta_count, compress_hyper_46_94_chunk.sensor_id, compress_hyper_46_94_chunk._ts_meta_min_1, compress_hyper_46_94_chunk._ts_meta_max_1, compress_hyper_46_94_chunk."time", compress_hyper_46_94_chunk.cpu, compress_hyper_46_94_chunk.temperature

--- a/tsl/test/expected/compression_sorted_merge.out
+++ b/tsl/test/expected/compression_sorted_merge.out
@@ -1006,6 +1006,7 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
          Sort Key: test1."time"
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=4.00 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+               Chunk Status: PARTIAL
                Batch Sorted Merge: true
                Reverse: true
                Bulk Decompression: false

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -1329,6 +1329,7 @@ SELECT sum(segment_by_value) FROM testtable;
                Grouping Policy: all compressed batches
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.segment_by_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1416,6 +1417,7 @@ SELECT sum(int_value) FROM testtable;
                Grouping Policy: all compressed batches
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1502,6 +1504,7 @@ SELECT sum(abs(int_value)) FROM testtable;
                Output: PARTIAL sum(abs(_hyper_1_1_chunk.int_value))
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1575,6 +1578,7 @@ SELECT sum(int_value) FROM testtable;
                Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1650,6 +1654,7 @@ SELECT sum(int_value) FROM testtable;
                Output: PARTIAL sum(_hyper_1_1_chunk.int_value)
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1722,6 +1727,7 @@ SELECT sum(segment_by_value) FROM testtable;
                Grouping Policy: all compressed batches
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.segment_by_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1810,6 +1816,7 @@ SELECT sum(int_value), sum(int_value) FROM testtable;
                Grouping Policy: all compressed batches
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1892,6 +1899,7 @@ SELECT sum(segment_by_value), sum(segment_by_value) FROM testtable;
                Grouping Policy: all compressed batches
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.segment_by_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -1974,6 +1982,7 @@ SELECT sum(int_value), sum(segment_by_value) FROM testtable;
                Grouping Policy: all compressed batches
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value, _hyper_1_1_chunk.segment_by_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -2060,6 +2069,7 @@ SELECT sum(int_value), bit_or(int_value) FROM testtable;
                Output: PARTIAL sum(_hyper_1_1_chunk.int_value), PARTIAL bit_or(_hyper_1_1_chunk.int_value)
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.int_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate
@@ -2132,6 +2142,7 @@ SELECT sum(segment_by_value), bit_or(segment_by_value) FROM testtable;
                Output: PARTIAL sum(_hyper_1_1_chunk.segment_by_value), PARTIAL bit_or(_hyper_1_1_chunk.segment_by_value)
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk
                      Output: _hyper_1_1_chunk.segment_by_value
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_2_11_chunk
                            Output: compress_hyper_2_11_chunk._ts_meta_count, compress_hyper_2_11_chunk.segment_by_value, compress_hyper_2_11_chunk._ts_meta_min_1, compress_hyper_2_11_chunk._ts_meta_max_1, compress_hyper_2_11_chunk."time", compress_hyper_2_11_chunk.int_value, compress_hyper_2_11_chunk.float_value
          ->  Partial Aggregate

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -21,6 +21,7 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -184,6 +185,7 @@ ORDER BY time, device_id;
                Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 16392
                Batches Removed by Filter: 18
+               Chunk Status: PARTIAL
                Bulk Decompression: true
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
@@ -471,6 +473,7 @@ ORDER BY time, device_id;
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                      Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -488,6 +491,7 @@ ORDER BY time, device_id;
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
                Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -553,6 +557,7 @@ ORDER BY time, device_id;
          ->  Append
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -578,6 +583,7 @@ ORDER BY time, device_id;
    Output: count(*)
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Chunk Status: PARTIAL
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk._ts_meta_count
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -594,6 +600,7 @@ ORDER BY time, device_id;
          ->  Append
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -613,6 +620,7 @@ ORDER BY time, device_id;
                ->  Append
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                            Output: _hyper_X_X_chunk.device_id
+                           Chunk Status: PARTIAL
                            ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                                  Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -689,6 +697,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -709,6 +718,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -729,6 +739,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
                Filter: (test_table.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -745,6 +756,7 @@ SET enable_seqscan TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -760,6 +772,7 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -776,6 +789,7 @@ SET enable_hashjoin TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -801,6 +815,7 @@ SET enable_hashjoin TO FALSE;
    ->  Append (actual rows=3598.00 loops=2)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -817,6 +832,7 @@ RESET enable_hashjoin;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -835,6 +851,7 @@ RESET enable_hashjoin;
    ->  Append (actual rows=17990.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=16392.00 loops=1)
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -861,6 +878,7 @@ SET seq_page_cost = 100;
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -21,6 +21,7 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -184,6 +185,7 @@ ORDER BY time, device_id;
                Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 16392
                Batches Removed by Filter: 18
+               Chunk Status: PARTIAL
                Bulk Decompression: true
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
@@ -471,6 +473,7 @@ ORDER BY time, device_id;
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                      Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -488,6 +491,7 @@ ORDER BY time, device_id;
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
                Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -553,6 +557,7 @@ ORDER BY time, device_id;
          ->  Append
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -578,6 +583,7 @@ ORDER BY time, device_id;
    Output: count(*)
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Chunk Status: PARTIAL
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk._ts_meta_count
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -594,6 +600,7 @@ ORDER BY time, device_id;
          ->  Append
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -613,6 +620,7 @@ ORDER BY time, device_id;
                ->  Append
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                            Output: _hyper_X_X_chunk.device_id
+                           Chunk Status: PARTIAL
                            ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                                  Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -689,6 +697,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -709,6 +718,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -729,6 +739,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
                Filter: (test_table.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -745,6 +756,7 @@ SET enable_seqscan TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -760,6 +772,7 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -776,6 +789,7 @@ SET enable_hashjoin TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -801,6 +815,7 @@ SET enable_hashjoin TO FALSE;
    ->  Append (actual rows=3598.00 loops=2)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -817,6 +832,7 @@ RESET enable_hashjoin;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -835,6 +851,7 @@ RESET enable_hashjoin;
    ->  Append (actual rows=17990.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=16392.00 loops=1)
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -861,6 +878,7 @@ SET seq_page_cost = 100;
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-17.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-17.out
@@ -21,6 +21,7 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -192,6 +193,7 @@ ORDER BY time, device_id;
                Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 16392
                Batches Removed by Filter: 18
+               Chunk Status: PARTIAL
                Bulk Decompression: true
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
@@ -524,6 +526,7 @@ ORDER BY time, device_id;
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                      Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
          ->  Sort
@@ -544,6 +547,7 @@ ORDER BY time, device_id;
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
                Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -616,6 +620,7 @@ ORDER BY time, device_id;
                Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
          ->  Sort
@@ -644,6 +649,7 @@ ORDER BY time, device_id;
    Output: count(*)
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Chunk Status: PARTIAL
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk._ts_meta_count
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -660,6 +666,7 @@ ORDER BY time, device_id;
          ->  Append
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -679,6 +686,7 @@ ORDER BY time, device_id;
                ->  Append
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                            Output: _hyper_X_X_chunk.device_id
+                           Chunk Status: PARTIAL
                            ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                                  Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -755,6 +763,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -775,6 +784,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -795,6 +805,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
                Filter: (test_table.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -811,6 +822,7 @@ SET enable_seqscan TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -826,6 +838,7 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -842,6 +855,7 @@ SET enable_hashjoin TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -867,6 +881,7 @@ SET enable_hashjoin TO FALSE;
    ->  Append (actual rows=3598.00 loops=2)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2799.00 loops=2)
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=3.00 loops=2)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -883,6 +898,7 @@ RESET enable_hashjoin;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -901,6 +917,7 @@ RESET enable_hashjoin;
    ->  Append (actual rows=17990.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=16392.00 loops=1)
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -927,6 +944,7 @@ SET seq_page_cost = 100;
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                Output: _hyper_X_X_chunk.device_id
+               Chunk Status: PARTIAL
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-18.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-18.out
@@ -21,6 +21,7 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -192,6 +193,7 @@ ORDER BY time, device_id;
                Vectorized Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 16392
                Batches Removed by Filter: 18
+               Chunk Status: PARTIAL
                Bulk Decompression: true
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=18.00 loops=1)
                      Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
@@ -524,6 +526,7 @@ ORDER BY time, device_id;
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                      Filter: (_hyper_X_X_chunk.v0 = _hyper_X_X_chunk.v1)
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3, compress_hyper_X_X_chunk._ts_meta_count
          ->  Sort
@@ -544,6 +547,7 @@ ORDER BY time, device_id;
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
                Vectorized Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Sort (actual rows=1.00 loops=1)
@@ -616,6 +620,7 @@ ORDER BY time, device_id;
                Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1, compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
          ->  Sort
@@ -644,6 +649,7 @@ ORDER BY time, device_id;
    Output: count(*)
    ->  Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
+               Chunk Status: PARTIAL
                ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                      Output: compress_hyper_X_X_chunk._ts_meta_count
          ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -660,6 +666,7 @@ ORDER BY time, device_id;
          ->  Append
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                      Output: _hyper_X_X_chunk.device_id
+                     Chunk Status: PARTIAL
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                            Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -679,6 +686,7 @@ ORDER BY time, device_id;
                ->  Append
                      ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
                            Output: _hyper_X_X_chunk.device_id
+                           Chunk Status: PARTIAL
                            ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk
                                  Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                      ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk
@@ -755,6 +763,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -775,6 +784,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -795,6 +805,7 @@ SET enable_seqscan TO FALSE;
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
                Filter: (test_table.device_id = 1)
+               Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
                ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -811,6 +822,7 @@ SET enable_seqscan TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -826,6 +838,7 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Filter: (_hyper_X_X_chunk.device_id = 1)
+               Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -842,6 +855,7 @@ SET enable_hashjoin TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -858,6 +872,7 @@ SET enable_hashjoin TO FALSE;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5598.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -874,6 +889,7 @@ RESET enable_hashjoin;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = 1)
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -890,6 +906,7 @@ RESET enable_hashjoin;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5598.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -907,6 +924,7 @@ SET seq_page_cost = 100;
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
          Output: _hyper_X_X_chunk.device_id
          Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
+         Chunk Status: PARTIAL
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
                Index Cond: (compress_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_FILES
     compress_sparse_config.sql
     compress_default.sql
     compress_dml_copy.sql
+    compress_explain.sql
     compress_float8_corrupt.sql
     compress_qualpushdown_saop.sql
     compress_sort_transform.sql

--- a/tsl/test/sql/compress_explain.sql
+++ b/tsl/test/sql/compress_explain.sql
@@ -1,0 +1,70 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Display extra statuses of compressed chunks in "explain verbose"
+\set PREFIX 'EXPLAIN (verbose, analyze, buffers off, costs off, timing off, summary off)'
+
+CREATE TABLE metrics (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time desc', tsdb.segmentby='device');
+
+-- uncompressed data: no explain extras
+BEGIN;
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+ROLLBACK;
+
+SET timescaledb.enable_direct_compress_insert = false;
+BEGIN;
+-- basic compressed chunks: no explain extras
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+-- Partial chunk
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,10) i;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ROLLBACK;
+
+SET timescaledb.enable_direct_compress_insert = true;
+SET timescaledb.enable_direct_compress_insert_sort_batches = true;
+SET timescaledb.enable_direct_compress_insert_client_sorted = false;
+
+BEGIN;
+-- direct insert producing UNORDERED chunks
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+-- Partial chunk
+SET timescaledb.enable_direct_compress_insert = false;
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,10) i;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+-- Freeze/unfreeze chunks
+SELECT _timescaledb_functions.freeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+:PREFIX SELECT device FROM metrics;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+SELECT _timescaledb_functions.unfreeze_chunk(ch) FROM show_chunks('metrics') AS ch;
+ROLLBACK;
+
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_direct_compress_insert_sort_batches;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+
+drop table metrics cascade;


### PR DESCRIPTION
There is value in knowing whether a compressed chunk is unordered as it may affect resulting plans.

For example, we cannot push down sort into compressed chunk if it's unordered, we also cannot apply SkipScan to unordered compressed chunks in many scenarios.

This PR will expose unordered chunk status in `explain verbose`.

Disable-check: force-changelog-file