### PR TITLE
fix missing deleted records on PG16 and earlier

### DIFF
--- a/.unreleased/pr_9120
+++ b/.unreleased/pr_9120
@@ -1,0 +1,1 @@
+Fixes: #9120 Fix for pre PG17, where a DELETE from a partially compressed chunk may miss records if BitmapHeapScan is being used.

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -10,6 +10,7 @@
 #include <foreign/fdwapi.h>
 #include <nodes/nodeFuncs.h>
 #include <nodes/parsenodes.h>
+#include <optimizer/pathnode.h>
 #include <optimizer/paths.h>
 #include <parser/parsetree.h>
 
@@ -150,6 +151,97 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("The MERGE command with UPDATE/DELETE merge actions is not support on "
 							"compressed hypertables")));
+
+#if !PG17_GE
+		/*
+		 * PG16 and earlier: Remove BitmapHeapScan paths for DML on partial chunks.
+		 *
+		 * On PG16, BitmapHeapScan eagerly initializes its heap scan descriptor
+		 * with the original snapshot during plan initialization. When we
+		 * decompress rows and call CommandCounterIncrement(), the stale
+		 * snapshot cannot see the newly decompressed rows.
+		 *
+		 * This bug only affects partial chunks because:
+		 * - Fully compressed chunks have rel->indexlist = NIL (set in
+		 *   timescaledb_get_relation_info_hook), so BitmapHeapScan is not
+		 *   available anyway.
+		 * - Partial chunks have indexes available, so BitmapHeapScan can be
+		 *   chosen, and decompression will add rows that it cannot see.
+		 *
+		 * PG17+ fixed this via commit 1577081e961 which lazily initializes
+		 * the scan descriptor in BitmapHeapNext(), using the current
+		 * estate->es_snapshot after CommandCounterIncrement().
+		 *
+		 * IMPORTANT: PostgreSQL's add_path() prunes dominated paths. If
+		 * BitmapHeapPath has lower cost than SeqScan (common with adjusted
+		 * cost parameters), SeqScan may have been pruned from the pathlist.
+		 * If removing BitmapHeapPath would leave no paths, we must add a
+		 * another path as fallback to ensure a valid plan exists.
+		 */
+		const Chunk *chunk = ts_planner_chunk_fetch(root, rel);
+		if (chunk && ts_chunk_is_partial(chunk))
+		{
+			ListCell *lc;
+			List *filtered_paths = NIL;
+
+			foreach (lc, rel->pathlist)
+			{
+				Path *path = lfirst(lc);
+				if (!IsA(path, BitmapHeapPath))
+					filtered_paths = lappend(filtered_paths, path);
+			}
+
+			/*
+			 * If removing BitmapHeapPath left us with no paths, try to add
+			 * alternative scan paths. This can happen when BitmapHeapPath
+			 * dominated and pruned other paths due to cost calculations.
+			 *
+			 * Prefer IndexScan if available, fall back to SeqScan.
+			 */
+			if (filtered_paths == NIL && rel->pathlist != NIL)
+			{
+				/*
+				 * Try to create index paths. create_index_paths() adds paths
+				 * to rel->pathlist, but it also creates BitmapHeapPath entries
+				 * which we must filter out again.
+				 */
+				rel->pathlist = NIL; /* Clear the BitmapHeapPath */
+				create_index_paths(root, rel);
+
+				/* Filter out any BitmapHeapPath that create_index_paths added */
+				foreach (lc, rel->pathlist)
+				{
+					Path *path = lfirst(lc);
+					if (!IsA(path, BitmapHeapPath))
+						filtered_paths = lappend(filtered_paths, path);
+				}
+
+				/*
+				 * If no non-bitmap index paths were created (e.g., enable_indexscan=off),
+				 * add SeqScan as the final fallback.
+				 */
+				if (filtered_paths == NIL)
+				{
+					Relids required_outer = rel->lateral_relids;
+					Path *seqpath = create_seqscan_path(root, rel, required_outer, 0);
+					filtered_paths = lappend(filtered_paths, seqpath);
+				}
+			}
+
+			rel->pathlist = filtered_paths;
+
+			/* Also filter partial_pathlist for parallel plans */
+			filtered_paths = NIL;
+			foreach (lc, rel->partial_pathlist)
+			{
+				Path *path = lfirst(lc);
+				if (!IsA(path, BitmapHeapPath))
+					filtered_paths = lappend(filtered_paths, path);
+			}
+			rel->partial_pathlist = filtered_paths;
+		}
+
+#endif /* !PG17_GE */
 	}
 }
 

