### PR TITLE
Restart loader check on PR body change

### DIFF
--- a/.github/workflows/loader_check.yml
+++ b/.github/workflows/loader_check.yml
@@ -1,7 +1,7 @@
 name: Check for loader changes
 "on":
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
 jobs:
   check_loader_change:


### PR DESCRIPTION
It reads the trailers in the PR body so must check for them again.