### PR TITLE
Remove column `dropped` from _timescaledb_catalog.chunk

### DIFF
--- a/.unreleased/pr_9142
+++ b/.unreleased/pr_9142
@@ -1,0 +1,1 @@
+Implements: #9142 Remove column `dropped` from _timescaledb_catalog.chunk

--- a/scripts/dump_meta_data.sql
+++ b/scripts/dump_meta_data.sql
@@ -72,7 +72,6 @@ SELECT hypertable,
               AND pns.oid = pgc.relnamespace
               AND pns.nspname = h.schema_name
               AND relkind = 'r'
-              AND c.dropped is false
               GROUP BY pgc.oid
               ) sub1
        ) sub2;
@@ -119,7 +118,6 @@ SELECT *,
              AND c.id = cc.chunk_id
              AND cc.dimension_slice_id = ds.id
              AND ds.dimension_id = d.id
-             AND c.dropped is false
        GROUP BY c.id, pgc.reltoastrelid, pgc.oid ORDER BY c.id
        ) sub1
 ) sub2;

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -158,7 +158,6 @@ BEGIN
   FOR _chunk_id IN
     SELECT id FROM _timescaledb_catalog.chunk
     WHERE hypertable_id = _hypertable_id
-    AND dropped IS TRUE
     AND NOT EXISTS (
         SELECT FROM information_schema.tables
         WHERE tables.table_schema = chunk.schema_name

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -107,8 +107,7 @@ BEGIN
       INNER JOIN pg_class pgc ON pgc.oid = show.oid
       INNER JOIN pg_namespace pgns ON pgc.relnamespace = pgns.oid
       INNER JOIN _timescaledb_catalog.chunk ch ON ch.table_name = pgc.relname AND ch.schema_name = pgns.nspname AND ch.hypertable_id = htid
-    WHERE NOT ch.dropped
-    AND NOT ch.osm_chunk
+    WHERE NOT ch.osm_chunk
     -- Checking for chunks which are not fully compressed and not frozen
     AND ch.status != status_fully_compressed
     AND ch.status & bit_frozen = 0

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -147,7 +147,6 @@ CREATE TABLE _timescaledb_catalog.chunk (
   schema_name name NOT NULL,
   table_name name NOT NULL,
   compressed_chunk_id integer ,
-  dropped boolean NOT NULL DEFAULT FALSE,
   status integer NOT NULL DEFAULT 0,
   osm_chunk boolean NOT NULL DEFAULT FALSE,
   creation_time timestamptz NOT NULL,

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -35,7 +35,6 @@ SELECT
 FROM
     _timescaledb_catalog.hypertable h
     JOIN _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
-        AND c.dropped IS FALSE
     JOIN pg_class cl ON cl.relname = c.table_name AND cl.relkind = 'r'
     JOIN pg_namespace n ON n.oid = cl.relnamespace
     AND n.nspname = c.schema_name
@@ -349,7 +348,7 @@ BEGIN
     IF FOUND THEN
         RETURN (SELECT coalesce(sum(_timescaledb_functions.get_approx_row_count(format('%I.%I',schema_name,table_name))),0)
           FROM _timescaledb_catalog.chunk
-          WHERE hypertable_id = v_hypertable_id AND NOT dropped);
+          WHERE hypertable_id = v_hypertable_id);
     END IF;
 
 		IF EXISTS (SELECT FROM pg_inherits WHERE inhparent = relation) THEN
@@ -419,7 +418,6 @@ FROM
     _timescaledb_catalog.hypertable AS srcht
     JOIN _timescaledb_catalog.chunk AS srcch ON srcht.id = srcch.hypertable_id
         AND srcht.compressed_hypertable_id IS NOT NULL
-        AND srcch.dropped = FALSE
     LEFT JOIN _timescaledb_catalog.compression_chunk_size map ON srcch.id = map.chunk_id;
 
 GRANT SELECT ON _timescaledb_internal.compressed_chunk_stats TO PUBLIC;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,82 @@
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.chunk` to drop column `dropped`
+--
+
+CREATE TABLE _timescaledb_internal.tmp_chunk AS SELECT * from _timescaledb_catalog.chunk WHERE NOT dropped;
+CREATE TABLE _timescaledb_internal.tmp_chunk_seq_value AS SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
+
+--drop foreign keys on chunk table
+ALTER TABLE _timescaledb_catalog.chunk_constraint DROP CONSTRAINT chunk_constraint_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_column_stats DROP CONSTRAINT chunk_column_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats DROP CONSTRAINT bgw_policy_chunk_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_compressed_chunk_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+DROP VIEW IF EXISTS timescaledb_information.chunk_columnstore_settings;
+DROP VIEW IF EXISTS timescaledb_information.chunk_compression_settings;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_id_seq;
+
+DROP TABLE _timescaledb_catalog.chunk;
+
+CREATE SEQUENCE _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE _timescaledb_catalog.chunk (
+  id integer NOT NULL DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
+  hypertable_id int NOT NULL,
+  schema_name name NOT NULL,
+  table_name name NOT NULL,
+  compressed_chunk_id integer ,
+  status integer NOT NULL DEFAULT 0,
+  osm_chunk boolean NOT NULL DEFAULT FALSE,
+  creation_time timestamptz NOT NULL,
+  -- table constraints
+  CONSTRAINT chunk_pkey PRIMARY KEY (id),
+  CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name)
+);
+
+INSERT INTO _timescaledb_catalog.chunk( id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk, creation_time)
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk, creation_time
+FROM _timescaledb_internal.tmp_chunk;
+
+--add indexes to the chunk table
+CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
+CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);
+CREATE INDEX chunk_hypertable_id_creation_time_idx ON _timescaledb_catalog.chunk(hypertable_id, creation_time);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_chunk_seq_value;
+
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id ) REFERENCES _timescaledb_catalog.chunk( id );
+
+--add foreign key constraint
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
+ALTER TABLE _timescaledb_catalog.chunk_column_stats ADD CONSTRAINT chunk_column_stats_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id);
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats ADD CONSTRAINT bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.tmp_chunk;
+DROP TABLE _timescaledb_internal.tmp_chunk_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
+-- end rebuild _timescaledb_catalog.chunk table --
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,81 @@
+--
+-- Rebuild the catalog table `_timescaledb_catalog.chunk` to add column `dropped`
+--
+
+CREATE TABLE _timescaledb_internal.tmp_chunk AS SELECT * from _timescaledb_catalog.chunk;
+CREATE TABLE _timescaledb_internal.tmp_chunk_seq_value AS SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
+
+--drop foreign keys on chunk table
+ALTER TABLE _timescaledb_catalog.chunk_constraint DROP CONSTRAINT chunk_constraint_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_column_stats DROP CONSTRAINT chunk_column_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats DROP CONSTRAINT bgw_policy_chunk_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_compressed_chunk_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+DROP VIEW IF EXISTS timescaledb_information.chunk_columnstore_settings;
+DROP VIEW IF EXISTS timescaledb_information.chunk_compression_settings;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_id_seq;
+
+DROP TABLE _timescaledb_catalog.chunk;
+
+CREATE SEQUENCE _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE _timescaledb_catalog.chunk (
+  id integer NOT NULL DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
+  hypertable_id int NOT NULL,
+  schema_name name NOT NULL,
+  table_name name NOT NULL,
+  compressed_chunk_id integer ,
+  dropped boolean NOT NULL DEFAULT FALSE,
+  status integer NOT NULL DEFAULT 0,
+  osm_chunk boolean NOT NULL DEFAULT FALSE,
+  creation_time timestamptz NOT NULL,
+  -- table constraints
+  CONSTRAINT chunk_pkey PRIMARY KEY (id),
+  CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name)
+);
+
+INSERT INTO _timescaledb_catalog.chunk( id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk, creation_time)
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, false, status, osm_chunk, creation_time
+FROM _timescaledb_internal.tmp_chunk;
+
+--add indexes to the chunk table
+CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
+CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);
+CREATE INDEX chunk_hypertable_id_creation_time_idx ON _timescaledb_catalog.chunk(hypertable_id, creation_time);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_chunk_seq_value;
+
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id ) REFERENCES _timescaledb_catalog.chunk( id );
+
+--add foreign key constraint
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
+ALTER TABLE _timescaledb_catalog.chunk_column_stats ADD CONSTRAINT chunk_column_stats_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id);
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats ADD CONSTRAINT bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.tmp_chunk;
+DROP TABLE _timescaledb_internal.tmp_chunk_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
+-- end recreate _timescaledb_catalog.chunk table --

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -23,7 +23,6 @@ SELECT
     SELECT count(1)
     FROM _timescaledb_catalog.chunk ch
     WHERE ch.hypertable_id = ht.hypertable_id
-      AND ch.dropped IS FALSE
       AND ch.osm_chunk IS FALSE
   ) AS num_chunks,
   ht.compression_enabled,
@@ -218,7 +217,7 @@ FROM (
       WHERE pg_class.relnamespace = pg_namespace.oid) cl ON srcch.table_name = cl.relname
       AND srcch.schema_name = cl.schema_name
     LEFT OUTER JOIN pg_tablespace pgtab ON pgtab.oid = reltablespace
-  WHERE srcch.dropped IS FALSE AND srcch.osm_chunk IS FALSE
+  WHERE srcch.osm_chunk IS FALSE
     AND ht.compression_state != 2 ) finalq
 WHERE chunk_dimension_num = 1;
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -123,8 +123,6 @@ typedef enum ChunkResult
  * which is useful if one, e.g., wants to fill in an memory-aligned array of
  * chunks.
  *
- * If the chunk is a tombstone (dropped flag set), then the Chunk will not be
- * created and instead is_dropped will be TRUE.
  */
 typedef struct ChunkStubScanCtx
 {
@@ -132,7 +130,6 @@ typedef struct ChunkStubScanCtx
 	Chunk *chunk;
 	LOCKMODE chunk_lockmode;
 	const ScanTupLock *slice_lock;
-	bool is_dropped;
 } ChunkStubScanCtx;
 
 static bool
@@ -155,7 +152,6 @@ static void init_scan_by_qualified_table_name(ScanIterator *iterator, const char
 static Chunk *get_chunks_in_time_range(Hypertable *ht, int64 older_than, int64 newer_than,
 									   MemoryContext mctx, uint64 *num_chunks_returned,
 									   ScanTupLock *tuplock);
-static Chunk *chunk_resurrect(const Hypertable *ht, int chunk_id);
 static Chunk *get_chunks_in_creation_time_range(Hypertable *ht, int64 older_than, int64 newer_than,
 												MemoryContext mctx, uint64 *num_chunks_returned,
 												ScanTupLock *tupLock);
@@ -180,7 +176,6 @@ chunk_formdata_make_tuple(const FormData_chunk *fd, TupleDesc desc)
 		values[AttrNumberGetAttrOffset(Anum_chunk_compressed_chunk_id)] =
 			Int32GetDatum(fd->compressed_chunk_id);
 	}
-	values[AttrNumberGetAttrOffset(Anum_chunk_dropped)] = BoolGetDatum(fd->dropped);
 	values[AttrNumberGetAttrOffset(Anum_chunk_status)] = Int32GetDatum(fd->status);
 	values[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)] = BoolGetDatum(fd->osm_chunk);
 	values[AttrNumberGetAttrOffset(Anum_chunk_creation_time)] = Int64GetDatum(fd->creation_time);
@@ -203,7 +198,6 @@ ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_hypertable_id)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_schema_name)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_table_name)]);
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_dropped)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_status)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_creation_time)]);
@@ -221,7 +215,6 @@ ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 		fd->compressed_chunk_id =
 			DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_compressed_chunk_id)]);
 
-	fd->dropped = DatumGetBool(values[AttrNumberGetAttrOffset(Anum_chunk_dropped)]);
 	fd->status = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_status)]);
 	fd->osm_chunk = DatumGetBool(values[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)]);
 	fd->creation_time = DatumGetInt64(values[AttrNumberGetAttrOffset(Anum_chunk_creation_time)]);
@@ -1479,7 +1472,6 @@ ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *sche
 						  const char *prefix, LOCKMODE chunk_lockmode)
 {
 	/*
-	 * We're going to have to resurrect or create the chunk.
 	 * Serialize chunk creation around a lock on the "main table" to avoid
 	 * multiple processes trying to create the same chunk. We use a
 	 * ShareUpdateExclusiveLock, which is the weakest lock possible that
@@ -1515,16 +1507,6 @@ ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *sche
 			 * release the lock early.
 			 */
 			UnlockRelationOid(ht->main_table_relid, ShareUpdateExclusiveLock);
-			return chunk;
-		}
-
-		/*
-		 * If we managed to find some metadata for the chunk (chunk_id != INVALID_CHUNK_ID),
-		 * but it is marked as dropped, try to resurrect it.
-		 */
-		chunk = chunk_resurrect(ht, chunk_id);
-		if (chunk != NULL)
-		{
 			return chunk;
 		}
 	}
@@ -1689,10 +1671,10 @@ ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkS
 	Chunk *chunk = NULL;
 	int num_constraints_hint = stub ? stub->constraints->num_constraints : 2;
 
-	if (NULL == chunkptr)
+	if (chunkptr == NULL)
 		chunkptr = &chunk;
 
-	if (NULL == *chunkptr)
+	if (*chunkptr == NULL)
 		*chunkptr = MemoryContextAllocZero(ti->mctx, sizeof(Chunk));
 
 	chunk = *chunkptr;
@@ -1732,23 +1714,24 @@ ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkS
 		ts_scan_iterator_close(&it);
 	}
 
+	chunk->hypertable_relid = ts_hypertable_id_to_relid(chunk->fd.hypertable_id, false);
+	ts_get_rel_info_by_name(NameStr(chunk->fd.schema_name),
+							NameStr(chunk->fd.table_name),
+							&chunk->table_id,
+							&chunk->relkind);
+
+	Ensure(chunk->relkind > 0,
+		   "relkind for chunk \"%s\".\"%s\" is invalid",
+		   NameStr(chunk->fd.schema_name),
+		   NameStr(chunk->fd.table_name));
+
 	return chunk;
 }
 
-static ScanFilterResult
-chunk_tuple_dropped_filter(const TupleInfo *ti, void *arg)
+static ScanTupleResult
+chunk_tuple_found(TupleInfo *ti, void *arg)
 {
 	ChunkStubScanCtx *stubctx = arg;
-	bool isnull;
-	Datum dropped;
-
-	dropped = slot_getattr(ti->slot, Anum_chunk_dropped, &isnull);
-	Assert(!isnull);
-
-	stubctx->is_dropped = DatumGetBool(dropped);
-
-	if (stubctx->is_dropped)
-		return SCAN_EXCLUDE;
 
 	/*
 	 * The chunk table could also have been dropped concurrently. Try to
@@ -1760,6 +1743,7 @@ chunk_tuple_dropped_filter(const TupleInfo *ti, void *arg)
 		Datum schema_name;
 		Datum table_name;
 		const RangeVar *rv;
+		bool isnull;
 
 		schema_name = slot_getattr(ti->slot, Anum_chunk_schema_name, &isnull);
 		Assert(!isnull);
@@ -1772,42 +1756,12 @@ chunk_tuple_dropped_filter(const TupleInfo *ti, void *arg)
 		Relation rel = table_openrv_extended(rv, stubctx->chunk_lockmode, true);
 
 		if (!rel)
-			return SCAN_EXCLUDE;
+			return SCAN_DONE;
 
 		table_close(rel, NoLock);
 	}
 
-	return SCAN_INCLUDE;
-}
-
-static ScanTupleResult
-chunk_tuple_found(TupleInfo *ti, void *arg)
-{
-	ChunkStubScanCtx *stubctx = arg;
-	Chunk *chunk;
-
-	chunk =
-		ts_chunk_build_from_tuple_and_stub(&stubctx->chunk, ti, stubctx->stub, stubctx->slice_lock);
-
-	if (!chunk)
-		return SCAN_DONE;
-
-	Assert(!chunk->fd.dropped);
-
-	/* Fill in table relids. Note that we cannot do this in
-	 * ts_chunk_build_from_tuple_and_stub() since chunk_resurrect() also uses
-	 * that function and, in that case, the chunk object is needed to create
-	 * the data table and related objects. */
-	chunk->hypertable_relid = ts_hypertable_id_to_relid(chunk->fd.hypertable_id, false);
-	ts_get_rel_info_by_name(NameStr(chunk->fd.schema_name),
-							NameStr(chunk->fd.table_name),
-							&chunk->table_id,
-							&chunk->relkind);
-
-	Ensure(chunk->relkind > 0,
-		   "relkind for chunk \"%s\".\"%s\" is invalid",
-		   NameStr(chunk->fd.schema_name),
-		   NameStr(chunk->fd.table_name));
+	ts_chunk_build_from_tuple_and_stub(&stubctx->chunk, ti, stubctx->stub, stubctx->slice_lock);
 
 	return SCAN_DONE;
 }
@@ -1825,7 +1779,6 @@ chunk_create_from_stub(ChunkStubScanCtx *stubctx)
 		.nkeys = 1,
 		.scankey = scankey,
 		.data = stubctx,
-		.filter = chunk_tuple_dropped_filter,
 		.tuple_found = chunk_tuple_found,
 		.lockmode = AccessShareLock,
 		.scandirection = ForwardScanDirection,
@@ -1844,16 +1797,10 @@ chunk_create_from_stub(ChunkStubScanCtx *stubctx)
 
 	Assert(num_found == 0 || num_found == 1);
 
-	if (stubctx->is_dropped)
-	{
-		Assert(num_found == 0);
-		return NULL;
-	}
-
 	if (num_found != 1)
 		elog(ERROR, "no chunk found with ID %d", stubctx->stub->id);
 
-	Assert(NULL != stubctx->chunk);
+	Assert(stubctx->chunk != NULL);
 
 	return stubctx->chunk;
 }
@@ -2007,9 +1954,6 @@ chunk_scan_context_add_chunk(ChunkScanCtx *scanctx, ChunkStub *stub)
 	Assert(data->num_chunks < data->max_chunks);
 	chunk_create_from_stub(&stubctx);
 
-	if (stubctx.is_dropped)
-		return CHUNK_IGNORED;
-
 	data->num_chunks++;
 
 	return CHUNK_PROCESSED;
@@ -2051,74 +1995,6 @@ ts_chunk_lock_for_creating_compressed_chunk(int32 chunk_id, int32 *compressed_ch
 		elog(ERROR, "chunk with ID %d does not exist", chunk_id);
 
 	return lockresult;
-}
-
-/*
- * Resurrect a chunk from a tombstone.
- *
- * A chunk can be dropped while retaining its metadata as a tombstone. Such a
- * chunk is marked with dropped=true.
- *
- * This function resurrects such a dropped chunk based on the original metadata,
- * including recreating the table and related objects.
- */
-static Chunk *
-chunk_resurrect(const Hypertable *ht, int chunk_id)
-{
-	ScanIterator iterator;
-	Chunk *chunk = NULL;
-	PG_USED_FOR_ASSERTS_ONLY int count = 0;
-
-	Assert(chunk_id != INVALID_CHUNK_ID);
-
-	iterator = ts_scan_iterator_create(CHUNK, RowExclusiveLock, CurrentMemoryContext);
-	ts_chunk_scan_iterator_set_chunk_id(&iterator, chunk_id);
-
-	ts_scanner_foreach(&iterator)
-	{
-		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-		HeapTuple new_tuple;
-		ScanTupLock slice_lock = {
-			.lockmode = LockTupleKeyShare,
-			.waitpolicy = LockWaitBlock,
-		};
-
-		Assert(count == 0 && chunk == NULL);
-		chunk = ts_chunk_build_from_tuple_and_stub(/* chunkptr = */ NULL,
-												   ti,
-												   /* stub = */ NULL,
-												   &slice_lock);
-		Assert(chunk->fd.dropped);
-
-		/* Create data table and related objects */
-		chunk->hypertable_relid = ht->main_table_relid;
-		chunk->relkind = RELKIND_RELATION;
-		chunk->table_id = chunk_create_table(chunk, ht);
-		chunk_create_table_constraints(ht, chunk);
-
-		/* Add chunk to publications if hypertable is in any publications */
-		if (ts_guc_enable_chunk_auto_publication)
-			chunk_add_to_publications(chunk);
-
-		/* Finally, update the chunk tuple to no longer be a tombstone */
-		chunk->fd.dropped = false;
-		new_tuple = chunk_formdata_make_tuple(&chunk->fd, ts_scan_iterator_tupledesc(&iterator));
-		ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
-		heap_freetuple(new_tuple);
-		count++;
-
-		/* Assume there's only one match. (We break early to avoid scanning
-		 * also the updated tuple.) */
-		break;
-	}
-
-	ts_scan_iterator_close(&iterator);
-
-	Assert(count == 0 || count == 1);
-
-	/* If count == 0 and chunk is NULL here, the tombstone (metadata) must
-	 * have been removed before we had a chance to resurrect the chunk */
-	return chunk;
 }
 
 /*
@@ -2537,9 +2413,9 @@ ts_chunk_copy(const Chunk *chunk)
 }
 
 static int
-chunk_scan_internal(int indexid, ScanKeyData scankey[], int nkeys, tuple_filter_func filter,
-					tuple_found_func tuple_found, void *data, int limit, ScanDirection scandir,
-					LOCKMODE lockmode, MemoryContext mctx)
+chunk_scan_internal(int indexid, ScanKeyData scankey[], int nkeys, tuple_found_func tuple_found,
+					void *data, int limit, ScanDirection scandir, LOCKMODE lockmode,
+					MemoryContext mctx)
 {
 	Catalog *catalog = ts_catalog_get();
 	ScannerCtx ctx = {
@@ -2548,7 +2424,6 @@ chunk_scan_internal(int indexid, ScanKeyData scankey[], int nkeys, tuple_filter_
 		.nkeys = nkeys,
 		.data = data,
 		.scankey = scankey,
-		.filter = filter,
 		.tuple_found = tuple_found,
 		.limit = limit,
 		.lockmode = lockmode,
@@ -2674,7 +2549,6 @@ chunk_scan_find(int indexid, ScanKeyData scankey[], int nkeys, MemoryContext mct
 	num_found = chunk_scan_internal(indexid,
 									scankey,
 									nkeys,
-									chunk_tuple_dropped_filter,
 									chunk_tuple_found,
 									&stubctx,
 									1,
@@ -2682,7 +2556,7 @@ chunk_scan_find(int indexid, ScanKeyData scankey[], int nkeys, MemoryContext mct
 									AccessShareLock,
 									mctx);
 
-	Assert(num_found == 0 || (num_found == 1 && !stubctx.is_dropped));
+	Assert(num_found == 0 || num_found == 1);
 	chunk = stubctx.chunk;
 
 	switch (num_found)
@@ -2905,9 +2779,7 @@ chunk_simple_scan(ScanIterator *iterator, FormData_chunk *form, bool missing_ok,
 	{
 		TupleInfo *ti = ts_scan_iterator_tuple_info(iterator);
 		ts_chunk_formdata_fill(form, ti);
-
-		if (!form->dropped)
-			count++;
+		count++;
 	}
 
 	Assert(count == 0 || count == 1);
@@ -3099,129 +2971,84 @@ ts_chunk_get_id(const char *schema, const char *table, int32 *chunk_id, bool mis
 	return true;
 }
 
-/*
- * Results of deleting a chunk.
- *
- * A chunk can be deleted in two ways: (1) full delete of data and metadata,
- * (2) delete data but preserve metadata (marked with dropped=true). The
- * deletion mode (preserve or not) combined with the current state of the
- * "dropped" flag on a chunk metadata row leads to a cross-product resulting
- * in the following outcomes:
- */
-typedef enum ChunkDeleteResult
-{
-	/* Deleted a live chunk */
-	CHUNK_DELETED,
-	/* Deleted a chunk previously marked "dropped" */
-	CHUNK_DELETED_DROPPED,
-	/* Marked a chunk as dropped instead of deleting */
-	CHUNK_MARKED_DROPPED,
-	/* Tried to mark a chunk as dropped when it was already marked */
-	CHUNK_ALREADY_MARKED_DROPPED,
-} ChunkDeleteResult;
-
 /* Delete the chunk tuple.
  *
  * relid: Required when deleting via an event trigger hook, because at that
  * point the relation is gone and it is no longer possible to resolve the Oid
  * from the PG catalog.
  *
- * preserve_chunk_catalog_row - instead of deleting the row, mark it as dropped.
- * this is used when we need to preserve catalog information about the chunk
- * after dropping it. Currently only used when preserving continuous aggregates
- * on the chunk after the raw data was dropped. Otherwise, we'd have dangling
- * chunk ids left over in the materialization table. Preserve the space dimension
- * info about these chunks too.
- *
- * When chunk rows are preserved, the rows need to be updated to set the
- * 'dropped' flag to TRUE. But since this produces a new tuple into the
- * metadata table we will process also the new tuple in the same loop, which
- * is not only inefficient but could also lead to bugs. For now, we just ignore
- * those tuples (the CHUNK_ALREADY_MARKED_DROPPED case), but ideally we
- * shouldn't scan the updated tuples at all since it means double the number
- * of tuples to process.
  */
-static ChunkDeleteResult
-chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool preserve_chunk_catalog_row,
-				   bool detach)
+static void
+chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool detach)
 {
 	FormData_chunk form;
 	CatalogSecurityContext sec_ctx;
-	ChunkDeleteResult res;
 	int i;
 
 	ts_chunk_formdata_fill(&form, ti);
 
-	if (preserve_chunk_catalog_row && form.dropped)
-		return CHUNK_ALREADY_MARKED_DROPPED;
+	ChunkConstraints *ccs;
 
-	/* if only marking as deleted, keep the constraints and dimension info */
-	if (!preserve_chunk_catalog_row)
+	/*
+	 * Do not drop any constraint if detaching
+	 * We will still need to delete dimension slices for the chunk
+	 */
+	ccs = ts_chunk_constraints_alloc(2, ti->mctx);
+	ts_chunk_constraint_delete_dimensional_constraints(form.id, ccs);
+	ts_chunk_constraint_delete_by_chunk_id(form.id, ccs, !detach);
+
+	/* Check for dimension slices that are orphaned by the chunk deletion */
+	for (i = 0; i < ccs->num_constraints; i++)
 	{
-		ChunkConstraints *ccs;
+		ChunkConstraint *cc = &ccs->constraints[i];
 
 		/*
-		 * Do not drop any constraint if detaching
-		 * We will still need to delete dimension slices for the chunk
+		 * Delete the dimension slice if there are no remaining constraints
+		 * referencing it
 		 */
-		ccs = ts_chunk_constraints_alloc(2, ti->mctx);
-		ts_chunk_constraint_delete_dimensional_constraints(form.id, ccs);
-		ts_chunk_constraint_delete_by_chunk_id(form.id, ccs, !detach);
-
-		/* Check for dimension slices that are orphaned by the chunk deletion */
-		for (i = 0; i < ccs->num_constraints; i++)
+		if (is_dimension_constraint(cc))
 		{
-			ChunkConstraint *cc = &ccs->constraints[i];
-
 			/*
-			 * Delete the dimension slice if there are no remaining constraints
-			 * referencing it
+			 * Dimension slices are shared between chunk constraints and
+			 * subsequently between chunks as well. Since different chunks
+			 * can reference the same dimension slice (through the chunk
+			 * constraint), we must lock the dimension slice in FOR UPDATE
+			 * mode *prior* to scanning the chunk constraints table. If we
+			 * do not do that, we can have the following scenario:
+			 *
+			 * - T1: Prepares to create a chunk that uses an existing dimension slice X
+			 * - T2: Deletes a chunk and dimension slice X because it is not
+			 *   references by a chunk constraint.
+			 * - T1: Adds a chunk constraint referencing dimension
+			 *   slice X (which is about to be deleted by T2).
 			 */
-			if (is_dimension_constraint(cc))
+			ScanTupLock tuplock = { .lockmode = LockTupleExclusive, .waitpolicy = LockWaitBlock };
+			DimensionSlice *slice =
+				ts_dimension_slice_scan_by_id_and_lock(cc->fd.dimension_slice_id,
+													   &tuplock,
+													   CurrentMemoryContext,
+													   AccessShareLock);
+			/* If the slice is not found in the scan above, the table is
+			 * broken so we do not delete the slice. We proceed
+			 * anyway since users need to be able to drop broken tables or
+			 * remove broken chunks. */
+			if (!slice)
 			{
-				/*
-				 * Dimension slices are shared between chunk constraints and
-				 * subsequently between chunks as well. Since different chunks
-				 * can reference the same dimension slice (through the chunk
-				 * constraint), we must lock the dimension slice in FOR UPDATE
-				 * mode *prior* to scanning the chunk constraints table. If we
-				 * do not do that, we can have the following scenario:
-				 *
-				 * - T1: Prepares to create a chunk that uses an existing dimension slice X
-				 * - T2: Deletes a chunk and dimension slice X because it is not
-				 *   references by a chunk constraint.
-				 * - T1: Adds a chunk constraint referencing dimension
-				 *   slice X (which is about to be deleted by T2).
-				 */
-				ScanTupLock tuplock = { .lockmode = LockTupleExclusive,
-										.waitpolicy = LockWaitBlock };
-				DimensionSlice *slice =
-					ts_dimension_slice_scan_by_id_and_lock(cc->fd.dimension_slice_id,
-														   &tuplock,
-														   CurrentMemoryContext,
-														   AccessShareLock);
-				/* If the slice is not found in the scan above, the table is
-				 * broken so we do not delete the slice. We proceed
-				 * anyway since users need to be able to drop broken tables or
-				 * remove broken chunks. */
-				if (!slice)
-				{
-					const Hypertable *const ht = ts_hypertable_get_by_id(form.hypertable_id);
-					ereport(WARNING,
-							(errmsg("unexpected state for chunk %s.%s, dropping anyway",
-									quote_identifier(NameStr(form.schema_name)),
-									quote_identifier(NameStr(form.table_name))),
-							 errdetail("The integrity of hypertable %s.%s might be "
-									   "compromised "
-									   "since one of its chunks lacked a dimension slice.",
-									   quote_identifier(NameStr(ht->fd.schema_name)),
-									   quote_identifier(NameStr(ht->fd.table_name)))));
-				}
-				else if (ts_chunk_constraint_scan_by_dimension_slice_id(slice->fd.id,
-																		NULL,
-																		CurrentMemoryContext) == 0)
-					ts_dimension_slice_delete_by_id(cc->fd.dimension_slice_id, false);
+				const Hypertable *const ht = ts_hypertable_get_by_id(form.hypertable_id);
+				ereport(WARNING,
+						(errmsg("unexpected state for chunk %s.%s, dropping anyway",
+								quote_identifier(NameStr(form.schema_name)),
+								quote_identifier(NameStr(form.table_name))),
+						 errdetail("The integrity of hypertable %s.%s might be "
+								   "compromised "
+								   "since one of its chunks lacked a dimension slice.",
+								   quote_identifier(NameStr(ht->fd.schema_name)),
+								   quote_identifier(NameStr(ht->fd.table_name)))));
 			}
+			else if (ts_chunk_constraint_scan_by_dimension_slice_id(slice->fd.id,
+																	NULL,
+																	CurrentMemoryContext) == 0)
+				ts_dimension_slice_delete_by_id(cc->fd.dimension_slice_id, false);
 		}
 	}
 
@@ -3283,34 +3110,8 @@ chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool preserv
 	}
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-
-	if (!preserve_chunk_catalog_row)
-	{
-		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
-
-		if (form.dropped)
-			res = CHUNK_DELETED_DROPPED;
-		else
-			res = CHUNK_DELETED;
-	}
-	else
-	{
-		HeapTuple new_tuple;
-
-		Assert(!form.dropped);
-
-		form.compressed_chunk_id = INVALID_CHUNK_ID;
-		form.dropped = true;
-		form.status = CHUNK_STATUS_DEFAULT;
-		new_tuple = chunk_formdata_make_tuple(&form, ts_scanner_get_tupledesc(ti));
-		ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
-		heap_freetuple(new_tuple);
-		res = CHUNK_MARKED_DROPPED;
-	}
-
+	ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
 	ts_catalog_restore_user(&sec_ctx);
-
-	return res;
 }
 
 static void
@@ -3331,31 +3132,14 @@ init_scan_by_qualified_table_name(ScanIterator *iterator, const char *schema_nam
 }
 
 static int
-chunk_delete(ScanIterator *iterator, Oid relid, DropBehavior behavior,
-			 bool preserve_chunk_catalog_row, bool detach)
+chunk_delete(ScanIterator *iterator, Oid relid, DropBehavior behavior, bool detach)
 {
 	int count = 0;
 
 	ts_scanner_foreach(iterator)
 	{
-		ChunkDeleteResult res;
-
-		res = chunk_tuple_delete(ts_scan_iterator_tuple_info(iterator),
-								 relid,
-								 behavior,
-								 preserve_chunk_catalog_row,
-								 detach);
-
-		switch (res)
-		{
-			case CHUNK_DELETED:
-			case CHUNK_MARKED_DROPPED:
-				count++;
-				break;
-			case CHUNK_ALREADY_MARKED_DROPPED:
-			case CHUNK_DELETED_DROPPED:
-				break;
-		}
+		chunk_tuple_delete(ts_scan_iterator_tuple_info(iterator), relid, behavior, detach);
+		count++;
 	}
 
 	return count;
@@ -3363,13 +3147,13 @@ chunk_delete(ScanIterator *iterator, Oid relid, DropBehavior behavior,
 
 static int
 ts_chunk_delete_by_name_internal(const char *schema, const char *table, Oid relid,
-								 DropBehavior behavior, bool preserve_chunk_catalog_row)
+								 DropBehavior behavior)
 {
 	ScanIterator iterator = ts_scan_iterator_create(CHUNK, RowExclusiveLock, CurrentMemoryContext);
 	int count;
 
 	init_scan_by_qualified_table_name(&iterator, schema, table);
-	count = chunk_delete(&iterator, relid, behavior, preserve_chunk_catalog_row, false);
+	count = chunk_delete(&iterator, relid, behavior, false);
 
 	/* (schema,table) names and (hypertable_id) are unique so should only have
 	 * dropped one chunk or none (if not found) */
@@ -3382,21 +3166,17 @@ int
 ts_chunk_delete_by_name(const char *schema, const char *table, DropBehavior behavior)
 {
 	Oid relid = ts_get_relation_relid(schema, table, false);
-	return ts_chunk_delete_by_name_internal(schema, table, relid, behavior, false);
+	return ts_chunk_delete_by_name_internal(schema, table, relid, behavior);
 }
 
 int
 ts_chunk_delete_by_relid_and_relname(Oid relid, const char *schemaname, const char *tablename,
-									 DropBehavior behavior, bool preserve_chunk_catalog_row)
+									 DropBehavior behavior)
 {
 	if (!OidIsValid(relid))
 		return 0;
 
-	return ts_chunk_delete_by_name_internal(schemaname,
-											tablename,
-											relid,
-											behavior,
-											preserve_chunk_catalog_row);
+	return ts_chunk_delete_by_name_internal(schemaname, tablename, relid, behavior);
 }
 
 static void
@@ -3417,7 +3197,7 @@ ts_chunk_delete_by_hypertable_id(int32 hypertable_id)
 
 	init_scan_by_hypertable_id(&iterator, hypertable_id);
 
-	return chunk_delete(&iterator, InvalidOid, DROP_RESTRICT, false, false);
+	return chunk_delete(&iterator, InvalidOid, DROP_RESTRICT, false);
 }
 
 bool
@@ -3429,15 +3209,10 @@ ts_chunk_exists_with_compression(int32 hypertable_id)
 	init_scan_by_hypertable_id(&iterator, hypertable_id);
 	ts_scanner_foreach(&iterator)
 	{
-		bool isnull_dropped;
 		bool isnull_chunk_id =
 			slot_attisnull(ts_scan_iterator_slot(&iterator), Anum_chunk_compressed_chunk_id);
-		bool dropped = DatumGetBool(
-			slot_getattr(ts_scan_iterator_slot(&iterator), Anum_chunk_dropped, &isnull_dropped));
-		/* dropped is not NULLABLE */
-		Assert(!isnull_dropped);
 
-		if (!isnull_chunk_id && !dropped)
+		if (!isnull_chunk_id)
 		{
 			found = true;
 			break;
@@ -3534,12 +3309,9 @@ ts_chunk_get_by_hypertable_id(int32 hypertable_id)
 
 		chunk->hypertable_relid = hypertable_relid;
 
-		if (!chunk->fd.dropped)
-		{
-			chunk->table_id = ts_get_relation_relid(NameStr(chunk->fd.schema_name),
-													NameStr(chunk->fd.table_name),
-													false);
-		}
+		chunk->table_id = ts_get_relation_relid(NameStr(chunk->fd.schema_name),
+												NameStr(chunk->fd.table_name),
+												false);
 
 		chunks = lappend(chunks, chunk);
 	}
@@ -3554,9 +3326,6 @@ chunk_recreate_constraint(ChunkScanCtx *ctx, ChunkStub *stub)
 		.stub = stub,
 	};
 	Chunk *chunk = chunk_create_from_stub(&stubctx);
-
-	if (stubctx.is_dropped)
-		elog(ERROR, "should not be recreating constraints on dropped chunks");
 
 	ts_chunk_constraints_recreate(ctx->ht, chunk);
 
@@ -3651,7 +3420,6 @@ lock_chunk_tuple(int32 chunk_id, ItemPointer tid, FormData_chunk *form)
 								   F_INT4EQ,
 								   Int32GetDatum(chunk_id));
 	bool success = false;
-	bool dropped, dropped_isnull;
 
 	ts_scanner_foreach(&iterator)
 	{
@@ -3679,17 +3447,12 @@ lock_chunk_tuple(int32 chunk_id, ItemPointer tid, FormData_chunk *form)
 			}
 		}
 
-		dropped = DatumGetBool(slot_getattr(ti->slot, Anum_chunk_dropped, &dropped_isnull));
-		Assert(!dropped_isnull);
-		if (!dropped)
-		{
-			ts_chunk_formdata_fill(form, ti);
-			ItemPointer result_tid = ts_scanner_get_tuple_tid(ti);
-			tid->ip_blkid = result_tid->ip_blkid;
-			tid->ip_posid = result_tid->ip_posid;
-			success = true;
-			break;
-		}
+		ts_chunk_formdata_fill(form, ti);
+		ItemPointer result_tid = ts_scanner_get_tuple_tid(ti);
+		tid->ip_blkid = result_tid->ip_blkid;
+		tid->ip_posid = result_tid->ip_posid;
+		success = true;
+		break;
 	}
 	ts_scan_iterator_close(&iterator);
 
@@ -4090,9 +3853,8 @@ show_chunks_return_srf(FunctionCallInfo fcinfo)
 		SRF_RETURN_DONE(funcctx);
 }
 
-static void
-ts_chunk_drop_internal(const Chunk *chunk, DropBehavior behavior, int32 log_level,
-					   bool preserve_catalog_row)
+void
+ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level)
 {
 	ObjectAddress objaddr = {
 		.classId = RelationRelationId,
@@ -4109,23 +3871,10 @@ ts_chunk_drop_internal(const Chunk *chunk, DropBehavior behavior, int32 log_leve
 	ts_chunk_delete_by_relid_and_relname(chunk->table_id,
 										 NameStr(chunk->fd.schema_name),
 										 NameStr(chunk->fd.table_name),
-										 behavior,
-										 preserve_catalog_row);
+										 behavior);
 
 	/* Drop the table */
 	performDeletion(&objaddr, behavior, 0);
-}
-
-void
-ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level)
-{
-	ts_chunk_drop_internal(chunk, behavior, log_level, false);
-}
-
-void
-ts_chunk_drop_preserve_catalog_row(const Chunk *chunk, DropBehavior behavior, int32 log_level)
-{
-	ts_chunk_drop_internal(chunk, behavior, log_level, true);
 }
 
 static void
@@ -4672,40 +4421,29 @@ ts_chunk_get_compression_status(int32 chunk_id)
 	ts_scanner_foreach(&iterator)
 	{
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-		bool dropped_isnull, status_isnull;
+		bool status_isnull;
 		Datum status;
-
-		bool dropped = DatumGetBool(slot_getattr(ti->slot, Anum_chunk_dropped, &dropped_isnull));
-		Assert(!dropped_isnull);
 
 		status = slot_getattr(ti->slot, Anum_chunk_status, &status_isnull);
 		Assert(!status_isnull);
-		/* Note that dropped attribute takes precedence over everything else.
-		 * We should not check status attribute for dropped chunks
-		 */
-		if (!dropped)
+		bool status_is_compressed =
+			ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED);
+		bool status_is_unordered =
+			ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED_UNORDERED);
+		bool status_is_partial =
+			ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED_PARTIAL);
+		if (status_is_compressed)
 		{
-			bool status_is_compressed =
-				ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED);
-			bool status_is_unordered =
-				ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED_UNORDERED);
-			bool status_is_partial =
-				ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED_PARTIAL);
-			if (status_is_compressed)
-			{
-				if (status_is_unordered || status_is_partial)
-					st = CHUNK_COMPRESS_UNORDERED;
-				else
-					st = CHUNK_COMPRESS_ORDERED;
-			}
+			if (status_is_unordered || status_is_partial)
+				st = CHUNK_COMPRESS_UNORDERED;
 			else
-			{
-				Assert(!status_is_unordered);
-				st = CHUNK_COMPRESS_NONE;
-			}
+				st = CHUNK_COMPRESS_ORDERED;
 		}
 		else
-			st = CHUNK_DROPPED;
+		{
+			Assert(!status_is_unordered);
+			st = CHUNK_COMPRESS_NONE;
+		}
 	}
 	ts_scan_iterator_close(&iterator);
 	return st;
@@ -5548,15 +5286,8 @@ get_chunks_in_creation_time_range_limit(Hypertable *ht, StrategyNumber start_str
 
 	ts_scanner_foreach(&it)
 	{
-		bool dropped_isnull, dropped;
-
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&it);
-
-		/* only add chunks that are not dropped */
-		dropped = DatumGetBool(slot_getattr(ti->slot, Anum_chunk_dropped, &dropped_isnull));
-		Assert(!dropped_isnull);
-		if (!dropped)
-			ts_chunk_vec_add_from_tuple(&chunk_vec, ti);
+		ts_chunk_vec_add_from_tuple(&chunk_vec, ti);
 	}
 
 	ts_scan_iterator_close(&it);
@@ -5664,7 +5395,7 @@ ts_chunk_detach_by_relid(Oid relid)
 	table = get_rel_name(relid);
 
 	init_scan_by_qualified_table_name(&iterator, schema, table);
-	count = chunk_delete(&iterator, relid, DROP_RESTRICT, false, true);
+	count = chunk_delete(&iterator, relid, DROP_RESTRICT, true);
 
 	/*
 	 * (schema,table) names and (hypertable_id) are unique so should only have

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -33,7 +33,6 @@ typedef enum ChunkCompressionStatus
 	CHUNK_COMPRESS_NONE = 0,
 	CHUNK_COMPRESS_UNORDERED,
 	CHUNK_COMPRESS_ORDERED,
-	CHUNK_DROPPED
 } ChunkCompressionStatus;
 
 typedef enum ChunkOperation
@@ -199,8 +198,7 @@ extern int ts_chunk_delete_by_hypertable_id(int32 hypertable_id);
 extern TSDLLEXPORT int ts_chunk_delete_by_name(const char *schema, const char *table,
 											   DropBehavior behavior);
 extern int ts_chunk_delete_by_relid_and_relname(Oid relid, const char *schemaname,
-												const char *tablename, DropBehavior behavior,
-												bool preserve_chunk_catalog_row);
+												const char *tablename, DropBehavior behavior);
 extern bool ts_chunk_set_name(Chunk *chunk, const char *newname);
 extern bool ts_chunk_set_schema(Chunk *chunk, const char *newschema);
 extern TSDLLEXPORT List *ts_chunk_get_window(int32 dimension_id, int64 point, int count,
@@ -215,8 +213,6 @@ extern TSDLLEXPORT bool ts_chunk_is_frozen(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id);
 extern TSDLLEXPORT bool ts_chunk_clear_compressed_chunk(Chunk *chunk);
 extern TSDLLEXPORT void ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level);
-extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(const Chunk *chunk,
-														   DropBehavior behavior, int32 log_level);
 extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than,
 												 int32 log_level, Oid time_type, Oid arg_type,
 												 bool older_newer);
@@ -275,7 +271,6 @@ extern TSDLLEXPORT void ts_chunk_detach_by_relid(Oid relid);
 	do                                                                                             \
 	{                                                                                              \
 		Assert(chunk);                                                                             \
-		Assert(!(chunk)->fd.dropped);                                                              \
 		Assert((chunk)->fd.id > 0);                                                                \
 		Assert((chunk)->fd.hypertable_id > 0);                                                     \
 		Assert(OidIsValid((chunk)->table_id));                                                     \

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -70,14 +70,8 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 			continue;
 		}
 		bool isnull;
-		Datum datum = slot_getattr(ti->slot, Anum_chunk_dropped, &isnull);
-		const bool is_dropped = isnull ? false : DatumGetBool(datum);
-		if (is_dropped)
-		{
-			continue;
-		}
 
-		/* We found a chunk that is not dropped. First, try to lock it. */
+		/* We found a chunk. First, try to lock it. */
 		Name schema_name = DatumGetName(slot_getattr(ti->slot, Anum_chunk_schema_name, &isnull));
 		Assert(!isnull);
 		Name table_name = DatumGetName(slot_getattr(ti->slot, Anum_chunk_table_name, &isnull));

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1423,7 +1423,7 @@ process_truncate(ProcessUtilityArgs *args)
 						{
 							Chunk *compressed_chunk =
 								ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, false);
-							if (compressed_chunk != NULL && !compressed_chunk->fd.dropped)
+							if (compressed_chunk != NULL)
 							{
 								/* Create list item into the same context of the list. */
 								oldctx = MemoryContextSwitchTo(parsetreectx);
@@ -5615,11 +5615,7 @@ process_drop_table(EventTriggerDropObject *obj)
 	EventTriggerDropRelation *table = (EventTriggerDropRelation *) obj;
 
 	Assert(obj->type == EVENT_TRIGGER_DROP_TABLE || obj->type == EVENT_TRIGGER_DROP_FOREIGN_TABLE);
-	ts_chunk_delete_by_relid_and_relname(table->relid,
-										 table->schema,
-										 table->name,
-										 DROP_RESTRICT,
-										 false);
+	ts_chunk_delete_by_relid_and_relname(table->relid, table->schema, table->name, DROP_RESTRICT);
 	ts_hypertable_delete_by_name(table->schema, table->name);
 	/*
 	 * Normally, dependent catalogs (like compression settings) are cleaned up

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -370,7 +370,6 @@ enum Anum_chunk
 	Anum_chunk_schema_name,
 	Anum_chunk_table_name,
 	Anum_chunk_compressed_chunk_id,
-	Anum_chunk_dropped,
 	Anum_chunk_status,
 	Anum_chunk_osm_chunk,
 	Anum_chunk_creation_time,
@@ -386,7 +385,6 @@ typedef struct FormData_chunk
 	NameData schema_name;
 	NameData table_name;
 	int32 compressed_chunk_id;
-	bool dropped;
 	int32 status;
 	bool osm_chunk;
 	TimestampTz creation_time;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1294,7 +1294,7 @@ ts_hypertable_approximate_size(PG_FUNCTION_ARGS)
 	init_scan_by_hypertable_id(&iterator, ht->fd.id);
 	ts_scanner_foreach(&iterator)
 	{
-		bool isnull, dropped, is_osm_chunk;
+		bool isnull, is_osm_chunk;
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		Datum id = slot_getattr(ti->slot, Anum_chunk_id, &isnull);
 		Datum comp_id = DatumGetInt32(slot_getattr(ti->slot, Anum_chunk_id, &isnull));
@@ -1303,12 +1303,6 @@ ts_hypertable_approximate_size(PG_FUNCTION_ARGS)
 		RelationSize chunk_relsize, compressed_chunk_relsize;
 
 		if (isnull)
-			continue;
-
-		/* only consider chunks that are not dropped */
-		dropped = DatumGetBool(slot_getattr(ti->slot, Anum_chunk_dropped, &isnull));
-		Assert(!isnull);
-		if (dropped)
 			continue;
 
 		chunk_id = DatumGetInt32(id);

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -189,24 +189,24 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+----------------+---------------------+---------+--------+-----------
-  2 |             2 | _timescaledb_internal | new_chunk_name |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+----------------+---------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | new_chunk_name |                     |      0 | f
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+----------------+---------------------+---------+--------+-----------
-  2 |             2 | public      | new_chunk_name |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+----------------+---------------------+--------+-----------
+  2 |             2 | public      | new_chunk_name |                     |      0 | f
 
 -- Test that we cannot rename chunk columns
 \set ON_ERROR_STOP 0
@@ -634,11 +634,11 @@ SELECT * from _timescaledb_catalog.hypertable;
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
  12 | public      | my_table   | new_associated_schema  | _hyper_12               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
- 24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     | f       |      0 | f
- 25 |            12 | new_associated_schema | _hyper_12_25_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+--------------------+---------------------+--------+-----------
+ 24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     |      0 | f
+ 25 |            12 | new_associated_schema | _hyper_12_25_chunk |                     |      0 | f
 
 DROP TABLE my_table;
 -- test renaming unique constraints/indexes

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -25,7 +25,6 @@ SELECT * FROM test.relation WHERE schema = 'test_schema';
  schema_name         | name                     |           | not null | 
  table_name          | name                     |           | not null | 
  compressed_chunk_id | integer                  |           |          | 
- dropped             | boolean                  |           | not null | false
  status              | integer                  |           | not null | 0
  osm_chunk           | boolean                  |           | not null | false
  creation_time       | timestamp with time zone |           | not null | 
@@ -510,13 +509,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
 ----+-------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
  10 | test_schema | test_migrate | _timescaledb_internal  | _hyper_10               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-select id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     | f       |      0 | f
-  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |                     | f       |      0 | f
-  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |                     | f       |      0 | f
- 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |                     | f       |      0 | f
+select id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+--------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     |      0 | f
+  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |                     |      0 | f
+  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |                     |      0 | f
+ 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |                     |      0 | f
 
 select * from test_schema.test_migrate;
            time           | temp 

--- a/test/expected/drop_owned-15.out
+++ b/test/expected/drop_owned-15.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_owned-16.out
+++ b/test/expected/drop_owned-16.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_owned-17.out
+++ b/test/expected/drop_owned-17.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_owned-18.out
+++ b/test/expected/drop_owned-18.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -31,11 +31,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | test1      | chunk_schema1          | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+---------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+---------------+------------------+---------------------+--------+-----------
+  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     |      0 | f
+  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     |      0 | f
 
 RESET ROLE;
 --drop the associated schema. We drop the extra schema to show we can
@@ -52,18 +52,18 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | test1      | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+---------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+---------------+------------------+---------------------+--------+-----------
+  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     |      0 | f
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
 
 RESET ROLE;
 --dropping the internal schema should not work
@@ -80,9 +80,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/dump_meta.out
+++ b/test/expected/dump_meta.out
@@ -141,7 +141,6 @@ SELECT hypertable,
               AND pns.oid = pgc.relnamespace
               AND pns.nspname = h.schema_name
               AND relkind = 'r'
-              AND c.dropped is false
               GROUP BY pgc.oid
               ) sub1
        ) sub2;
@@ -192,7 +191,6 @@ SELECT *,
              AND c.id = cc.chunk_id
              AND cc.dimension_slice_id = ds.id
              AND ds.dimension_id = d.id
-             AND c.dropped is false
        GROUP BY c.id, pgc.reltoastrelid, pgc.oid ORDER BY c.id
        ) sub1
 ) sub2;

--- a/test/expected/insert-15.out
+++ b/test/expected/insert-15.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert-16.out
+++ b/test/expected/insert-16.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert-17.out
+++ b/test/expected/insert-17.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert-18.out
+++ b/test/expected/insert-18.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -229,23 +229,23 @@ SELECT * FROM "1dim_neg";
    19 | 21.2
    20 | 21.2
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+-------------------+---------------------+---------+--------+-----------
-  1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     | f       |      0 | f
-  2 |             1 | one_Partition         | _hyper_1_2_chunk  |                     | f       |      0 | f
-  3 |             1 | one_Partition         | _hyper_1_3_chunk  |                     | f       |      0 | f
-  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |                     | f       |      0 | f
-  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |                     | f       |      0 | f
-  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |                     | f       |      0 | f
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |                     | f       |      0 | f
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |                     | f       |      0 | f
- 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |                     | f       |      0 | f
- 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |                     | f       |      0 | f
- 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |                     | f       |      0 | f
- 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |                     | f       |      0 | f
- 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |                     | f       |      0 | f
- 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+-------------------+---------------------+--------+-----------
+  1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     |      0 | f
+  2 |             1 | one_Partition         | _hyper_1_2_chunk  |                     |      0 | f
+  3 |             1 | one_Partition         | _hyper_1_3_chunk  |                     |      0 | f
+  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |                     |      0 | f
+  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |                     |      0 | f
+  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |                     |      0 | f
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |                     |      0 | f
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |                     |      0 | f
+ 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |                     |      0 | f
+ 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |                     |      0 | f
+ 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |                     |      0 | f
+ 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |                     |      0 | f
+ 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |                     |      0 | f
+ 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |                     |      0 | f
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;
  id | dimension_id |     range_start     |      range_end      

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -39,13 +39,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 ----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
 
 SELECT * FROM test.show_subtables('"two_Partitions"');
                  Child                  | Tablespace 
@@ -78,9 +78,9 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 ----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+--------+-----------
 
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -96,12 +96,12 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257987600000000000, 'dev1', 1.5, 2),
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0 | f
-  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     |      0 | f
+  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |                     |      0 | f
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;
 CREATE OR REPLACE FUNCTION test_trigger()

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -101,15 +101,15 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Test that we cannot rename chunk columns
 \set ON_ERROR_STOP 0
@@ -385,7 +385,7 @@ ALTER SCHEMA my_associated_schema RENAME TO new_associated_schema;
 INSERT INTO my_table (date, quantity) VALUES ('2018-08-10T23:00:00+00:00', 20);
 -- Make sure the schema name is changed in both catalog tables
 SELECT * from _timescaledb_catalog.hypertable;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
 
 DROP TABLE my_table;
 

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -276,7 +276,7 @@ select create_hypertable('test_schema.test_migrate', 'time', migrate_data => tru
 
 --there should be two new chunks
 select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
-select id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk from _timescaledb_catalog.chunk;
+select id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
 select * from test_schema.test_migrate;
 --main table should now be empty
 select * from only test_schema.test_migrate;

--- a/test/sql/drop_owned.sql.in
+++ b/test/sql/drop_owned.sql.in
@@ -18,18 +18,18 @@ SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
 INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 DROP TABLE  hypertable_schema.superuser;
 
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT * FROM _timescaledb_catalog.chunk_constraint;

--- a/test/sql/drop_schema.sql
+++ b/test/sql/drop_schema.sql
@@ -22,7 +22,7 @@ INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 INSERT INTO hypertable_schema.test2 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 RESET ROLE;
 --drop the associated schema. We drop the extra schema to show we can
@@ -33,11 +33,11 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 --show that the metadata for the table using the dropped schema is
 --changed. The other table is not affected.
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 RESET ROLE;
 --dropping the internal schema should not work
@@ -50,7 +50,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT * FROM _timescaledb_catalog.chunk_constraint;

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -8,7 +8,7 @@ SET enable_seqscan TO off;
 
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 SELECT * FROM ONLY "two_Partitions";

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -55,7 +55,7 @@ INSERT INTO "1dim_neg" VALUES (19, 21.2);
 INSERT INTO "1dim_neg" VALUES (20, 21.2);
 SELECT * FROM "1dim_pre1970";
 SELECT * FROM "1dim_neg";
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 
 

--- a/test/sql/truncate.sql
+++ b/test/sql/truncate.sql
@@ -7,7 +7,7 @@
 \o
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM test.show_subtables('"two_Partitions"');
 SELECT * FROM "two_Partitions";
 
@@ -15,7 +15,7 @@ SET client_min_messages = WARNING;
 TRUNCATE "two_Partitions";
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -27,7 +27,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;
 

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -146,16 +146,14 @@ ORDER BY 1, 2, 4;
 -- The list of tables configured to be dumped.
 SELECT unnest(extconfig)::regclass::text, unnest(extcondition) FROM pg_extension WHERE extname = 'timescaledb' ORDER BY 1;
 
--- Show chunks that are not dropped and include owner in the output
-SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.dropped, cl.relowner::regrole
+-- Show chunks that include owner in the output
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, cl.relowner::regrole
 FROM  _timescaledb_catalog.chunk c
 INNER JOIN pg_class cl ON (cl.oid=format('%I.%I', schema_name, table_name)::regclass)
-WHERE NOT c.dropped
 ORDER BY c.id, c.hypertable_id;
 
 SELECT chunk_constraint.* FROM _timescaledb_catalog.chunk_constraint
 JOIN _timescaledb_catalog.chunk ON chunk.id = chunk_constraint.chunk_id
-WHERE NOT chunk.dropped
 ORDER BY chunk_constraint.chunk_id, chunk_constraint.dimension_slice_id, chunk_constraint.constraint_name;
 
 -- Show attnum of all regclass objects belonging to our extension

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -538,11 +538,6 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 ------+------
    30 |   30
 
---chunks are removed
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE dropped;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
-
 --still see data in the view
 SELECT * FROM drop_chunks_view WHERE time_bucket < (integer_now_test2()-9) ORDER BY time_bucket DESC;
  time_bucket | max 

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -538,11 +538,6 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 ------+------
    30 |   30
 
---chunks are removed
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE dropped;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
-
 --still see data in the view
 SELECT * FROM drop_chunks_view WHERE time_bucket < (integer_now_test2()-9) ORDER BY time_bucket DESC;
  time_bucket | max 

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -538,11 +538,6 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 ------+------
    30 |   30
 
---chunks are removed
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE dropped;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
-
 --still see data in the view
 SELECT * FROM drop_chunks_view WHERE time_bucket < (integer_now_test2()-9) ORDER BY time_bucket DESC;
  time_bucket | max 

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -538,11 +538,6 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 ------+------
    30 |   30
 
---chunks are removed
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE dropped;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+---------+--------+-----------
-
 --still see data in the view
 SELECT * FROM drop_chunks_view WHERE time_bucket < (integer_now_test2()-9) ORDER BY time_bucket DESC;
  time_bucket | max 

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_16_chunk |            0 | f       |        
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_16_chunk |            0 |        
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,53 +452,49 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- dropping chunk should NOT remove the catalog data
+-- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_17_chunk
 
--- should return 3 chunks and one of them should be marked as dropped
+-- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- remove the fake old format cagg
-DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_20_chunk
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_18_chunk
 
--- should return 2 chunks and one of them should be marked as dropped
--- because we dropped chunk before when an old format cagg exists
+-- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_19_chunk |            0 |        
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_16_chunk |            0 | f       |        
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_16_chunk |            0 |        
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,53 +452,49 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- dropping chunk should NOT remove the catalog data
+-- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_17_chunk
 
--- should return 3 chunks and one of them should be marked as dropped
+-- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- remove the fake old format cagg
-DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_20_chunk
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_18_chunk
 
--- should return 2 chunks and one of them should be marked as dropped
--- because we dropped chunk before when an old format cagg exists
+-- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_19_chunk |            0 |        
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_16_chunk |            0 | f       |        
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_16_chunk |            0 |        
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,53 +452,49 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- dropping chunk should NOT remove the catalog data
+-- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_17_chunk
 
--- should return 3 chunks and one of them should be marked as dropped
+-- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- remove the fake old format cagg
-DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_20_chunk
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_18_chunk
 
--- should return 2 chunks and one of them should be marked as dropped
--- because we dropped chunk before when an old format cagg exists
+-- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_19_chunk |            0 |        
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-18.out
+++ b/tsl/test/expected/cagg_usage-18.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_16_chunk |            0 | f       |        
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_16_chunk |            0 |        
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,53 +452,49 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_17_chunk |            0 | f       |        
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_17_chunk |            0 |        
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- dropping chunk should NOT remove the catalog data
+-- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_17_chunk
 
--- should return 3 chunks and one of them should be marked as dropped
+-- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_18_chunk |            0 | f       |        
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_18_chunk |            0 |        
+ _hyper_11_19_chunk |            0 |        
 
--- remove the fake old format cagg
-DROP MATERIALIZED VIEW cagg1;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_20_chunk
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_18_chunk
 
--- should return 2 chunks and one of them should be marked as dropped
--- because we dropped chunk before when an old format cagg exists
+-- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_11_19_chunk |            0 | f       |        
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_11_19_chunk |            0 |        
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -31,18 +31,18 @@ SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> 
 
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0 | f
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk |                     | f       |      0 | f
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk |                     | f       |      0 | f
-  9 |             3 | _timescaledb_internal | _hyper_3_9_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     |      0 | f
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk |                     |      0 | f
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk |                     |      0 | f
+  9 |             3 | _timescaledb_internal | _hyper_3_9_chunk |                     |      0 | f
 
 \set ON_ERROR_STOP 0
 -- Cannot merge chunks from different hypertables

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1285,14 +1285,14 @@ ORDER BY 2,3;
 CREATE TABLE test_multicon(time timestamptz not null unique, a int);
 SELECT hypertable_id as htid FROM create_hypertable('test_multicon', 'time', chunk_time_interval => interval '1 day') \gset
 insert into test_multicon values ('2020-01-02 01:00'::timestamptz, 1);
-SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.dropped, c.status, c.osm_chunk,
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.status, c.osm_chunk,
 cc.chunk_id, cc.dimension_slice_id, cc.constraint_name, cc.hypertable_constraint_name FROM
 _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc WHERE c.hypertable_id = :htid
 AND c.id = cc.chunk_id;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk | chunk_id | dimension_slice_id |       constraint_name       | hypertable_constraint_name 
-----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------+----------+--------------------+-----------------------------+----------------------------
- 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     | f       |      0 | f         |       31 |                    | 31_5_test_multicon_time_key | test_multicon_time_key
- 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     | f       |      0 | f         |       31 |                 28 | constraint_28               | 
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk | chunk_id | dimension_slice_id |       constraint_name       | hypertable_constraint_name 
+----+---------------+-----------------------+--------------------+---------------------+--------+-----------+----------+--------------------+-----------------------------+----------------------------
+ 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     |      0 | f         |       31 |                    | 31_5_test_multicon_time_key | test_multicon_time_key
+ 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     |      0 | f         |       31 |                 28 | constraint_28               | 
 
 \c :TEST_DBNAME :ROLE_SUPERUSER ;
 UPDATE _timescaledb_catalog.chunk SET osm_chunk = true WHERE hypertable_id = :htid;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1447,12 +1447,12 @@ SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
 
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
- chunk_name | chunk_status | dropped | comp_id 
-------------+--------------+---------+---------
+ chunk_name | chunk_status | comp_id 
+------------+--------------+---------
 
 SELECT "time", cnt  FROM cagg_expr ORDER BY time LIMIT 5;
              time             | cnt  
@@ -1473,14 +1473,14 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | dropped | comp_id 
---------------------+--------------+---------+---------
- _hyper_13_64_chunk |            1 | f       |      66
- _hyper_13_65_chunk |            1 | f       |      67
+     chunk_name     | chunk_status | comp_id 
+--------------------+--------------+---------
+ _hyper_13_64_chunk |            1 |      66
+ _hyper_13_65_chunk |            1 |      67
 
 SELECT count(*) FROM metrics;
  count 

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -67,13 +67,13 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
 ------------------+--------------+-------------
  _hyper_1_1_chunk | 32 kB        | 40 kB
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
- id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
-----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 | f       |      1 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                     | f       |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                     | f       |      0 | f
-  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
+ id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | status | osm_chunk 
+----+---------------+-----------------------+--------------------------+---------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 |      1 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                     |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                     |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     |      0 | f
 
 -- TEST 4 --
 --cannot set another policy
@@ -829,7 +829,7 @@ SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
 ERROR:  columnstore policy failure
 DETAIL:  Failed to convert '20' chunks to columnstore. Successfully converted '11' chunks.
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 118 at RAISE
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 117 at RAISE
 SQL statement "CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time)"
 PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 62 at CALL
 \set VERBOSITY terse

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1881,7 +1881,7 @@ DECLARE
 BEGIN
   FOR chunk IN
   SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL AND NOT dropped
+    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL
     ORDER BY id
   LOOP
     EXECUTE format('select decompress_chunk(''%s'');', chunk::text);

--- a/tsl/test/expected/compression_nulls_and_defaults.out
+++ b/tsl/test/expected/compression_nulls_and_defaults.out
@@ -598,7 +598,7 @@ BEGIN
 			_timescaledb_catalog.chunk comp,
 			(SELECT show_chunks('codecov') as c) as x
 		WHERE
-			uncomp.dropped IS FALSE AND uncomp.compressed_chunk_id IS NOT NULL AND
+			uncomp.compressed_chunk_id IS NOT NULL AND
 			comp.id = uncomp.compressed_chunk_id AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -3457,7 +3457,7 @@ BEGIN
 			_timescaledb_catalog.chunk comp,
 			(SELECT show_chunks('bool_table') as c UNION SELECT show_chunks('int_table') as c) as x
 		WHERE
-			uncomp.dropped IS FALSE AND uncomp.compressed_chunk_id IS NOT NULL AND
+			uncomp.compressed_chunk_id IS NOT NULL AND
 			comp.id = uncomp.compressed_chunk_id AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -692,11 +692,11 @@ order by time;
  Sun Jan 07 09:03:11 2024 PST |      1 |   21 |       21
  Wed Jan 10 02:04:12 2024 PST |      1 |   17 |       32
 
-select table_name, dropped, status, compressed_chunk_id
+select table_name, status, compressed_chunk_id
 from _timescaledb_catalog.chunk where table_name = '_hyper_1_3_chunk';
-    table_name    | dropped | status | compressed_chunk_id 
-------------------+---------+--------+---------------------
- _hyper_1_3_chunk | f       |      9 |                  15
+    table_name    | status | compressed_chunk_id 
+------------------+--------+---------------------
+ _hyper_1_3_chunk |      9 |                  15
 
 analyze _timescaledb_internal._hyper_1_3_chunk;
 truncate chunk_summary_before_split;
@@ -735,13 +735,13 @@ select * from chunk_info;
  _hyper_1_7_chunk  | heap |      5760 | constraint_11 | (("time" >= 'Wed Dec 27 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone))
  _hyper_1_8_chunk  | heap |     28800 | constraint_13 | (("time" >= 'Fri Jan 05 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone))
 
-select table_name, dropped, status, compressed_chunk_id
+select table_name, status, compressed_chunk_id
 from _timescaledb_catalog.chunk
 where table_name in ('_hyper_1_3_chunk', '_hyper_1_16_chunk');
-    table_name     | dropped | status | compressed_chunk_id 
--------------------+---------+--------+---------------------
- _hyper_1_16_chunk | f       |      9 |                  17
- _hyper_1_3_chunk  | f       |      9 |                  15
+    table_name     | status | compressed_chunk_id 
+-------------------+--------+---------------------
+ _hyper_1_16_chunk |      9 |                  17
+ _hyper_1_3_chunk  |      9 |                  15
 
 -- Check that the non-compressed data rows ended up in separate partitions
 select *

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -390,8 +390,6 @@ SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 --earliest datapoint now in table
 SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
---chunks are removed
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE dropped;
 --still see data in the view
 SELECT * FROM drop_chunks_view WHERE time_bucket < (integer_now_test2()-9) ORDER BY time_bucket DESC;
 --no data but covers dropped chunks

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -295,7 +295,7 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
@@ -306,33 +306,29 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
 
--- dropping chunk should NOT remove the catalog data
+-- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
 
--- should return 3 chunks and one of them should be marked as dropped
+-- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
 
--- remove the fake old format cagg
-DROP MATERIALIZED VIEW cagg1;
-
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
 
--- should return 2 chunks and one of them should be marked as dropped
--- because we dropped chunk before when an old format cagg exists
+-- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -26,7 +26,7 @@ SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> 
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 \set ON_ERROR_STOP 0
 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -684,7 +684,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
@@ -696,7 +696,7 @@ INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10
 SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+   c.status as chunk_status, c.compressed_chunk_id as comp_id
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -53,7 +53,7 @@ CALL run_job(:compressjob_id);
 select chunk_name, pg_size_pretty(before_compression_total_bytes) before_total,
 pg_size_pretty( after_compression_total_bytes)  after_total
 from chunk_compression_stats('conditions') where compression_status like 'Compressed' order by chunk_name;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
 
 -- TEST 4 --
 --cannot set another policy

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -911,7 +911,7 @@ DECLARE
 BEGIN
   FOR chunk IN
   SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL AND NOT dropped
+    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL
     ORDER BY id
   LOOP
     EXECUTE format('select decompress_chunk(''%s'');', chunk::text);

--- a/tsl/test/sql/compression_nulls_and_defaults.sql
+++ b/tsl/test/sql/compression_nulls_and_defaults.sql
@@ -279,7 +279,7 @@ BEGIN
 			_timescaledb_catalog.chunk comp,
 			(SELECT show_chunks('codecov') as c) as x
 		WHERE
-			uncomp.dropped IS FALSE AND uncomp.compressed_chunk_id IS NOT NULL AND
+			uncomp.compressed_chunk_id IS NOT NULL AND
 			comp.id = uncomp.compressed_chunk_id AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -851,7 +851,7 @@ BEGIN
 			_timescaledb_catalog.chunk comp,
 			(SELECT show_chunks('bool_table') as c UNION SELECT show_chunks('int_table') as c) as x
 		WHERE
-			uncomp.dropped IS FALSE AND uncomp.compressed_chunk_id IS NOT NULL AND
+			uncomp.compressed_chunk_id IS NOT NULL AND
 			comp.id = uncomp.compressed_chunk_id AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP

--- a/tsl/test/sql/include/chunk_utils_internal_orderedappend.sql
+++ b/tsl/test/sql/include/chunk_utils_internal_orderedappend.sql
@@ -40,7 +40,7 @@ ORDER BY 2,3;
 CREATE TABLE test_multicon(time timestamptz not null unique, a int);
 SELECT hypertable_id as htid FROM create_hypertable('test_multicon', 'time', chunk_time_interval => interval '1 day') \gset
 insert into test_multicon values ('2020-01-02 01:00'::timestamptz, 1);
-SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.dropped, c.status, c.osm_chunk,
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.status, c.osm_chunk,
 cc.chunk_id, cc.dimension_slice_id, cc.constraint_name, cc.hypertable_constraint_name FROM
 _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc WHERE c.hypertable_id = :htid
 AND c.id = cc.chunk_id;

--- a/tsl/test/sql/split_chunk.sql
+++ b/tsl/test/sql/split_chunk.sql
@@ -438,7 +438,7 @@ select *
 from ONLY _timescaledb_internal._hyper_1_3_chunk
 order by time;
 
-select table_name, dropped, status, compressed_chunk_id
+select table_name, status, compressed_chunk_id
 from _timescaledb_catalog.chunk where table_name = '_hyper_1_3_chunk';
 analyze _timescaledb_internal._hyper_1_3_chunk;
 
@@ -458,7 +458,7 @@ call split_chunk('_timescaledb_internal._hyper_1_3_chunk');
 -- Check that the resulting chunks look OK and have the right access method
 select * from chunk_info;
 
-select table_name, dropped, status, compressed_chunk_id
+select table_name, status, compressed_chunk_id
 from _timescaledb_catalog.chunk
 where table_name in ('_hyper_1_3_chunk', '_hyper_1_16_chunk');
 

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -77,7 +77,7 @@ query_generates_wal(
 	"insert into plain chunk",
 	qq/INSERT INTO metrics VALUES ('2023-07-01T00:00:00Z', 1, 1.0);/,
 	qq(table _timescaledb_catalog.dimension_slice: INSERT: id[integer]:1 dimension_id[integer]:1 range_start[bigint]:1687996800000000 range_end[bigint]:1688601600000000
-table _timescaledb_catalog.chunk: INSERT: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: INSERT: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null status[integer]:0 osm_chunk[boolean]:false
 table _timescaledb_catalog.chunk_constraint: INSERT: chunk_id[integer]:1 dimension_slice_id[integer]:1 constraint_name[name]:'constraint_1' hypertable_constraint_name[name]:null
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1)
 );
@@ -86,9 +86,9 @@ query_generates_wal(
 	"compress chunk",
 	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
 	qq(message: transactional: 1 prefix: ::timescaledb-compression-start, sz: 0 content:
-table _timescaledb_catalog.chunk: INSERT: id[integer]:2 hypertable_id[integer]:2 schema_name[name]:'_timescaledb_internal' table_name[name]:'compress_hyper_2_2_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: INSERT: id[integer]:2 hypertable_id[integer]:2 schema_name[name]:'_timescaledb_internal' table_name[name]:'compress_hyper_2_2_chunk' compressed_chunk_id[integer]:null status[integer]:0 osm_chunk[boolean]:false
 table _timescaledb_catalog.compression_settings: INSERT: relid[regclass]:'_timescaledb_internal._hyper_1_1_chunk' compress_relid[regclass]:'_timescaledb_internal.compress_hyper_2_2_chunk' segmentby[text[]]:'{device_id}' orderby[text[]]:'{time}' orderby_desc[boolean[]]:'{f}' orderby_nullsfirst[boolean[]]:'{f}' index[jsonb]:'[{"type": "minmax", "column": "time", "source": "orderby"}]'
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:2 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:2 status[integer]:1 osm_chunk[boolean]:false
 table _timescaledb_internal.compress_hyper_2_2_chunk: INSERT: _ts_meta_count[integer]:1 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-06-30 17:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJgYhxAAAAComBiHEAAAAAAAQAAAAEAAAAAAAAADgAFRMDEOIAA' value[_timescaledb_internal.compressed_data]:'AwA/8AAAAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAEAAAAAAAAAAoAAAABCgAAAAAAAAP/'
 table _timescaledb_catalog.compression_chunk_size: INSERT: chunk_id[integer]:1 compressed_chunk_id[integer]:2 uncompressed_heap_size[bigint]:8192 uncompressed_toast_size[bigint]:0 uncompressed_index_size[bigint]:16384 compressed_heap_size[bigint]:16384 compressed_toast_size[bigint]:8192 compressed_index_size[bigint]:16384 numrows_pre_compression[bigint]:1 numrows_post_compression[bigint]:1 numrows_frozen_immediately[bigint]:1
 message: transactional: 1 prefix: ::timescaledb-compression-end, sz: 0 content:)
@@ -100,7 +100,7 @@ query_generates_wal(
 	qq(message: transactional: 1 prefix: ::timescaledb-decompression-start, sz: 0 content:
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_catalog.compression_chunk_size: DELETE: chunk_id[integer]:1
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null status[integer]:0 osm_chunk[boolean]:false
 table _timescaledb_catalog.compression_settings: DELETE: relid[regclass]:'_timescaledb_internal._hyper_1_1_chunk'
 table _timescaledb_catalog.chunk: DELETE: id[integer]:2
 message: transactional: 1 prefix: ::timescaledb-decompression-end, sz: 0 content:)
@@ -122,7 +122,7 @@ query_generates_wal(
 	"insert into uncompressed chunk",
 	qq(INSERT INTO metrics VALUES ('2023-07-01T01:00:00Z', 1, 1.0);),
 	qq(table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 18:00:00-07' device_id[bigint]:1 value[double precision]:1
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:9 osm_chunk[boolean]:false),
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 status[integer]:9 osm_chunk[boolean]:false),
 );
 
 query_generates_wal(
@@ -131,7 +131,7 @@ query_generates_wal(
 	qq(message: transactional: 1 prefix: ::timescaledb-compression-start, sz: 0 content:
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 18:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_internal.compress_hyper_2_3_chunk: INSERT: _ts_meta_count[integer]:1 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 18:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-06-30 18:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJhOK/kAAAComE4r+QAAAAAAQAAAAEAAAAAAAAADgAFRMJxX8gA' value[_timescaledb_internal.compressed_data]:'AwA/8AAAAAAAAAAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAEAAAAAAAAAAoAAAABCgAAAAAAAAP/'
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 status[integer]:1 osm_chunk[boolean]:false
 message: transactional: 1 prefix: ::timescaledb-compression-end, sz: 0 content:)
 );
 
@@ -139,7 +139,7 @@ query_generates_wal(
 	"insert into uncompressed chunk 2",
 	qq(INSERT INTO metrics VALUES ('2023-07-01T02:00:00Z', 1, 1.0);),
 	qq(table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 19:00:00-07' device_id[bigint]:1 value[double precision]:1
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:9 osm_chunk[boolean]:false),
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 status[integer]:9 osm_chunk[boolean]:false),
 );
 
 query_generates_wal(
@@ -165,7 +165,7 @@ table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 19:00:00-07' device_id[bigint]:1 value[double precision]:22
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:22
 table _timescaledb_internal.compress_hyper_2_3_chunk: INSERT: _ts_meta_count[integer]:3 device_id[bigint]:1 _ts_meta_min_1[timestamp with time zone]:'2023-06-30 17:00:00-07' _ts_meta_max_1[timestamp with time zone]:'2023-06-30 19:00:00-07' "time"[_timescaledb_internal.compressed_data]:'BAAAAqJiD0OIAAAAAADWk6QAAAAAAwAAAAMAAAAAAAAB7gAFRMDEOIAAAAVEvxcRN/8AAAAAAAAAAA==' value[_timescaledb_internal.compressed_data]:'AwBANgAAAAAAAAAAAAMAAAABAAAAAAAAAAEAAAAAAAAABwAAAAMAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAEAAAABAAAAAQAAAAAAAAAEAAAAAAAAAA4AAAABKgAAA/4/+OAb'
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 status[integer]:1 osm_chunk[boolean]:false
 message: transactional: 1 prefix: ::timescaledb-compression-end, sz: 0 content:)
 );
 
@@ -173,7 +173,7 @@ query_generates_wal(
 	"insert into uncompressed chunk 3",
 	qq(INSERT INTO metrics VALUES ('2023-07-01T03:00:00Z', 1, 1.0);),
 	qq(table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 20:00:00-07' device_id[bigint]:1 value[double precision]:1
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 dropped[boolean]:false status[integer]:9 osm_chunk[boolean]:false),
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:3 status[integer]:9 osm_chunk[boolean]:false),
 );
 
 query_generates_wal(
@@ -208,7 +208,7 @@ discard_wal();
 query_generates_wal(
 	"insert into compressed chunk with pk forces decompression",
 	qq/INSERT INTO metrics VALUES ('2023-07-01 00:00:00Z', 1, 5555) ON CONFLICT DO NOTHING;/,
-	qq/table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 dropped[boolean]:false status[integer]:9 osm_chunk[boolean]:false/
+	qq/table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 status[integer]:9 osm_chunk[boolean]:false/
 );
 
 # Disable marker generation through GUC
@@ -219,7 +219,7 @@ $db->reload();
 query_generates_wal(
 	"compress chunk after disabling markers",
 	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);),
-	qq(table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 dropped[boolean]:false status[integer]:1 osm_chunk[boolean]:false)
+	qq(table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:4 status[integer]:1 osm_chunk[boolean]:false)
 );
 
 query_generates_wal(
@@ -228,7 +228,7 @@ query_generates_wal(
 	qq(table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:1
 table _timescaledb_internal._hyper_1_1_chunk: INSERT: "time"[timestamp with time zone]:'2023-07-01 05:00:00-07' device_id[bigint]:1 value[double precision]:2
 table _timescaledb_catalog.compression_chunk_size: DELETE: chunk_id[integer]:1
-table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null dropped[boolean]:false status[integer]:0 osm_chunk[boolean]:false
+table _timescaledb_catalog.chunk: UPDATE: id[integer]:1 hypertable_id[integer]:1 schema_name[name]:'_timescaledb_internal' table_name[name]:'_hyper_1_1_chunk' compressed_chunk_id[integer]:null status[integer]:0 osm_chunk[boolean]:false
 table _timescaledb_catalog.compression_settings: DELETE: relid[regclass]:'_timescaledb_internal._hyper_1_1_chunk'
 table _timescaledb_catalog.chunk: DELETE: id[integer]:4)
 );


### PR DESCRIPTION
With the removal of support for old format caggs we can remove
support for chunks to be marked as dropped instead of always dropping
from our catalog. This commit removes the code dealing with this
variant and removes the `dropped` flag from our catalog.
