### PR TITLE
Allow sort push down into unordered compressed chunks if possible

### DIFF
--- a/.unreleased/pr_9128
+++ b/.unreleased/pr_9128
@@ -1,0 +1,1 @@
+Implements: #9128 Allow pushing down sort into columnar unordered chunks when it is possible

--- a/src/guc.c
+++ b/src/guc.c
@@ -142,6 +142,8 @@ bool ts_guc_enable_tss_callbacks = true;
 TSDLLEXPORT bool ts_guc_enable_delete_after_compression = false;
 TSDLLEXPORT bool ts_guc_enable_merge_on_cagg_refresh = false;
 
+TSDLLEXPORT bool ts_guc_enable_compressed_unordered_sort = true;
+
 bool ts_guc_enable_partitioned_hypertables = false;
 
 /* default value of ts_guc_max_open_chunks_per_insert and
@@ -759,6 +761,17 @@ _guc_init(void)
 							 "Print debug info about SkipScan distinct columns",
 							 &ts_guc_debug_skip_scan_info,
 							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compressed_unordered_sort"),
+							 "Enable pushing sort into compressed unordered chunks if possible",
+							 "Enable pushing sort into compressed unordered chunks if possible",
+							 &ts_guc_enable_compressed_unordered_sort,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -77,6 +77,8 @@ extern TSDLLEXPORT bool ts_guc_enable_multikey_skip_scan;
 extern TSDLLEXPORT double ts_guc_skip_scan_run_cost_multiplier;
 extern TSDLLEXPORT bool ts_guc_debug_skip_scan_info;
 
+extern TSDLLEXPORT bool ts_guc_enable_compressed_unordered_sort;
+
 /* Only settable in debug mode for testing */
 extern TSDLLEXPORT bool ts_guc_enable_null_compression;
 extern TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings;

