### PR TITLE
Improve Claude automation workflows

### DIFF
--- a/.github/CLAUDE_AUTOMATION.md
+++ b/.github/CLAUDE_AUTOMATION.md
@@ -1,0 +1,388 @@
+# Claude Automation
+
+This document describes the Claude-powered automation workflows for analyzing test failures and responding to PR review feedback.
+
+## Overview
+
+Two automated workflows use Claude Code to assist with maintenance tasks:
+
+| Workflow | Purpose | Trigger |
+|----------|---------|---------|
+| **Nightly Test Fix** | Analyze CI failures and create fix PRs | Failed nightly tests or manual |
+| **PR Review Handler** | Address review feedback on Claude PRs | PR review submitted |
+
+Both workflows:
+- Use a GitHub App for authentication (not personal tokens)
+- Are disabled by default in forks (require explicit opt-in)
+- Only operate on PRs they created (author verification)
+- Refuse to modify workflow files (`.github/workflows/`)
+
+---
+
+## Nightly Test Fix
+
+### What It Does
+
+1. Detects failed nightly CI runs
+2. Downloads failure artifacts (logs, regression diffs, stack traces)
+3. Invokes Claude Code to analyze failures and implement fixes
+4. Creates a separate PR for each identified test failure
+5. Optionally sends Slack notifications
+
+### Design
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Nightly Tests  │────▶│  workflow_call   │────▶│  Claude Code    │
+│  (scheduled)    │     │  (on failure)    │     │  analyzes &     │
+└─────────────────┘     └──────────────────┘     │  creates PRs    │
+                                                  └─────────────────┘
+```
+
+The nightly fix workflow is called directly from the Regression workflow when tests fail, using `workflow_call`. This approach:
+- Only triggers on actual failures (no phantom workflow runs)
+- Keeps the fix attempt visible in the same workflow run
+- Passes the run ID directly without needing to query the API
+
+**Workflow file**: `.github/workflows/claude-nightly-fix.yaml`
+**Script**: `.github/scripts/claude-analyze-failures.sh`
+**Caller**: `.github/workflows/linux-build-and-test.yaml` (trigger-claude-fix job)
+
+### Triggers
+
+| Trigger | Description |
+|---------|-------------|
+| `workflow_call` | Called by Regression workflow when nightly tests fail |
+| `workflow_dispatch` | Manual trigger with required `run_id` input |
+
+### Duplicate Prevention
+
+Before creating a fix, the script checks for existing open PRs with:
+- The `claude-code` label
+- Title or body mentioning the same test name
+
+This prevents creating duplicate PRs for the same failure.
+
+---
+
+## PR Review Handler
+
+### What It Does
+
+1. Triggered on PR review submissions (not standalone comments)
+2. Checks PR has `claude-code` label and review state is `changes_requested` or `commented`
+3. Verifies PR author matches the GitHub App bot
+4. Fetches review comments and feedback
+5. Invokes Claude Code to address the feedback
+6. Commits and pushes changes, or posts a comment if no changes needed
+
+Note: This only triggers on formal review submissions (when reviewer clicks "Submit review"), not on inline diff comments or general PR conversation comments.
+
+### Design
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Review on PR   │────▶│  Label check     │────▶│  Author check    │────▶│  Claude Code    │
+│                 │     │  (claude-code)   │     │  (via app-slug)  │     │  addresses      │
+└─────────────────┘     └──────────────────┘     └──────────────────┘     │  feedback       │
+                                                                           └─────────────────┘
+```
+
+The label check allows users to disable review handling on a PR by removing the `claude-code` label.
+
+**Workflow file**: `.github/workflows/claude-pr-review-handler.yaml`
+**Script**: `.github/scripts/claude-handle-pr-review.sh`
+
+### Triggers
+
+| Trigger | Description |
+|---------|-------------|
+| `pull_request_review` | Fires when review submitted on PR with `claude-code` label |
+| `workflow_dispatch` | Manual trigger with required `pr_number` input |
+
+**Note**: Manual triggers (`workflow_dispatch`) bypass reviewer trust checks since the person triggering the workflow is assumed to be authorized. Author verification still applies.
+
+For automatic triggers (`pull_request_review`):
+- PR must have `claude-code` label (user-controllable filter)
+- Review state must be `changes_requested` or `commented`
+- PR author must match the GitHub App bot (verified using app-slug)
+- Reviewer must NOT be the bot itself (prevents infinite loops)
+- Reviewer must have trusted association: OWNER, MEMBER, or COLLABORATOR
+
+---
+
+## Configuration
+
+### Repository Variables
+
+Set these in **Settings > Secrets and variables > Actions > Variables**:
+
+| Variable | Workflow | Required | Description |
+|----------|----------|----------|-------------|
+| `CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY` | Nightly Fix | Yes | Source repository (e.g., `timescale/timescaledb`) |
+| `CLAUDE_PR_REVIEW_HANDLER_ENABLED` | PR Review | Yes | Set to any value to enable |
+| `CLAUDE_GIT_AUTHOR_NAME` | Both | No | Git author name (default: `<app-slug>[bot]`) |
+| `CLAUDE_GIT_AUTHOR_EMAIL` | Both | No | Git author email (default: `<app-id>+<app-slug>[bot]@users.noreply.github.com`) |
+
+### Repository Secrets
+
+Set these in **Settings > Secrets and variables > Actions > Secrets**:
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `ANTHROPIC_API_KEY` | Yes | API key for Claude |
+| `CLAUDE_APP_ID` | Yes | GitHub App ID |
+| `CLAUDE_APP_PRIVATE_KEY` | Yes | GitHub App private key (PEM format) |
+| `CLAUDE_SLACK_BOT_TOKEN` | No | Slack bot token for notifications |
+| `CLAUDE_SLACK_CHANNEL` | No | Slack channel ID for notifications |
+
+---
+
+## GitHub App Setup
+
+### Creating the App
+
+1. Go to **Settings > Developer settings > GitHub Apps > New GitHub App**
+2. Configure:
+   - **Name**: Choose a descriptive name (e.g., `timescale-claude-automation`)
+   - **Homepage URL**: Repository URL
+   - **Webhook**: Disable (not needed)
+
+### Required Permissions
+
+| Permission | Access | Reason |
+|------------|--------|--------|
+| **Actions** | Read-only | Fetch workflow runs, jobs, and artifacts |
+| **Contents** | Read & Write | Push commits to branches |
+| **Pull requests** | Read & Write | Create PRs, add labels, post comments |
+| **Metadata** | Read-only | Required for API access |
+
+### Installation
+
+1. Install the app on the target repository
+2. Note the **App ID** (visible on app settings page)
+3. Generate a **Private Key** (PEM file)
+4. Add both as repository secrets
+
+### Bot Username
+
+The bot username is automatically derived from the app slug:
+- App slug: `timescale-claude-automation`
+- Bot username: `timescale-claude-automation[bot]`
+
+This is used for author verification in the PR review handler.
+
+---
+
+## Local Testing
+
+### Manual Workflow Triggers
+
+Both workflows support manual triggering via GitHub UI or CLI:
+
+```bash
+# Nightly Test Fix - provide a failed workflow run ID
+gh workflow run claude-nightly-fix.yaml -f run_id=12345678
+
+# PR Review Handler - provide a PR number
+gh workflow run claude-pr-review-handler.yaml -f pr_number=123
+```
+
+When manually triggered, the workflows fetch missing context from the GitHub API.
+
+### Running Scripts Directly
+
+For faster iteration during development, run the scripts directly without the workflow.
+
+#### Prerequisites
+
+- `gh` CLI authenticated (`gh auth login`)
+- `claude` CLI installed and authenticated
+- `jq` installed
+
+### Nightly Test Fix Script
+
+```bash
+# Required environment variables
+export SOURCE_REPOSITORY="timescale/timescaledb"
+export ANALYZE_RUN_ID="12345678"  # Failed workflow run ID
+export CLAUDE_BOT_USERNAME="github-actions[bot]"  # Or your app's bot name
+
+# Optional: test without creating PRs
+export DRY_RUN=true      # Show context only, don't invoke Claude
+export SKIP_PR=true      # Make changes but don't create PRs
+export KEEP_WORK_DIR=true  # Preserve /tmp/claude-fix-* for inspection
+
+# Run the script
+.github/scripts/claude-analyze-failures.sh
+```
+
+### PR Review Handler Script
+
+```bash
+# Required: PR number and bot username
+export CLAUDE_BOT_USERNAME="github-actions[bot]"  # Must match PR author
+
+# Optional overrides
+export PR_REPOSITORY="timescale/timescaledb"
+export DRY_RUN=true      # Show context only
+export SKIP_PUSH=true    # Make changes but don't push
+export KEEP_WORK_DIR=true
+
+# Run with PR number as argument
+.github/scripts/claude-handle-pr-review.sh 123
+
+# Or via environment variable
+PR_NUMBER=123 .github/scripts/claude-handle-pr-review.sh
+```
+
+### Environment Variables Reference
+
+#### claude-analyze-failures.sh
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SOURCE_REPOSITORY` | Yes | - | Repository to fetch artifacts from |
+| `ANALYZE_RUN_ID` | Yes | - | Workflow run ID to analyze (preferred over `GITHUB_RUN_ID`) |
+| `CLAUDE_BOT_USERNAME` | Yes | - | Bot username for identification |
+| `GITHUB_TOKEN` | No | `gh auth token` | GitHub token for API calls |
+| `TARGET_REPOSITORY` | No | `SOURCE_REPOSITORY` | Repository to create PRs in |
+| `BASE_BRANCH` | No | `main` | Branch to create PRs against |
+| `CLAUDE_MODEL` | No | `claude-sonnet-4-20250514` | Claude model to use |
+| `MAX_ARTIFACTS` | No | `10` | Max artifacts to download |
+| `DRY_RUN` | No | `false` | Skip Claude and PR creation |
+| `SKIP_PR` | No | `false` | Make changes but skip PR creation |
+| `KEEP_WORK_DIR` | No | `false` | Keep temp directory after completion |
+| `ANALYSIS_OUTPUT_DIR` | No | - | Copy analysis output to this directory |
+| `SLACK_BOT_TOKEN` | No | - | Slack token for notifications |
+| `SLACK_CHANNEL` | No | - | Slack channel ID |
+
+#### claude-handle-pr-review.sh
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PR_NUMBER` | Yes | - | PR number (or pass as first argument) |
+| `CLAUDE_BOT_USERNAME` | Yes | - | Expected PR author (bot username) |
+| `GITHUB_TOKEN` | No | `gh auth token` | GitHub token for API calls |
+| `GITHUB_REPOSITORY` | No | From git remote | Repository in `owner/repo` format |
+| `PR_REPOSITORY` | No | `GITHUB_REPOSITORY` | Repository where PR lives |
+| `PUSH_REPOSITORY` | No | Auto-detected | Repository to push to (for forks) |
+| `PR_BRANCH` | No | From PR | Branch name |
+| `PR_AUTHOR` | No | From PR | PR author login |
+| `REVIEWER` | No | From review | Reviewer for commit message |
+| `CLAUDE_MODEL` | No | `claude-sonnet-4-20250514` | Claude model to use |
+| `DRY_RUN` | No | `false` | Show context only |
+| `SKIP_PUSH` | No | `false` | Make changes but don't push |
+| `KEEP_WORK_DIR` | No | `false` | Keep temp directory |
+
+---
+
+## Security Considerations
+
+### Workflow Permissions
+
+Both workflows follow the principle of least privilege for GitHub Actions permissions:
+
+```yaml
+# Workflow level - deny all by default
+permissions: {}
+
+jobs:
+  job-name:
+    # Job level - request only what's needed
+    permissions:
+      contents: write       # Push commits
+      pull-requests: write  # Create PRs, post comments
+```
+
+This approach:
+- Defaults to no permissions at the workflow level (`permissions: {}`)
+- Each job explicitly declares only the permissions it needs
+- Prevents accidental token privilege escalation
+- Makes permission requirements visible and auditable
+
+### Authentication & Authorization
+
+| Aspect | Implementation |
+|--------|----------------|
+| **Token type** | GitHub App installation tokens (not PATs) |
+| **Token scope** | Limited to installed repositories |
+| **Token lifetime** | Short-lived (1 hour max) |
+
+### Access Controls
+
+| Control | Description |
+|---------|-------------|
+| **Opt-in required** | Workflows require explicit repository variables to run |
+| **Label filter** | PR review handler only runs on PRs with `claude-code` label (user can remove to disable) |
+| **Author verification** | PR review handler verifies PR author matches GitHub App bot (using app-slug) |
+| **Reviewer trust** | PR review handler only responds to reviews from OWNER, MEMBER, or COLLABORATOR |
+| **Defense in depth** | Author verified in both workflow step and script |
+| **Fork isolation** | Workflows don't run in forks without explicit configuration |
+
+### Code Modification Restrictions
+
+| Restriction | Reason |
+|-------------|--------|
+| **No workflow edits** | Scripts refuse to modify `.github/workflows/` files |
+| **Scoped changes** | PR review handler only addresses feedback within PR scope |
+
+### Audit Trail
+
+| Event | Tracking |
+|-------|----------|
+| **PR creation** | PRs include link to triggering workflow run |
+| **Commits** | All commits include `Co-Authored-By: Claude` |
+| **Labels** | `claude-code` label identifies automated PRs |
+| **Artifacts** | Analysis output saved as workflow artifacts |
+
+### Threat Model Considerations
+
+| Threat | Mitigation |
+|--------|------------|
+| **PR impersonation** | Author verified using app-slug from token generation (cannot be spoofed) |
+| **Infinite loops** | Reviewer checked to not be the bot itself before processing |
+| **Untrusted reviewers** | Only OWNER, MEMBER, or COLLABORATOR can trigger review handling |
+| **Prompt injection via PR** | Claude operates with limited tools and cannot modify workflows |
+| **Token leakage** | Tokens are short-lived and scoped to specific permissions |
+| **Unauthorized access** | Requires both API key and GitHub App credentials |
+
+### Recommendations for Security Review
+
+1. **Review GitHub App permissions** - Ensure only necessary permissions are granted
+2. **Audit repository variables** - Verify `SOURCE_REPOSITORY` points to expected repo
+3. **Monitor PR activity** - Watch for unexpected PRs with `claude-code` label
+4. **Review Claude output** - Artifacts contain full Claude analysis for audit
+5. **Slack notifications** - Enable to get alerts when PRs are created
+
+---
+
+## Troubleshooting
+
+### Workflow Not Running
+
+1. Check that required repository variables are set
+2. Verify secrets are configured (workflow will skip silently if missing)
+3. For nightly fix: ensure the `trigger-claude-fix` job exists in `linux-build-and-test.yaml`
+
+### Author Verification Failing
+
+1. Verify `CLAUDE_BOT_USERNAME` matches the GitHub App's bot username
+2. Bot username format: `<app-slug>[bot]` (e.g., `my-app[bot]`)
+3. Check PR author in GitHub UI matches expected bot
+
+### Local Testing Issues
+
+1. Ensure `gh auth login` is completed
+2. Verify `claude` CLI is authenticated (`claude --version`)
+3. Check `CLAUDE_BOT_USERNAME` matches the PR author you're testing against
+
+### PR Creation Failing
+
+1. Check GitHub App has `contents: write` and `pull-requests: write` permissions
+2. Verify app is installed on the target repository
+3. Review workflow logs for specific error messages
+
+### Source and Target Commits Differ (Warning)
+
+When using `TARGET_REPOSITORY` different from `SOURCE_REPOSITORY`, the script warns if the repos are at different commits. This is informational only - the failed workflow may have run on a commit that differs from both repos' current HEAD. Consider syncing your fork if fixes don't apply cleanly.