--- a/tsl/test/expected/compression_delete_bitmapscan-15.out
+++ b/tsl/test/expected/compression_delete_bitmapscan-15.out
@@ -1,0 +1,214 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--
+-- Test DELETE with BitmapHeapScan on partial chunk
+--
+-- The goal of this test is to make sure the issue in SDC3656
+-- doesn't regress later. This issue was reported on PG15.15 and
+-- verified on later versions, where it still exists on PG16.9 and
+-- it doesn't happen on PG17.7 and PG18.1,
+--
+-- The problem was that bitmap scan created the bitmap at an
+-- earlier time, then later the decompression added more
+-- tuples to the chunk table. For this reason the delete didn't
+-- see the new data and thus, it didn't remove them.
+--
+-- This problem doesn't exist in later versions, because the bitmap
+-- scan is lazily initialized at a time where the tuples were
+-- already decompressed.
+--
+-- There is a related test: compression_update_delete.sql.in that
+-- tests another related bug, where we tried to fix this problem
+-- by rescanning the records, but this together with a NestedLoopJoin
+-- crashed. This only happen on PG16 and earlier versions.
+--
+\set ON_ERROR_STOP 1
+CREATE TABLE test_bitmap_delete (
+    time_col BIGINT NOT NULL,
+    device_id INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    value INTEGER,
+    PRIMARY KEY (time_col, device_id)
+);
+SELECT create_hypertable('test_bitmap_delete', 'time_col', chunk_time_interval => 1000000);
+        create_hypertable        
+---------------------------------
+ (1,public,test_bitmap_delete,t)
+
+-- Create index that would enable BitmapHeapScan
+CREATE INDEX idx_device_status ON test_bitmap_delete (device_id, status);
+ALTER TABLE test_bitmap_delete SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time_col DESC'
+);
+-- Insert rows to be deleted (will be compressed)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i, 1, 'delete_me', i FROM generate_series(1, 100) i;
+-- Insert rows to keep (same segment)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 500, 1, 'keep', i FROM generate_series(1, 100) i;
+-- Insert more data so BitmapHeapScan is naturally preferred
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 2000, (i % 100) + 1,
+       CASE WHEN i % 100 = 0 THEN 'delete_me' ELSE 'keep' END,
+       i
+FROM generate_series(1, 100000) i;
+-- Compress the chunk
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- Make chunk partial by inserting uncompressed data
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 1000, 1, 'keep', i FROM generate_series(1, 50) i;
+ANALYZE test_bitmap_delete;
+-- Test: DELETE should work when bitmap and index scans are allowed
+BEGIN;
+-- Disable SeqScan to test BitmapHeapScan path and also make
+-- the bitmap scan more favorable. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+SET LOCAL random_page_cost = 0.5;  -- (default 4.0)
+SET LOCAL cpu_index_tuple_cost = 0.1; -- (default 0.005)
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: DELETE should work when bitmap scan is strongly preferred
+BEGIN;
+-- Disable IndexScan to test BitmapHeapScan path. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_seqscan = on;
+-- Make sequential scan more expensive (default is 1.0)
+SET seq_page_cost = 10.0;
+-- Make random page cost lower to favor bitmap heap scan (default is 4.0)
+SET random_page_cost = 1.0;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Seq Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Filter: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: the fully compressed table did not trigger the problem
+--   but I put this case here for completeness and to make sure
+--   we exercise the new code paths in both cases
+BEGIN;
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Seq Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Filter: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: similarly to the above, the fully decompressed test
+--  is only here for completeness
+BEGIN;
+SELECT decompress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+DROP TABLE test_bitmap_delete;

