### PR TITLE
Retain compression settings on columnstore disable

### DIFF
--- a/.unreleased/pr_9122
+++ b/.unreleased/pr_9122
@@ -1,0 +1,1 @@
+Fixes: #8841 Retain compression settings when disabling columnstore

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -576,31 +576,99 @@ DROP TABLE table1;
 -- 2. disable compression (settings retained)
 -- 3. re-enable without explicit settings
 -- 4. compress and verify device_id appears in orderby (from fresh defaults)
-CREATE TABLE test_retained (time timestamptz NOT NULL, device_id text, val float);
-SELECT create_hypertable('test_retained', 'time');
-      create_hypertable      
------------------------------
- (18,public,test_retained,t)
+CREATE TABLE test_retained_orderby (time timestamptz NOT NULL, device_id text, val float);
+SELECT create_hypertable('test_retained_orderby', 'time');
+          create_hypertable          
+-------------------------------------
+ (18,public,test_retained_orderby,t)
 
-CREATE INDEX ON test_retained(device_id, time);
-INSERT INTO test_retained SELECT t, 'dev1', 1.0 FROM generate_series('2020-01-01'::timestamptz, '2020-01-02'::timestamptz, '1 hour') t;
-ANALYZE test_retained;
-ALTER TABLE test_retained SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
-ALTER TABLE test_retained SET (timescaledb.compress = false);
-ALTER TABLE test_retained SET (timescaledb.compress = true);
-SELECT count(compress_chunk(x)) FROM show_chunks('test_retained') x;
+CREATE INDEX ON test_retained_orderby(device_id, time);
+INSERT INTO test_retained_orderby SELECT t, 'dev1', 1.0 FROM generate_series('2020-01-01'::timestamptz, '2020-01-02'::timestamptz, '1 hour') t;
+ANALYZE test_retained_orderby;
+ALTER TABLE test_retained_orderby SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE test_retained_orderby SET (timescaledb.compress = false);
+ALTER TABLE test_retained_orderby SET (timescaledb.compress = true);
+SELECT count(compress_chunk(x)) FROM show_chunks('test_retained_orderby') x;
  count 
 -------
      2
 
 -- verify device_id appears in orderby from fresh defaults
 SELECT orderby FROM timescaledb_information.chunk_compression_settings
-WHERE hypertable = 'test_retained'::regclass LIMIT 1;
+WHERE hypertable = 'test_retained_orderby'::regclass LIMIT 1;
         orderby        
 -----------------------
  "time" DESC,device_id
 