--- a/.github/scripts/claude-analyze-failures.sh
+++ b/.github/scripts/claude-analyze-failures.sh
@@ -6,21 +6,25 @@
 # 1. Downloads and aggregates test failure artifacts
 # 2. Prepares context for Claude Code
 # 3. Invokes Claude Code to analyze failures and propose fixes
-# 4. Creates a PR with the proposed fix
+# 4. Creates a separate PR for each fix with a descriptive title
 #
 # Required environment variables:
-#   GITHUB_RUN_ID      - The workflow run ID
+#   ANALYZE_RUN_ID     - The workflow run ID to analyze (preferred)
+#                        Falls back to GITHUB_RUN_ID for backwards compatibility
+#   SOURCE_REPOSITORY  - The source repository to clone and fetch artifacts from
 #
 # Optional environment variables (with defaults):
-#   GITHUB_TOKEN       - GitHub token (default: from gh auth token)
-#   GITHUB_REPOSITORY  - The source repository for artifacts (default: timescale/timescaledb)
+#   GITHUB_TOKEN       - GitHub token for target repo operations (default: from gh auth token)
+#   SOURCE_GITHUB_TOKEN - GitHub token for source repo API calls (default: GITHUB_TOKEN)
+#                         Required when source repo is in a different org than target
 #
 # Optional environment variables:
 #   ANTHROPIC_API_KEY  - API key for Claude Code (not needed if logged in locally)
-#   TARGET_REPOSITORY  - Repository to create the PR in (default: GITHUB_REPOSITORY)
+#   TARGET_REPOSITORY  - Repository to create the PR in (default: SOURCE_REPOSITORY)
 #                        Useful for creating PRs in a fork during testing
 #   BASE_BRANCH        - Branch to create the PR against (default: main)
 #   CLAUDE_MODEL       - Model to use (default: claude-sonnet-4-20250514)
+#   CLAUDE_BOT_USERNAME - Bot username (required, e.g., github-actions[bot])
 #   MAX_ARTIFACTS      - Maximum number of artifacts to download (default: 10)
 #   DRY_RUN            - If set to "true", skip Claude invocation and PR creation
 #   SKIP_PR            - If set to "true", run Claude to make local changes but skip PR creation
@@ -33,8 +37,6 @@
 set -euo pipefail
 
 # Configuration
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 WORK_DIR="${WORK_DIR:-/tmp/claude-fix-$$}"
 MAX_ARTIFACTS="${MAX_ARTIFACTS:-10}"
 CLAUDE_MODEL="${CLAUDE_MODEL:-claude-sonnet-4-20250514}"
@@ -44,9 +46,21 @@ SKIP_PR="${SKIP_PR:-false}"
 KEEP_WORK_DIR="${KEEP_WORK_DIR:-false}"
 ANALYSIS_OUTPUT_DIR="${ANALYSIS_OUTPUT_DIR:-}"
 
-# GITHUB_REPOSITORY defaults to timescale/timescaledb
-GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-timescale/timescaledb}"
-export GITHUB_REPOSITORY
+# Set up debug logging early - capture all stderr to a log file
+# Create work dir immediately so we can start logging
+mkdir -p "${WORK_DIR}"
+DEBUG_LOG="${WORK_DIR}/debug.log"
+: > "${DEBUG_LOG}"  # Initialize empty log file
+
+# Redirect stderr through tee to capture to log while still displaying
+exec 2> >(tee -a "${DEBUG_LOG}" >&2)
+
+# SOURCE_REPOSITORY is required (no default - must be explicitly set)
+if [[ -z "${SOURCE_REPOSITORY:-}" ]]; then
+    echo "ERROR: SOURCE_REPOSITORY is not set" >&2
+    exit 1
+fi
+export SOURCE_REPOSITORY
 
 # GITHUB_TOKEN defaults to gh auth token if not set
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
@@ -54,7 +68,34 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
 fi
 export GITHUB_TOKEN
 
-# TARGET_REPOSITORY defaults to GITHUB_REPOSITORY (set after env var check)
+# SOURCE_GITHUB_TOKEN is used for API calls to the source repository
+# Defaults to GITHUB_TOKEN if not set (same-org scenario)
+SOURCE_GITHUB_TOKEN="${SOURCE_GITHUB_TOKEN:-${GITHUB_TOKEN}}"
+export SOURCE_GITHUB_TOKEN
+
+# Debug: Check if we have separate tokens for source and target
+if [[ "${SOURCE_GITHUB_TOKEN}" == "${GITHUB_TOKEN}" ]]; then
+    echo "[DEBUG] Using same token for source and target repos" >&2
+else
+    echo "[DEBUG] Using separate token for source repo (cross-org)" >&2
+fi
+
+# ANALYZE_RUN_ID is the run ID to analyze. Fall back to GITHUB_RUN_ID for backwards
+# compatibility, but note that GITHUB_RUN_ID is a built-in GitHub Actions variable
+# that contains the CURRENT workflow's run ID, not the one we want to analyze.
+# Using ANALYZE_RUN_ID avoids this conflict.
+if [[ -z "${ANALYZE_RUN_ID:-}" ]]; then
+    if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+        ANALYZE_RUN_ID="${GITHUB_RUN_ID}"
+        echo "[DEBUG] Using GITHUB_RUN_ID as fallback: ${ANALYZE_RUN_ID}" >&2
+        echo "[WARN] GITHUB_RUN_ID may be the current workflow's run ID, not the target" >&2
+    fi
+else
+    echo "[DEBUG] Using ANALYZE_RUN_ID: ${ANALYZE_RUN_ID}" >&2
+fi
+export ANALYZE_RUN_ID
+
+# TARGET_REPOSITORY defaults to SOURCE_REPOSITORY (set in check_prerequisites)
 
 # Colors for output
 RED='\033[0;31m'
@@ -80,6 +121,9 @@ cleanup() {
         log_info "Saving analysis output to: ${ANALYSIS_OUTPUT_DIR}"
         mkdir -p "${ANALYSIS_OUTPUT_DIR}"
 
+        # Copy the debug log (all stderr output)
+        [[ -f "${DEBUG_LOG}" ]] && cp "${DEBUG_LOG}" "${ANALYSIS_OUTPUT_DIR}/"
+
         # Copy analysis output files (Claude's reasoning and conclusions)
         for f in "${WORK_DIR}"/analysis_*.txt; do
             [[ -f "$f" ]] && cp "$f" "${ANALYSIS_OUTPUT_DIR}/"
@@ -90,6 +134,11 @@ cleanup() {
 
         # Copy prompt files for debugging
         for f in "${WORK_DIR}"/prompt*.txt; do
+            [[ -f "$f" ]] && cp "$f" "${ANALYSIS_OUTPUT_DIR}/"
+        done
+
+        # Copy any API error files for debugging
+        for f in "${WORK_DIR}"/*_error.txt; do
             [[ -f "$f" ]] && cp "$f" "${ANALYSIS_OUTPUT_DIR}/"
         done
 
@@ -111,8 +160,7 @@ cleanup() {
 trap cleanup EXIT
 
 send_slack_notification() {
-    local pr_url="$1"
-    local test_count="$2"
+    local pr_count="$1"
 
     if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
         log_info "SLACK_BOT_TOKEN not set, skipping Slack notification"
@@ -124,19 +172,40 @@ send_slack_notification() {
         return 0
     fi
 
+    if [[ ! -s "${WORK_DIR}/created_prs.txt" ]]; then
+        log_info "No PRs created, skipping Slack notification"
+        return 0
+    fi
+
     log_info "Sending Slack notification to channel ${SLACK_CHANNEL}..."
+
+    # Build PR list for the message
+    local pr_list=""
+    local pr_buttons="["
+    local first=true
+    while read -r pr_url; do
+        [[ -z "${pr_url}" ]] && continue
+        pr_list="${pr_list}\n• <${pr_url}|${pr_url##*/}>"
+        if [[ "${first}" == "true" ]]; then
+            first=false
+        else
+            pr_buttons="${pr_buttons},"
+        fi
+        pr_buttons="${pr_buttons}{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\"PR ${pr_url##*/}\"},\"url\":\"${pr_url}\"}"
+    done < "${WORK_DIR}/created_prs.txt"
+    pr_buttons="${pr_buttons}]"
 
     local message
     message=$(cat <<EOF
 {
     "channel": "${SLACK_CHANNEL}",
-    "text": "Claude created a PR to fix nightly test failures",
+    "text": "Claude created ${pr_count} PR(s) to fix nightly test failures",
     "blocks": [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": ":robot_face: *Claude created a PR to fix nightly test failures*"
+                "text": ":robot_face: *Claude created ${pr_count} PR(s) to fix nightly test failures*"
             }
         },
         {
@@ -144,27 +213,20 @@ send_slack_notification() {
             "fields": [
                 {
                     "type": "mrkdwn",
-                    "text": "*Tests Fixed:*\n${test_count}"
+                    "text": "*PRs Created:*\n${pr_count}"
                 },
                 {
                     "type": "mrkdwn",
-                    "text": "*Repository:*\n${TARGET_REPOSITORY:-${GITHUB_REPOSITORY}}"
+                    "text": "*Repository:*\n${TARGET_REPOSITORY:-${SOURCE_REPOSITORY}}"
                 }
             ]
         },
         {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "View Pull Request"
-                    },
-                    "url": "${pr_url}",
-                    "style": "primary"
-                }
-            ]
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Pull Requests:*${pr_list}"
+            }
         }
     ]
 }
