### PR TITLE
Add missing ORDER BY to tests

### DIFF
--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -207,7 +207,7 @@ FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_start');
          Index Cond: (_hyper_1_6_chunk.id < '0194244f-d800-7000-8000-000000000000'::uuid)
 
 SELECT uuid_timestamp(id), device, temp
-FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_start');
+FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_start') ORDER BY id;
         uuid_timestamp        | device | temp 
 ------------------------------+--------+------
  Wed Jan 01 01:00:00 2025 PST |      1 |    1

--- a/test/sql/uuid.sql
+++ b/test/sql/uuid.sql
@@ -129,7 +129,7 @@ SELECT uuid_timestamp(id), device, temp
 FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_start');
 
 SELECT uuid_timestamp(id), device, temp
-FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_start');
+FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_start') ORDER BY id;
 
 -- Exclude only one chunk. Add ordering (DESC)
 EXPLAIN (verbose, buffers off, costs off, timing off)

--- a/tsl/test/expected/cagg-15.out
+++ b/tsl/test/expected/cagg-15.out
@@ -1820,7 +1820,7 @@ SELECT
   SUM(humidity),
   round(newavg(temperature::int4))
 FROM conditions
-GROUP BY time_bucket('1week', timec), location;
+GROUP BY time_bucket('1week', timec), location ORDER BY 1,2;
 NOTICE:  refreshing continuous aggregate "mat_m1"
 SELECT * FROM mat_m1 ORDER BY 1, 2;
  sum | round 

--- a/tsl/test/expected/cagg-16.out
+++ b/tsl/test/expected/cagg-16.out
@@ -1820,7 +1820,7 @@ SELECT
   SUM(humidity),
   round(newavg(temperature::int4))
 FROM conditions
-GROUP BY time_bucket('1week', timec), location;
+GROUP BY time_bucket('1week', timec), location ORDER BY 1,2;
 NOTICE:  refreshing continuous aggregate "mat_m1"
 SELECT * FROM mat_m1 ORDER BY 1, 2;
  sum | round 

--- a/tsl/test/expected/cagg-17.out
+++ b/tsl/test/expected/cagg-17.out
@@ -1820,7 +1820,7 @@ SELECT
   SUM(humidity),
   round(newavg(temperature::int4))
 FROM conditions
-GROUP BY time_bucket('1week', timec), location;
+GROUP BY time_bucket('1week', timec), location ORDER BY 1,2;
 NOTICE:  refreshing continuous aggregate "mat_m1"
 SELECT * FROM mat_m1 ORDER BY 1, 2;
  sum | round 

--- a/tsl/test/expected/cagg-18.out
+++ b/tsl/test/expected/cagg-18.out
@@ -1820,7 +1820,7 @@ SELECT
   SUM(humidity),
   round(newavg(temperature::int4))
 FROM conditions
-GROUP BY time_bucket('1week', timec), location;
+GROUP BY time_bucket('1week', timec), location ORDER BY 1,2;
 NOTICE:  refreshing continuous aggregate "mat_m1"
 SELECT * FROM mat_m1 ORDER BY 1, 2;
  sum | round 

--- a/tsl/test/expected/cagg_bgw_drop_chunks.out
+++ b/tsl/test/expected/cagg_bgw_drop_chunks.out
@@ -50,7 +50,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
 CREATE MATERIALIZED VIEW drop_chunks_view1 WITH (timescaledb.continuous)
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
-    GROUP BY 1 WITH NO DATA;
+    GROUP BY 1 ORDER BY 1 WITH NO DATA;
 --raw hypertable will have 40 chunks and the mat. hypertable will have 2 and 4
 -- chunks respectively
 SELECT set_chunk_time_interval('_timescaledb_internal._materialized_hypertable_2', 10);

--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -780,7 +780,7 @@ WHERE devices.device_id = cagg.thermo_id
 GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_on_cagg"
 HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
-SELECT * FROM cagg_on_cagg;
+SELECT * FROM cagg_on_cagg ORDER BY bucket;
             bucket            |     temperature     
 ------------------------------+---------------------
  Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000
@@ -814,7 +814,7 @@ ON devices.device_id = cagg.thermo_id
 GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_on_cagg_join"
 HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