--- a/tsl/test/expected/compression_delete_bitmapscan-16.out
+++ b/tsl/test/expected/compression_delete_bitmapscan-16.out
@@ -1,0 +1,214 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--
+-- Test DELETE with BitmapHeapScan on partial chunk
+--
+-- The goal of this test is to make sure the issue in SDC3656
+-- doesn't regress later. This issue was reported on PG15.15 and
+-- verified on later versions, where it still exists on PG16.9 and
+-- it doesn't happen on PG17.7 and PG18.1,
+--
+-- The problem was that bitmap scan created the bitmap at an
+-- earlier time, then later the decompression added more
+-- tuples to the chunk table. For this reason the delete didn't
+-- see the new data and thus, it didn't remove them.
+--
+-- This problem doesn't exist in later versions, because the bitmap
+-- scan is lazily initialized at a time where the tuples were
+-- already decompressed.
+--
+-- There is a related test: compression_update_delete.sql.in that
+-- tests another related bug, where we tried to fix this problem
+-- by rescanning the records, but this together with a NestedLoopJoin
+-- crashed. This only happen on PG16 and earlier versions.
+--
+\set ON_ERROR_STOP 1
+CREATE TABLE test_bitmap_delete (
+    time_col BIGINT NOT NULL,
+    device_id INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    value INTEGER,
+    PRIMARY KEY (time_col, device_id)
+);
+SELECT create_hypertable('test_bitmap_delete', 'time_col', chunk_time_interval => 1000000);
+        create_hypertable        
+---------------------------------
+ (1,public,test_bitmap_delete,t)
+
+-- Create index that would enable BitmapHeapScan
+CREATE INDEX idx_device_status ON test_bitmap_delete (device_id, status);
+ALTER TABLE test_bitmap_delete SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time_col DESC'
+);
+-- Insert rows to be deleted (will be compressed)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i, 1, 'delete_me', i FROM generate_series(1, 100) i;
+-- Insert rows to keep (same segment)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 500, 1, 'keep', i FROM generate_series(1, 100) i;
+-- Insert more data so BitmapHeapScan is naturally preferred
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 2000, (i % 100) + 1,
+       CASE WHEN i % 100 = 0 THEN 'delete_me' ELSE 'keep' END,
+       i
+FROM generate_series(1, 100000) i;
+-- Compress the chunk
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- Make chunk partial by inserting uncompressed data
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 1000, 1, 'keep', i FROM generate_series(1, 50) i;
+ANALYZE test_bitmap_delete;
+-- Test: DELETE should work when bitmap and index scans are allowed
+BEGIN;
+-- Disable SeqScan to test BitmapHeapScan path and also make
+-- the bitmap scan more favorable. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+SET LOCAL random_page_cost = 0.5;  -- (default 4.0)
+SET LOCAL cpu_index_tuple_cost = 0.1; -- (default 0.005)
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: DELETE should work when bitmap scan is strongly preferred
+BEGIN;
+-- Disable IndexScan to test BitmapHeapScan path. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_seqscan = on;
+-- Make sequential scan more expensive (default is 1.0)
+SET seq_page_cost = 10.0;
+-- Make random page cost lower to favor bitmap heap scan (default is 4.0)
+SET random_page_cost = 1.0;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Seq Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Filter: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: the fully compressed table did not trigger the problem
+--   but I put this case here for completeness and to make sure
+--   we exercise the new code paths in both cases
+BEGIN;
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Seq Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Filter: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: similarly to the above, the fully decompressed test
+--  is only here for completeness
+BEGIN;
+SELECT decompress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+DROP TABLE test_bitmap_delete;

