### PR TITLE
Support multiple aggregates in ColumnarIndexScan

### DIFF
--- a/.unreleased/pr_9108
+++ b/.unreleased/pr_9108
@@ -1,0 +1,1 @@
+Implements: #9108 Support multiple aggregates in ColumnarIndexScan

--- a/src/expression_utils.h
+++ b/src/expression_utils.h
@@ -12,3 +12,5 @@
 
 bool TSDLLEXPORT ts_extract_expr_args(Expr *expr, Var **var, Expr **arg_value, Oid *opno,
 									  Oid *opcode);
+
+TSDLLEXPORT List *ts_build_trivial_custom_output_targetlist(List *scan_targetlist);

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
@@ -14,9 +14,16 @@ typedef struct ColumnarIndexScanPath
 {
 	CustomPath custom_path;
 	const CompressionInfo *info;
-	AttrNumber aggregate_attno; /* Chunk attno of the aggregate column */
-	AttrNumber metadata_attno;	/* Compressed chunk attno for metadata */
+	List *aggregate_attnos; /* Chunk attnos of aggregate columns in target list order */
+	List *metadata_attnos;	/* Compressed chunk attnos for metadata in target list order */
+	List *aggregate_fnoids; /* Aggregate function OIDs in target list order */
 } ColumnarIndexScanPath;
+
+/*
+ * Post-process a plan tree to fix Aggref references for ColumnarIndexScan.
+ * This is needed when multiple aggregates reference the same column.
+ */
+extern void ts_columnar_index_scan_fix_aggrefs(Plan *plan);
 
 extern void _columnar_index_scan_init(void);
 extern bool ts_is_columnar_index_scan_path(Path *path);

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan_exec.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan_exec.c
@@ -39,6 +39,7 @@ columnar_index_scan_state_create(CustomScan *cscan)
 		(ColumnarIndexScanState *) newNode(sizeof(ColumnarIndexScanState), T_CustomScanState);
 
 	state->csstate.methods = &columnar_index_scan_state_methods;
+	/* custom_private contains (output_map, remap_info), we only need output_map for execution */
 	state->output_map = linitial(cscan->custom_private);
 
 	return (Node *) state;

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -20,6 +20,7 @@
 #include "continuous_aggs/planner.h"
 #include "guc.h"
 #include "hypertable.h"
+#include "nodes/columnar_index_scan/columnar_index_scan.h"
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/gapfill/gapfill.h"
 #include "nodes/skip_scan/skip_scan.h"
