### PR TITLE
Fix compress_chunk to respect recompress flag

### DIFF
--- a/.unreleased/pr_9109
+++ b/.unreleased/pr_9109
@@ -1,0 +1,1 @@
+Fixes: #9109 Fix compress_chunk to respect recompress flag

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -709,7 +709,7 @@ recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
 		recompressed = true;
 	}
 	/* TODO: optimize cases where settings differ but recompression is still possible */
-	else if (ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings))
+	else if (recompress && ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings))
 	{
 		if (!ts_guc_enable_in_memory_recompression)
 		{
@@ -830,7 +830,7 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 	{
 		uncompressed_chunk_id = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
 	}
-	else if (recompress || ts_chunk_needs_recompression(chunk))
+	else if (recompress || ts_chunk_is_partial(chunk))
 	{
 		/* Try in-memory recompression first and then fall back to decompress/recompress */
 		bool recompressed = recompress_chunk_impl(chunk, &uncompressed_chunk_id, recompress);

--- a/tsl/test/expected/recompression_integrity_unordered.out
+++ b/tsl/test/expected/recompression_integrity_unordered.out
@@ -497,6 +497,42 @@ SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
  _timescaledb_internal._hyper_7_10_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {device}  | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 DROP TABLE IF EXISTS recomp_truly_unordered CASCADE;
+-- Test Case 5: Should not recompress, unless recompress flag is set to true
+DROP TABLE IF EXISTS recomp_without_flag CASCADE;
+NOTICE:  table "recomp_without_flag" does not exist, skipping
+CREATE TABLE recomp_without_flag (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.segmentby='device', tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO recomp_without_flag SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(50,200) i;
+INSERT INTO recomp_without_flag SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_without_flag') chunk;
+                  chunk                  |   chunk_status_text    
+-----------------------------------------+------------------------
+ _timescaledb_internal._hyper_9_13_chunk | {COMPRESSED,UNORDERED}
+
+SELECT compress_chunk(ch) FROM show_chunks('recomp_without_flag') ch; -- should be a no-op
+NOTICE:  chunk "_hyper_9_13_chunk" is already converted to columnstore
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_13_chunk
+
+-- status should be compressed, unordered
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_without_flag') chunk;
+                  chunk                  |   chunk_status_text    
+-----------------------------------------+------------------------
+ _timescaledb_internal._hyper_9_13_chunk | {COMPRESSED,UNORDERED}
+
+SELECT compress_chunk(ch, recompress => true) FROM show_chunks('recomp_without_flag') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_13_chunk
+
+-- status should be compressed
+SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('recomp_without_flag') chunk;
+                  chunk                  | chunk_status_text 
+-----------------------------------------+-------------------
+ _timescaledb_internal._hyper_9_13_chunk | {COMPRESSED}
+
+DROP TABLE IF EXISTS recomp_without_flag CASCADE;
 RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.enable_direct_compress_insert_sort_batches;
 RESET timescaledb.enable_direct_compress_insert_client_sorted;


### PR DESCRIPTION
compress_chunk() was incorrectly recompressing UNORDERED chunks even when the recompress flag was not set. This prevents unordered chunks from being implicitly recompressed in-memory, which is undesirable since in-memory recompression takes heavy locks.