-DROP TABLE test_retained;
+DROP TABLE test_retained_orderby;
+-- test that retained segmentby settings don't block defaults when re-enabling:
+-- use a table where default segmentby function returns device_id
+CREATE TABLE test_retained_segmentby (time timestamptz NOT NULL, device_id text, val float);
+SELECT create_hypertable('test_retained_segmentby', 'time');
+           create_hypertable           
+---------------------------------------
+ (21,public,test_retained_segmentby,t)
+
+CREATE UNIQUE INDEX ON test_retained_segmentby(device_id, time);
+-- insert data with multiple device_ids to get good cardinality for segmentby
+INSERT INTO test_retained_segmentby SELECT t + (i || ' seconds')::interval, 'dev' || (i % 10), i FROM generate_series('2020-01-01'::timestamptz, '2020-01-02'::timestamptz, '1 hour') t, generate_series(1, 100) i;
+ANALYZE test_retained_segmentby;
+-- verify default segmentby would return device_id
+SELECT _timescaledb_functions.get_segmentby_defaults('test_retained_segmentby'::regclass);
+            get_segmentby_defaults            
+----------------------------------------------
+ {"columns": ["device_id"], "confidence": 10}
+
+-- enable with explicit different segmentby (val instead of device_id)
+ALTER TABLE test_retained_segmentby SET (timescaledb.compress, timescaledb.compress_segmentby = 'val');
+ALTER TABLE test_retained_segmentby SET (timescaledb.compress = false);
+ALTER TABLE test_retained_segmentby SET (timescaledb.compress = true);
+SELECT count(compress_chunk(x)) FROM show_chunks('test_retained_segmentby') x;
+ count 
+-------
+     2
+
+-- verify segmentby is device_id from fresh defaults, not val from retained
+SELECT segmentby FROM timescaledb_information.chunk_compression_settings
+WHERE hypertable = 'test_retained_segmentby'::regclass LIMIT 1;
+ segmentby 
+-----------
+ device_id
+
+DROP TABLE test_retained_segmentby;
+-- test that retained index settings don't block defaults when re-enabling
+CREATE TABLE test_retained_index (time timestamptz NOT NULL, device_id text, val float);
+SELECT create_hypertable('test_retained_index', 'time');
+         create_hypertable         
+-----------------------------------
+ (24,public,test_retained_index,t)
+
+CREATE INDEX ON test_retained_index(device_id, time);
+INSERT INTO test_retained_index SELECT t, 'dev' || (i % 10), i FROM generate_series('2020-01-01'::timestamptz, '2020-01-02'::timestamptz, '1 hour') t, generate_series(1, 10) i;
+ANALYZE test_retained_index;
+-- enable with explicit empty index (no sparse indexes)
+ALTER TABLE test_retained_index SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC', timescaledb.compress_index = '');
+-- verify no index settings
+SELECT index FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_retained_index'::regclass;
+                                       index                                       
+-----------------------------------------------------------------------------------
+ [{"source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+
+ALTER TABLE test_retained_index SET (timescaledb.compress = false);
+ALTER TABLE test_retained_index SET (timescaledb.compress = true);
+SELECT count(compress_chunk(x)) FROM show_chunks('test_retained_index') x;
+ count 
+-------
+     2
+
+-- verify index is populated from fresh defaults (auto sparse indexes)
+SELECT index IS NOT NULL as has_index FROM timescaledb_information.chunk_compression_settings
+WHERE hypertable = 'test_retained_index'::regclass LIMIT 1;
+ has_index 
+-----------
+ t
+
+DROP TABLE test_retained_index;
 \set ON_ERROR_STOP 0
 SET timescaledb.compression_segmentby_default_function = 'function_does_not_exist';
 ERROR:  invalid value for parameter "timescaledb.compression_segmentby_default_function": "function_does_not_exist"
@@ -622,7 +690,7 @@ CREATE TABLE public.t1 (time timestamptz NOT NULL, segment_value text NOT NULL);
 SELECT public.create_hypertable('public.t1', 'time');
  create_hypertable 
 -------------------
- (21,public,t1,t)
+ (27,public,t1,t)
 
 ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 'segment_value');
 RESET search_path;
@@ -640,7 +708,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (23,schema1,page_events2,t)
+ (29,schema1,page_events2,t)
 
 ALTER TABLE schema1.page_events2 SET (
  timescaledb.compress,
@@ -653,7 +721,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (25,schema2,page_events2,t)
+ (31,schema2,page_events2,t)
 
 ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress,
@@ -670,7 +738,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (27,schema1,page_events2,t)
+ (33,schema1,page_events2,t)
 
 ALTER TABLE schema1.page_events2 SET (
  timescaledb.compress,
@@ -684,7 +752,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (29,schema2,page_events2,t)
+ (35,schema2,page_events2,t)
 
 ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress,
@@ -704,7 +772,7 @@ SELECT create_hypertable(
 );
     create_hypertable     
 --------------------------
- (31,public,test_table,t)
+ (37,public,test_table,t)
 
 INSERT INTO test_table (ts, uuid, val) VALUES
   (1, 1001, 10.1),
@@ -844,7 +912,7 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_exclude_datetype') x;
 SELECT * FROM timescaledb_information.chunk_compression_settings WHERE hypertable = 'test_exclude_datetype'::regclass ORDER BY chunk LIMIT 1;
       hypertable       |                   chunk                   | segmentby |      orderby       |                                                           index                                                            
 -----------------------+-------------------------------------------+-----------+--------------------+----------------------------------------------------------------------------------------------------------------------------
- test_exclude_datetype | _timescaledb_internal._hyper_33_285_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+ test_exclude_datetype | _timescaledb_internal._hyper_39_293_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_exclude_datetype;
 -- test that continuous aggregate materialized hypertables DELETE settings on disable
@@ -853,7 +921,7 @@ CREATE TABLE cagg_test (time TIMESTAMPTZ NOT NULL, device_id TEXT, val FLOAT);
 SELECT create_hypertable('cagg_test', 'time');
     create_hypertable    
 -------------------------
- (35,public,cagg_test,t)
+ (41,public,cagg_test,t)
 
 INSERT INTO cagg_test SELECT t, 'dev1', random() FROM generate_series('2020-01-01'::timestamptz, '2020-01-10'::timestamptz, '1 hour') t;
 CREATE MATERIALIZED VIEW cagg_test_agg WITH (timescaledb.continuous) AS

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -85,15 +85,16 @@ ALTER TABLE metrics SET (timescaledb.compress = false);
 SET timescaledb.compression_segmentby_default_function   = '';
 RESET timescaledb.compression_orderby_default_function;
 ALTER TABLE metrics SET (timescaledb.compress = true);
+WARNING:  column "device_id" should be used for segmenting or ordering
 select count(compress_chunk(x)) from show_chunks('metrics') x;
  count 
 -------
     27
 
 select * from chunk_settings;
- hypertable | chunks | segmentby |        orderby        |                                                            index                                                            
-------------+--------+-----------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------
- metrics    |     27 |           | device_id,"time" DESC | [{"type": "minmax", "column": "device_id", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ hypertable | chunks | segmentby |   orderby   |                                                           index                                                            
+------------+--------+-----------+-------------+----------------------------------------------------------------------------------------------------------------------------
+ metrics    |     27 |           | "time" DESC | [{"type": "bloom", "column": "device_id", "source": "default"}, {"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -104,15 +105,16 @@ ALTER TABLE metrics SET (timescaledb.compress = false);
 RESET timescaledb.compression_segmentby_default_function;
 SET timescaledb.compression_orderby_default_function = '';
 ALTER TABLE metrics SET (timescaledb.compress = true);
+WARNING:  column "device_id" should be used for segmenting or ordering
 select count(compress_chunk(x)) from show_chunks('metrics') x;
  count 
 -------
     27
 
 select * from chunk_settings;
- hypertable | chunks | segmentby |   orderby   |                            index                            
-------------+--------+-----------+-------------+-------------------------------------------------------------
- metrics    |     27 | device_id | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ hypertable | chunks | segmentby |   orderby   |                                                           index                                                            
+------------+--------+-----------+-------------+----------------------------------------------------------------------------------------------------------------------------
+ metrics    |     27 |           | "time" DESC | [{"type": "bloom", "column": "device_id", "source": "default"}, {"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -223,7 +225,7 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
 select * from chunk_settings;
  hypertable | chunks | segmentby |   orderby   |                            index                            
 ------------+--------+-----------+-------------+-------------------------------------------------------------
- metrics    |     27 | device_id | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics    |     27 |           | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -522,6 +524,55 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  table1 |                | {col1}    |         |              |                    | 
 
 ALTER TABLE table1 SET (timescaledb.compress = false);
+-- test that compression settings are retained when disabling columnstore (issue #8841)
+-- settings should still exist after disabling
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+--------+----------------+-----------+---------+--------------+--------------------+-------
+ table1 |                | {col1}    |         |              |                    | 
+
+-- re-enable without specifying settings, should use retained settings
+ALTER TABLE table1 SET (timescaledb.compress = true);
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+--------+----------------+-----------+---------+--------------+--------------------+-------
+ table1 |                | {col1}    |         |              |                    | 
+
+ALTER TABLE table1 SET (timescaledb.compress = false);
+-- test that INSERT works when settings exist but compression is disabled
+INSERT INTO table1 VALUES (1, 100), (2, 200), (11, 300);
+SELECT * FROM table1 ORDER BY col1;
+ col1 | col2 
+------+------
+    1 |  100
+    2 |  200
+   11 |  300
+
+-- verify compression_state is off even though settings exist
+SELECT compression_state FROM _timescaledb_catalog.hypertable WHERE table_name = 'table1';
+ compression_state 
+-------------------
+                 0
+
+SELECT count(*) FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
+ count 
+-------
+     1
+
+-- test that re-enabling with explicit NEW settings clears retained settings
+ALTER TABLE table1 SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'col2');
+SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
+ segmentby 
+-----------
+ {col2}
+
+ALTER TABLE table1 SET (timescaledb.compress = false);
+-- verify settings updated to new value (col2, not col1)
+SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
+ segmentby 
+-----------
+ {col2}
+
 \set ON_ERROR_STOP 0
 SET timescaledb.compression_segmentby_default_function = 'function_does_not_exist';
 ERROR:  invalid value for parameter "timescaledb.compression_segmentby_default_function": "function_does_not_exist"
@@ -543,7 +594,7 @@ CREATE TABLE public.t1 (time timestamptz NOT NULL, segment_value text NOT NULL);
 SELECT public.create_hypertable('public.t1', 'time');
  create_hypertable 
 -------------------
- (16,public,t1,t)
+ (18,public,t1,t)
 
 ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 'segment_value');
 RESET search_path;
@@ -561,7 +612,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (18,schema1,page_events2,t)
+ (20,schema1,page_events2,t)
 
 ALTER TABLE schema1.page_events2 SET (
  timescaledb.compress,
@@ -574,7 +625,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (20,schema2,page_events2,t)
+ (22,schema2,page_events2,t)
 
 ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress,
@@ -591,7 +642,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (22,schema1,page_events2,t)
+ (24,schema1,page_events2,t)
 
 ALTER TABLE schema1.page_events2 SET (
  timescaledb.compress,
@@ -605,7 +656,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (24,schema2,page_events2,t)
+ (26,schema2,page_events2,t)
 
 ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress,
@@ -625,7 +676,7 @@ SELECT create_hypertable(
 );
     create_hypertable     
 --------------------------
- (26,public,test_table,t)
+ (28,public,test_table,t)
 
 INSERT INTO test_table (ts, uuid, val) VALUES
   (1, 1001, 10.1),
@@ -765,6 +816,6 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_exclude_datetype') x;
 SELECT * FROM timescaledb_information.chunk_compression_settings WHERE hypertable = 'test_exclude_datetype'::regclass ORDER BY chunk LIMIT 1;
       hypertable       |                   chunk                   | segmentby |      orderby       |                                                           index                                                            
 -----------------------+-------------------------------------------+-----------+--------------------+----------------------------------------------------------------------------------------------------------------------------
- test_exclude_datetype | _timescaledb_internal._hyper_28_279_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+ test_exclude_datetype | _timescaledb_internal._hyper_30_281_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_exclude_datetype;

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -85,16 +85,15 @@ ALTER TABLE metrics SET (timescaledb.compress = false);
 SET timescaledb.compression_segmentby_default_function   = '';
 RESET timescaledb.compression_orderby_default_function;
 ALTER TABLE metrics SET (timescaledb.compress = true);
-WARNING:  column "device_id" should be used for segmenting or ordering
 select count(compress_chunk(x)) from show_chunks('metrics') x;
  count 
 -------
     27
 
 select * from chunk_settings;
- hypertable | chunks | segmentby |   orderby   |                                                           index                                                            
-------------+--------+-----------+-------------+----------------------------------------------------------------------------------------------------------------------------
- metrics    |     27 |           | "time" DESC | [{"type": "bloom", "column": "device_id", "source": "default"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ hypertable | chunks | segmentby |        orderby        |                                                            index                                                            
+------------+--------+-----------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------
+ metrics    |     27 |           | device_id,"time" DESC | [{"type": "minmax", "column": "device_id", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -105,16 +104,15 @@ ALTER TABLE metrics SET (timescaledb.compress = false);
 RESET timescaledb.compression_segmentby_default_function;
 SET timescaledb.compression_orderby_default_function = '';
 ALTER TABLE metrics SET (timescaledb.compress = true);
-WARNING:  column "device_id" should be used for segmenting or ordering
 select count(compress_chunk(x)) from show_chunks('metrics') x;
  count 
 -------
     27
 
 select * from chunk_settings;
- hypertable | chunks | segmentby |   orderby   |                                                           index                                                            
-------------+--------+-----------+-------------+----------------------------------------------------------------------------------------------------------------------------
- metrics    |     27 |           | "time" DESC | [{"type": "bloom", "column": "device_id", "source": "default"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ hypertable | chunks | segmentby |   orderby   |                            index                            
+------------+--------+-----------+-------------+-------------------------------------------------------------
+ metrics    |     27 | device_id | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -225,7 +223,7 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
 select * from chunk_settings;
  hypertable | chunks | segmentby |   orderby   |                            index                            
 ------------+--------+-----------+-------------+-------------------------------------------------------------
- metrics    |     27 |           | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics    |     27 | device_id | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -525,18 +523,17 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
 
 ALTER TABLE table1 SET (timescaledb.compress = false);
 -- test that compression settings are retained when disabling columnstore (issue #8841)
--- settings should still exist after disabling
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
 --------+----------------+-----------+---------+--------------+--------------------+-------
  table1 |                | {col1}    |         |              |                    | 
 
--- re-enable without specifying settings, should use retained settings
+-- re-enable without specifying settings - settings cleared if default functions available
 ALTER TABLE table1 SET (timescaledb.compress = true);
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
 --------+----------------+-----------+---------+--------------+--------------------+-------
- table1 |                | {col1}    |         |              |                    | 
+ table1 |                |           |         |              |                    | 
 
 ALTER TABLE table1 SET (timescaledb.compress = false);
 -- test that INSERT works when settings exist but compression is disabled
@@ -559,7 +556,7 @@ SELECT count(*) FROM _timescaledb_catalog.compression_settings WHERE relid = 'ta
 -------
      1
 
--- test that re-enabling with explicit NEW settings clears retained settings
+-- test that re-enabling with explicit NEW settings uses those settings
 ALTER TABLE table1 SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'col2');
 SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
  segmentby 
@@ -567,12 +564,42 @@ SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 't
  {col2}
 
 ALTER TABLE table1 SET (timescaledb.compress = false);
--- verify settings updated to new value (col2, not col1)
+-- verify settings are retained on disable
 SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
  segmentby 
 -----------
  {col2}
 
+DROP TABLE table1;
+-- test that retained settings don't block defaults when re-enabling:
+-- 1. enable compression with explicit orderby (only time, no device_id)
+-- 2. disable compression (settings retained)
+-- 3. re-enable without explicit settings
+-- 4. compress and verify device_id appears in orderby (from fresh defaults)
+CREATE TABLE test_retained (time timestamptz NOT NULL, device_id text, val float);
+SELECT create_hypertable('test_retained', 'time');
+      create_hypertable      
+-----------------------------
+ (18,public,test_retained,t)
+
+CREATE INDEX ON test_retained(device_id, time);
+INSERT INTO test_retained SELECT t, 'dev1', 1.0 FROM generate_series('2020-01-01'::timestamptz, '2020-01-02'::timestamptz, '1 hour') t;
+ANALYZE test_retained;
+ALTER TABLE test_retained SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE test_retained SET (timescaledb.compress = false);
+ALTER TABLE test_retained SET (timescaledb.compress = true);
+SELECT count(compress_chunk(x)) FROM show_chunks('test_retained') x;
+ count 
+-------
+     2
+
+SELECT segmentby, orderby FROM timescaledb_information.chunk_compression_settings
+WHERE hypertable = 'test_retained'::regclass LIMIT 1;
+ segmentby |        orderby        
+-----------+-----------------------
+           | "time" DESC,device_id
+
+DROP TABLE test_retained;
 \set ON_ERROR_STOP 0
 SET timescaledb.compression_segmentby_default_function = 'function_does_not_exist';
 ERROR:  invalid value for parameter "timescaledb.compression_segmentby_default_function": "function_does_not_exist"
@@ -594,7 +621,7 @@ CREATE TABLE public.t1 (time timestamptz NOT NULL, segment_value text NOT NULL);
 SELECT public.create_hypertable('public.t1', 'time');
  create_hypertable 
 -------------------
- (18,public,t1,t)
+ (21,public,t1,t)
 
 ALTER TABLE public.t1 SET (timescaledb.compress, timescaledb.compress_orderby = 'segment_value');
 RESET search_path;
@@ -612,7 +639,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (20,schema1,page_events2,t)
+ (23,schema1,page_events2,t)
 
 ALTER TABLE schema1.page_events2 SET (
  timescaledb.compress,
@@ -625,7 +652,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (22,schema2,page_events2,t)
+ (25,schema2,page_events2,t)
 
 ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress,
@@ -642,7 +669,7 @@ CREATE TABLE schema1.page_events2 (
 SELECT create_hypertable('schema1.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (24,schema1,page_events2,t)
+ (27,schema1,page_events2,t)
 
 ALTER TABLE schema1.page_events2 SET (
  timescaledb.compress,
@@ -656,7 +683,7 @@ CREATE TABLE schema2.page_events2 (
 SELECT create_hypertable('schema2.page_events2', 'time');
       create_hypertable      
 -----------------------------
- (26,schema2,page_events2,t)
+ (29,schema2,page_events2,t)
 
 ALTER TABLE schema2.page_events2 SET (
  timescaledb.compress,
@@ -676,7 +703,7 @@ SELECT create_hypertable(
 );
     create_hypertable     
 --------------------------
- (28,public,test_table,t)
+ (31,public,test_table,t)
 
 INSERT INTO test_table (ts, uuid, val) VALUES
   (1, 1001, 10.1),
@@ -816,7 +843,7 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_exclude_datetype') x;
 SELECT * FROM timescaledb_information.chunk_compression_settings WHERE hypertable = 'test_exclude_datetype'::regclass ORDER BY chunk LIMIT 1;
       hypertable       |                   chunk                   | segmentby |      orderby       |                                                           index                                                            
 -----------------------+-------------------------------------------+-----------+--------------------+----------------------------------------------------------------------------------------------------------------------------
- test_exclude_datetype | _timescaledb_internal._hyper_30_281_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+ test_exclude_datetype | _timescaledb_internal._hyper_33_285_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_exclude_datetype;
 -- test that continuous aggregate materialized hypertables DELETE settings on disable
@@ -825,7 +852,7 @@ CREATE TABLE cagg_test (time TIMESTAMPTZ NOT NULL, device_id TEXT, val FLOAT);
 SELECT create_hypertable('cagg_test', 'time');
     create_hypertable    
 -------------------------
- (32,public,cagg_test,t)
+ (35,public,cagg_test,t)
 
 INSERT INTO cagg_test SELECT t, 'dev1', random() FROM generate_series('2020-01-01'::timestamptz, '2020-01-10'::timestamptz, '1 hour') t;
 CREATE MATERIALIZED VIEW cagg_test_agg WITH (timescaledb.continuous) AS

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -536,26 +536,6 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  table1 |                |           |         |              |                    | 
 
 ALTER TABLE table1 SET (timescaledb.compress = false);
--- test that INSERT works when settings exist but compression is disabled
-INSERT INTO table1 VALUES (1, 100), (2, 200), (11, 300);
-SELECT * FROM table1 ORDER BY col1;
- col1 | col2 
-------+------
-    1 |  100
-    2 |  200
-   11 |  300
-
--- verify compression_state is off even though settings exist
-SELECT compression_state FROM _timescaledb_catalog.hypertable WHERE table_name = 'table1';
- compression_state 
--------------------
-                 0
-
-SELECT count(*) FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
- count 
--------
-     1
-
 -- test that re-enabling with explicit NEW settings uses those settings
 ALTER TABLE table1 SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'col2');
 SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
@@ -912,7 +892,7 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_exclude_datetype') x;
 SELECT * FROM timescaledb_information.chunk_compression_settings WHERE hypertable = 'test_exclude_datetype'::regclass ORDER BY chunk LIMIT 1;
       hypertable       |                   chunk                   | segmentby |      orderby       |                                                           index                                                            
 -----------------------+-------------------------------------------+-----------+--------------------+----------------------------------------------------------------------------------------------------------------------------
- test_exclude_datetype | _timescaledb_internal._hyper_39_293_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+ test_exclude_datetype | _timescaledb_internal._hyper_39_291_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_exclude_datetype;
 -- test that continuous aggregate materialized hypertables DELETE settings on disable

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -528,7 +528,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
 --------+----------------+-----------+---------+--------------+--------------------+-------
  table1 |                | {col1}    |         |              |                    | 
 
--- re-enable without specifying settings - settings cleared if default functions available
+-- re-enable without specifying settings - segmentby cleared because default function available
 ALTER TABLE table1 SET (timescaledb.compress = true);
 SELECT * FROM _timescaledb_catalog.compression_settings;
  relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -819,3 +819,41 @@ SELECT * FROM timescaledb_information.chunk_compression_settings WHERE hypertabl
  test_exclude_datetype | _timescaledb_internal._hyper_30_281_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_exclude_datetype;
+-- test that continuous aggregate materialized hypertables DELETE settings on disable
+-- (unlike regular hypertables which retain them)
+CREATE TABLE cagg_test (time TIMESTAMPTZ NOT NULL, device_id TEXT, val FLOAT);
+SELECT create_hypertable('cagg_test', 'time');
+    create_hypertable    
+-------------------------
+ (32,public,cagg_test,t)
+
+INSERT INTO cagg_test SELECT t, 'dev1', random() FROM generate_series('2020-01-01'::timestamptz, '2020-01-10'::timestamptz, '1 hour') t;
+CREATE MATERIALIZED VIEW cagg_test_agg WITH (timescaledb.continuous) AS
+  SELECT time_bucket('1 day', time) AS bucket, device_id, avg(val) FROM cagg_test GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_test_agg', NULL, NULL);
+-- enable compression on the cagg with specific settings
+ALTER MATERIALIZED VIEW cagg_test_agg SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'device_id');
+NOTICE:  defaulting compress_orderby to bucket
+-- verify settings exist (join through hypertable to get the mat_hypertable's relid)
+SELECT count(*) FROM _timescaledb_catalog.compression_settings cs
+  JOIN _timescaledb_catalog.hypertable h ON cs.relid = format('%I.%I', h.schema_name, h.table_name)::regclass
+  JOIN _timescaledb_catalog.continuous_agg ca ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'cagg_test_agg';
+ count 
+-------
+     1
+
+-- disable compression on the cagg
+ALTER MATERIALIZED VIEW cagg_test_agg SET (timescaledb.compress = false);
+-- verify settings are deleted for caggs (unlike regular hypertables)
+SELECT count(*) FROM _timescaledb_catalog.compression_settings cs
+  JOIN _timescaledb_catalog.hypertable h ON cs.relid = format('%I.%I', h.schema_name, h.table_name)::regclass
+  JOIN _timescaledb_catalog.continuous_agg ca ON h.id = ca.mat_hypertable_id
+  WHERE ca.user_view_name = 'cagg_test_agg';
+ count 
+-------
+     0
+
+DROP TABLE cagg_test CASCADE;
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 2 other objects

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -571,7 +571,7 @@ SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 't
  {col2}
 
 DROP TABLE table1;
--- test that retained settings don't block defaults when re-enabling:
+-- test that retained orderby settings don't block defaults when re-enabling:
 -- 1. enable compression with explicit orderby (only time, no device_id)
 -- 2. disable compression (settings retained)
 -- 3. re-enable without explicit settings
@@ -593,11 +593,12 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_retained') x;
 -------
      2
 
-SELECT segmentby, orderby FROM timescaledb_information.chunk_compression_settings
+-- verify device_id appears in orderby from fresh defaults
+SELECT orderby FROM timescaledb_information.chunk_compression_settings
 WHERE hypertable = 'test_retained'::regclass LIMIT 1;
- segmentby |        orderby        
------------+-----------------------
-           | "time" DESC,device_id
+        orderby        
+-----------------------
+ "time" DESC,device_id
 
 DROP TABLE test_retained;
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -434,7 +434,7 @@ select compressed_chunk_name as compressed_chunk_name_before_recompression from 
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);
 -- expect to see same chunk after recompression
 SELECT compress_chunk(:'chunk_to_compress_mytab');
-INFO:  Using index "compress_hyper_13_14_chunk__ts_meta_min_1__ts_meta_max_1_idx" for recompression
+INFO:  Using index "compress_hyper_13_14_chunk_a_c__ts_meta_min_1__ts_meta_max__idx" for recompression
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_11_12_chunk

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -423,7 +423,8 @@ SELECT decompress_chunk(show_chunks('mytab'));
  _timescaledb_internal._hyper_11_12_chunk
 
 alter table mytab set (timescaledb.compress = false);
-alter table mytab set (timescaledb.compress);
+-- explicit segmentby to avoid relying on retained settings from previous enable
+alter table mytab set (timescaledb.compress, timescaledb.compress_segmentby = 'a, c');
 select compress_chunk(show_chunks('mytab'));
 INFO:  using tuplesort to scan rows from "_hyper_11_12_chunk" for converting to columnstore
               compress_chunk              

--- a/tsl/test/sql/compression_defaults.sql
+++ b/tsl/test/sql/compression_defaults.sql
@@ -307,7 +307,7 @@ ALTER TABLE table1 SET (timescaledb.compress = false);
 
 -- test that compression settings are retained when disabling columnstore (issue #8841)
 SELECT * FROM _timescaledb_catalog.compression_settings;
--- re-enable without specifying settings - settings cleared if default functions available
+-- re-enable without specifying settings - segmentby cleared because default function available
 ALTER TABLE table1 SET (timescaledb.compress = true);
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ALTER TABLE table1 SET (timescaledb.compress = false);

--- a/tsl/test/sql/compression_defaults.sql
+++ b/tsl/test/sql/compression_defaults.sql
@@ -328,7 +328,7 @@ ALTER TABLE table1 SET (timescaledb.compress = false);
 SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
 DROP TABLE table1;
 
--- test that retained settings don't block defaults when re-enabling:
+-- test that retained orderby settings don't block defaults when re-enabling:
 -- 1. enable compression with explicit orderby (only time, no device_id)
 -- 2. disable compression (settings retained)
 -- 3. re-enable without explicit settings
@@ -342,7 +342,8 @@ ALTER TABLE test_retained SET (timescaledb.compress, timescaledb.compress_orderb
 ALTER TABLE test_retained SET (timescaledb.compress = false);
 ALTER TABLE test_retained SET (timescaledb.compress = true);
 SELECT count(compress_chunk(x)) FROM show_chunks('test_retained') x;
-SELECT segmentby, orderby FROM timescaledb_information.chunk_compression_settings
+-- verify device_id appears in orderby from fresh defaults
+SELECT orderby FROM timescaledb_information.chunk_compression_settings
 WHERE hypertable = 'test_retained'::regclass LIMIT 1;
 DROP TABLE test_retained;
 

--- a/tsl/test/sql/compression_defaults.sql
+++ b/tsl/test/sql/compression_defaults.sql
@@ -312,13 +312,6 @@ ALTER TABLE table1 SET (timescaledb.compress = true);
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ALTER TABLE table1 SET (timescaledb.compress = false);
 
--- test that INSERT works when settings exist but compression is disabled
-INSERT INTO table1 VALUES (1, 100), (2, 200), (11, 300);
-SELECT * FROM table1 ORDER BY col1;
--- verify compression_state is off even though settings exist
-SELECT compression_state FROM _timescaledb_catalog.hypertable WHERE table_name = 'table1';
-SELECT count(*) FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;
-
 -- test that re-enabling with explicit NEW settings uses those settings
 ALTER TABLE table1 SET (timescaledb.compress = true, timescaledb.compress_segmentby = 'col2');
 SELECT segmentby FROM _timescaledb_catalog.compression_settings WHERE relid = 'table1'::regclass;

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -242,7 +242,8 @@ RESET enable_seqscan;
 
 SELECT decompress_chunk(show_chunks('mytab'));
 alter table mytab set (timescaledb.compress = false);
-alter table mytab set (timescaledb.compress);
+-- explicit segmentby to avoid relying on retained settings from previous enable
+alter table mytab set (timescaledb.compress, timescaledb.compress_segmentby = 'a, c');
 select compress_chunk(show_chunks('mytab'));
 select compressed_chunk_name as compressed_chunk_name_before_recompression from compressed_chunk_info_view where hypertable_name = 'mytab' \gset
 INSERT INTO mytab VALUES ('2023-01-01'::timestamptz, 2, 3, 2);


### PR DESCRIPTION
## Summary

From #8841:
> Currently we remove compression settings when disabling columnstore. We should retain the settings so subsequent enabling of columnstore would restore them.

This PR implements that with one refinement: retained settings are cleared on re-enable when default functions are available. Otherwise, re-enabling without explicit settings would silently use stale retained values instead of computing fresh defaults.

Behavior:
- **Disable compression**: settings retained in catalog
- **Re-enable without explicit settings**: retained settings cleared if default functions available, then fresh defaults computed
- **Re-enable with explicit settings**: uses the new explicit settings
- **Continuous aggregates**: settings deleted on disable (system-managed)

## Testing

Added tests for all three clearing branches (orderby, segmentby, index) and for cagg settings deletion.

Fixes #8841