### PR TITLE
Adjust formatting to make ci happy

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -358,7 +358,7 @@ elif len(sys.argv) > 2:
         stdout=subprocess.PIPE,
         shell=True,
     )
-    (output, err) = p.communicate()
+    output, err = p.communicate()
     p_status = p.wait()
     if p_status != 0:
         print(

--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -10,7 +10,6 @@ import sys
 from github import Github  # This is PyGithub.
 import requests
 
-
 # Limit our history search and fetch depth to this value, not to get stuck in
 # case of a bug.
 HISTORY_DEPTH = 1000
@@ -47,9 +46,7 @@ def get_referenced_issue(pr_number):
     # We only need the first issue here. We also request only the first 30 labels,
     # because GitHub requires some small restriction there that is counted
     # towards the GraphQL API usage quota.
-    ref_result = run_query(
-        string.Template(
-            """
+    ref_result = run_query(string.Template("""
         query {
             repository(owner: "timescale", name: "timescaledb") {
               pullRequest(number: $pr_number) {
@@ -62,9 +59,7 @@ def get_referenced_issue(pr_number):
               }
             }
           }
-          """
-        ).substitute({"pr_number": pr_number})
-    )
+          """).substitute({"pr_number": pr_number}))
 
     # The above returns:
     # {'data': {'repository': {'pullRequest': {'closingIssuesReferences': {'nodes': [{'number': 6819,
@@ -93,22 +88,19 @@ def set_auto_merge(pr_number):
 
     # We first have to find out the PR id, which is some base64 string, different
     # from its number.
-    query = string.Template(
-        """query {
+    query = string.Template("""query {
           repository(owner: "$owner", name: "$name") {
             pullRequest(number: $pr_number) {
               id
             }
           }
-        }"""
-    ).substitute(
+        }""").substitute(
         pr_number=pr_number, owner=source_repo.owner.login, name=source_repo.name
     )
     result = run_query(query)
     pr_id = result["data"]["repository"]["pullRequest"]["id"]
 
-    query = string.Template(
-        """mutation {
+    query = string.Template("""mutation {
             enablePullRequestAutoMerge(
                 input: {
                     pullRequestId: "$pr_id",
@@ -117,8 +109,7 @@ def set_auto_merge(pr_number):
             ) {
                 clientMutationId
             }
-        }"""
-    ).substitute(pr_id=pr_id)
+        }""").substitute(pr_id=pr_id)
     run_query(query)
 
 

--- a/scripts/check_changelog_format.py
+++ b/scripts/check_changelog_format.py
@@ -35,9 +35,7 @@ def run_query(query):
 def get_referenced_issues(pr_number):
     """Get the numbers of issue fixed by the given pull request."""
 
-    ref_result = run_query(
-        string.Template(
-            """
+    ref_result = run_query(string.Template("""
         query {
             repository(owner: "timescale", name: "timescaledb") {
               pullRequest(number: $pr_number) {
@@ -51,9 +49,7 @@ def get_referenced_issues(pr_number):
               }
             }
           }
-          """
-        ).substitute({"pr_number": pr_number})
-    )
+          """).substitute({"pr_number": pr_number}))
 
     # The above returns {'data': {'repository': {'pullRequest': {'closingIssuesReferences': {'edges': [{'node': {'number': 4944}}]}}}}}
 

--- a/scripts/label-released.py
+++ b/scripts/label-released.py
@@ -3,6 +3,7 @@
 Look at commits between the given release and the previous one, and label all
 PRs that made these commits with the "released-..." label.
 """
+
 import os
 import sys
 import argparse

--- a/scripts/test_pg_upgrade.py
+++ b/scripts/test_pg_upgrade.py
@@ -95,7 +95,7 @@ node_old.safe_psql(dbname=pg_database_test, query="CHECKPOINT")
 node_old.safe_psql(dbname=pg_database_test, filename="test/sql/updates/setup.check.sql")
 
 # Run over the old node to check the output
-(code, old_out, old_err) = node_old.psql(
+code, old_out, old_err = node_old.psql(
     dbname=pg_database_test, filename="test/sql/updates/post.pg_upgrade.sql"
 )
 
@@ -107,7 +107,7 @@ print(f"Upgrading node {pg_node_old} to {pg_node_new}")
 res = node_new.upgrade_from(old_node=node_old, options=["--retain"])
 node_new.start()
 
-(code, new_out, new_err) = node_new.psql(
+code, new_out, new_err = node_new.psql(
     dbname=pg_database_test,
     filename="test/sql/updates/post.pg_upgrade.sql",
 )


### PR DESCRIPTION
The most recent version of black changed formatting of python code
slightly.

Disable-check: force-changelog-file
Disable-check: approval-count