--- a/tsl/test/expected/compression_delete_bitmapscan-17.out
+++ b/tsl/test/expected/compression_delete_bitmapscan-17.out
@@ -1,0 +1,216 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--
+-- Test DELETE with BitmapHeapScan on partial chunk
+--
+-- The goal of this test is to make sure the issue in SDC3656
+-- doesn't regress later. This issue was reported on PG15.15 and
+-- verified on later versions, where it still exists on PG16.9 and
+-- it doesn't happen on PG17.7 and PG18.1,
+--
+-- The problem was that bitmap scan created the bitmap at an
+-- earlier time, then later the decompression added more
+-- tuples to the chunk table. For this reason the delete didn't
+-- see the new data and thus, it didn't remove them.
+--
+-- This problem doesn't exist in later versions, because the bitmap
+-- scan is lazily initialized at a time where the tuples were
+-- already decompressed.
+--
+-- There is a related test: compression_update_delete.sql.in that
+-- tests another related bug, where we tried to fix this problem
+-- by rescanning the records, but this together with a NestedLoopJoin
+-- crashed. This only happen on PG16 and earlier versions.
+--
+\set ON_ERROR_STOP 1
+CREATE TABLE test_bitmap_delete (
+    time_col BIGINT NOT NULL,
+    device_id INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    value INTEGER,
+    PRIMARY KEY (time_col, device_id)
+);
+SELECT create_hypertable('test_bitmap_delete', 'time_col', chunk_time_interval => 1000000);
+        create_hypertable        
+---------------------------------
+ (1,public,test_bitmap_delete,t)
+
+-- Create index that would enable BitmapHeapScan
+CREATE INDEX idx_device_status ON test_bitmap_delete (device_id, status);
+ALTER TABLE test_bitmap_delete SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time_col DESC'
+);
+-- Insert rows to be deleted (will be compressed)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i, 1, 'delete_me', i FROM generate_series(1, 100) i;
+-- Insert rows to keep (same segment)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 500, 1, 'keep', i FROM generate_series(1, 100) i;
+-- Insert more data so BitmapHeapScan is naturally preferred
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 2000, (i % 100) + 1,
+       CASE WHEN i % 100 = 0 THEN 'delete_me' ELSE 'keep' END,
+       i
+FROM generate_series(1, 100000) i;
+-- Compress the chunk
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- Make chunk partial by inserting uncompressed data
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 1000, 1, 'keep', i FROM generate_series(1, 50) i;
+ANALYZE test_bitmap_delete;
+-- Test: DELETE should work when bitmap and index scans are allowed
+BEGIN;
+-- Disable SeqScan to test BitmapHeapScan path and also make
+-- the bitmap scan more favorable. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+SET LOCAL random_page_cost = 0.5;  -- (default 4.0)
+SET LOCAL cpu_index_tuple_cost = 0.1; -- (default 0.005)
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: DELETE should work when bitmap scan is strongly preferred
+BEGIN;
+-- Disable IndexScan to test BitmapHeapScan path. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_seqscan = on;
+-- Make sequential scan more expensive (default is 1.0)
+SET seq_page_cost = 10.0;
+-- Make random page cost lower to favor bitmap heap scan (default is 4.0)
+SET random_page_cost = 1.0;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Bitmap Heap Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Recheck Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+               ->  Bitmap Index Scan on _hyper_1_1_chunk_idx_device_status
+                     Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: the fully compressed table did not trigger the problem
+--   but I put this case here for completeness and to make sure
+--   we exercise the new code paths in both cases
+BEGIN;
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Seq Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Filter: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: similarly to the above, the fully decompressed test
+--  is only here for completeness
+BEGIN;
+SELECT decompress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+DROP TABLE test_bitmap_delete;

