### PR TITLE
Disable ColumnarIndexScan

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -128,7 +128,7 @@ TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings = true;
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
 TSDLLEXPORT bool ts_guc_enable_columnarscan = true;
-TSDLLEXPORT bool ts_guc_enable_columnarindexscan = true;
+TSDLLEXPORT bool ts_guc_enable_columnarindexscan = false;
 TSDLLEXPORT int ts_guc_bgw_log_level = WARNING;
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 #if PG16_GE
@@ -1126,7 +1126,7 @@ _guc_init(void)
 							 "Enable returning results directly from compression "
 							 "metadata without decompression",
 							 &ts_guc_enable_columnarindexscan,
-							 true,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/tsl/test/expected/compress_unordered_sort.out
+++ b/tsl/test/expected/compress_unordered_sort.out
@@ -290,10 +290,8 @@ select device, sensor||'1', min(time), max(time) from metrics group by device, s
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
  device | sensor |             min              
@@ -307,10 +305,8 @@ select device, sensor, min(time) from metrics group by device, sensor order by 1
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;
  device | sensor |            first             


### PR DESCRIPTION
ColumnarIndexScan does not currently work with partial aggregates
and may crash with partial aggregates. To prevent any problems
with the node we disable it until we add support for partial
aggregates.

Disable-check: force-changelog-file
