### PR TITLE
Use enable_columnarscan to control columnarscan

### DIFF
--- a/.unreleased/pr_9113
+++ b/.unreleased/pr_9113
@@ -1,0 +1,1 @@
+Implements: #9113 Use enable_columnarscan to control columnarscan

--- a/src/guc.c
+++ b/src/guc.c
@@ -96,7 +96,6 @@ TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering = true;
 TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml = 100000;
-TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_compression_wal_markers = false;
 TSDLLEXPORT bool ts_guc_enable_decompression_sorted_merge = true;
 bool ts_guc_enable_chunkwise_aggregation = true;
@@ -695,17 +694,6 @@ _guc_init(void)
 							NULL,
 							NULL);
 
-	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_transparent_decompression"),
-							 "Enable transparent decompression",
-							 "Enable transparent decompression when querying hypertable",
-							 &ts_guc_enable_transparent_decompression,
-							 true,
-							 PGC_USERSET,
-							 0,
-							 NULL,
-							 NULL,
-							 NULL);
-
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_skipscan"),
 							 "Enable SkipScan",
 							 "Enable SkipScan for DISTINCT queries",
@@ -1097,12 +1085,10 @@ _guc_init(void)
 							 NULL);
 
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_columnarscan"),
-							 "Enable columnar-optimized scans for supported access methods",
-							 "A columnar scan replaces sequence scans for columnar-oriented "
-							 "storage "
-							 "and enables storage-specific optimizations like vectorized filters. "
-							 "Disabling columnar scan will make PostgreSQL fall back to regular "
-							 "sequence scans.",
+							 "Enable ColumnarScan for columnar storage",
+							 "Transparently decompress columnar data using ColumnarScan custom "
+							 "node. Disabling columnar scan will ignore data stored in columnar "
+							 "format in queries.",
 							 &ts_guc_enable_columnarscan,
 							 true,
 							 PGC_USERSET,

--- a/src/guc.h
+++ b/src/guc.h
@@ -48,7 +48,6 @@ extern TSDLLEXPORT bool ts_guc_enable_direct_compress_on_cagg_refresh;
 extern int ts_guc_direct_compress_insert_tuple_sort_limit;
 extern TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete;
 extern TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml;
-extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_compression_wal_markers;
 extern TSDLLEXPORT bool ts_guc_enable_decompression_sorted_merge;
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan;

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1475,14 +1475,14 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 			 * based on the Chunk struct cached by our hypertable expansion, but
 			 * in cases when these functions don't run, we have to do it here.
 			 */
-			const bool use_transparent_decompression =
-				ts_guc_enable_transparent_decompression && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht);
+			const bool use_columnar_scan =
+				ts_guc_enable_columnarscan && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht);
 			const bool is_standalone_chunk = (type == TS_REL_CHUNK_STANDALONE) &&
 											 !TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht);
 			const bool is_child_chunk_in_update =
 				(type == TS_REL_CHUNK_CHILD) && IS_UPDL_CMD(query);
 