--- a/tsl/test/expected/compression_delete_bitmapscan-18.out
+++ b/tsl/test/expected/compression_delete_bitmapscan-18.out
@@ -1,0 +1,216 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--
+-- Test DELETE with BitmapHeapScan on partial chunk
+--
+-- The goal of this test is to make sure the issue in SDC3656
+-- doesn't regress later. This issue was reported on PG15.15 and
+-- verified on later versions, where it still exists on PG16.9 and
+-- it doesn't happen on PG17.7 and PG18.1,
+--
+-- The problem was that bitmap scan created the bitmap at an
+-- earlier time, then later the decompression added more
+-- tuples to the chunk table. For this reason the delete didn't
+-- see the new data and thus, it didn't remove them.
+--
+-- This problem doesn't exist in later versions, because the bitmap
+-- scan is lazily initialized at a time where the tuples were
+-- already decompressed.
+--
+-- There is a related test: compression_update_delete.sql.in that
+-- tests another related bug, where we tried to fix this problem
+-- by rescanning the records, but this together with a NestedLoopJoin
+-- crashed. This only happen on PG16 and earlier versions.
+--
+\set ON_ERROR_STOP 1
+CREATE TABLE test_bitmap_delete (
+    time_col BIGINT NOT NULL,
+    device_id INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    value INTEGER,
+    PRIMARY KEY (time_col, device_id)
+);
+SELECT create_hypertable('test_bitmap_delete', 'time_col', chunk_time_interval => 1000000);
+        create_hypertable        
+---------------------------------
+ (1,public,test_bitmap_delete,t)
+
+-- Create index that would enable BitmapHeapScan
+CREATE INDEX idx_device_status ON test_bitmap_delete (device_id, status);
+ALTER TABLE test_bitmap_delete SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time_col DESC'
+);
+-- Insert rows to be deleted (will be compressed)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i, 1, 'delete_me', i FROM generate_series(1, 100) i;
+-- Insert rows to keep (same segment)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 500, 1, 'keep', i FROM generate_series(1, 100) i;
+-- Insert more data so BitmapHeapScan is naturally preferred
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 2000, (i % 100) + 1,
+       CASE WHEN i % 100 = 0 THEN 'delete_me' ELSE 'keep' END,
+       i
+FROM generate_series(1, 100000) i;
+-- Compress the chunk
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- Make chunk partial by inserting uncompressed data
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 1000, 1, 'keep', i FROM generate_series(1, 50) i;
+ANALYZE test_bitmap_delete;
+-- Test: DELETE should work when bitmap and index scans are allowed
+BEGIN;
+-- Disable SeqScan to test BitmapHeapScan path and also make
+-- the bitmap scan more favorable. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+SET LOCAL random_page_cost = 0.5;  -- (default 4.0)
+SET LOCAL cpu_index_tuple_cost = 0.1; -- (default 0.005)
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: DELETE should work when bitmap scan is strongly preferred
+BEGIN;
+-- Disable IndexScan to test BitmapHeapScan path. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_seqscan = on;
+-- Make sequential scan more expensive (default is 1.0)
+SET seq_page_cost = 10.0;
+-- Make random page cost lower to favor bitmap heap scan (default is 4.0)
+SET random_page_cost = 1.0;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Bitmap Heap Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Recheck Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+               ->  Bitmap Index Scan on _hyper_1_1_chunk_idx_device_status
+                     Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: the fully compressed table did not trigger the problem
+--   but I put this case here for completeness and to make sure
+--   we exercise the new code paths in both cases
+BEGIN;
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Seq Scan on _hyper_1_1_chunk test_bitmap_delete_1
+               Filter: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+-- Test: similarly to the above, the fully decompressed test
+--  is only here for completeness
+BEGIN;
+SELECT decompress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on test_bitmap_delete
+         Delete on _hyper_1_1_chunk test_bitmap_delete_1
+         ->  Index Scan using _hyper_1_1_chunk_idx_device_status on _hyper_1_1_chunk test_bitmap_delete_1
+               Index Cond: ((device_id = 1) AND (status = 'delete_me'::text))
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+ remaining_delete_me 
+---------------------
+                   0
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+ remaining_keep 
+----------------
+            150
+
+ROLLBACK;
+DROP TABLE test_bitmap_delete;

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -1708,10 +1708,8 @@ EXPLAIN (buffers off, costs off) DELETE FROM tab1 WHERE tab1.device_id = 1;
          Delete on _hyper_21_40_chunk tab1_2
          Delete on _hyper_21_41_chunk tab1_3
          ->  Append
