### PR TITLE
Allow ommitting pg version on version specific tests in TESTS

### DIFF
--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -142,6 +142,8 @@ else
       if ! matches "${SKIPS}" "${test_name}"; then
         if [[ $test_name == $test_pattern ]]; then
           current_tests="${current_tests} ${test_name}"
+        elif [[ $test_name =~ ^${test_pattern}-[1-9][0-9]$ ]]; then
+          current_tests="${current_tests} ${test_name}"
         fi
       fi
     done


### PR DESCRIPTION
This is a convenience features when using make installcheck with
a test filter. With this change specifying the pg version is
no longer required and `make regresscheck TESTS=columnarindexscan`
will run the columnarindexscan-18 test.
