### PR TITLE
Fix handling implicit constraints in ALTER TABLE

### DIFF
--- a/.unreleased/pr_9144
+++ b/.unreleased/pr_9144
@@ -1,0 +1,2 @@
+Fixes: #9144 Fix handling implicit constraints in ALTER TABLE
+Thanks: @vahnrr for reporting a crash when adding columns and constraints to a hypertable at the same time

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4677,7 +4677,14 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 			if (conname == NULL)
 				conname = get_rel_name(obj->objectId);
 
-			process_altertable_add_constraint(ht, cmd, conname);
+			/*
+			 * Implicit constraints (e.g., those created by PRIMARY KEY or UNIQUE
+			 * constraints) have already been processed when the index was created.
+			 * These will have no objectId in the ObjectAddress passed to this
+			 * function and no conname.
+			 */
+			if (conname)
+				process_altertable_add_constraint(ht, cmd, conname);
 		}
 		break;
 		case AT_AlterColumnType:

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -821,5 +821,19 @@ ORDER BY index_name;
 
 -- Alter replica identity directly on a chunk is not supported
 SELECT ch AS chunk_name FROM show_chunks('replid') ch ORDER BY chunk_name LIMIT 1 \gset
+\set ON_ERROR_STOP 0
 ALTER TABLE :chunk_name REPLICA IDENTITY FULL;
 ERROR:  operation not supported on chunk tables
+\set ON_ERROR_STOP 1
+SELECT relname, relreplident FROM show_chunks('replid') ch INNER JOIN pg_class c ON (ch = c.oid) ORDER BY relname;
+      relname       | relreplident 
+--------------------+--------------
+ _hyper_16_31_chunk | i
+ _hyper_16_32_chunk | i
+ _hyper_16_33_chunk | n
+
+-- test implicit constraints gh issue #9132
+CREATE TABLE i9132(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i9132 VALUES ('2024-01-01'), ('2024-02-02');
+ALTER TABLE i9132 ADD COLUMN id serial, ADD CONSTRAINT implicit_pk PRIMARY KEY (id, time);

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -510,6 +510,13 @@ ORDER BY index_name;
 
 -- Alter replica identity directly on a chunk is not supported
 SELECT ch AS chunk_name FROM show_chunks('replid') ch ORDER BY chunk_name LIMIT 1 \gset
+\set ON_ERROR_STOP 0
 ALTER TABLE :chunk_name REPLICA IDENTITY FULL;
+\set ON_ERROR_STOP 1
 SELECT relname, relreplident FROM show_chunks('replid') ch INNER JOIN pg_class c ON (ch = c.oid) ORDER BY relname;
+
+-- test implicit constraints gh issue #9132
+CREATE TABLE i9132(time timestamptz) WITH (tsdb.hypertable);
+INSERT INTO i9132 VALUES ('2024-01-01'), ('2024-02-02');
+ALTER TABLE i9132 ADD COLUMN id serial, ADD CONSTRAINT implicit_pk PRIMARY KEY (id, time);
 


### PR DESCRIPTION
When ALTER TABLE encountered constraints that had no constraint name
and no object id the command could cause a segfault when trying to
look up the constraint. This patch makes us ignore implicit constraints
like NOT NULL created by PRIMARY KEY since we don't need to propagate
them individually since they have already been propagated by the PRIMARY
KEY creation.

Fixes #9132 