-               ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
-                     Recheck Cond: (device_id = 1)
-                     ->  Bitmap Index Scan on _hyper_21_39_chunk_tab1_device_id_time_idx
-                           Index Cond: (device_id = 1)
+               ->  Seq Scan on _hyper_21_39_chunk tab1_1
+                     Filter: (device_id = 1)
                ->  Seq Scan on _hyper_21_40_chunk tab1_2
                      Filter: (device_id = 1)
                ->  Seq Scan on _hyper_21_41_chunk tab1_3
@@ -1734,6 +1732,7 @@ CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
 ANALYZE tab1;
 SET enable_seqscan = off;
 SET enable_indexscan = off;
+SET enable_hashjoin = off;
 EXPLAIN (buffers off, costs off) UPDATE tab1
 SET v0 = 0 FROM
 	(SELECT repeat, count(*)
@@ -1747,20 +1746,16 @@ WHERE repeat('t', device_id) = devices.repeat;
          Update on _hyper_21_40_chunk tab1_2
          Update on _hyper_21_41_chunk tab1_3
          ->  Nested Loop
+               Join Filter: (repeat('t'::text, tab1.device_id) = devices.repeat)
                ->  Subquery Scan on devices
                      ->  HashAggregate
                            Group Key: repeat
                            ->  Result
                                  One-Time Filter: false
                ->  Append
-                     ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
-                           Recheck Cond: (repeat('t'::text, device_id) = devices.repeat)
-                           ->  Bitmap Index Scan on _hyper_21_39_chunk_test
-                                 Index Cond: (repeat('t'::text, device_id) = devices.repeat)
+                     ->  Index Scan using _hyper_21_39_chunk_test on _hyper_21_39_chunk tab1_1
                      ->  Seq Scan on _hyper_21_40_chunk tab1_2
-                           Filter: (devices.repeat = repeat('t'::text, device_id))
                      ->  Seq Scan on _hyper_21_41_chunk tab1_3
-                           Filter: (devices.repeat = repeat('t'::text, device_id))
 
 UPDATE tab1
 SET v0 = 0 FROM

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -1708,10 +1708,8 @@ EXPLAIN (buffers off, costs off) DELETE FROM tab1 WHERE tab1.device_id = 1;
          Delete on _hyper_21_40_chunk tab1_2
          Delete on _hyper_21_41_chunk tab1_3
          ->  Append
-               ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
-                     Recheck Cond: (device_id = 1)
-                     ->  Bitmap Index Scan on _hyper_21_39_chunk_tab1_device_id_time_idx
-                           Index Cond: (device_id = 1)
+               ->  Seq Scan on _hyper_21_39_chunk tab1_1
+                     Filter: (device_id = 1)
                ->  Seq Scan on _hyper_21_40_chunk tab1_2
                      Filter: (device_id = 1)
                ->  Seq Scan on _hyper_21_41_chunk tab1_3
@@ -1734,6 +1732,7 @@ CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
 ANALYZE tab1;
 SET enable_seqscan = off;
 SET enable_indexscan = off;
+SET enable_hashjoin = off;
 EXPLAIN (buffers off, costs off) UPDATE tab1
 SET v0 = 0 FROM
 	(SELECT repeat, count(*)
@@ -1747,20 +1746,16 @@ WHERE repeat('t', device_id) = devices.repeat;
          Update on _hyper_21_40_chunk tab1_2
          Update on _hyper_21_41_chunk tab1_3
          ->  Nested Loop
+               Join Filter: (repeat('t'::text, tab1.device_id) = devices.repeat)
                ->  Subquery Scan on devices
                      ->  HashAggregate
                            Group Key: repeat
                            ->  Result
                                  One-Time Filter: false
                ->  Append
-                     ->  Bitmap Heap Scan on _hyper_21_39_chunk tab1_1
-                           Recheck Cond: (repeat('t'::text, device_id) = devices.repeat)
-                           ->  Bitmap Index Scan on _hyper_21_39_chunk_test
-                                 Index Cond: (repeat('t'::text, device_id) = devices.repeat)
+                     ->  Index Scan using _hyper_21_39_chunk_test on _hyper_21_39_chunk tab1_1
                      ->  Seq Scan on _hyper_21_40_chunk tab1_2
-                           Filter: (devices.repeat = repeat('t'::text, device_id))
                      ->  Seq Scan on _hyper_21_41_chunk tab1_3
-                           Filter: (devices.repeat = repeat('t'::text, device_id))
 
 UPDATE tab1
 SET v0 = 0 FROM

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -1734,6 +1734,7 @@ CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
 ANALYZE tab1;
 SET enable_seqscan = off;
 SET enable_indexscan = off;
+SET enable_hashjoin = off;
 EXPLAIN (buffers off, costs off) UPDATE tab1
 SET v0 = 0 FROM
 	(SELECT repeat, count(*)

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -1734,6 +1734,7 @@ CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
 ANALYZE tab1;
 SET enable_seqscan = off;
 SET enable_indexscan = off;
+SET enable_hashjoin = off;
 EXPLAIN (buffers off, costs off) UPDATE tab1
 SET v0 = 0 FROM
 	(SELECT repeat, count(*)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -179,6 +179,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     cagg_usage.sql.in
     cagg.sql.in
     compression_update_delete.sql.in
+    compression_delete_bitmapscan.sql.in
     transparent_decompression_queries.sql.in)
 
   if(USE_TELEMETRY)

--- a/tsl/test/sql/compression_delete_bitmapscan.sql.in
+++ b/tsl/test/sql/compression_delete_bitmapscan.sql.in
@@ -1,0 +1,186 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+--
+-- Test DELETE with BitmapHeapScan on partial chunk
+--
+-- The goal of this test is to make sure the issue in SDC3656
+-- doesn't regress later. This issue was reported on PG15.15 and
+-- verified on later versions, where it still exists on PG16.9 and
+-- it doesn't happen on PG17.7 and PG18.1,
+--
+-- The problem was that bitmap scan created the bitmap at an
+-- earlier time, then later the decompression added more
+-- tuples to the chunk table. For this reason the delete didn't
+-- see the new data and thus, it didn't remove them.
+--
+-- This problem doesn't exist in later versions, because the bitmap
+-- scan is lazily initialized at a time where the tuples were
+-- already decompressed.
+--
+-- There is a related test: compression_update_delete.sql.in that
+-- tests another related bug, where we tried to fix this problem
+-- by rescanning the records, but this together with a NestedLoopJoin
+-- crashed. This only happen on PG16 and earlier versions.
+--
+\set ON_ERROR_STOP 1
+
+CREATE TABLE test_bitmap_delete (
+    time_col BIGINT NOT NULL,
+    device_id INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    value INTEGER,
+    PRIMARY KEY (time_col, device_id)
+);
+
+SELECT create_hypertable('test_bitmap_delete', 'time_col', chunk_time_interval => 1000000);
+
+-- Create index that would enable BitmapHeapScan
+CREATE INDEX idx_device_status ON test_bitmap_delete (device_id, status);
+
+ALTER TABLE test_bitmap_delete SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time_col DESC'
+);
+
+-- Insert rows to be deleted (will be compressed)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i, 1, 'delete_me', i FROM generate_series(1, 100) i;
+
+-- Insert rows to keep (same segment)
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 500, 1, 'keep', i FROM generate_series(1, 100) i;
+
+-- Insert more data so BitmapHeapScan is naturally preferred
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 2000, (i % 100) + 1,
+       CASE WHEN i % 100 = 0 THEN 'delete_me' ELSE 'keep' END,
+       i
+FROM generate_series(1, 100000) i;
+
+-- Compress the chunk
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+
+-- Make chunk partial by inserting uncompressed data
+INSERT INTO test_bitmap_delete (time_col, device_id, status, value)
+SELECT i + 1000, 1, 'keep', i FROM generate_series(1, 50) i;
+
+ANALYZE test_bitmap_delete;
+
+-- Test: DELETE should work when bitmap and index scans are allowed
+BEGIN;
+
+-- Disable SeqScan to test BitmapHeapScan path and also make
+-- the bitmap scan more favorable. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+SET LOCAL random_page_cost = 0.5;  -- (default 4.0)
+SET LOCAL cpu_index_tuple_cost = 0.1; -- (default 0.005)
+
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+
+ROLLBACK;
+
+
+-- Test: DELETE should work when bitmap scan is strongly preferred
+BEGIN;
+
+-- Disable IndexScan to test BitmapHeapScan path. Note that BitmapHeapScan is
+-- removed from the paths on PG16 and earlier
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_seqscan = on;
+-- Make sequential scan more expensive (default is 1.0)
+SET seq_page_cost = 10.0;
+-- Make random page cost lower to favor bitmap heap scan (default is 4.0)
+SET random_page_cost = 1.0;
+
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+-- Verify all rows were deleted (must be 0)
+-- (before the fix, it was 100)
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+
+-- Verify other rows were NOT deleted (must be 150)
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+
+ROLLBACK;
+
+
+
+-- Test: the fully compressed table did not trigger the problem
+--   but I put this case here for completeness and to make sure
+--   we exercise the new code paths in both cases
+
+BEGIN;
+
+SELECT compress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+
+ROLLBACK;
+
+-- Test: similarly to the above, the fully decompressed test
+--  is only here for completeness
+
+BEGIN;
+
+SELECT decompress_chunk(c) FROM show_chunks('test_bitmap_delete') c;
+
+SET LOCAL enable_indexscan = on;
+SET LOCAL enable_seqscan = off;
+
+EXPLAIN (buffers off, costs off)
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+DELETE FROM test_bitmap_delete WHERE device_id = 1 AND status = 'delete_me';
+
+SELECT count(*) AS remaining_delete_me
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'delete_me';
+
+SELECT count(*) AS remaining_keep
+FROM test_bitmap_delete
+WHERE device_id = 1 AND status = 'keep';
+
+ROLLBACK;
+
+DROP TABLE test_bitmap_delete;
+

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1025,6 +1025,7 @@ CREATE TABLE join_table AS SELECT repeat('t', d) FROM generate_series(1,3,1) d;
 ANALYZE tab1;
 SET enable_seqscan = off;
 SET enable_indexscan = off;
+SET enable_hashjoin = off;
 EXPLAIN (buffers off, costs off) UPDATE tab1
 SET v0 = 0 FROM
 	(SELECT repeat, count(*)


### PR DESCRIPTION
In SDC3656 we found that deleting from a partilally compressed chunk may miss deleting records that come from the compressed part because the BitmapHeapScan being used during the delete is not aware of the decompressed records.

The BitmapHeapScan was later fixed in PG17 which solved this problem, for this reason I only change the behaviour for PG16 and earlier. With this change the BitmapHeapScan will be disabled for UPDATE and DELETE commands on partially compressed chunks. Other combinations of commands and types are not affected.

The PG fix was in 1577081e961, that introduced lazy initialization of the BitmapHeapScan.