@@ -298,6 +299,11 @@ tsl_sort_transform_replace_pathkeys(void *path, List *transformed_pathkeys, List
 void
 tsl_postprocess_plan(PlannedStmt *stmt)
 {
+	if (ts_guc_enable_columnarindexscan)
+	{
+		ts_columnar_index_scan_fix_aggrefs(stmt->planTree);
+	}
+
 	if (ts_guc_enable_vectorized_aggregation)
 	{
 		stmt->planTree = try_insert_vector_agg_node(stmt->planTree, stmt->rtable);

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -11,18 +11,18 @@ CREATE TABLE metrics(
 ) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -31,6 +31,7 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 
 SET max_parallel_workers_per_gather = 0;
 SET timescaledb.enable_columnarindexscan = on;
+-- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
  HashAggregate
@@ -44,41 +45,50 @@ SELECT device, max(time) FROM metrics GROUP BY device;
  d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 02:30:00 2025 PST
 
-:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor |             min              
 --------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST
  B      | Wed Jan 01 00:30:00 2025 PST
  C      | Wed Jan 01 00:30:00 2025 PST
- A      | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, first(time, time) FROM metrics GROUP BY device;
+SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |            first             
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, last(time, time) FROM metrics GROUP BY device;
+SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |             last             
 --------+------------------------------
  d1     | Wed Jan 01 02:30:00 2025 PST
@@ -92,28 +102,114 @@ SELECT device, last(time, time) FROM metrics GROUP BY device;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor | min 
 --------+-----
- B      |   5
- C      |   5
  A      |  10
+ B      |   4
+ C      |   6
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min | max 
+--------+-----+-----
+ A      |  10 |  20
+ B      |   4 |  29
+ C      |   6 |  31
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              |             max              |            first             |             last             
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              | min 
+--------+------------------------------+-----
+ A      | Wed Jan 01 00:00:00 2025 PST |  10
+ B      | Wed Jan 01 00:30:00 2025 PST |   4
+ C      | Wed Jan 01 00:30:00 2025 PST |   6
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min |             min              | sensor 
+--------+-----+------------------------------+--------
+ A      |  10 | Wed Jan 01 00:00:00 2025 PST | A
+ B      |   4 | Wed Jan 01 00:30:00 2025 PST | B
+ C      |   6 | Wed Jan 01 00:30:00 2025 PST | C
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |            first             |             last             | first | last 
+--------+------------------------------+------------------------------+-------+------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST |    10 |   20
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     4 |   29
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     6 |   31
 
 -- test multiple group by columns
-:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
- HashAggregate
+ GroupAggregate
    Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
  device | sensor |             max              
 --------+--------+------------------------------
- d2     | A      | Wed Jan 01 02:00:00 2025 PST
  d1     | A      | Wed Jan 01 02:00:00 2025 PST
- d2     | C      | Wed Jan 01 02:30:00 2025 PST
  d1     | B      | Wed Jan 01 02:30:00 2025 PST
+ d2     | A      | Wed Jan 01 02:00:00 2025 PST
+ d2     | C      | Wed Jan 01 02:30:00 2025 PST
 
 -- order by does currently prevent optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
@@ -187,10 +283,12 @@ SELECT max(time) FROM metrics GROUP BY value;
              max              
 ------------------------------
  Wed Jan 01 01:00:00 2025 PST
- Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 02:30:00 2025 PST
  Wed Jan 01 00:00:00 2025 PST
  Wed Jan 01 01:30:00 2025 PST
  Wed Jan 01 02:00:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
  Wed Jan 01 02:30:00 2025 PST
 
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
@@ -204,17 +302,17 @@ SELECT device, max(time) FROM metrics GROUP BY device,value;
  device |             max              
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
- d1     | Wed Jan 01 00:30:00 2025 PST
  d1     | Wed Jan 01 02:00:00 2025 PST
- d1     | Wed Jan 01 02:30:00 2025 PST
  d1     | Wed Jan 01 01:30:00 2025 PST
- d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 02:00:00 2025 PST
- d2     | Wed Jan 01 02:30:00 2025 PST
+ d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 01:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 01:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
  d1     | Wed Jan 01 01:00:00 2025 PST
+ d1     | Wed Jan 01 00:30:00 2025 PST
 
 -- no group by prevents optimization
 :PREFIX SELECT max(time) FROM metrics;
@@ -233,13 +331,89 @@ SELECT max(time) FROM metrics;
 ------------------------------
  Wed Jan 01 02:30:00 2025 PST
 
--- multiple min/max prevent optimization
+-- multiple aggregates on same column use optimization
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- GroupAggregate
+ HashAggregate
    Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+ device |             min              |             max              
+--------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+ device |             min              |            first             |             last             |             max              
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+            first             |             last             | device 
+------------------------------+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d1
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d2
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+ device |             min              | max 
+--------+------------------------------+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST |  31
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+ device | min | max 
+--------+-----+-----
+ d1     |   4 |  29
+ d2     |   6 |  31
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+ device |             min              |             max              | min | max 
+--------+------------------------------+------------------------------+-----+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   4 |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   6 |  31
 
 -- aggregate on segmentby can use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -260,6 +434,6 @@ SELECT max(time) FROM metrics;
 SELECT device, min(value2) FROM metrics GROUP BY device;
  device | min 
 --------+-----
- d1     |   5
- d2     |   5
+ d1     | 4.1
+ d2     | 6.1
 

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -11,18 +11,18 @@ CREATE TABLE metrics(
 ) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -31,6 +31,7 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 
 SET max_parallel_workers_per_gather = 0;
 SET timescaledb.enable_columnarindexscan = on;
+-- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
  HashAggregate
@@ -44,41 +45,50 @@ SELECT device, max(time) FROM metrics GROUP BY device;
  d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 02:30:00 2025 PST
 
-:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor |             min              
 --------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST
  B      | Wed Jan 01 00:30:00 2025 PST
  C      | Wed Jan 01 00:30:00 2025 PST
- A      | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, first(time, time) FROM metrics GROUP BY device;
+SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |            first             
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, last(time, time) FROM metrics GROUP BY device;
+SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |             last             
 --------+------------------------------
  d1     | Wed Jan 01 02:30:00 2025 PST
@@ -92,28 +102,114 @@ SELECT device, last(time, time) FROM metrics GROUP BY device;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor | min 
 --------+-----
- B      |   5
- C      |   5
  A      |  10
+ B      |   4
+ C      |   6
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min | max 
+--------+-----+-----
+ A      |  10 |  20
+ B      |   4 |  29
+ C      |   6 |  31
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              |             max              |            first             |             last             
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              | min 
+--------+------------------------------+-----
+ A      | Wed Jan 01 00:00:00 2025 PST |  10
+ B      | Wed Jan 01 00:30:00 2025 PST |   4
+ C      | Wed Jan 01 00:30:00 2025 PST |   6
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min |             min              | sensor 
+--------+-----+------------------------------+--------
+ A      |  10 | Wed Jan 01 00:00:00 2025 PST | A
+ B      |   4 | Wed Jan 01 00:30:00 2025 PST | B
+ C      |   6 | Wed Jan 01 00:30:00 2025 PST | C
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |            first             |             last             | first | last 
+--------+------------------------------+------------------------------+-------+------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST |    10 |   20
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     4 |   29
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     6 |   31
 
 -- test multiple group by columns
-:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
- HashAggregate
+ GroupAggregate
    Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
  device | sensor |             max              
 --------+--------+------------------------------
- d2     | A      | Wed Jan 01 02:00:00 2025 PST
  d1     | A      | Wed Jan 01 02:00:00 2025 PST
- d2     | C      | Wed Jan 01 02:30:00 2025 PST
  d1     | B      | Wed Jan 01 02:30:00 2025 PST
+ d2     | A      | Wed Jan 01 02:00:00 2025 PST
+ d2     | C      | Wed Jan 01 02:30:00 2025 PST
 
 -- order by does currently prevent optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
@@ -187,10 +283,12 @@ SELECT max(time) FROM metrics GROUP BY value;
              max              
 ------------------------------
  Wed Jan 01 01:00:00 2025 PST
- Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 02:30:00 2025 PST
  Wed Jan 01 00:00:00 2025 PST
  Wed Jan 01 01:30:00 2025 PST
  Wed Jan 01 02:00:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
  Wed Jan 01 02:30:00 2025 PST
 
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
@@ -204,17 +302,17 @@ SELECT device, max(time) FROM metrics GROUP BY device,value;
  device |             max              
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
- d1     | Wed Jan 01 00:30:00 2025 PST
  d1     | Wed Jan 01 02:00:00 2025 PST
- d1     | Wed Jan 01 02:30:00 2025 PST
  d1     | Wed Jan 01 01:30:00 2025 PST
- d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 02:00:00 2025 PST
- d2     | Wed Jan 01 02:30:00 2025 PST
+ d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 01:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 01:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
  d1     | Wed Jan 01 01:00:00 2025 PST
+ d1     | Wed Jan 01 00:30:00 2025 PST
 
 -- no group by prevents optimization
 :PREFIX SELECT max(time) FROM metrics;
@@ -233,13 +331,89 @@ SELECT max(time) FROM metrics;
 ------------------------------
  Wed Jan 01 02:30:00 2025 PST
 
--- multiple min/max prevent optimization
+-- multiple aggregates on same column use optimization
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- GroupAggregate
+ HashAggregate
    Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+ device |             min              |             max              
+--------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+ device |             min              |            first             |             last             |             max              
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+            first             |             last             | device 
+------------------------------+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d1
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d2
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+ device |             min              | max 
+--------+------------------------------+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST |  31
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+ device | min | max 
+--------+-----+-----
+ d1     |   4 |  29
+ d2     |   6 |  31
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+ device |             min              |             max              | min | max 
+--------+------------------------------+------------------------------+-----+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   4 |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   6 |  31
 
 -- aggregate on segmentby can use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -260,6 +434,6 @@ SELECT max(time) FROM metrics;
 SELECT device, min(value2) FROM metrics GROUP BY device;
  device | min 
 --------+-----
- d1     |   5
- d2     |   5
+ d1     | 4.1
+ d2     | 6.1
 

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -11,18 +11,18 @@ CREATE TABLE metrics(
 ) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -31,6 +31,7 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 
 SET max_parallel_workers_per_gather = 0;
 SET timescaledb.enable_columnarindexscan = on;
+-- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
  HashAggregate
@@ -44,41 +45,50 @@ SELECT device, max(time) FROM metrics GROUP BY device;
  d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 02:30:00 2025 PST
 
-:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor |             min              
 --------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST
  B      | Wed Jan 01 00:30:00 2025 PST
  C      | Wed Jan 01 00:30:00 2025 PST
- A      | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, first(time, time) FROM metrics GROUP BY device;
+SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |            first             
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, last(time, time) FROM metrics GROUP BY device;
+SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |             last             
 --------+------------------------------
  d1     | Wed Jan 01 02:30:00 2025 PST
@@ -92,28 +102,114 @@ SELECT device, last(time, time) FROM metrics GROUP BY device;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor | min 
 --------+-----
- B      |   5
- C      |   5
  A      |  10
+ B      |   4
+ C      |   6
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min | max 
+--------+-----+-----
+ A      |  10 |  20
+ B      |   4 |  29
+ C      |   6 |  31
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              |             max              |            first             |             last             
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              | min 
+--------+------------------------------+-----
+ A      | Wed Jan 01 00:00:00 2025 PST |  10
+ B      | Wed Jan 01 00:30:00 2025 PST |   4
+ C      | Wed Jan 01 00:30:00 2025 PST |   6
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min |             min              | sensor 
+--------+-----+------------------------------+--------
+ A      |  10 | Wed Jan 01 00:00:00 2025 PST | A
+ B      |   4 | Wed Jan 01 00:30:00 2025 PST | B
+ C      |   6 | Wed Jan 01 00:30:00 2025 PST | C
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |            first             |             last             | first | last 
+--------+------------------------------+------------------------------+-------+------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST |    10 |   20
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     4 |   29
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     6 |   31
 
 -- test multiple group by columns
-:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
- HashAggregate
+ GroupAggregate
    Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
  device | sensor |             max              
 --------+--------+------------------------------
- d2     | A      | Wed Jan 01 02:00:00 2025 PST
  d1     | A      | Wed Jan 01 02:00:00 2025 PST
- d2     | C      | Wed Jan 01 02:30:00 2025 PST
  d1     | B      | Wed Jan 01 02:30:00 2025 PST
+ d2     | A      | Wed Jan 01 02:00:00 2025 PST
+ d2     | C      | Wed Jan 01 02:30:00 2025 PST
 
 -- order by does currently prevent optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
@@ -187,10 +283,12 @@ SELECT max(time) FROM metrics GROUP BY value;
              max              
 ------------------------------
  Wed Jan 01 01:00:00 2025 PST
- Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 02:30:00 2025 PST
  Wed Jan 01 00:00:00 2025 PST
  Wed Jan 01 01:30:00 2025 PST
  Wed Jan 01 02:00:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
  Wed Jan 01 02:30:00 2025 PST
 
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
@@ -204,17 +302,17 @@ SELECT device, max(time) FROM metrics GROUP BY device,value;
  device |             max              
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
- d1     | Wed Jan 01 00:30:00 2025 PST
  d1     | Wed Jan 01 02:00:00 2025 PST
- d1     | Wed Jan 01 02:30:00 2025 PST
  d1     | Wed Jan 01 01:30:00 2025 PST
- d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 02:00:00 2025 PST
- d2     | Wed Jan 01 02:30:00 2025 PST
+ d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 01:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 01:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
  d1     | Wed Jan 01 01:00:00 2025 PST
+ d1     | Wed Jan 01 00:30:00 2025 PST
 
 -- no group by prevents optimization
 :PREFIX SELECT max(time) FROM metrics;
@@ -232,13 +330,89 @@ SELECT max(time) FROM metrics;
 ------------------------------
  Wed Jan 01 02:30:00 2025 PST
 
--- multiple min/max prevent optimization
+-- multiple aggregates on same column use optimization
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- GroupAggregate
+ HashAggregate
    Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+ device |             min              |             max              
+--------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+ device |             min              |            first             |             last             |             max              
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+            first             |             last             | device 
+------------------------------+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d1
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d2
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+ device |             min              | max 
+--------+------------------------------+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST |  31
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+ device | min | max 
+--------+-----+-----
+ d1     |   4 |  29
+ d2     |   6 |  31
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+ device |             min              |             max              | min | max 
+--------+------------------------------+------------------------------+-----+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   4 |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   6 |  31
 
 -- aggregate on segmentby can use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -259,6 +433,6 @@ SELECT max(time) FROM metrics;
 SELECT device, min(value2) FROM metrics GROUP BY device;
  device | min 
 --------+-----
- d1     |   5
- d2     |   5
+ d1     | 4.1
+ d2     | 6.1
 

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -11,18 +11,18 @@ CREATE TABLE metrics(
 ) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -31,6 +31,7 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 
 SET max_parallel_workers_per_gather = 0;
 SET timescaledb.enable_columnarindexscan = on;
+-- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
  HashAggregate
@@ -44,41 +45,50 @@ SELECT device, max(time) FROM metrics GROUP BY device;
  d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 02:30:00 2025 PST
 
-:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor |             min              
 --------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST
  B      | Wed Jan 01 00:30:00 2025 PST
  C      | Wed Jan 01 00:30:00 2025 PST
- A      | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, first(time, time) FROM metrics GROUP BY device;
+SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |            first             
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
 
-:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: _hyper_1_1_chunk.device
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, last(time, time) FROM metrics GROUP BY device;
+SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
  device |             last             
 --------+------------------------------
  d1     | Wed Jan 01 02:30:00 2025 PST
@@ -92,28 +102,114 @@ SELECT device, last(time, time) FROM metrics GROUP BY device;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
  sensor | min 
 --------+-----
- B      |   5
- C      |   5
  A      |  10
+ B      |   4
+ C      |   6
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min | max 
+--------+-----+-----
+ A      |  10 |  20
+ B      |   4 |  29
+ C      |   6 |  31
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              |             max              |            first             |             last             
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |             min              | min 
+--------+------------------------------+-----
+ A      | Wed Jan 01 00:00:00 2025 PST |  10
+ B      | Wed Jan 01 00:30:00 2025 PST |   4
+ C      | Wed Jan 01 00:30:00 2025 PST |   6
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor | min |             min              | sensor 
+--------+-----+------------------------------+--------
+ A      |  10 | Wed Jan 01 00:00:00 2025 PST | A
+ B      |   4 | Wed Jan 01 00:30:00 2025 PST | B
+ C      |   6 | Wed Jan 01 00:30:00 2025 PST | C
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+ sensor |            first             |             last             | first | last 
+--------+------------------------------+------------------------------+-------+------
+ A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:00:00 2025 PST |    10 |   20
+ B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     4 |   29
+ C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |     6 |   31
 
 -- test multiple group by columns
-:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
- HashAggregate
+ GroupAggregate
    Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
 
-SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
  device | sensor |             max              
 --------+--------+------------------------------
- d2     | A      | Wed Jan 01 02:00:00 2025 PST
  d1     | A      | Wed Jan 01 02:00:00 2025 PST
- d2     | C      | Wed Jan 01 02:30:00 2025 PST
  d1     | B      | Wed Jan 01 02:30:00 2025 PST
+ d2     | A      | Wed Jan 01 02:00:00 2025 PST
+ d2     | C      | Wed Jan 01 02:30:00 2025 PST
 
 -- order by does currently prevent optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
@@ -187,10 +283,12 @@ SELECT max(time) FROM metrics GROUP BY value;
              max              
 ------------------------------
  Wed Jan 01 01:00:00 2025 PST
- Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 02:30:00 2025 PST
  Wed Jan 01 00:00:00 2025 PST
  Wed Jan 01 01:30:00 2025 PST
  Wed Jan 01 02:00:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
+ Wed Jan 01 00:30:00 2025 PST
  Wed Jan 01 02:30:00 2025 PST
 
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
@@ -204,17 +302,17 @@ SELECT device, max(time) FROM metrics GROUP BY device,value;
  device |             max              
 --------+------------------------------
  d1     | Wed Jan 01 00:00:00 2025 PST
- d1     | Wed Jan 01 00:30:00 2025 PST
  d1     | Wed Jan 01 02:00:00 2025 PST
- d1     | Wed Jan 01 02:30:00 2025 PST
  d1     | Wed Jan 01 01:30:00 2025 PST
- d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 02:00:00 2025 PST
- d2     | Wed Jan 01 02:30:00 2025 PST
+ d1     | Wed Jan 01 02:30:00 2025 PST
  d2     | Wed Jan 01 01:30:00 2025 PST
+ d2     | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:30:00 2025 PST
  d2     | Wed Jan 01 01:00:00 2025 PST
  d2     | Wed Jan 01 00:00:00 2025 PST
  d1     | Wed Jan 01 01:00:00 2025 PST
+ d1     | Wed Jan 01 00:30:00 2025 PST
 
 -- no group by prevents optimization
 :PREFIX SELECT max(time) FROM metrics;
@@ -232,13 +330,89 @@ SELECT max(time) FROM metrics;
 ------------------------------
  Wed Jan 01 02:30:00 2025 PST
 
--- multiple min/max prevent optimization
+-- multiple aggregates on same column use optimization
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- GroupAggregate
+ HashAggregate
    Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+ device |             min              |             max              
+--------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+ device |             min              |            first             |             last             |             max              
+--------+------------------------------+------------------------------+------------------------------+------------------------------
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+            first             |             last             | device 
+------------------------------+------------------------------+--------
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d1
+ Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST | d2
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+ device |             min              | max 
+--------+------------------------------+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST |  31
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+ device | min | max 
+--------+-----+-----
+ d1     |   4 |  29
+ d2     |   6 |  31
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+ device |             min              |             max              | min | max 
+--------+------------------------------+------------------------------+-----+-----
+ d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   4 |  29
+ d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST |   6 |  31
 
 -- aggregate on segmentby can use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -259,6 +433,6 @@ SELECT max(time) FROM metrics;
 SELECT device, min(value2) FROM metrics GROUP BY device;
  device | min 
 --------+-----
- d1     |   5
- d2     |   5
+ d1     | 4.1
+ d2     | 6.1
 

--- a/tsl/test/sql/columnar_index_scan.sql.in
+++ b/tsl/test/sql/columnar_index_scan.sql.in
@@ -13,18 +13,18 @@ CREATE TABLE metrics(
 ) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
 
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
 
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
@@ -32,25 +32,48 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 SET max_parallel_workers_per_gather = 0;
 SET timescaledb.enable_columnarindexscan = on;
 
+-- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 SELECT device, max(time) FROM metrics GROUP BY device;
 
-:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor;
-SELECT sensor, min(time) FROM metrics GROUP BY sensor;
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 
-:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device;
-SELECT device, first(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 
-:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device;
-SELECT device, last(time, time) FROM metrics GROUP BY device;
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor;
-SELECT sensor, min(value) FROM metrics GROUP BY sensor;
+SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 
 -- test multiple group by columns
-:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
-SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor;
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 
 -- order by does currently prevent optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
@@ -77,8 +100,29 @@ SELECT device, max(time) FROM metrics GROUP BY device,value;
 :PREFIX SELECT max(time) FROM metrics;
 SELECT max(time) FROM metrics;
 
--- multiple min/max prevent optimization
+-- multiple aggregates on same column use optimization
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
 
 -- aggregate on segmentby can use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;


### PR DESCRIPTION
Previously ColumnarIndexScan was limited to a single aggregate per
query.

This change enables queries like:
  SELECT device, min(time), max(time) FROM metrics GROUP BY device
to use the ColumnarIndexScan optimization.