-			if (use_transparent_decompression && (is_standalone_chunk || is_child_chunk_in_update))
+			if (use_columnar_scan && (is_standalone_chunk || is_child_chunk_in_update))
 			{
 				const Chunk *chunk = ts_planner_chunk_fetch(root, rel);
 

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -97,7 +97,7 @@ tsl_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptIn
 static inline bool
 use_columnar_scan(const RelOptInfo *rel, const RangeTblEntry *rte, const Chunk *chunk)
 {
-	if (!ts_guc_enable_transparent_decompression)
+	if (!ts_guc_enable_columnarscan)
 		return false;
 
 	/* Check that the chunk is actually compressed */

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-SET timescaledb.enable_transparent_decompression to OFF;
+SET timescaledb.enable_columnarscan to OFF;
 SET timezone TO 'America/Los_Angeles';
 \set PREFIX 'EXPLAIN (analyze, verbose, buffers off, costs off, timing off, summary off)'
 \ir include/rand_generator.sql
@@ -52,10 +52,10 @@ SELECT count(*) from foo;
 
 alter table foo set (timescaledb.compress, timescaledb.compress_segmentby = 'a,b', timescaledb.compress_orderby = 'c desc, d asc nulls last');
 --test self-refencing updates
-SET timescaledb.enable_transparent_decompression to ON;
+SET timescaledb.enable_columnarscan to ON;
 update foo set c = 40
 where  a = (SELECT max(a) FROM foo);
-SET timescaledb.enable_transparent_decompression to OFF;
+SET timescaledb.enable_columnarscan to OFF;
 SELECT id, schema_name, table_name, compression_state as compressed, compressed_hypertable_id FROM _timescaledb_catalog.hypertable ORDER BY id;
  id |      schema_name      |        table_name        | compressed | compressed_hypertable_id 
 ----+-----------------------+--------------------------+------------+--------------------------
@@ -488,7 +488,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
  t
 
 -- test plans get invalidated when chunks get compressed
-SET timescaledb.enable_transparent_decompression TO ON;
+SET timescaledb.enable_columnarscan TO ON;
 CREATE TABLE plan_inval(time timestamptz, device_id int);
 SELECT create_hypertable('plan_inval','time');
     create_hypertable    

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -3442,7 +3442,7 @@ select * from int_table where b is null and b is not null order by 1;
 ----+---
 
 -- check the compression algorithm for the compressed chunks
-set timescaledb.enable_transparent_decompression='off';
+set timescaledb.enable_columnarscan='off';
 DO $$
 DECLARE
 	comp_regclass REGCLASS;
@@ -3479,6 +3479,6 @@ NOTICE:  Compressed info results: (Bg==,"(NULL,t)")
 NOTICE:  Has nulls results: (Bg==,t)
 NOTICE:  Compressed info results: (Bg==,"(NULL,t)")
 NOTICE:  Has nulls results: (Bg==,t)
-reset timescaledb.enable_transparent_decompression;
+reset timescaledb.enable_columnarscan;
 reset timescaledb.debug_require_vector_qual;
 reset timescaledb.enable_bool_compression;

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -390,7 +390,6 @@ select sum(temp) from mergeme;
   15
 
 -- Test that indexes work after merge
-set timescaledb.enable_columnarscan = false;
 set enable_seqscan = false;
 analyze mergeme;
 explain (buffers off, costs off)
@@ -420,7 +419,6 @@ select * from _timescaledb_internal._hyper_1_1_chunk where device = 1;
 ------------------------------+--------+------
  Mon Jan 01 00:00:00 2024 PST |      1 |    1
 
-reset timescaledb.enable_columnarscan;
 reset enable_seqscan;
 rollback;
 ---

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-SET timescaledb.enable_transparent_decompression to OFF;
+SET timescaledb.enable_columnarscan to OFF;
 SET timezone TO 'America/Los_Angeles';
 
 \set PREFIX 'EXPLAIN (analyze, verbose, buffers off, costs off, timing off, summary off)'
@@ -28,10 +28,10 @@ SELECT count(*) from foo;
 alter table foo set (timescaledb.compress, timescaledb.compress_segmentby = 'a,b', timescaledb.compress_orderby = 'c desc, d asc nulls last');
 
 --test self-refencing updates
-SET timescaledb.enable_transparent_decompression to ON;
+SET timescaledb.enable_columnarscan to ON;
 update foo set c = 40
 where  a = (SELECT max(a) FROM foo);
-SET timescaledb.enable_transparent_decompression to OFF;
+SET timescaledb.enable_columnarscan to OFF;
 
 SELECT id, schema_name, table_name, compression_state as compressed, compressed_hypertable_id FROM _timescaledb_catalog.hypertable ORDER BY id;
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::regclass;
@@ -211,7 +211,7 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 
 -- test plans get invalidated when chunks get compressed
 
-SET timescaledb.enable_transparent_decompression TO ON;
+SET timescaledb.enable_columnarscan TO ON;
 CREATE TABLE plan_inval(time timestamptz, device_id int);
 SELECT create_hypertable('plan_inval','time');
 ALTER TABLE plan_inval SET (timescaledb.compress,timescaledb.compress_orderby='time desc');

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -835,7 +835,7 @@ select * from int_table where b is null or b is not null order by 1;
 select * from int_table where b is null and b is not null order by 1;
 
 -- check the compression algorithm for the compressed chunks
-set timescaledb.enable_transparent_decompression='off';
+set timescaledb.enable_columnarscan='off';
 DO $$
 DECLARE
 	comp_regclass REGCLASS;
@@ -869,7 +869,7 @@ BEGIN
 END;
 $$;
 
-reset timescaledb.enable_transparent_decompression;
+reset timescaledb.enable_columnarscan;
 reset timescaledb.debug_require_vector_qual;
 reset timescaledb.enable_bool_compression;
 

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -206,14 +206,12 @@ select count(*) as num_orphaned_slices from orphaned_slices;
 select sum(temp) from mergeme;
 
 -- Test that indexes work after merge
-set timescaledb.enable_columnarscan = false;
 set enable_seqscan = false;
 analyze mergeme;
 explain (buffers off, costs off)
 select * from mergeme where device = 1;
 select * from mergeme where device = 1;
 select * from _timescaledb_internal._hyper_1_1_chunk where device = 1;
-reset timescaledb.enable_columnarscan;
 reset enable_seqscan;
 rollback;
 


### PR DESCRIPTION
The GUC enable_columnarscan was doing nothing as it was initially
introduced to control TAM behaviour. This commit changes the GUC
to control ColumnarScan behaviour and take over the functionality
of enable_transparent_decompression.
