### PR TITLE
Allow recompression with orderby/index changes

### DIFF
--- a/.unreleased/pr_9111
+++ b/.unreleased/pr_9111
@@ -1,0 +1,1 @@
+Implements: #9111 Allow recompression with orderby/index changes

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -665,7 +665,6 @@ static bool
 recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
 {
 	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
-	CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
 	bool recompressed = false;
 
 	if (!chunk_settings || !chunk_settings->fd.orderby)
@@ -708,8 +707,7 @@ recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
 		*uncompressed_chunk_id = recompress_chunk_segmentwise_impl(chunk);
 		recompressed = true;
 	}
-	/* TODO: optimize cases where settings differ but recompression is still possible */
-	else if (ts_compression_settings_equal_with_defaults(ht_settings, chunk_settings))
+	else
 	{
 		if (!ts_guc_enable_in_memory_recompression)
 		{

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -795,8 +795,7 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 									  check_new_settings,
 									  ts_alter_table_with_clause_parse(NIL));
 
-	/* TODO: evaluate which settings would affect this and only check inquality for those */
-	if (!ts_compression_settings_equal(check_new_settings, settings))
+	if (!ts_array_equal(settings->fd.segmentby, check_new_settings->fd.segmentby))
 	{
 		table_close(uncompressed_chunk_rel, lockmode);
 		table_close(compressed_chunk_rel, lockmode);
@@ -832,7 +831,7 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	CompressionSettings *new_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
 	Relation new_compressed_chunk_rel = table_open(new_compressed_chunk->table_id, lockmode);
 
-	Ensure(ts_compression_settings_equal(new_settings, settings),
+	Ensure(ts_compression_settings_equal(new_settings, check_new_settings),
 		   "compression settings mismatch during recompression of \"%s.%s\"",
 		   NameStr(uncompressed_chunk->fd.schema_name),
 		   NameStr(uncompressed_chunk->fd.table_name));

--- a/tsl/test/expected/recompression_integrity_unordered.out
+++ b/tsl/test/expected/recompression_integrity_unordered.out
@@ -497,6 +497,269 @@ SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
  _timescaledb_internal._hyper_7_10_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {device}  | {time}  | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 DROP TABLE IF EXISTS recomp_truly_unordered CASCADE;
+-- Test Case 5: Different compression settings
+CREATE TABLE recomp_comp_settings (time TIMESTAMPTZ NOT NULL, time2 TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.segmentby='device', tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO recomp_comp_settings SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, '2025-02-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(50,500) i;
+INSERT INTO recomp_comp_settings SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, '2025-02-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,500) i;
+INSERT INTO recomp_comp_settings SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, '2025-02-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,700) i;
+INSERT INTO recomp_comp_settings SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, '2025-02-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,700) i;
+-- change orderby setting
+ALTER TABLE recomp_comp_settings SET (tsdb.orderby='time2', tsdb.segmentby='device');
+\set TEST_TABLE_NAME 'recomp_comp_settings'
+\set ORDER_BY_CLAUSE ' ORDER BY device, time, time2'
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+            451 | Wed Jan 01 00:50:00 2025 PST | Wed Jan 01 08:20:00 2025 PST
+            501 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 08:20:00 2025 PST
+            701 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+            701 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_13_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+           1000 | Sat Feb 01 00:00:00 2025 PST | Sat Feb 01 05:49:00 2025 PST
+            653 | Sat Feb 01 05:50:00 2025 PST | Sat Feb 01 11:40:00 2025 PST
+            701 | Sat Feb 01 00:00:00 2025 PST | Sat Feb 01 11:40:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                     recompression_status                     
+--------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=14, new_chunk_id=15
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                  relid                  |                  compress_relid                  | segmentby |   orderby    | orderby_desc | orderby_nullsfirst |                                                          index                                                          
+-----------------------------------------+--------------------------------------------------+-----------+--------------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------
+ recomp_comp_settings                    |                                                  | {device}  | {time2,time} | {f,t}        | {f,t}              | 
+ _timescaledb_internal._hyper_9_13_chunk | _timescaledb_internal.compress_hyper_10_15_chunk | {device}  | {time2,time} | {f,t}        | {f,t}              | [{"type": "minmax", "column": "time2", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+
+-- change sparse index setting
+ALTER TABLE recomp_comp_settings SET (tsdb.orderby='time', tsdb.index='bloom("time2")');
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+           1000 | Sat Feb 01 00:00:00 2025 PST | Sat Feb 01 05:49:00 2025 PST
+            653 | Sat Feb 01 05:50:00 2025 PST | Sat Feb 01 11:40:00 2025 PST
+            701 | Sat Feb 01 00:00:00 2025 PST | Sat Feb 01 11:40:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_13_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+           1000 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 05:49:00 2025 PST
+            653 | Wed Jan 01 05:50:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+            701 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                     recompression_status                     
+--------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=15, new_chunk_id=16
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                  relid                  |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+-----------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ recomp_comp_settings                    |                                                  | {device}  | {time}  | {f}          | {f}                | [{"type": "bloom", "column": "time2", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_13_chunk | _timescaledb_internal.compress_hyper_10_16_chunk | {device}  | {time}  | {f}          | {f}                | [{"type": "bloom", "column": "time2", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+
+-- change segmentby setting, will fallback to decompress/compress
+ALTER TABLE recomp_comp_settings SET (tsdb.segmentby='');
+\ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESS",
+       format('%s/results/%s_results_recompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_RECOMPRESS"
+\gset
+SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed result" %s %s', :'TEST_RESULTS_COMPRESS', :'TEST_RESULTS_RECOMPRESS') as "DIFF_CMD"
+\gset
+-- Store initial compressed chunk info before recompression
+SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
+        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "OLD_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.hypertable_id = (
+          SELECT id
+          FROM _timescaledb_catalog.hypertable
+          WHERE table_name = :'TEST_TABLE_NAME'
+      )
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :OLD_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+           1000 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 05:49:00 2025 PST
+            653 | Wed Jan 01 05:50:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+            701 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+
+\set QUERY1 'SELECT COUNT(*) FROM ' :OLD_CHUNK_NAME ';'
+\set QUERY2 'SELECT * FROM ' :OLD_CHUNK_NAME :ORDER_BY_CLAUSE ';'
+\o :TEST_RESULTS_COMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Recompress the chunk in-memory
+SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_13_chunk
+
+-- Get info for the new compressed chunk
+SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
+        compressed.id AS "NEW_CHUNK_ID"
+FROM _timescaledb_catalog.chunk uncompressed
+JOIN _timescaledb_catalog.chunk compressed
+  ON uncompressed.compressed_chunk_id = compressed.id
+WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
+LIMIT 1 \gset
+\set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
+:BATCH_METADATA_QUERY
+ _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
+----------------+------------------------------+------------------------------
+           1000 | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 04:22:00 2025 PST
+           1000 | Wed Jan 01 04:22:00 2025 PST | Wed Jan 01 08:43:00 2025 PST
+            354 | Wed Jan 01 08:44:00 2025 PST | Wed Jan 01 11:40:00 2025 PST
+
+-- Get data after in-memory recompression
+\o :TEST_RESULTS_RECOMPRESS
+:QUERY1
+:QUERY2
+\o
+-- Check if a new chunk was created (this will show in the output)
+SELECT
+  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+    'ERROR: Recompression did not create a new chunk'
+  ELSE
+    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+  END AS recompression_status;
+                     recompression_status                     
+--------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk_id=16, new_chunk_id=17
+
+-- Compare result using diff to validate integrity of recompressed data
+:DIFF_CMD
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                  relid                  |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+-----------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ recomp_comp_settings                    |                                                  | {}        | {time}  | {f}          | {f}                | [{"type": "bloom", "column": "time2", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_13_chunk | _timescaledb_internal.compress_hyper_10_17_chunk | {}        | {time}  | {f}          | {f}                | [{"type": "bloom", "column": "time2", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+
+DROP TABLE IF EXISTS recomp_comp_settings CASCADE;
 RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.enable_direct_compress_insert_sort_batches;
 RESET timescaledb.enable_direct_compress_insert_client_sorted;


### PR DESCRIPTION
Removes overly strict compression settings equality checks that prevented in-memory recompression when only orderby or sparse index settings changed. Now only segmentby changes trigger fallback to decompress/compress path.