### PR TITLE
Only check for core dumps on failure in update tests

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -56,7 +56,7 @@ jobs:
         find update_test -name postgres.log -exec grep ERROR {} \;
 
     - name: Check for coredumps
-      if: always()
+      if: failure()
       id: collectlogs
       run: |
         # wait for in progress coredumps


### PR DESCRIPTION
Saves a 10-second wait otherwise.