-SELECT * FROM cagg_on_cagg_join;
+SELECT * FROM cagg_on_cagg_join ORDER BY bucket;
             bucket            |     temperature     
 ------------------------------+---------------------
  Sun Jun 13 17:00:00 2021 PDT | 26.0000000000000000

--- a/tsl/test/expected/cagg_uuid.out
+++ b/tsl/test/expected/cagg_uuid.out
@@ -49,12 +49,12 @@ LIMIT 1 OFFSET 1 \gset
 CREATE MATERIALIZED VIEW daily_uuid_events WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 day', id) AS day, round(avg(temp)::numeric, 3) AS temp
 FROM uuid_events WHERE device < 6
-GROUP BY 1;
+GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "daily_uuid_events"
 CREATE MATERIALIZED VIEW daily_ts_events WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 day', ts) AS day, round(avg(temp)::numeric, 3) AS temp
 FROM ts_events WHERE device < 6
-GROUP BY 1;
+GROUP BY 1 ORDER BY 1;
 NOTICE:  refreshing continuous aggregate "daily_ts_events"
 -- The uuid and timestmap caggs should look the same
 SELECT * FROM daily_uuid_events ORDER BY day;

--- a/tsl/test/sql/cagg.sql.in
+++ b/tsl/test/sql/cagg.sql.in
@@ -1384,7 +1384,7 @@ SELECT
   SUM(humidity),
   round(newavg(temperature::int4))
 FROM conditions
-GROUP BY time_bucket('1week', timec), location;
+GROUP BY time_bucket('1week', timec), location ORDER BY 1,2;
 
 SELECT * FROM mat_m1 ORDER BY 1, 2;
 

--- a/tsl/test/sql/cagg_bgw_drop_chunks.sql
+++ b/tsl/test/sql/cagg_bgw_drop_chunks.sql
@@ -52,7 +52,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
 CREATE MATERIALIZED VIEW drop_chunks_view1 WITH (timescaledb.continuous)
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
-    GROUP BY 1 WITH NO DATA;
+    GROUP BY 1 ORDER BY 1 WITH NO DATA;
 
 --raw hypertable will have 40 chunks and the mat. hypertable will have 2 and 4
 -- chunks respectively

--- a/tsl/test/sql/cagg_joins.sql
+++ b/tsl/test/sql/cagg_joins.sql
@@ -282,7 +282,7 @@ FROM cagg, devices
 WHERE devices.device_id = cagg.thermo_id
 GROUP BY 1;
 
-SELECT * FROM cagg_on_cagg;
+SELECT * FROM cagg_on_cagg ORDER BY bucket;
 
 DROP MATERIALIZED VIEW cagg_on_cagg CASCADE;
 
@@ -295,7 +295,7 @@ FROM cagg JOIN devices
 ON devices.device_id = cagg.thermo_id
 GROUP BY 1;
 
-SELECT * FROM cagg_on_cagg_join;
+SELECT * FROM cagg_on_cagg_join ORDER BY bucket;
 
 DROP MATERIALIZED VIEW cagg_on_cagg_join CASCADE;
 

--- a/tsl/test/sql/cagg_uuid.sql
+++ b/tsl/test/sql/cagg_uuid.sql
@@ -44,12 +44,12 @@ LIMIT 1 OFFSET 1 \gset
 CREATE MATERIALIZED VIEW daily_uuid_events WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 day', id) AS day, round(avg(temp)::numeric, 3) AS temp
 FROM uuid_events WHERE device < 6
-GROUP BY 1;
+GROUP BY 1 ORDER BY 1;
 
 CREATE MATERIALIZED VIEW daily_ts_events WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 day', ts) AS day, round(avg(temp)::numeric, 3) AS temp
 FROM ts_events WHERE device < 6
-GROUP BY 1;
+GROUP BY 1 ORDER BY 1;
 
 -- The uuid and timestmap caggs should look the same
 SELECT * FROM daily_uuid_events ORDER BY day;


### PR DESCRIPTION
When a cagg without ORDER BY switches from GroupAggregate to
HashAggregate the chunk numbering might differ as the chunks are
not created ordered by time leading to test failures when the
plan switches.