@@ -190,7 +252,8 @@ check_prerequisites() {
 
     local missing_vars=()
     [[ -z "${GITHUB_TOKEN:-}" ]] && missing_vars+=("GITHUB_TOKEN (set it or run 'gh auth login')")
-    [[ -z "${GITHUB_RUN_ID:-}" ]] && missing_vars+=("GITHUB_RUN_ID")
+    [[ -z "${ANALYZE_RUN_ID:-}" ]] && missing_vars+=("ANALYZE_RUN_ID")
+    [[ -z "${CLAUDE_BOT_USERNAME:-}" ]] && missing_vars+=("CLAUDE_BOT_USERNAME (e.g., github-actions[bot])")
 
     if [[ ${#missing_vars[@]} -gt 0 ]]; then
         log_error "Missing required environment variables: ${missing_vars[*]}"
@@ -218,11 +281,11 @@ check_prerequisites() {
         log_info "Using ANTHROPIC_API_KEY for authentication"
     fi
 
-    # Set TARGET_REPOSITORY (defaults to GITHUB_REPOSITORY)
-    TARGET_REPOSITORY="${TARGET_REPOSITORY:-${GITHUB_REPOSITORY}}"
+    # Set TARGET_REPOSITORY (defaults to SOURCE_REPOSITORY)
+    TARGET_REPOSITORY="${TARGET_REPOSITORY:-${SOURCE_REPOSITORY}}"
     export TARGET_REPOSITORY
-    if [[ "${TARGET_REPOSITORY}" != "${GITHUB_REPOSITORY}" ]]; then
-        log_info "Artifacts from: ${GITHUB_REPOSITORY}"
+    if [[ "${TARGET_REPOSITORY}" != "${SOURCE_REPOSITORY}" ]]; then
+        log_info "Artifacts from: ${SOURCE_REPOSITORY}"
         log_info "PR will be created in: ${TARGET_REPOSITORY}"
     fi
 
@@ -230,18 +293,26 @@ check_prerequisites() {
 }
 
 get_failed_jobs() {
-    log_info "Fetching failed jobs from run ${GITHUB_RUN_ID}..."
+    log_info "Fetching failed jobs from run ${ANALYZE_RUN_ID}..."
 
     local jobs_file="${WORK_DIR}/failed_jobs.json"
 
     # Get all jobs from the run, filter for failed ones (excluding ignored failures)
-    gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+    # Use SOURCE_GITHUB_TOKEN for cross-org access to source repository
+    local api_error_file="${WORK_DIR}/api_error.txt"
+    if ! GH_TOKEN="${SOURCE_GITHUB_TOKEN}" gh api "repos/${SOURCE_REPOSITORY}/actions/runs/${ANALYZE_RUN_ID}/jobs" \
         --paginate \
         --jq '.jobs[] | select(.conclusion == "failure") | {id: .id, name: .name}' \
-        > "${jobs_file}" 2>/dev/null || {
-        log_error "Failed to fetch jobs list"
+        > "${jobs_file}" 2>"${api_error_file}"; then
+        log_error "Failed to fetch jobs list from ${SOURCE_REPOSITORY}"
+        log_error "API endpoint: repos/${SOURCE_REPOSITORY}/actions/runs/${ANALYZE_RUN_ID}/jobs"
+        if [[ -s "${api_error_file}" ]]; then
+            log_error "Error details:"
+            cat "${api_error_file}" >&2
+        fi
+        log_error "This may be a permission issue - ensure the GitHub token has 'actions:read' access to ${SOURCE_REPOSITORY}"
         return 1
-    }
+    fi
 
     if [[ ! -s "${jobs_file}" ]]; then
         log_warn "No failed jobs found"
@@ -272,11 +343,11 @@ download_job_logs() {
         local safe_name
         safe_name=$(echo "${job_name}" | tr '/' '_' | tr ' ' '_')
 
-        gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" \
-            > "${WORK_DIR}/logs/${safe_name}.log" 2>/dev/null || {
-            log_warn "Failed to download log for job: ${job_name}"
+        if ! GH_TOKEN="${SOURCE_GITHUB_TOKEN}" gh api "repos/${SOURCE_REPOSITORY}/actions/jobs/${job_id}/logs" \
+            > "${WORK_DIR}/logs/${safe_name}.log"; then
+            log_warn "Failed to download log for job: ${job_name} (job_id: ${job_id})"
             continue
-        }
+        fi
     done < "${jobs_file}"
 }
 
@@ -364,20 +435,33 @@ download_failure_artifacts() {
     local artifacts_file="${WORK_DIR}/artifacts.json"
 
     # Get artifacts that match failed jobs and are relevant types
-    gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+    # Use SOURCE_GITHUB_TOKEN for cross-org access to source repository
+    local artifacts_error_file="${WORK_DIR}/artifacts_api_error.txt"
+    if ! GH_TOKEN="${SOURCE_GITHUB_TOKEN}" gh api "repos/${SOURCE_REPOSITORY}/actions/runs/${ANALYZE_RUN_ID}/artifacts" \
         --paginate \
         --jq ".artifacts[] | select(.name | test(\"Regression|PostgreSQL log|Stacktrace|TAP\")) | {name: .name, id: .id}" \
-        > "${artifacts_file}.all" 2>/dev/null || {
-        log_error "Failed to fetch artifacts list"
+        > "${artifacts_file}.all" 2>"${artifacts_error_file}"; then
+        log_error "Failed to fetch artifacts list from ${SOURCE_REPOSITORY}"
+        log_error "API endpoint: repos/${SOURCE_REPOSITORY}/actions/runs/${ANALYZE_RUN_ID}/artifacts"
+        if [[ -s "${artifacts_error_file}" ]]; then
+            log_error "Error details:"
+            cat "${artifacts_error_file}" >&2
+        fi
+        log_error "This may be a permission issue - ensure the GitHub token has 'actions:read' access to ${SOURCE_REPOSITORY}"
         return 1
-    }
+    fi
 
     # Filter artifacts matching our failed jobs
     : > "${artifacts_file}"
     while IFS= read -r artifact; do
         [[ -z "${artifact}" ]] && continue
+        # Skip malformed JSON entries
+        if ! echo "$artifact" | jq -e '.' >/dev/null 2>&1; then
+            continue
+        fi
         local name
-        name=$(echo "$artifact" | jq -r '.name')
+        name=$(echo "$artifact" | jq -r '.name // empty')
+        [[ -z "${name}" ]] && continue
         if echo "${name}" | grep -qE "${combined_pattern}"; then
             echo "${artifact}" >> "${artifacts_file}"
         fi
@@ -403,13 +487,25 @@ download_failure_artifacts() {
             break
         fi
 
+        # Validate JSON before parsing
+        if ! echo "$artifact" | jq -e '.' >/dev/null 2>&1; then
+            log_warn "Skipping malformed artifact entry"
+            continue
+        fi
+
         local name id
-        name=$(echo "$artifact" | jq -r '.name')
-        id=$(echo "$artifact" | jq -r '.id')
+        name=$(echo "$artifact" | jq -r '.name // empty')
+        id=$(echo "$artifact" | jq -r '.id // empty')
+
+        # Skip if name or id is empty
+        if [[ -z "${name}" || -z "${id}" ]]; then
+            log_warn "Skipping artifact with missing name or id"
+            continue
+        fi
 
         ((count++))
         log_info "Downloading artifact: ${name} (${count}/${total_artifacts})"
-        gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}/zip" > "${name}.zip" || {
+        GH_TOKEN="${SOURCE_GITHUB_TOKEN}" gh api "repos/${SOURCE_REPOSITORY}/actions/artifacts/${id}/zip" > "${name}.zip" || {
             log_warn "Failed to download artifact: ${name}"
             continue
         }
@@ -565,6 +661,8 @@ EOF
 commit_claude_changes() {
     local test_name="$1"
     local analysis_output="$2"
+    # Output variable for failure reason (caller can read COMMIT_FAILURE_REASON)
+    COMMIT_FAILURE_REASON=""
 
     # Check if there are any changes to commit
     local modified_files new_files_list
@@ -576,46 +674,59 @@ commit_claude_changes() {
     done)
 
     if [[ -z "${modified_files}" && -z "${new_files_list}" ]]; then
-        log_info "No changes made for test: ${test_name}"
+        COMMIT_FAILURE_REASON="Claude analyzed the failure but did not modify any files"
         return 1
     fi
 
-    # Filter out workflow files - these require special 'workflow' scope that we don't have
-    # This is a safety measure in case Claude modifies workflow files despite instructions
+    # Filter out .github/ files - workflows require special scope, and scripts shouldn't be modified
+    # This is a safety measure in case Claude modifies these files despite instructions
     local filtered_modified filtered_new
-    filtered_modified=$(echo "${modified_files}" | grep -v '^\.github/workflows/' || true)
-    filtered_new=$(echo "${new_files_list}" | grep -v '^\.github/workflows/' || true)
+    filtered_modified=$(echo "${modified_files}" | grep -v '^\.github/' || true)
+    filtered_new=$(echo "${new_files_list}" | grep -v '^\.github/' || true)
 
-    # Check if any workflow files were modified and warn
-    local workflow_changes
-    workflow_changes=$(echo "${modified_files}" | grep '^\.github/workflows/' || true)
-    if [[ -n "${workflow_changes}" ]]; then
-        log_warn "Skipping workflow file changes (requires 'workflow' scope):"
-        echo "${workflow_changes}" | while read -r f; do
+    # Check if any .github files were modified and warn
+    local github_changes
+    github_changes=$(echo "${modified_files}" | grep '^\.github/' || true)
+    if [[ -n "${github_changes}" ]]; then
+        log_warn "Skipping .github/ file changes:"
+        echo "${github_changes}" | while read -r f; do
             log_warn "  - ${f}"
             git checkout -- "${f}" 2>/dev/null || true  # Revert the changes
         done >&2
     fi
 
     if [[ -z "${filtered_modified}" && -z "${filtered_new}" ]]; then
-        log_info "No non-workflow changes made for test: ${test_name}"
+        COMMIT_FAILURE_REASON="Claude only modified .github/ files which are not allowed"
         return 1
     fi
 
-    # Stage modified files (excluding workflows)
+    # Stage modified files (excluding .github/)
     if [[ -n "${filtered_modified}" ]]; then
         echo "${filtered_modified}" | xargs git add >&2
     fi
 
-    # Stage new files created by Claude (excluding workflows)
+    # Stage new files created by Claude (excluding .github/)
     if [[ -n "${filtered_new}" ]]; then
         echo "${filtered_new}" | xargs git add >&2
     fi
 
-    # Extract commit message from Claude's output using markers
-    local summary
+    # Extract commit title from Claude's output using markers
+    local title=""
+    if grep -q "COMMIT_TITLE:" "${analysis_output}"; then
+        title=$(sed -n '/COMMIT_TITLE:/,/END_COMMIT_TITLE/p' "${analysis_output}" | \
+            grep -v "COMMIT_TITLE:\|END_COMMIT_TITLE\|COMMIT_MESSAGE:" | \
+            head -1 | \
+            sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | \
+            cut -c1-72)
+    fi
 
-    # Look for content between COMMIT_MESSAGE: and END_COMMIT_MESSAGE markers
+    # Fallback title if extraction failed or result is invalid
+    if [[ -z "${title}" ]] || [[ "${#title}" -gt 72 ]] || [[ "${title}" == *"COMMIT_MESSAGE"* ]]; then
+        title="Fix test: ${test_name}"
+    fi
+
+    # Extract commit message body from Claude's output using markers
+    local summary=""
     if grep -q "COMMIT_MESSAGE:" "${analysis_output}"; then
         summary=$(sed -n '/COMMIT_MESSAGE:/,/END_COMMIT_MESSAGE/p' "${analysis_output}" | \
             grep -v "COMMIT_MESSAGE:\|END_COMMIT_MESSAGE" | \
@@ -632,11 +743,9 @@ commit_claude_changes() {
 
     # Create commit with descriptive message (redirect to stderr to avoid capturing in return value)
     git commit -m "$(cat <<EOF
-Fix test: ${test_name}
+${title}
 
 ${summary}
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 Co-Authored-By: Claude <noreply@anthropic.com>
 EOF
@@ -650,6 +759,7 @@ check_existing_pr_for_test() {
     local test_name="$1"
 
     # Search for open PRs with the claude-code label that mention this test
+    # Check all authors to avoid duplicating work even if someone manually created a fix
     local matching_pr
     matching_pr=$(gh pr list \
         --repo "${TARGET_REPOSITORY}" \
@@ -657,7 +767,7 @@ check_existing_pr_for_test() {
         --label "claude-code" \
         --json number,title,url,body \
         --jq ".[] | select(.title + .body | test(\"${test_name}\"; \"i\")) | .url" \
-        2>/dev/null | head -1)
+        | head -1)
 
     if [[ -n "${matching_pr}" ]]; then
         echo "${matching_pr}"
@@ -680,11 +790,34 @@ fix_single_test() {
     # Check if an unmerged PR already exists for this test
     local existing_pr
     if existing_pr=$(check_existing_pr_for_test "${test_name}"); then
-        log_warn "SKIPPING: An unmerged PR already exists for test '${test_name}'"
-        log_warn "Existing PR: ${existing_pr}"
-        log_info "Not creating a duplicate fix. Please review and merge the existing PR."
+        log_info "No fix applied for test: ${test_name}"
+        log_info "Reason: An unmerged PR already exists: ${existing_pr}"
+        # Create analysis file to document skip reason for artifact upload
+        local analysis_output="${WORK_DIR}/analysis_${test_number}.txt"
+        {
+            echo "=============================================="
+            echo "FIX NOT APPLIED - EXISTING PR"
+            echo "=============================================="
+            echo "Test: ${test_name}"
+            echo "Reason: An unmerged PR already exists for this test"
+            echo "Existing PR: ${existing_pr}"
+            echo ""
+            echo "Please review and merge the existing PR to resolve this failure."
+        } > "${analysis_output}"
         return 2  # Return code 2 indicates "skipped due to existing PR"
     fi
+
+    # Create a unique branch for this test fix
+    local safe_test_name
+    safe_test_name=$(echo "${test_name}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//; s/-$//' | cut -c1-40)
+    local branch_name
+    branch_name="claude-fix/${safe_test_name}-$(date +%Y%m%d-%H%M%S)"
+
+    log_info "Creating branch: ${branch_name}"
+    git checkout -b "${branch_name}" "${BASE_BRANCH}" >&2
+
+    # Save list of untracked files before Claude runs
+    git status --porcelain | grep '^??' | cut -c4- > "${WORK_DIR}/untracked_before.txt"
 
     # Create a prompt file for this specific test
     local prompt_file="${WORK_DIR}/prompt_${test_number}.txt"
@@ -708,10 +841,21 @@ ${test_context}
 Important:
 - Focus ONLY on fixing this one test: ${test_name}
 - Do not modify files unrelated to this test
-- NEVER modify files in .github/workflows/ - these require special permissions we don't have
+- NEVER modify files in .github/ (workflows, scripts, etc.)
+- After making C code changes, run \`make format\` to format the code
+- For other code (shell scripts, Python, etc.), check scripts/ for formatting tools
+- NEVER modify expected output files (.out files) directly. Instead:
+  1. Modify the test SQL file (.sql) if needed
+  2. Run the test to generate new output
+  3. If the test passes without errors, crashes, or truncated output, copy the new output over the expected file
+  4. This ensures all output changes (including unexpected ones like plan changes) are captured
 - Explain your reasoning briefly
 
-After making changes, output a commit message in this exact format:
+After making changes, output BOTH a title and description for the commit in this exact format:
+
+COMMIT_TITLE:
+<A concise title describing the fix, ideally under 50 characters (max 72), e.g., "Fix race condition in chunk_column_stats">
+END_COMMIT_TITLE
 
 COMMIT_MESSAGE:
 <A brief description of the root cause and the fix, suitable for a git commit message body. 2-4 sentences.>
@@ -730,7 +874,18 @@ EOF
         --allowedTools "Edit,Write,Read,Glob,Grep,Bash" \
         < "${prompt_file}" \
         2>&1 | tee "${analysis_output}" >&2; then
-        log_warn "Claude Code failed to fix test: ${test_name}"
+        log_warn "No fix applied for test: ${test_name}"
+        log_warn "Reason: Claude Code command exited with an error"
+        # Append reason to analysis output for artifact upload
+        {
+            echo ""
+            echo "=============================================="
+            echo "FIX NOT APPLIED"
+            echo "=============================================="
+            echo "Reason: Claude Code command exited with an error"
+        } >> "${analysis_output}"
+        git checkout "${BASE_BRANCH}" >&2
+        git branch -D "${branch_name}" >&2 2>/dev/null || true
         return 1
     fi
 
@@ -740,11 +895,45 @@ EOF
     log_info "Analysis completed in ${duration} seconds"
 
     # Commit the changes for this test
-    if commit_claude_changes "${test_name}" "${analysis_output}"; then
-        return 0
-    else
+    if ! commit_claude_changes "${test_name}" "${analysis_output}"; then
+        log_warn "No fix applied for test: ${test_name}"
+        if [[ -n "${COMMIT_FAILURE_REASON:-}" ]]; then
+            log_warn "Reason: ${COMMIT_FAILURE_REASON}"
+            # Append reason to analysis output for artifact upload
+            {
+                echo ""
+                echo "=============================================="
+                echo "FIX NOT APPLIED"
+                echo "=============================================="
+                echo "Reason: ${COMMIT_FAILURE_REASON}"
+                echo ""
+                echo "This may happen when Claude analyzes the failure and provides"
+                echo "an explanation but does not make actual code changes. Review"
+                echo "Claude's analysis above to understand the issue and determine"
+                echo "if manual intervention is needed."
+            } >> "${analysis_output}"
+        fi
+        git checkout "${BASE_BRANCH}" >&2
+        git branch -D "${branch_name}" >&2 2>/dev/null || true
         return 1
     fi
+
+    # Create PR for this specific fix (unless SKIP_PR is set)
+    if [[ "${SKIP_PR}" != "true" ]]; then
+        local pr_url
+        if pr_url=$(create_pull_request "${branch_name}" "${test_name}" "${analysis_output}"); then
+            log_info "PR created for ${test_name}: ${pr_url}"
+            # Store PR URL for later notification
+            echo "${pr_url}" >> "${WORK_DIR}/created_prs.txt"
+        else
+            log_warn "Failed to create PR for ${test_name}"
+        fi
+    fi
+
+    # Return to base branch for next test
+    git checkout "${BASE_BRANCH}" >&2
+
+    return 0
 }
 
 extract_test_context() {
@@ -785,24 +974,15 @@ $(cat "${context_file}")
 invoke_claude_code() {
     local context_file="$1"
     local failed_tests_file="$2"
-    local branch_name
-    branch_name="claude-fix/nightly-$(date +%Y%m%d-%H%M%S)"
 
     log_info "=============================================="
     log_info "INVOKING CLAUDE CODE"
     log_info "=============================================="
 
-    cd "${REPO_ROOT}"
+    cd "${CLONE_DIR}"
 
-    # Save list of untracked files before Claude runs
-    git status --porcelain | grep '^??' | cut -c4- > "${WORK_DIR}/untracked_before.txt"
-    local untracked_count
-    untracked_count=$(wc -l < "${WORK_DIR}/untracked_before.txt")
-    log_info "Pre-existing untracked files: ${untracked_count}"
-
-    # Create a new branch for the fix
-    log_info "Creating branch: ${branch_name}"
-    git checkout -b "${branch_name}" >&2
+    # Initialize PR tracking file
+    : > "${WORK_DIR}/created_prs.txt"
 
     # Get list of unique failed tests
     local unique_tests_file="${WORK_DIR}/unique_failed_tests.txt"
@@ -817,10 +997,12 @@ invoke_claude_code() {
         #   "not ok 1 - test_name"
         #   "not ok 51    + chunk_column_stats    1542 ms"  (TAP format with timestamp prefix)
         #   "foo ... FAILED 123 ms"
-        sed 's/^[^:]*: //' "${failed_tests_file}" | tee "${WORK_DIR}/tests_without_prefix.txt" | \
-            sed 's/^[0-9T:.Z-]* //' | \
-            grep -oE 'test [^ ]+|^[^ ]+ \.\.\.|not ok [0-9]+\s+[+-]\s+[a-zA-Z0-9_]+|not ok [0-9]+ - [^ ]+' | \
-            sed 's/^test //; s/ \.\.\..*//; s/^not ok [0-9]* - //; s/^not ok [0-9]*\s*[+-]\s*//' | \
+        sed 's/^[^:]*: //' "${failed_tests_file}" | \
+            sed 's/^[^ ]* *//' | \
+            tee "${WORK_DIR}/tests_without_prefix.txt" | \
+            sed 's/^[[:space:]]*//' | \
+            grep -oE 'test [^ ]+|^[^ ]+ +\.\.\.|not ok [0-9]+\s+[+-]\s+[a-zA-Z0-9_]+|not ok [0-9]+ - [^ ]+' | \
+            sed 's/^test //; s/ *\.\.\..*//; s/^not ok [0-9]* - //; s/^not ok [0-9]*\s*[+-]\s*//' | \
             sort -u > "${unique_tests_file}"
 
         log_info "After extraction (tests_without_prefix.txt):"
@@ -850,7 +1032,7 @@ invoke_claude_code() {
             local test_context
             test_context=$(extract_test_context "${test_name}" "${context_file}")
 
-            # Fix this specific test
+            # Fix this specific test (creates its own branch and PR)
             local fix_result
             fix_single_test "${test_name}" "${test_context}" "${test_number}" "${total_tests}"
             fix_result=$?
@@ -863,14 +1045,20 @@ invoke_claude_code() {
                 ((failed_fixes++))
             fi
 
-            # Update untracked files list after each commit
-            git status --porcelain | grep '^??' | cut -c4- > "${WORK_DIR}/untracked_before.txt"
-
         done < "${unique_tests_file}"
     else
         # Fallback: if we can't identify individual tests, do one big fix
         log_info "Could not identify individual tests, attempting bulk fix..."
         total_tests=1
+
+        # Create a branch for the bulk fix
+        local branch_name
+        branch_name="claude-fix/nightly-$(date +%Y%m%d-%H%M%S)"
+        log_info "Creating branch: ${branch_name}"
+        git checkout -b "${branch_name}" "${BASE_BRANCH}" >&2
+
+        # Save list of untracked files before Claude runs
+        git status --porcelain | grep '^??' | cut -c4- > "${WORK_DIR}/untracked_before.txt"
 
         local prompt_file="${WORK_DIR}/prompt.txt"
         cat > "${prompt_file}" << EOF
@@ -883,15 +1071,26 @@ Please:
 1. Analyze the test failures shown above
 2. Identify the root cause of each failure
 3. Implement fixes for the issues in the codebase
-4. If the test expectations need updating (not the code), update the expected output files
+4. If the test expectations need updating (not the code), regenerate the expected output files
 
 Important guidelines:
 - Only fix actual bugs, don't just update test expectations to make tests pass unless the new behavior is correct
 - If a test is flaky due to timing issues, make the test more robust rather than ignoring it
-- NEVER modify files in .github/workflows/ - these require special permissions we don't have
+- NEVER modify files in .github/ (workflows, scripts, etc.)
+- After making C code changes, run \`make format\` to format the code
+- For other code (shell scripts, Python, etc.), check scripts/ for formatting tools
+- NEVER modify expected output files (.out files) directly. Instead:
+  1. Modify the test SQL file (.sql) if needed
+  2. Run the test to generate new output
+  3. If the test passes without errors, crashes, or truncated output, copy the new output over the expected file
+  4. This ensures all output changes (including unexpected ones like plan changes) are captured
 - Explain your reasoning for each fix
 
-After making changes, output a commit message in this exact format:
+After making changes, output BOTH a title and description for the commit in this exact format:
+
+COMMIT_TITLE:
+<A concise title describing the fix, ideally under 50 characters (max 72)>
+END_COMMIT_TITLE
 
 COMMIT_MESSAGE:
 <A brief description of the root cause and the fix, suitable for a git commit message body. 2-4 sentences.>
@@ -905,12 +1104,42 @@ EOF
             2>&1 | tee "${analysis_output}" >&2; then
             if commit_claude_changes "all-failures" "${analysis_output}"; then
                 ((fixed_tests++))
+                # Create PR for bulk fix
+                if [[ "${SKIP_PR}" != "true" ]]; then
+                    local pr_url
+                    if pr_url=$(create_pull_request "${branch_name}" "all-failures" "${analysis_output}"); then
+                        echo "${pr_url}" >> "${WORK_DIR}/created_prs.txt"
+                    fi
+                fi
             else
+                log_warn "No fix applied for bulk analysis"
+                if [[ -n "${COMMIT_FAILURE_REASON:-}" ]]; then
+                    log_warn "Reason: ${COMMIT_FAILURE_REASON}"
+                    # Append reason to analysis output for artifact upload
+                    {
+                        echo ""
+                        echo "=============================================="
+                        echo "FIX NOT APPLIED"
+                        echo "=============================================="
+                        echo "Reason: ${COMMIT_FAILURE_REASON}"
+                    } >> "${analysis_output}"
+                fi
                 ((failed_fixes++))
             fi
         else
+            log_warn "Claude Code command failed"
+            # Append reason to analysis output for artifact upload
+            {
+                echo ""
+                echo "=============================================="
+                echo "FIX NOT APPLIED"
+                echo "=============================================="
+                echo "Reason: Claude Code command exited with an error"
+            } >> "${analysis_output}"
             ((failed_fixes++))
         fi
+
+        git checkout "${BASE_BRANCH}" >&2
     fi
 
     log_info "=============================================="
@@ -921,11 +1150,13 @@ EOF
     log_info "Skipped (existing PR): ${skipped_tests}"
     log_info "Failed to fix: ${failed_fixes}"
 
-    # Show all commits made
-    log_info "Commits created:"
-    git log --oneline "${BASE_BRANCH}..HEAD" 2>/dev/null | while read -r line; do
-        log_info "  ${line}"
-    done >&2
+    # Show created PRs
+    if [[ -s "${WORK_DIR}/created_prs.txt" ]]; then
+        log_info "PRs created:"
+        while read -r pr_url; do
+            log_info "  ${pr_url}"
+        done < "${WORK_DIR}/created_prs.txt"
+    fi
 
     log_info "=============================================="
 
@@ -939,15 +1170,18 @@ EOF
         return 1
     fi
 
-    echo "${branch_name}"
+    # Return the number of fixes (used for Slack notification)
+    echo "${fixed_tests}"
 }
 
 create_pull_request() {
     local branch_name="$1"
+    local test_name="${2:-}"
+    local analysis_output="${3:-}"
 
     log_info "Creating pull request..."
 
-    cd "${REPO_ROOT}"
+    cd "${CLONE_DIR}"
 
     # Check if there are any commits on this branch
     local commit_count
@@ -961,7 +1195,7 @@ create_pull_request() {
 
     # Set up the remote for the target repository if different from source
     local push_remote="origin"
-    if [[ "${TARGET_REPOSITORY}" != "${GITHUB_REPOSITORY}" ]]; then
+    if [[ "${TARGET_REPOSITORY}" != "${SOURCE_REPOSITORY}" ]]; then
         log_info "Setting up remote for target repository: ${TARGET_REPOSITORY}"
         # Use token in URL for authentication
         local target_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${TARGET_REPOSITORY}.git"
@@ -970,7 +1204,7 @@ create_pull_request() {
         push_remote="target"
     else
         # For same repo, also ensure origin uses token authentication
-        local origin_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        local origin_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${SOURCE_REPOSITORY}.git"
         git remote set-url origin "${origin_url}" 2>/dev/null || true
     fi
 
@@ -999,31 +1233,61 @@ create_pull_request() {
 
     log_info "Push successful"
 
-    # Generate commit list for PR body
-    local commit_list
-    commit_list=$(git log --format="- **%s**%n  %b" "${BASE_BRANCH}..HEAD" 2>/dev/null | head -100)
+    # Generate PR title from commit message or test name
+    local pr_title=""
+    if [[ -n "${analysis_output}" ]] && [[ -f "${analysis_output}" ]]; then
+        # Extract title from Claude's output
+        if grep -q "COMMIT_TITLE:" "${analysis_output}"; then
+            pr_title=$(sed -n '/COMMIT_TITLE:/,/END_COMMIT_TITLE/p' "${analysis_output}" | \
+                grep -v "COMMIT_TITLE:\|END_COMMIT_TITLE\|COMMIT_MESSAGE:" | \
+                head -1 | \
+                sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+        fi
+    fi
+
+    # Validate extracted title - reject if empty, too long, or contains markers
+    if [[ -z "${pr_title}" ]] || [[ "${#pr_title}" -gt 256 ]] || [[ "${pr_title}" == *"COMMIT_MESSAGE"* ]]; then
+        # Fallback: use commit subject line
+        pr_title=$(git log -1 --format="%s" 2>/dev/null)
+    fi
+
+    # Final fallback: use test name
+    if [[ -z "${pr_title}" ]] || [[ "${#pr_title}" -gt 256 ]] || [[ "${pr_title}" == *"COMMIT_MESSAGE"* ]]; then
+        if [[ -n "${test_name}" ]]; then
+            pr_title="Fix test: ${test_name}"
+        else
+            pr_title="Fix nightly test failure"
+        fi
+    fi
+
+    # Generate commit details for PR body
+    local commit_body
+    commit_body=$(git log -1 --format="%b" 2>/dev/null)
 
     # Create the PR body
     local pr_body
     pr_body=$(cat <<EOF
 ## Summary
 
-This PR was automatically generated by Claude Code to fix failing nightly CI tests.
-Each test fix is in a separate commit with its own description.
+This PR was automatically generated by Claude Code to fix a failing nightly CI test.
+
+### Test Fixed
+
+\`${test_name}\`
+
+### What Changed
+
+${commit_body}
 
 ### Original Failure
 
-- **Run ID**: ${GITHUB_RUN_ID}
-- **Run URL**: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
-
-### Commits (${commit_count} fixes)
-
-${commit_list}
+- **Run ID**: ${ANALYZE_RUN_ID}
+- **Run URL**: https://github.com/${SOURCE_REPOSITORY}/actions/runs/${ANALYZE_RUN_ID}
 
 ### Testing
 
-Please review each commit and ensure the fixes are appropriate before merging.
-The CI will run the full test suite to verify the fixes.
+Please review the fix and ensure it is appropriate before merging.
+The CI will run the full test suite to verify the fix.
 
 ---
 
@@ -1035,28 +1299,27 @@ EOF
     log_info "Creating PR in repository: ${TARGET_REPOSITORY}"
     log_info "Base: ${BASE_BRANCH}, Head: ${branch_name}"
 
-    # Save PR body to file for debugging
-    echo "${pr_body}" > "${WORK_DIR}/pr_body.md"
-    log_info "PR body saved to: ${WORK_DIR}/pr_body.md"
+    # Save PR body to file for debugging (use safe_test_name to avoid path traversal)
+    local safe_test_name_for_file
+    safe_test_name_for_file=$(echo "${test_name}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//; s/-$//' | cut -c1-40)
+    echo "${pr_body}" > "${WORK_DIR}/pr_body_${safe_test_name_for_file}.md"
 
     local pr_url
     local gh_output
-    gh_output="${WORK_DIR}/gh_pr_output.txt"
+    gh_output="${WORK_DIR}/gh_pr_output_${safe_test_name_for_file}.txt"
 
     # Determine head ref format
-    # - Same repo: just branch name
-    # - Cross-repo (fork): owner:branch format
     local head_ref="${branch_name}"
     log_info "Creating PR: base=${BASE_BRANCH}, head=${head_ref}"
-    log_info "Target repo: ${TARGET_REPOSITORY}"
+    log_info "PR title: ${pr_title}"
 
     if gh pr create \
         --repo "${TARGET_REPOSITORY}" \
-        --title "Fix nightly test failures ($(date +%Y-%m-%d))" \
+        --title "${pr_title}" \
         --body "${pr_body}" \
         --base "${BASE_BRANCH}" \
         --head "${head_ref}" \
-        2>&1 | tee "${gh_output}"; then
+        2>&1 | tee "${gh_output}" >&2; then
         pr_url=$(grep -oE 'https://github.com/[^ ]+' "${gh_output}" | head -1)
         log_info "Pull request created: ${pr_url}"
 
@@ -1071,14 +1334,14 @@ EOF
                 --repo "${TARGET_REPOSITORY}" \
                 --description "PR generated by Claude Code" \
                 --color "7C3AED" \
-                2>/dev/null || log_warn "Could not create label (may already exist)"
+                &>/dev/null || log_warn "Could not create label (may already exist)"
         fi
 
         # Add the label to the PR
         gh pr edit "${head_ref}" \
             --repo "${TARGET_REPOSITORY}" \
             --add-label "${label_name}" \
-            2>/dev/null || log_warn "Could not add label to PR"
+            &>/dev/null || log_warn "Could not add label to PR"
 
         echo "${pr_url}"
     else
@@ -1092,21 +1355,51 @@ EOF
 
 main() {
     log_info "Starting Claude failure analysis..."
-    log_info "Source repository: ${GITHUB_REPOSITORY:-not set}"
-    log_info "Target repository: ${TARGET_REPOSITORY:-${GITHUB_REPOSITORY:-not set}}"
+    log_info "Source repository: ${SOURCE_REPOSITORY:-not set}"
+    log_info "Target repository: ${TARGET_REPOSITORY:-${SOURCE_REPOSITORY:-not set}}"
     log_info "Base branch: ${BASE_BRANCH}"
-    log_info "Run ID: ${GITHUB_RUN_ID:-not set}"
+    log_info "Run ID: ${ANALYZE_RUN_ID:-not set}"
     log_info "Mode: $(if [[ "${DRY_RUN}" == "true" ]]; then echo "DRY_RUN"; elif [[ "${SKIP_PR}" == "true" ]]; then echo "SKIP_PR"; else echo "FULL"; fi)"
 
     check_prerequisites
 
     mkdir -p "${WORK_DIR}"
 
+    # Clone repo to temp directory for isolation
+    # When TARGET_REPOSITORY differs from SOURCE_REPOSITORY, clone from TARGET
+    # to ensure we don't include files (like workflows) that exist in source but not target
+    CLONE_DIR="${WORK_DIR}/repo"
+    local clone_repo="${TARGET_REPOSITORY}"
+    log_info "Cloning ${clone_repo} to temp directory..."
+    if ! git clone --depth=1 --branch "${BASE_BRANCH}" \
+        "https://x-access-token:${GITHUB_TOKEN}@github.com/${clone_repo}.git" \
+        "${CLONE_DIR}" >&2; then
+        log_error "Failed to clone repository"
+        exit 1
+    fi
+    log_info "Clone complete"
+
+    # Warn if source and target repos are at different commits
+    # Note: This is informational only. The failed workflow may have run on a
+    # different commit than either repo's current HEAD, so this check can't
+    # definitively detect problems.
+    if [[ "${TARGET_REPOSITORY}" != "${SOURCE_REPOSITORY}" ]]; then
+        local target_sha source_sha
+        target_sha=$(git -C "${CLONE_DIR}" rev-parse HEAD 2>/dev/null)
+        source_sha=$(GH_TOKEN="${SOURCE_GITHUB_TOKEN}" gh api "repos/${SOURCE_REPOSITORY}/commits/${BASE_BRANCH}" --jq '.sha' || echo "")
+
+        if [[ -n "${source_sha}" && "${target_sha}" != "${source_sha}" ]]; then
+            log_warn "Source and target repos are at different commits:"
+            log_warn "  Source (${SOURCE_REPOSITORY}): ${source_sha:0:12}"
+            log_warn "  Target (${TARGET_REPOSITORY}): ${target_sha:0:12}"
+        fi
+    fi
+
     # Step 1: Get list of failed jobs
     local jobs_file
     jobs_file=$(get_failed_jobs)
     if [[ -z "${jobs_file}" || ! -s "${jobs_file}" ]]; then
-        log_error "No failed jobs found in run ${GITHUB_RUN_ID}"
+        log_error "No failed jobs found in run ${ANALYZE_RUN_ID}"
         exit 1
     fi
 
@@ -1135,30 +1428,25 @@ main() {
         exit 0
     fi
 
-    # Step 5: Invoke Claude Code (one commit per test)
-    local branch_name
-    branch_name=$(invoke_claude_code "${context_file}" "${failed_tests_file}")
+    # Step 5: Invoke Claude Code (creates separate PR for each fix)
+    local fixed_count
+    fixed_count=$(invoke_claude_code "${context_file}" "${failed_tests_file}")
 
     if [[ "${SKIP_PR}" == "true" ]]; then
-        log_info "SKIP_PR mode - skipping PR creation"
-        log_info "Changes are on branch: ${branch_name}"
-        log_info "To review changes: git diff ${BASE_BRANCH}...${branch_name}"
-        log_info "To push manually: git push origin ${branch_name}"
+        log_info "SKIP_PR mode - PRs were not created"
+        log_info "Fixed ${fixed_count} tests locally"
         exit 0
     fi
 
-    # Step 6: Create PR
-    local pr_url
-    pr_url=$(create_pull_request "${branch_name}")
+    # Step 6: Send Slack notification for all created PRs
+    send_slack_notification "${fixed_count}"
 
-    # Count fixed tests (number of commits on the branch)
-    local fixed_count
-    fixed_count=$(git rev-list --count "${BASE_BRANCH}..${branch_name}" 2>/dev/null || echo "unknown")
-
-    # Step 7: Send Slack notification
-    send_slack_notification "${pr_url}" "${fixed_count}"
-
-    log_info "Done! PR created: ${pr_url}"
+    # Show summary
+    local pr_count=0
+    if [[ -s "${WORK_DIR}/created_prs.txt" ]]; then
+        pr_count=$(wc -l < "${WORK_DIR}/created_prs.txt")
+    fi
+    log_info "Done! Created ${pr_count} PR(s) for ${fixed_count} fix(es)"
 }
 
 main "$@"

--- a/.github/scripts/claude-handle-pr-review.sh
+++ b/.github/scripts/claude-handle-pr-review.sh
@@ -32,9 +32,11 @@
 #   PUSH_REPOSITORY   - Repository to push to, for forks (default: auto-detected from PR)
 #   ANTHROPIC_API_KEY - API key for Claude Code (default: use local auth)
 #   CLAUDE_MODEL      - Model to use (default: claude-sonnet-4-20250514)
+#   CLAUDE_BOT_USERNAME - Bot username for author verification (required, e.g., github-actions[bot])
 #   DRY_RUN           - If "true", show context but don't invoke Claude
 #   SKIP_PUSH         - If "true", make changes locally but don't push
 #   KEEP_WORK_DIR     - If "true", preserve work directory after completion
+#   ANALYSIS_OUTPUT_DIR - If set, copy analysis output files to this directory before cleanup
 #
 
 set -euo pipefail
@@ -47,6 +49,16 @@ CLAUDE_MODEL="${CLAUDE_MODEL:-claude-sonnet-4-20250514}"
 DRY_RUN="${DRY_RUN:-false}"
 SKIP_PUSH="${SKIP_PUSH:-false}"
 KEEP_WORK_DIR="${KEEP_WORK_DIR:-false}"
+ANALYSIS_OUTPUT_DIR="${ANALYSIS_OUTPUT_DIR:-}"
+
+# Set up debug logging early - capture all stderr to a log file
+# Create work dir immediately so we can start logging
+mkdir -p "${WORK_DIR}"
+DEBUG_LOG="${WORK_DIR}/debug.log"
+: > "${DEBUG_LOG}"  # Initialize empty log file
+
+# Redirect stderr through tee to capture to log while still displaying
+exec 2> >(tee -a "${DEBUG_LOG}" >&2)
 
 # Handle command-line arguments for local testing
 if [[ $# -ge 1 ]]; then
@@ -109,6 +121,33 @@ find_remote_for_repo() {
 }
 
 cleanup() {
+    # Save analysis output if requested
+    if [[ -n "${ANALYSIS_OUTPUT_DIR}" && -d "${WORK_DIR}" ]]; then
+        log_info "Saving analysis output to: ${ANALYSIS_OUTPUT_DIR}"
+        mkdir -p "${ANALYSIS_OUTPUT_DIR}"
+
+        # Copy the debug log (all stderr output)
+        [[ -f "${DEBUG_LOG}" ]] && cp "${DEBUG_LOG}" "${ANALYSIS_OUTPUT_DIR}/"
+
+        # Copy analysis output files
+        [[ -f "${WORK_DIR}/analysis_output.txt" ]] && cp "${WORK_DIR}/analysis_output.txt" "${ANALYSIS_OUTPUT_DIR}/"
+
+        # Copy the review context that was sent to Claude
+        [[ -f "${WORK_DIR}/review_context.md" ]] && cp "${WORK_DIR}/review_context.md" "${ANALYSIS_OUTPUT_DIR}/"
+
+        # Copy prompt file for debugging
+        [[ -f "${WORK_DIR}/prompt.txt" ]] && cp "${WORK_DIR}/prompt.txt" "${ANALYSIS_OUTPUT_DIR}/"
+
+        # Copy review data files
+        for f in "${WORK_DIR}"/*.json; do
+            [[ -f "$f" ]] && cp "$f" "${ANALYSIS_OUTPUT_DIR}/"
+        done
+
+        # List what was saved
+        log_info "Saved files:"
+        ls -la "${ANALYSIS_OUTPUT_DIR}" >&2
+    fi
+
     if [[ -d "${WORK_DIR}" ]]; then
         if [[ "${KEEP_WORK_DIR}" == "true" ]]; then
             log_info "Work directory preserved at: ${WORK_DIR}"
@@ -139,6 +178,27 @@ fetch_pr_info() {
         PR_BRANCH=$(echo "${pr_info}" | jq -r '.head.ref')
         log_info "PR branch: ${PR_BRANCH}"
     fi
+
+    # Get PR author if not provided
+    if [[ -z "${PR_AUTHOR:-}" ]]; then
+        PR_AUTHOR=$(echo "${pr_info}" | jq -r '.user.login')
+    fi
+    log_info "PR author: ${PR_AUTHOR}"
+
+    # Verify PR was created by the expected bot
+    if [[ -z "${CLAUDE_BOT_USERNAME:-}" ]]; then
+        log_error "CLAUDE_BOT_USERNAME is required"
+        log_error "For local testing, set it to the bot that authored the PR (e.g., github-actions[bot])"
+        exit 1
+    fi
+
+    # Use case-insensitive comparison since GitHub usernames are case-insensitive
+    if [[ "${PR_AUTHOR,,}" != "${CLAUDE_BOT_USERNAME,,}" ]]; then
+        log_error "PR #${PR_NUMBER} was not created by ${CLAUDE_BOT_USERNAME} (author: ${PR_AUTHOR})"
+        log_error "This script only handles PRs created by the Claude bot"
+        exit 1
+    fi
+    log_info "Verified PR author matches expected bot: ${CLAUDE_BOT_USERNAME}"
 
     # Detect if PR is from a fork and set PUSH_REPOSITORY accordingly
     local head_repo
@@ -230,11 +290,12 @@ fetch_review_comments() {
     review_status=$(jq -r '.[] | "\(.id):\(.addressed)"' "${reviews_file}" 2>/dev/null || true)
 
     # Fetch comments for each review, marking addressed status
+    # Include comment id so Claude can reply to specific comments
     while IFS=: read -r review_id addressed; do
         [[ -z "${review_id}" ]] && continue
         gh api "repos/${PR_REPOSITORY}/pulls/${PR_NUMBER}/reviews/${review_id}/comments" \
-            --jq '.[] | {review_id: '"${review_id}"', path: .path, line: .line, body: .body, diff_hunk: .diff_hunk, user: .user.login, addressed: '"${addressed}"'}' \
-            >> "${comments_file}" 2>/dev/null || true
+            --jq '.[] | {id: .id, review_id: '"${review_id}"', path: .path, line: .line, body: .body, diff_hunk: .diff_hunk, user: .user.login, addressed: '"${addressed}"'}' \
+            >> "${comments_file}" || true
     done <<< "${review_status}"
 
     # Count comments
@@ -254,7 +315,7 @@ fetch_pr_conversation() {
     # Get issue comments (general PR comments, not inline)
     gh api "repos/${PR_REPOSITORY}/issues/${PR_NUMBER}/comments" \
         --jq '.[] | {user: .user.login, body: .body, created_at: .created_at}' \
-        > "${conversation_file}" 2>/dev/null || true
+        > "${conversation_file}" || true
 
     echo "${conversation_file}"
 }
@@ -264,7 +325,7 @@ fetch_pr_diff() {
 
     local diff_file="${WORK_DIR}/pr_diff.patch"
 
-    gh pr diff "${PR_NUMBER}" --repo "${PR_REPOSITORY}" > "${diff_file}" 2>/dev/null || true
+    gh pr diff "${PR_NUMBER}" --repo "${PR_REPOSITORY}" > "${diff_file}" || true
 
     echo "${diff_file}"
 }
@@ -334,14 +395,15 @@ EOF
                 [[ "${filter}" == "unaddressed" && "${addressed}" == "true" ]] && continue
                 [[ "${filter}" == "addressed" && "${addressed}" != "true" ]] && continue
 
-                local path line body diff_hunk user
+                local comment_id path line body diff_hunk user
+                comment_id=$(echo "${comment}" | jq -r '.id')
                 path=$(echo "${comment}" | jq -r '.path')
                 line=$(echo "${comment}" | jq -r '.line')
                 body=$(echo "${comment}" | jq -r '.body')
                 diff_hunk=$(echo "${comment}" | jq -r '.diff_hunk')
                 user=$(echo "${comment}" | jq -r '.user // "unknown"')
 
-                echo "### ${path}:${line} (${user})"
+                echo "### ${path}:${line} (${user}) [comment_id: ${comment_id}]"
                 echo ""
                 echo "**Comment:**"
                 echo "${body}"
@@ -429,6 +491,85 @@ $(cat "${context_file}")
 
 ## Instructions
 
+IMPORTANT: First, analyze each comment to determine if it requires action from you.
+
+### Step 1: Classify Each Comment
+
+For each review comment, determine which category it falls into:
+
+1. **Actionable feedback FOR YOU**: Comments requesting code changes, fixes, or improvements
+   - Examples: "Please fix this bug", "Add error handling here", "This should use X instead"
+   - These require you to make changes
+
+2. **Discussion between humans**: Comments where people are talking to each other, not to you
+   - Examples: "@john what do you think?", "I agree with Sarah's point", "Let's discuss this in standup"
+   - DO NOT act on these - they are not addressed to you
+
+3. **Acknowledgements or approvals**: Comments that don't request changes
+   - Examples: "LGTM", "Thanks!", "Good catch", "I see", "Makes sense"
+   - No action required
+
+4. **Questions needing clarification**: Comments asking for explanation rather than changes
+   - Examples: "Why did you do it this way?", "What's the purpose of this?"
+   - You may respond but don't necessarily need to change code
+
+### Step 2: Respond to Inline Comments Directly
+
+When addressing inline code comments, **reply directly in that comment thread** to acknowledge the specific feedback. This keeps the conversation organized.
+
+To reply to an inline comment, use the comment_id shown in brackets (e.g., [comment_id: 123456]):
+\`\`\`bash
+gh api repos/${PR_REPOSITORY}/pulls/${PR_NUMBER}/comments/COMMENT_ID/replies -f body="Your reply here"
+\`\`\`
+
+**IMPORTANT: Always be friendly, patient, and polite in your responses.**
+
+Examples of good inline replies:
+- "Done! Added the comment as suggested."
+- "Good catch! Fixed."
+- "Thanks for the suggestion! I chose this approach because [reason]. Let me know if you'd prefer a different approach."
+
+Keep inline replies **brief and to the point**. The commit message will have more detail.
+
+If you disagree with feedback:
+- Always provide clear, respectful motivation for your decision
+- Explain the trade-offs or reasoning behind your approach
+- Be open to changing if the reviewer provides additional context
+- Never be dismissive or defensive
+
+**DO NOT** post a general PR-level comment for each inline comment - reply in the thread instead.
+
+### Step 3: Decide on Code Changes
+
+Only make code changes for comments in category 1 (actionable feedback FOR YOU).
+
+**IMPORTANT: Stay within the scope of the original PR.**
+
+This PR was created to fix nightly test failures. You should ONLY make changes that:
+- Directly address the original test failure
+- Fix issues with the proposed solution
+- Improve the fix based on reviewer feedback
+
+You should NOT make changes that:
+- Add new features unrelated to the test fix
+- Refactor code outside the scope of the fix
+- Address pre-existing issues that weren't part of the original failure
+- Implement reviewer suggestions that go beyond fixing the test
+
+If a reviewer requests out-of-scope changes, respond politely:
+- "Thanks for the suggestion! However, that change is outside the scope of this PR, which focuses on fixing the nightly test failure. I'd recommend opening a separate PR for that improvement."
+- "I appreciate the feedback! That's a good idea, but it's not directly related to the test fix this PR addresses. A separate PR would be the best way to handle that change."
+
+If ALL comments are in categories 2-4 (discussions, acknowledgements, questions), OR if you only need to respond/explain without changing code, then:
+- Respond to comments as needed (see Step 2)
+- Do NOT make code changes
+- Output "NO_CHANGES_NEEDED" instead of a commit message
+- Briefly explain why no code changes were required
+
+**IMPORTANT**: Use NO_CHANGES_NEEDED whenever you don't make code changes, even if you responded to comments. Only use COMMIT_MESSAGE when you actually modified files.
+
+### Step 4: Making Changes (when needed)
+
 YOU MUST CALL TOOLS TO MAKE CHANGES. This is mandatory, not optional.
 
 To delete a file: Call the Bash tool with command "rm <filepath>"
@@ -447,8 +588,55 @@ RIGHT: [Calls Edit tool with old and new strings] (tool call = file changed)
 Important constraints:
 - Make minimal, targeted changes to address the feedback
 - Don't make unrelated changes or refactors
-- NEVER modify files in .github/workflows/
+- NEVER modify files in .github/ (workflows, scripts, etc.)
+- After making C code changes, run \`make format\` to format the code
+- For other code (shell scripts, Python, etc.), check scripts/ for formatting tools
+- NEVER modify expected output files (.out files) directly. Instead:
+  1. Modify the test SQL file (.sql) if needed
+  2. Run the test to generate new output
+  3. If the test passes without errors, crashes, or truncated output, copy the new output over the expected file
+  4. This ensures all output changes (including unexpected ones like plan changes) are captured
 - If you cannot address a comment, explain why
+
+### Step 5: PR-Level Summary (Only When Needed)
+
+**DO NOT** post a PR-level summary comment for small fixes. The inline replies and commit message are sufficient.
+
+**ONLY** post a PR-level summary if:
+- You made significant changes to the approach (not just small tweaks)
+- Multiple reviewers asked questions that need a consolidated answer
+- The changes affect the overall PR in a way that needs explanation
+
+To post a PR-level comment (only when truly needed):
+\`\`\`bash
+gh pr comment ${PR_NUMBER} --repo ${PR_REPOSITORY} --body "Your summary here"
+\`\`\`
+
+### Step 6: Update PR Title/Description (If Approach Changed)
+
+If the reviewer feedback caused you to **fundamentally change the approach**, update the PR:
+
+\`\`\`bash
+# Update PR title
+gh pr edit ${PR_NUMBER} --repo ${PR_REPOSITORY} --title "New title here"
+
+# Update PR body/description
+gh pr edit ${PR_NUMBER} --repo ${PR_REPOSITORY} --body "New description here"
+\`\`\`
+
+Only do this if the fix approach changed significantly - not for minor refinements.
+
+### Step 7: Re-request Review
+
+After making code changes to address feedback, **always re-request a review** from the reviewer(s) so they know to look at your changes:
+
+\`\`\`bash
+gh pr edit ${PR_NUMBER} --repo ${PR_REPOSITORY} --add-reviewer ${REVIEWER}
+\`\`\`
+
+This notifies the reviewer that you've addressed their feedback and the PR is ready for another look.
+
+### Output Format
 
 After making changes, output a summary in this exact format:
 
@@ -457,6 +645,11 @@ Address PR review feedback from ${REVIEWER}
 
 <Brief description of changes made to address the feedback>
 END_COMMIT_MESSAGE
+
+If no changes are needed, output:
+
+NO_CHANGES_NEEDED
+<Explanation of why no code changes were required - e.g., comments were discussions between reviewers, acknowledgements, or questions not requiring code changes>
 EOF
 
     local prompt_size
@@ -506,23 +699,24 @@ commit_and_push_changes() {
         return 1
     fi
 
-    # Filter out workflow files
+    # Filter out .github/ files - workflows require special scope, scripts shouldn't be modified
     local filtered_modified
-    filtered_modified=$(echo "${modified_files}" | grep -v '^\.github/workflows/' || true)
+    filtered_modified=$(echo "${modified_files}" | grep -v '^\.github/' || true)
 
-    local workflow_changes
-    workflow_changes=$(echo "${modified_files}" | grep '^\.github/workflows/' || true)
-    if [[ -n "${workflow_changes}" ]]; then
-        log_warn "Reverting workflow file changes (requires special permissions):"
-        echo "${workflow_changes}" | while read -r f; do
+    local github_changes
+    github_changes=$(echo "${modified_files}" | grep '^\.github/' || true)
+    if [[ -n "${github_changes}" ]]; then
+        log_warn "Reverting .github/ file changes:"
+        echo "${github_changes}" | while read -r f; do
             if [[ -n "${f}" ]]; then
+                log_warn "  - ${f}"
                 git checkout -- "${f}" 2>/dev/null || true
             fi
         done
     fi
 
     if [[ -z "${filtered_modified}" ]]; then
-        log_info "No non-workflow changes to commit"
+        log_info "No changes to commit (excluding .github/)"
         return 1
     fi
 
@@ -547,8 +741,6 @@ ${commit_msg}
 
 Addresses feedback from review by @${REVIEWER}
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
 Co-Authored-By: Claude <noreply@anthropic.com>
 EOF
 )"
@@ -561,19 +753,13 @@ EOF
         return 0
     fi
 
-    # Find or create a remote for pushing
-    local push_remote
-    push_remote=$(find_remote_for_repo "${PUSH_REPOSITORY}" || true)
-
-    if [[ -z "${push_remote}" ]]; then
-        log_info "Setting up remote for push repository: ${PUSH_REPOSITORY}"
-        local push_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUSH_REPOSITORY}.git"
-        git remote add push-target "${push_url}" 2>/dev/null || \
-            git remote set-url push-target "${push_url}"
-        push_remote="push-target"
-    else
-        log_info "Using existing remote '${push_remote}' for pushing"
-    fi
+    # Always set up an authenticated remote for pushing
+    # Even if an existing remote matches the repo, it may not have the token
+    local push_remote="push-target"
+    local push_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${PUSH_REPOSITORY}.git"
+    log_info "Setting up authenticated remote for push repository: ${PUSH_REPOSITORY}"
+    git remote add "${push_remote}" "${push_url}" 2>/dev/null || \
+        git remote set-url "${push_remote}" "${push_url}"
 
     # Push to the PR branch
     log_info "Pushing to ${PUSH_REPOSITORY}:${PR_BRANCH}"
@@ -590,27 +776,16 @@ post_pr_comment() {
     local success="$1"
     local analysis_output="$2"
 
-    log_info "Posting comment to PR..."
+    # Only post PR-level comments for errors - Claude handles inline replies for success cases
+    if [[ "${success}" == "true" || "${success}" == "no_action" ]]; then
+        return
+    fi
+
+    log_info "Posting error comment to PR..."
 
     local comment_body
-    if [[ "${success}" == "true" ]]; then
-        comment_body=$(cat <<EOF
-## 🤖 Claude has addressed the review feedback
-
-I've pushed changes to address the feedback from @${REVIEWER}.
-
-**Changes made:**
-$(git log -1 --format="%b" | head -20)
-
-Please review the new changes and let me know if there's anything else to address.
-
----
-*This comment was automatically generated by Claude Code in response to PR review feedback.*
-EOF
-)
-    else
-        comment_body=$(cat <<EOF
-## 🤖 Claude attempted to address the review feedback
+    comment_body=$(cat <<EOF
+## 🤖 Claude encountered an issue
 
 I reviewed the feedback from @${REVIEWER} but was unable to make changes automatically.
 
@@ -620,12 +795,8 @@ This could be because:
 - There was an error processing the request
 
 Please review the feedback manually or provide more specific guidance.
-
----
-*This comment was automatically generated by Claude Code in response to PR review feedback.*
 EOF
 )
-    fi
 
     if [[ "${SKIP_PUSH}" == "true" ]]; then
         log_info "SKIP_PUSH mode - not posting PR comment"
@@ -741,13 +912,23 @@ main() {
     local analysis_output
     analysis_output=$(invoke_claude_for_review "${context_file}")
 
-    # Commit and push changes
-    if commit_and_push_changes "${analysis_output}"; then
-        post_pr_comment "true" "${analysis_output}"
+    # Check if Claude determined no changes were needed
+    if grep -q "NO_CHANGES_NEEDED" "${analysis_output}"; then
+        log_info "Claude determined no code changes are needed"
+        # Claude should have already replied to inline comments - no PR-level comment needed
+        log_info "Claude handled responses inline"
+    # Try to commit and push changes
+    elif commit_and_push_changes "${analysis_output}"; then
+        # Claude should have already replied to inline comments - no PR-level comment needed
         log_info "Successfully addressed PR review feedback"
     else
-        post_pr_comment "false" "${analysis_output}"
-        log_info "No changes made in response to review feedback"
+        # No changes to commit - this is NOT an error
+        # Claude may have:
+        # 1. Only responded to comments without needing code changes
+        # 2. Found the changes were already applied
+        # 3. Decided after analysis that no changes were needed
+        # Claude should have already replied inline, so no error comment needed
+        log_info "No code changes were made (Claude may have only responded to comments)"
     fi
 
     log_info "Done!"

--- a/.github/workflows/claude-nightly-fix.yaml
+++ b/.github/workflows/claude-nightly-fix.yaml
@@ -1,0 +1,207 @@
+name: Claude Nightly Test Fixer
+
+# This workflow analyzes nightly test failures and creates PRs to fix them.
+# It can be triggered in two ways:
+# 1. Called by the Regression workflow when nightly tests fail (workflow_call)
+# 2. Manually for testing (workflow_dispatch)
+#
+# Required repository variables (for workflow_call triggers):
+#   CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY - e.g., "timescale/timescaledb"
+#     Acts as an enable flag; if not set, workflow_call triggers are skipped.
+#
+# Required secrets (passed via workflow_call or available in repository):
+#   ANTHROPIC_API_KEY - API key for Claude
+#   CLAUDE_APP_ID - GitHub App ID for authentication
+#   CLAUDE_APP_PRIVATE_KEY - GitHub App private key
+
+on:
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID to analyze (required)"
+        required: true
+        type: string
+      source_repository:
+        description: |
+          Repository to fetch artifacts from. Defaults to the current repo if
+          not specified. Use when, e.g., running from a fork to analyze
+          failures from the parent repo. PRs will still be created in this
+          repo.
+        required: false
+        type: string
+
+  # Called by the Regression workflow on nightly failures
+  workflow_call:
+    inputs:
+      run_id:
+        description: "Workflow run ID to analyze"
+        required: true
+        type: string
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
+      CLAUDE_APP_ID:
+        required: true
+      CLAUDE_APP_PRIVATE_KEY:
+        required: true
+      CLAUDE_SLACK_BOT_TOKEN:
+        required: false
+      CLAUDE_SLACK_CHANNEL:
+        required: false
+
+# Restrict default permissions for security - jobs declare only what they need
+permissions: {}
+concurrency:
+  group: claude-nightly-fix
+  cancel-in-progress: true # Should only run one job at a time per failed nightly run
+
+jobs:
+  analyze-and-fix:
+    name: Analyze Failures with Claude
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Needed to push commits to new branches for fix PRs
+      pull-requests: write # Needed to create PRs, add labels, post comments
+
+    steps:
+      - name: Check prerequisites
+        id: check-prereqs
+        run: |
+          skip=false
+          # For workflow_call triggers, require the source repository variable to be set
+          # This acts as an enable/disable flag for automatic triggers
+          if [[ "${EVENT_NAME}" == "workflow_call" && -z "${VARS_CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY}" ]]; then
+            echo "CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY variable is not configured, skipping"
+            skip=true
+          fi
+          if [[ -z "${SECRETS_ANTHROPIC_API_KEY}" ]]; then
+            echo "ANTHROPIC_API_KEY secret is not configured, skipping"
+            skip=true
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          VARS_CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY: ${{ vars.CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY }}
+          SECRETS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Determine run ID to analyze
+        if: steps.check-prereqs.outputs.skip != 'true'
+        id: get-run-id
+        env:
+          INPUTS_RUN_ID: ${{ inputs.run_id }}
+        run: |
+          # Run ID is always provided via inputs (workflow_dispatch or workflow_call)
+          RUN_ID="${INPUTS_RUN_ID}"
+          echo "Using run ID: ${RUN_ID}"
+          echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        if: steps.check-prereqs.outputs.skip != 'true'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        if: steps.check-prereqs.outputs.skip != 'true'
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code
+        if: steps.check-prereqs.outputs.skip != 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Determine source repository
+        if: steps.check-prereqs.outputs.skip != 'true'
+        id: source-repo
+        env:
+          INPUT_SOURCE_REPO: ${{ inputs.source_repository }}
+          VAR_SOURCE_REPO: ${{ vars.CLAUDE_NIGHTLY_FIX_SOURCE_REPOSITORY }}
+          CURRENT_REPO: ${{ github.repository }}
+        run: |
+          # Determine the source repository (where to fetch artifacts from)
+          SOURCE_REPO="${INPUT_SOURCE_REPO:-${VAR_SOURCE_REPO:-${CURRENT_REPO}}}"
+          echo "source_repo=${SOURCE_REPO}" >> $GITHUB_OUTPUT
+
+          # Check if source repo is different from current repo (cross-org access needed)
+          SOURCE_OWNER="${SOURCE_REPO%%/*}"
+          CURRENT_OWNER="${CURRENT_REPO%%/*}"
+          if [[ "${SOURCE_OWNER}" != "${CURRENT_OWNER}" ]]; then
+            echo "Cross-org access needed: ${SOURCE_OWNER} -> ${CURRENT_OWNER}"
+            echo "needs_source_token=true" >> $GITHUB_OUTPUT
+            echo "source_owner=${SOURCE_OWNER}" >> $GITHUB_OUTPUT
+            echo "source_repo_name=${SOURCE_REPO##*/}" >> $GITHUB_OUTPUT
+          else
+            echo "Same org, single token sufficient"
+            echo "needs_source_token=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate GitHub App token
+        if: steps.check-prereqs.outputs.skip != 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+
+      - name: Generate GitHub App token for source repository
+        if: steps.check-prereqs.outputs.skip != 'true' && steps.source-repo.outputs.needs_source_token == 'true'
+        id: generate-source-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ steps.source-repo.outputs.source_owner }}
+          repositories: ${{ steps.source-repo.outputs.source_repo_name }}
+
+      - name: Configure Git
+        if: steps.check-prereqs.outputs.skip != 'true'
+        env:
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+          APP_ID: ${{ secrets.CLAUDE_APP_ID }}
+          VARS_CLAUDE_GIT_AUTHOR_NAME: ${{ vars.CLAUDE_GIT_AUTHOR_NAME }}
+          VARS_CLAUDE_GIT_AUTHOR_EMAIL: ${{ vars.CLAUDE_GIT_AUTHOR_EMAIL }}
+        run: |
+          # Use configured variables if set, otherwise fall back to GitHub App bot identity
+          GIT_USER="${VARS_CLAUDE_GIT_AUTHOR_NAME}"
+          GIT_EMAIL="${VARS_CLAUDE_GIT_AUTHOR_EMAIL}"
+          if [[ -z "${GIT_USER}" ]]; then
+            GIT_USER="${APP_SLUG}[bot]"
+          fi
+          if [[ -z "${GIT_EMAIL}" ]]; then
+            GIT_EMAIL="${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          fi
+          git config --global user.name "${GIT_USER}"
+          git config --global user.email "${GIT_EMAIL}"
+          echo "Configured git author: ${GIT_USER} <${GIT_EMAIL}>"
+
+      - name: Analyze failures and create fix PR
+        if: steps.check-prereqs.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          # Token for accessing source repository (for cross-org scenarios)
+          # Falls back to GITHUB_TOKEN if not needed
+          SOURCE_GITHUB_TOKEN: ${{ steps.generate-source-token.outputs.token || steps.generate-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.CLAUDE_SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.CLAUDE_SLACK_CHANNEL }}
+          SOURCE_REPOSITORY: ${{ steps.source-repo.outputs.source_repo }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          ANALYZE_RUN_ID: ${{ steps.get-run-id.outputs.run_id }}
+          ANALYSIS_OUTPUT_DIR: ${{ github.workspace }}/claude-analysis-output
+          # Bot username for filtering existing PRs (constructed from app slug)
+          CLAUDE_BOT_USERNAME: ${{ steps.generate-token.outputs.app-slug }}[bot]
+        run: |
+          .github/scripts/claude-analyze-failures.sh
+
+      - name: Upload Claude analysis output
+        if: always() && steps.check-prereqs.outputs.skip != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Claude analysis output
+          path: claude-analysis-output/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/claude-pr-review-handler.yaml
+++ b/.github/workflows/claude-pr-review-handler.yaml
@@ -1,81 +1,206 @@
-name: Handle PR Review Feedback
+name: Claude PR Feedback Handler
 
 # This workflow allows Claude to respond to PR review feedback on PRs it created.
-# When a review is submitted on a claude-code labeled PR, Claude will attempt
-# to address the feedback and push fixes.
+# When a review is submitted, the workflow verifies the PR was created by the
+# GitHub App bot before processing. This is more secure than label-based filtering.
+#
+# Required repository variables:
+#   CLAUDE_PR_REVIEW_HANDLER_ENABLED - Set to any value to enable this workflow
+#
+# Required secrets:
+#   ANTHROPIC_API_KEY - API key for Claude
+#   CLAUDE_APP_ID - GitHub App ID for authentication
+#   CLAUDE_APP_PRIVATE_KEY - GitHub App private key
 
 on:
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to process (required)"
+        required: true
+        type: string
+
+  # Automatic trigger on PR review
   pull_request_review:
     types: [submitted]
+
+# Restrict default permissions for security - jobs declare only what they need
+permissions: {}
+
+# Run one job at a time per PR
+concurrency:
+  group: claude-handle-review-${{ inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   handle-review:
     name: Handle PR Review with Claude
-    # Only run on PRs with the claude-code label and when review requests changes or comments
+    # For pull_request_review: only run on PRs with claude-code label when review requests changes or comments
+    # For workflow_dispatch: always run (useful for testing)
+    # Author verification happens after token generation (needs app-slug)
+    # The label check allows users to disable review handling by removing the label
+    # Requires CLAUDE_PR_REVIEW_HANDLER_ENABLED variable and ANTHROPIC_API_KEY secret
     if: |
-      contains(github.event.pull_request.labels.*.name, 'claude-code') &&
-      (github.event.review.state == 'changes_requested' || github.event.review.state == 'commented')
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'claude-code') &&
+       (github.event.review.state == 'changes_requested' || github.event.review.state == 'commented'))
     runs-on: ubuntu-latest
-
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Needed to push commits addressing review feedback
+      pull-requests: write # Needed to post comments on PRs
 
     steps:
-    - name: Check for API key
-      id: check-key
-      run: |
-        if [[ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]]; then
-          echo "ANTHROPIC_API_KEY secret is not configured, skipping Claude review handler"
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
+      - name: Check prerequisites
+        id: check-prereqs
+        run: |
+          skip=false
+          if [[ -z "${VARS_CLAUDE_PR_REVIEW_HANDLER_ENABLED}" ]]; then
+            echo "CLAUDE_PR_REVIEW_HANDLER_ENABLED variable is not configured, skipping"
+            skip=true
+          fi
+          if [[ -z "${SECRETS_ANTHROPIC_API_KEY}" ]]; then
+            echo "ANTHROPIC_API_KEY secret is not configured, skipping Claude review handler"
+            skip=true
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+        env:
+          VARS_CLAUDE_PR_REVIEW_HANDLER_ENABLED: ${{ vars.CLAUDE_PR_REVIEW_HANDLER_ENABLED }}
+          SECRETS_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-    - name: Checkout PR branch
-      if: steps.check-key.outputs.skip != 'true'
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        fetch-depth: 0
+      - name: Generate GitHub App token
+        if: steps.check-prereqs.outputs.skip != 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
 
-    - name: Configure Git
-      if: steps.check-key.outputs.skip != 'true'
-      run: |
-        git config user.name "timescale-automation"
-        git config user.email "123763385+github-actions[bot]@users.noreply.github.com"
+      - name: Get PR info and verify author
+        if: steps.check-prereqs.outputs.skip != 'true'
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          STEPS_GENERATE_TOKEN_OUTPUTS_APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+          INPUTS_PR_NUMBER: ${{ inputs.pr_number }}
+          GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          GITHUB_EVENT_REVIEW_USER_LOGIN: ${{ github.event.review.user.login }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_ASSOCIATION: ${{ github.event.review.author_association }}
+        run: |
+          EXPECTED_AUTHOR="${STEPS_GENERATE_TOKEN_OUTPUTS_APP_SLUG}[bot]"
 
-    - name: Setup Node.js
-      if: steps.check-key.outputs.skip != 'true'
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20"
+          # For workflow_dispatch, fetch PR info from API
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            PR_NUMBER="${INPUTS_PR_NUMBER}"
+            echo "Fetching PR #${PR_NUMBER} info..."
+            PR_INFO=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+            ACTUAL_AUTHOR=$(echo "$PR_INFO" | jq -r '.user.login')
+            PR_BRANCH=$(echo "$PR_INFO" | jq -r '.head.ref')
+            PUSH_REPO=$(echo "$PR_INFO" | jq -r '.head.repo.full_name')
+          else
+            ACTUAL_AUTHOR="${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}"
+            PR_BRANCH="${GITHUB_EVENT_PULL_REQUEST_HEAD_REF}"
+            PUSH_REPO="${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}"
 
-    - name: Install Claude Code
-      if: steps.check-key.outputs.skip != 'true'
-      run: npm install -g @anthropic-ai/claude-code
+            # Check reviewer is not the bot itself (prevent loops)
+            REVIEWER="${GITHUB_EVENT_REVIEW_USER_LOGIN}"
+            if [[ "$REVIEWER" == "$EXPECTED_AUTHOR" ]]; then
+              echo "::notice::Review submitted by bot itself, skipping to prevent loops"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
 
-    - name: Handle review feedback
-      if: steps.check-key.outputs.skip != 'true'
-      env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        REVIEW_ID: ${{ github.event.review.id }}
-        REVIEW_BODY: ${{ github.event.review.body }}
-        REVIEW_STATE: ${{ github.event.review.state }}
-        REVIEWER: ${{ github.event.review.user.login }}
-        # PR_REPOSITORY is where the PR lives (for API calls)
-        PR_REPOSITORY: ${{ github.repository }}
-        # PUSH_REPOSITORY is where to push (may be a fork)
-        PUSH_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-      run: .github/scripts/claude-handle-pr-review.sh
+            # Check reviewer has trusted association (OWNER, MEMBER, or COLLABORATOR)
+            if [[ ! "$GITHUB_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+              echo "::notice::Reviewer association ($GITHUB_ASSOCIATION) is not trusted, skipping"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "Reviewer association verified: $GITHUB_ASSOCIATION"
+          fi
 
-    - name: Upload Claude review handler output
-      if: always() && steps.check-key.outputs.skip != 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: Claude review handler output PR-${{ github.event.pull_request.number }}
-        path: /tmp/claude-review-*/
-        if-no-files-found: ignore
-        retention-days: 7
+          echo "pr_branch=${PR_BRANCH}" >> $GITHUB_OUTPUT
+          echo "push_repo=${PUSH_REPO}" >> $GITHUB_OUTPUT
+          echo "pr_author=${ACTUAL_AUTHOR}" >> $GITHUB_OUTPUT
+
+          # Verify PR author is the bot
+          if [[ "$ACTUAL_AUTHOR" != "$EXPECTED_AUTHOR" ]]; then
+            echo "::notice::PR author ($ACTUAL_AUTHOR) does not match expected bot ($EXPECTED_AUTHOR), skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Author verified: $ACTUAL_AUTHOR"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        if: steps.check-prereqs.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # Check out default branch to get latest scripts
+          # The script will fetch and check out the PR branch
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Configure Git
+        if: steps.check-prereqs.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
+        env:
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+          APP_ID: ${{ secrets.CLAUDE_APP_ID }}
+          VARS_CLAUDE_GIT_AUTHOR_NAME: ${{ vars.CLAUDE_GIT_AUTHOR_NAME }}
+          VARS_CLAUDE_GIT_AUTHOR_EMAIL: ${{ vars.CLAUDE_GIT_AUTHOR_EMAIL }}
+        run: |
+          # Use configured variables if set, otherwise fall back to GitHub App bot identity
+          GIT_USER="${VARS_CLAUDE_GIT_AUTHOR_NAME}"
+          GIT_EMAIL="${VARS_CLAUDE_GIT_AUTHOR_EMAIL}"
+          if [[ -z "${GIT_USER}" ]]; then
+            GIT_USER="${APP_SLUG}[bot]"
+          fi
+          if [[ -z "${GIT_EMAIL}" ]]; then
+            GIT_EMAIL="${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          fi
+          git config user.name "${GIT_USER}"
+          git config user.email "${GIT_EMAIL}"
+          echo "Configured git author: ${GIT_USER} <${GIT_EMAIL}>"
+
+      - name: Setup Node.js
+        if: steps.check-prereqs.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code
+        if: steps.check-prereqs.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Handle review feedback
+        if: steps.check-prereqs.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          PR_BRANCH: ${{ steps.pr-info.outputs.pr_branch }}
+          PR_AUTHOR: ${{ steps.pr-info.outputs.pr_author }}
+          # Review context - only available for pull_request_review events
+          REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          REVIEWER: ${{ github.event.review.user.login }}
+          PR_REPOSITORY: ${{ github.repository }}
+          PUSH_REPOSITORY: ${{ steps.pr-info.outputs.push_repo }}
+          CLAUDE_BOT_USERNAME: ${{ steps.generate-token.outputs.app-slug }}[bot]
+          ANALYSIS_OUTPUT_DIR: ${{ github.workspace }}/claude-review-output
+        run: .github/scripts/claude-handle-pr-review.sh
+
+      - name: Upload Claude review handler output
+        if: always() && steps.check-prereqs.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Claude review handler output PR-${{ inputs.pr_number || github.event.pull_request.number }}
+          path: claude-review-output/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -352,71 +352,23 @@ jobs:
         export GITHUB_PR_NUMBER
         scripts/upload_ci_stats.sh
 
-  # Analyze test failures with Claude Code and create a fix PR
-  # This job only runs on scheduled (nightly) builds when tests fail
-  claude-analyze-failures:
-    name: Analyze Failures with Claude Code
+  # Trigger Claude to analyze and fix nightly test failures
+  trigger-claude-fix:
     needs: regress
-    # Only run on nightly (scheduled) builds when regress job fails
-    # Also requires ANTHROPIC_API_KEY to be configured
-    if: always() && github.event_name == 'schedule' && needs.regress.result == 'failure'
-    runs-on: ubuntu-latest
-
+    # Run on nightly failures - always() ensures this runs even when regress fails
+    if: |
+      always() &&
+      github.event_name == 'schedule' &&
+      needs.regress.result == 'failure'
     permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-    - name: Check for API key
-      id: check-key
-      run: |
-        if [[ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]]; then
-          echo "ANTHROPIC_API_KEY secret is not configured, skipping Claude analysis"
-          echo "skip=true" >> $GITHUB_OUTPUT
-        else
-          echo "skip=false" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Checkout TimescaleDB
-      if: steps.check-key.outputs.skip != 'true'
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Configure Git
-      if: steps.check-key.outputs.skip != 'true'
-      run: |
-        git config user.name "timescale-automation"
-        git config user.email "123763385+github-actions[bot]@users.noreply.github.com"
-
-    - name: Setup Node.js
-      if: steps.check-key.outputs.skip != 'true'
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20"
-
-    - name: Install Claude Code
-      if: steps.check-key.outputs.skip != 'true'
-      run: |
-        npm install -g @anthropic-ai/claude-code
-
-    - name: Analyze failures and create fix PR
-      if: steps.check-key.outputs.skip != 'true'
-      env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_CLAUDE }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_RUN_ID: ${{ github.run_id }}
-        ANALYSIS_OUTPUT_DIR: ${{ github.workspace }}/claude-analysis-output
-      run: |
-        .github/scripts/claude-analyze-failures.sh
-
-    - name: Upload Claude analysis output
-      if: always() && steps.check-key.outputs.skip != 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: Claude analysis output
-        path: claude-analysis-output/
-        if-no-files-found: ignore
-        retention-days: 30
+      contents: write # Needed by called workflow to push commits
+      pull-requests: write # Needed by called workflow to create PRs
+    uses: ./.github/workflows/claude-nightly-fix.yaml
+    with:
+      run_id: "${{ github.run_id }}"
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_APP_ID: ${{ secrets.CLAUDE_APP_ID }}
+      CLAUDE_APP_PRIVATE_KEY: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_CLAUDE: ${{ secrets.SLACK_CHANNEL_CLAUDE }}


### PR DESCRIPTION
Improve Claude automation workflows

Major changes:
- Switch from ORG_AUTOMATION_TOKEN to GitHub App authentication for better security with short-lived, scoped tokens
- Create separate PRs for each nightly test fix instead of one combined PR
- Move Claude nightly fix to separate workflow using workflow_call
- Add cross-org support for running from forks against parent repo
- Add security controls: reviewer trust checks, bot author verification, and require explicit opt-in via repository variables

Other improvements:
- Reply to inline review comments in their threads
- Re-request review after addressing feedback
- Add Claude automation documentation
- Pin Actions to release hashes (zizmor audit)