--- a/src/utils.h
+++ b/src/utils.h
@@ -416,3 +416,4 @@ extern TSDLLEXPORT void ts_relation_set_reloption(Relation rel, List *options, L
 extern TSDLLEXPORT Jsonb *ts_errdata_to_jsonb(ErrorData *edata, Name proc_schema, Name proc_name);
 extern TSDLLEXPORT char *ts_get_attr_expr(Relation rel, AttrNumber attno);
 extern TSDLLEXPORT char *ts_list_to_string(List *list, append_cell_func append);
+extern TSDLLEXPORT List *ts_find_aggrefs(Node *node);

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
@@ -22,6 +22,8 @@ extern void _columnar_index_scan_init(void);
 extern bool ts_is_columnar_index_scan_path(Path *path);
 extern bool ts_is_columnar_index_scan_plan(Plan *plan);
 
+extern char *get_supported_aggregate_type(Aggref *aggref);
+
 extern ColumnarIndexScanPath *
 ts_columnar_index_scan_path_create(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 								   const CompressionInfo *info, Path *compressed_path);

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -276,28 +276,6 @@ static CustomPathMethods skip_scan_path_methods = {
 	.PlanCustomPath = skip_scan_plan_create,
 };
 
-#if PG16_GE
-typedef struct FindAggrefsContext
-{
-	List *aggrefs; /* all non-nested Aggrefs found in a node */
-} FindAggrefsContext;
-
-static bool
-find_aggrefs_walker(Node *node, FindAggrefsContext *context)
-{
-	if (node == NULL)
-		return false;
-	if (IsA(node, Aggref))
-	{
-		context->aggrefs = lappend(context->aggrefs, node);
-		/* don't recurse inside Aggrefs */
-		return false;
-	}
-
-	return expression_tree_walker(node, find_aggrefs_walker, context);
-}
-#endif
-
 static Expr *
 get_distint_clause_expr(PlannerInfo *root, SortGroupClause *distinct_clause)
 {
@@ -401,13 +379,11 @@ get_upper_distinct_expr(PlannerInfo *root, UpperRelationKind stage)
 #if PG16_GE
 	else if (stage == UPPERREL_GROUP_AGG)
 	{
-		/* Find all non-nested Aggrefs in the query target list */
-		FindAggrefsContext agg_ctx = { .aggrefs = NULL };
-		find_aggrefs_walker((Node *) root->parse->targetList, &agg_ctx);
-
-		foreach (lc, agg_ctx.aggrefs)
+		/* Find all non-nested Aggref in the query target list */
+		List *aggrefs = ts_find_aggrefs((Node *) root->parse->targetList);
+		foreach (lc, aggrefs)
 		{
-			Aggref *agg = lfirst_node(Aggref, lc);
+			Aggref *agg = castNode(Aggref, lfirst(lc));
 			/* Only distinct aggs with 1 sorted argument are eligible*/
 			if (agg->aggdistinct && agg->aggpresorted && list_length(agg->args) == 1)
 			{

--- a/tsl/test/expected/compress_unordered_sort.out
+++ b/tsl/test/expected/compress_unordered_sort.out
@@ -1,0 +1,469 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE metrics(
+    time timestamptz NOT NULL,
+    device text NOT NULL,
+    sensor text NOT NULL,
+    value float,
+    value2 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor');
+NOTICE:  using column "time" as partitioning column
+-- create unordered chunks
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO metrics VALUES
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+INSERT INTO metrics VALUES
+('2025-01-01 03:00:00 PST', 'd1', 'A', 11.0, 11.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 21.0, 21.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.1, 15.1),
+('2025-01-01 03:30:00 PST', 'd1', 'B', 5.1, 5.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.1, 25.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 31.0, 31.0),
+('2025-01-01 03:00:00 PST', 'd2', 'A', 11.0, 11.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 21.0, 21.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.2, 15.2),
+('2025-01-01 03:30:00 PST', 'd2', 'C', 5.3, 5.3),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.3, 25.3),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 32.0, 32.0);
+SELECT _timescaledb_functions.chunk_status_text(ch.status)
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk ch
+WHERE h.id = ch.hypertable_id AND h.table_name = 'metrics';
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+SET timescaledb.enable_compressed_unordered_sort = 1;
+SET max_parallel_workers_per_gather = 0;
+SET enable_bitmapscan=0;
+SET enable_seqscan=0;
+SET timezone TO PST8PDT;
+-- Can use SkipScan on unordered chunks if only segmentby columns are involved
+:PREFIX select distinct device, sensor from metrics order by 1,2;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select distinct device, sensor from metrics order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+:PREFIX select distinct on(device) device from metrics order by device;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select distinct on(device) device from metrics order by device;
+ device 
+--------
+ d1
+ d2
+
+:PREFIX select distinct on(device,sensor) device, sensor from metrics order by 1,2;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select distinct on(device,sensor) device, sensor from metrics order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+:PREFIX select distinct on(device, sensor) device, sensor from metrics where sensor='A' order by 1,2;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (sensor = 'A'::text)
+
+select distinct on(device, sensor) device, sensor from metrics where sensor='A' order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d2     | A
+
+:PREFIX select distinct on(device) device from metrics where sensor='A' order by device;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (sensor = 'A'::text)
+
+select distinct on(device) device from metrics where sensor='A' order by device;
+ device 
+--------
+ d1
+ d2
+
+:PREFIX select distinct on(device, sensor) device, sensor from metrics where sensor>'A' order by 1,2;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (sensor > 'A'::text)
+
+select distinct on(device, sensor) device, sensor from metrics where sensor>'A' order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | B
+ d2     | C
+
+:PREFIX select distinct on(device, sensor) device, sensor from metrics where device = 'd2' order by device, sensor;
+--- QUERY PLAN ---
+ Unique
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (device = 'd2'::text)
+
+select distinct on(device, sensor) device, sensor from metrics where device = 'd2' order by device, sensor;
+ device | sensor 
+--------+--------
+ d2     | A
+ d2     | C
+
+-- If nonsegmentby columns are involved we cannot use compressed index as is and therefore cannot use SkipScan
+:PREFIX select distinct device, sensor from metrics where value > 5 order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Vectorized Filter: (value > '5'::double precision)
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select distinct device, sensor from metrics where value > 5 order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+:PREFIX select distinct device, sensor from metrics where time > '2025-01-01 01:00:00 PST' order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Vectorized Filter: ("time" > 'Wed Jan 01 01:00:00 2025 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (_ts_meta_max_1 > 'Wed Jan 01 01:00:00 2025 PST'::timestamp with time zone)
+
+select distinct device, sensor from metrics where time > '2025-01-01 01:00:00 PST' order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+-- Can use compressed index when we need ordered aggregation results
+:PREFIX select device, sensor from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Group
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor from metrics group by device, sensor order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+:PREFIX select device, sensor, count(*), max(sensor) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, count(*), max(sensor) from metrics group by device, sensor order by 1,2;
+ device | sensor | count | max 
+--------+--------+-------+-----
+ d1     | A      |     6 | A
+ d1     | B      |     6 | B
+ d2     | A      |     6 | A
+ d2     | C      |     6 | C
+
+:PREFIX select device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+ device | sensor |            first             |             last             
+--------+--------+------------------------------+------------------------------
+ d1     | A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 03:00:00 2025 PST
+ d1     | B      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 03:30:00 2025 PST
+ d2     | A      | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 03:00:00 2025 PST
+ d2     | C      | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 03:30:00 2025 PST
+
+-- Can use expressions on aggregates as it won't affect grouping/sorting
+:PREFIX select device, sensor, max(sensor||'1'), min(time), max(time) + interval '1 day' from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, max(sensor||'1'), min(time), max(time) + interval '1 day' from metrics group by device, sensor order by 1,2;
+ device | sensor | max |             min              |           ?column?           
+--------+--------+-----+------------------------------+------------------------------
+ d1     | A      | A1  | Wed Jan 01 00:00:00 2025 PST | Thu Jan 02 03:00:00 2025 PST
+ d1     | B      | B1  | Wed Jan 01 00:30:00 2025 PST | Thu Jan 02 03:30:00 2025 PST
+ d2     | A      | A1  | Wed Jan 01 00:00:00 2025 PST | Thu Jan 02 03:00:00 2025 PST
+ d2     | C      | C1  | Wed Jan 01 00:30:00 2025 PST | Thu Jan 02 03:30:00 2025 PST
+
+:PREFIX select device, sensor, min(time), max(time) + make_interval(days => length(sensor)) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, min(time), max(time) + make_interval(days => length(sensor)) from metrics group by device, sensor order by 1,2;
+ device | sensor |             min              |           ?column?           
+--------+--------+------------------------------+------------------------------
+ d1     | A      | Wed Jan 01 00:00:00 2025 PST | Thu Jan 02 03:00:00 2025 PST
+ d1     | B      | Wed Jan 01 00:30:00 2025 PST | Thu Jan 02 03:30:00 2025 PST
+ d2     | A      | Wed Jan 01 00:00:00 2025 PST | Thu Jan 02 03:00:00 2025 PST
+ d2     | C      | Wed Jan 01 00:30:00 2025 PST | Thu Jan 02 03:30:00 2025 PST
+
+-- Can aggregate on expression over segmentby
+:PREFIX select device, sensor, max(sensor||'1'), avg(length(device)) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, max(sensor||'1'), avg(length(device)) from metrics group by device, sensor order by 1,2;
+ device | sensor | max |        avg         
+--------+--------+-----+--------------------
+ d1     | A      | A1  | 2.0000000000000000
+ d1     | B      | B1  | 2.0000000000000000
+ d2     | A      | A1  | 2.0000000000000000
+ d2     | C      | C1  | 2.0000000000000000
+
+-- Can use Having as it filters on aggregate outputs without changing sort
+:PREFIX select device, sensor, count(*) from metrics group by device, sensor having count(*) > length(sensor) order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   Filter: (count(*) > length(_hyper_1_1_chunk.sensor))
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, count(*) from metrics group by device, sensor having count(*) > length(sensor) order by 1,2;
+ device | sensor | count 
+--------+--------+-------
+ d1     | A      |     6
+ d1     | B      |     6
+ d2     | A      |     6
+ d2     | C      |     6
+
+-- Cannot use expressions on order by keys as sort might be broken
+:PREFIX select device, sensor||'1', min(time), max(time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, ((_hyper_1_1_chunk.sensor || '1'::text))
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor||'1', min(time), max(time) from metrics group by device, sensor order by 1,2;
+ device | ?column? |             min              |             max              
+--------+----------+------------------------------+------------------------------
+ d1     | A1       | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 03:00:00 2025 PST
+ d1     | B1       | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 03:30:00 2025 PST
+ d2     | A1       | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 03:00:00 2025 PST
+ d2     | C1       | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 03:30:00 2025 PST
+
+-- Cannot pushdown sort on non-var keys
+:PREFIX select device, sensor||'1', min(time), max(time) from metrics group by device, sensor||'1' order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, ((_hyper_1_1_chunk.sensor || '1'::text))
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, (_hyper_1_1_chunk.sensor || '1'::text)
+         ->  Result
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor||'1', min(time), max(time) from metrics group by device, sensor||'1' order by 1,2;
+ device | ?column? |             min              |             max              
+--------+----------+------------------------------+------------------------------
+ d1     | A1       | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 03:00:00 2025 PST
+ d1     | B1       | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 03:30:00 2025 PST
+ d2     | A1       | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 03:00:00 2025 PST
+ d2     | C1       | Wed Jan 01 00:30:00 2025 PST | Wed Jan 01 03:30:00 2025 PST
+
+-- Cannot use non-segmentby columns outside of eligible aggregates
+:PREFIX select device, sensor from metrics where value > length(sensor) group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (value > (length(sensor))::double precision)
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor from metrics where value > length(sensor) group by device, sensor order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+:PREFIX select device, sensor from metrics where time > '2025-01-01 01:00:00 PST' group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Vectorized Filter: ("time" > 'Wed Jan 01 01:00:00 2025 PST'::timestamp with time zone)
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (_ts_meta_max_1 > 'Wed Jan 01 01:00:00 2025 PST'::timestamp with time zone)
+
+select device, sensor from metrics where time > '2025-01-01 01:00:00 PST' group by device, sensor order by 1,2;
+ device | sensor 
+--------+--------
+ d1     | A
+ d1     | B
+ d2     | A
+ d2     | C
+
+:PREFIX select device, sensor, avg(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, avg(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+ device | sensor |         avg         
+--------+--------+---------------------
+ d1     | A      | 1735723800.00000000
+ d1     | B      | 1735725600.00000000
+ d2     | A      | 1735723800.00000000
+ d2     | C      | 1735725600.00000000
+
+:PREFIX select device, sensor, max(value) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, count(*), max(value) from metrics group by device, sensor order by 1,2;
+ device | sensor | count | max 
+--------+--------+-------+-----
+ d1     | A      |     6 |  21
+ d1     | B      |     6 |  31
+ d2     | A      |     6 |  21
+ d2     | C      |     6 |  32
+
+-- Min/max over expression on orderby column is also not permissible
+:PREFIX select device, sensor, max(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  HashAggregate
+         Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, max(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+ device | sensor |    max     
+--------+--------+------------
+ d1     | A      | 1735729200
+ d1     | B      | 1735731000
+ d2     | A      | 1735729200
+ d2     | C      | 1735731000
+
+-- Columnar Index Scan produces unsorted output currently,
+-- so Columnar Index Scan eligible queries will not benefit from unordered sort, yet
+:PREFIX select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
+ device | sensor |             min              
+--------+--------+------------------------------
+ d1     | A      | Wed Jan 01 00:00:00 2025 PST
+ d1     | B      | Wed Jan 01 00:30:00 2025 PST
+ d2     | A      | Wed Jan 01 00:00:00 2025 PST
+ d2     | C      | Wed Jan 01 00:30:00 2025 PST
+
+:PREFIX select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;
+ device | sensor |            first             
+--------+--------+------------------------------
+ d1     | A      | Wed Jan 01 00:00:00 2025 PST
+ d1     | B      | Wed Jan 01 00:30:00 2025 PST
+ d2     | A      | Wed Jan 01 00:00:00 2025 PST
+ d2     | C      | Wed Jan 01 00:30:00 2025 PST
+
+drop table metrics cascade;
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_compressed_unordered_sort;
+RESET max_parallel_workers_per_gather;
+RESET enable_bitmapscan;
+RESET enable_seqscan;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -2860,6 +2860,10 @@ psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hype
 psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
 -- RowCompareExpr
 :PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
 -- no tuples matching

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_FILES
     compress_dml_copy.sql
     compress_explain.sql
     compress_float8_corrupt.sql
+    compress_unordered_sort.sql
     compress_qualpushdown_saop.sql
     compress_sort_transform.sql
     compressed_collation.sql

--- a/tsl/test/sql/compress_unordered_sort.sql
+++ b/tsl/test/sql/compress_unordered_sort.sql
@@ -1,0 +1,151 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE metrics(
+    time timestamptz NOT NULL,
+    device text NOT NULL,
+    sensor text NOT NULL,
+    value float,
+    value2 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor');
+
+-- create unordered chunks
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO metrics VALUES
+('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 5.0, 5.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 30.0, 30.0),
+('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 5.0, 5.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 30.0, 30.0);
+
+INSERT INTO metrics VALUES
+('2025-01-01 03:00:00 PST', 'd1', 'A', 11.0, 11.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 21.0, 21.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.1, 15.1),
+('2025-01-01 03:30:00 PST', 'd1', 'B', 5.1, 5.1),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.1, 25.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 31.0, 31.0),
+('2025-01-01 03:00:00 PST', 'd2', 'A', 11.0, 11.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 21.0, 21.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.2, 15.2),
+('2025-01-01 03:30:00 PST', 'd2', 'C', 5.3, 5.3),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.3, 25.3),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 32.0, 32.0);
+
+SELECT _timescaledb_functions.chunk_status_text(ch.status)
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk ch
+WHERE h.id = ch.hypertable_id AND h.table_name = 'metrics';
+
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+
+SET timescaledb.enable_compressed_unordered_sort = 1;
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_bitmapscan=0;
+SET enable_seqscan=0;
+
+SET timezone TO PST8PDT;
+
+-- Can use SkipScan on unordered chunks if only segmentby columns are involved
+:PREFIX select distinct device, sensor from metrics order by 1,2;
+select distinct device, sensor from metrics order by 1,2;
+
+:PREFIX select distinct on(device) device from metrics order by device;
+select distinct on(device) device from metrics order by device;
+
+:PREFIX select distinct on(device,sensor) device, sensor from metrics order by 1,2;
+select distinct on(device,sensor) device, sensor from metrics order by 1,2;
+
+:PREFIX select distinct on(device, sensor) device, sensor from metrics where sensor='A' order by 1,2;
+select distinct on(device, sensor) device, sensor from metrics where sensor='A' order by 1,2;
+
+:PREFIX select distinct on(device) device from metrics where sensor='A' order by device;
+select distinct on(device) device from metrics where sensor='A' order by device;
+
+:PREFIX select distinct on(device, sensor) device, sensor from metrics where sensor>'A' order by 1,2;
+select distinct on(device, sensor) device, sensor from metrics where sensor>'A' order by 1,2;
+
+:PREFIX select distinct on(device, sensor) device, sensor from metrics where device = 'd2' order by device, sensor;
+select distinct on(device, sensor) device, sensor from metrics where device = 'd2' order by device, sensor;
+
+-- If nonsegmentby columns are involved we cannot use compressed index as is and therefore cannot use SkipScan
+:PREFIX select distinct device, sensor from metrics where value > 5 order by 1,2;
+select distinct device, sensor from metrics where value > 5 order by 1,2;
+
+:PREFIX select distinct device, sensor from metrics where time > '2025-01-01 01:00:00 PST' order by 1,2;
+select distinct device, sensor from metrics where time > '2025-01-01 01:00:00 PST' order by 1,2;
+
+-- Can use compressed index when we need ordered aggregation results
+:PREFIX select device, sensor from metrics group by device, sensor order by 1,2;
+select device, sensor from metrics group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor, count(*), max(sensor) from metrics group by device, sensor order by 1,2;
+select device, sensor, count(*), max(sensor) from metrics group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+select device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+
+-- Can use expressions on aggregates as it won't affect grouping/sorting
+:PREFIX select device, sensor, max(sensor||'1'), min(time), max(time) + interval '1 day' from metrics group by device, sensor order by 1,2;
+select device, sensor, max(sensor||'1'), min(time), max(time) + interval '1 day' from metrics group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor, min(time), max(time) + make_interval(days => length(sensor)) from metrics group by device, sensor order by 1,2;
+select device, sensor, min(time), max(time) + make_interval(days => length(sensor)) from metrics group by device, sensor order by 1,2;
+
+-- Can aggregate on expression over segmentby
+:PREFIX select device, sensor, max(sensor||'1'), avg(length(device)) from metrics group by device, sensor order by 1,2;
+select device, sensor, max(sensor||'1'), avg(length(device)) from metrics group by device, sensor order by 1,2;
+
+-- Can use Having as it filters on aggregate outputs without changing sort
+:PREFIX select device, sensor, count(*) from metrics group by device, sensor having count(*) > length(sensor) order by 1,2;
+select device, sensor, count(*) from metrics group by device, sensor having count(*) > length(sensor) order by 1,2;
+
+-- Cannot use expressions on order by keys as sort might be broken
+:PREFIX select device, sensor||'1', min(time), max(time) from metrics group by device, sensor order by 1,2;
+select device, sensor||'1', min(time), max(time) from metrics group by device, sensor order by 1,2;
+
+-- Cannot pushdown sort on non-var keys
+:PREFIX select device, sensor||'1', min(time), max(time) from metrics group by device, sensor||'1' order by 1,2;
+select device, sensor||'1', min(time), max(time) from metrics group by device, sensor||'1' order by 1,2;
+
+-- Cannot use non-segmentby columns outside of eligible aggregates
+:PREFIX select device, sensor from metrics where value > length(sensor) group by device, sensor order by 1,2;
+select device, sensor from metrics where value > length(sensor) group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor from metrics where time > '2025-01-01 01:00:00 PST' group by device, sensor order by 1,2;
+select device, sensor from metrics where time > '2025-01-01 01:00:00 PST' group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor, avg(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+select device, sensor, avg(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor, max(value) from metrics group by device, sensor order by 1,2;
+select device, sensor, count(*), max(value) from metrics group by device, sensor order by 1,2;
+
+-- Min/max over expression on orderby column is also not permissible
+:PREFIX select device, sensor, max(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+select device, sensor, max(EXTRACT(epoch FROM time)::integer) from metrics group by device, sensor order by 1,2;
+
+-- Columnar Index Scan produces unsorted output currently,
+-- so Columnar Index Scan eligible queries will not benefit from unordered sort, yet
+:PREFIX select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
+select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
+
+:PREFIX select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;
+select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;
+
+drop table metrics cascade;
+
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_compressed_unordered_sort;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_bitmapscan;
+RESET enable_seqscan;


### PR DESCRIPTION
Fixes #9116 

Push down sort into compressed unordered chunk when we reference segmentby columns only, or min/max aggregates on plain orderby columns.