### PR TITLE
Add explicit NULL checks for sort_transform and group_estimate

### DIFF
--- a/src/estimate.c
+++ b/src/estimate.c
@@ -137,7 +137,7 @@ group_estimate_funcexpr(PlannerInfo *root, FuncExpr *group_estimate_func, double
 {
 	FuncInfo *func_est = ts_func_cache_get_bucketing_func(group_estimate_func->funcid);
 
-	if (NULL != func_est)
+	if (func_est && func_est->group_estimate)
 		return func_est->group_estimate(root, group_estimate_func, path_rows);
 	return INVALID_ESTIMATE;
 }

--- a/src/func_cache.h
+++ b/src/func_cache.h
@@ -48,5 +48,5 @@ typedef struct FuncInfo
 extern TSDLLEXPORT FuncInfo *ts_func_cache_get(Oid funcid);
 extern TSDLLEXPORT FuncInfo *ts_func_cache_get_bucketing_func(Oid funcid);
 
-extern Oid ts_first_func_oid;
-extern Oid ts_last_func_oid;
+extern TSDLLEXPORT Oid ts_first_func_oid;
+extern TSDLLEXPORT Oid ts_last_func_oid;

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -508,7 +508,7 @@ ts_ordered_append_should_optimize(PlannerInfo *root, RelOptInfo *rel, Hypertable
 		FuncInfo *info = ts_func_cache_get_bucketing_func(castNode(FuncExpr, tle->expr)->funcid);
 		Expr *transformed;
 
-		if (info == NULL)
+		if (!info || !info->sort_transform)
 			return false;
 
 		transformed = info->sort_transform(castNode(FuncExpr, tle->expr));

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1054,7 +1054,7 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 					FuncInfo *info = ts_func_cache_get_bucketing_func(func->funcid);
 					Expr *transformed;
 
-					if (info != NULL)
+					if (info && info->sort_transform)
 					{
 						transformed = info->sort_transform(func);
 						if (IsA(transformed, Var) &&


### PR DESCRIPTION
Not all places using sort_transform and group_estimate had explicit
NULL checks for these. This commit adds those checks in places that
were missing them.

Disable-check: force-changelog-file
Disable-check: approval-count
