### PR TITLE
Do not remove dimension constraints from OSM chunks

### DIFF
--- a/.unreleased/pr_9175
+++ b/.unreleased/pr_9175
@@ -1,0 +1,1 @@
+Fixes: #9175 Do not remove dimension constraints for OSM chunks

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1141,7 +1141,10 @@ chunk_fully_covered(HypertableRestrictInfo *hri, Chunk *chunk)
 	Ensure(dri->base.dimension->type == DIMENSION_TYPE_OPEN, "primary dimension must be open");
 	Ensure(hri->num_base_restrictions > 0, "must have base restrictions");
 
-	if (dri->lower_strategy == InvalidStrategy && dri->upper_strategy == InvalidStrategy)
+	if (IS_OSM_CHUNK(chunk) ||
+		(dri->lower_strategy == InvalidStrategy && dri->upper_strategy == InvalidStrategy) ||
+		(chunk->cube->slices[0]->fd.range_start == TS_TIME_NOBEGIN ||
+		 chunk->cube->slices[0]->fd.range_end == TS_TIME_NOEND))
 		return false;
 
 	/*

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -1308,7 +1308,7 @@ test overflow behaviour of time_bucket exclusion
          ->  Seq Scan on _hyper_1_101_chunk
                Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
          ->  Seq Scan on _hyper_1_102_chunk
-               Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
+               Filter: (("time" > 950) AND (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint))
 
 \qecho test timestamp upper boundary
 test timestamp upper boundary

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -1308,7 +1308,7 @@ test overflow behaviour of time_bucket exclusion
          ->  Seq Scan on _hyper_1_101_chunk
                Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
          ->  Seq Scan on _hyper_1_102_chunk
-               Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
+               Filter: (("time" > 950) AND (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint))
 
 \qecho test timestamp upper boundary
 test timestamp upper boundary

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -1308,7 +1308,7 @@ test overflow behaviour of time_bucket exclusion
          ->  Seq Scan on _hyper_1_101_chunk
                Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
          ->  Seq Scan on _hyper_1_102_chunk
-               Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
+               Filter: (("time" > 950) AND (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint))
 
 \qecho test timestamp upper boundary
 test timestamp upper boundary

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -1308,7 +1308,7 @@ test overflow behaviour of time_bucket exclusion
          ->  Seq Scan on _hyper_1_101_chunk
                Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
          ->  Seq Scan on _hyper_1_102_chunk
-               Filter: (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint)
+               Filter: (("time" > 950) AND (time_bucket('10'::bigint, "time") < '9223372036854775807'::bigint))
 
 \qecho test timestamp upper boundary
 test timestamp upper boundary

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -16,6 +16,8 @@ CREATE OR REPLACE VIEW chunk_view AS
     srcch.table_name AS chunk_name,
     _timescaledb_functions.to_timestamp(dimsl.range_start)
      AS range_start,
+    dimsl.range_start AS range_start_int,
+    dimsl.range_end AS range_end_int,
     _timescaledb_functions.to_timestamp(dimsl.range_end)
      AS range_end
   FROM _timescaledb_catalog.chunk srcch
@@ -961,6 +963,8 @@ INSERT INTO hyper_constr VALUES( 10, 200, 22, 1, 111, 44);
 \c postgres_fdw_db :ROLE_4
 CREATE TABLE fdw_hyper_constr(id integer, time bigint, temp float, mid integer, dev integer, devref integer);
 INSERT INTO fdw_hyper_constr VALUES( 10, 100, 33, 2, 222, 55);
+INSERT INTO fdw_hyper_constr VALUES( 10, 300, 44, 2, 333, 30);
+INSERT INTO fdw_hyper_constr VALUES( 10, 400, 55, 2, 444, 40);
 \c :TEST_DBNAME :ROLE_4
 -- this is a stand-in for the OSM table
 CREATE FOREIGN TABLE child_hyper_constr
@@ -972,11 +976,14 @@ SELECT _timescaledb_functions.attach_osm_table_chunk('hyper_constr', 'child_hype
 ------------------------
  t
 
--- was attached with data, so must update the range
-SELECT _timescaledb_functions.hypertable_osm_range_update('hyper_constr', 100, 110);
- hypertable_osm_range_update 
------------------------------
- f
+SELECT chunk_name, range_start_int, range_end_int
+FROM chunk_view
+WHERE hypertable_name = 'hyper_constr'
+ORDER BY chunk_name;
+     chunk_name     |   range_start_int   |    range_end_int    
+--------------------+---------------------+---------------------
+ _hyper_11_21_chunk |                 200 |                 210
+ child_hyper_constr | 9223372036854775806 | 9223372036854775807
 
 SELECT table_name, status, osm_chunk
 FROM _timescaledb_catalog.chunk
@@ -993,8 +1000,22 @@ SELECT * FROM hyper_constr order by time;
 ----+------+------+-----+-----+--------
  10 |  100 |   33 |   2 | 222 |     55
  10 |  200 |   22 |   1 | 111 |     44
+ 10 |  300 |   44 |   2 | 333 |     30
+ 10 |  400 |   55 |   2 | 444 |     40
 
---verify the check constraint exists on the OSM chunk
+-- TEST verify data from fdw is selected correctly
+SELECT * FROM hyper_constr WHERE time > 200 order by time;
+ id | time | temp | mid | dev | devref 
+----+------+------+-----+-----+--------
+ 10 |  300 |   44 |   2 | 333 |     30
+ 10 |  400 |   55 |   2 | 444 |     40
+
+SELECT * FROM hyper_constr WHERE time > 200 and time < 400 order by time;
+ id | time | temp | mid | dev | devref 
+----+------+------+-----+-----+--------
+ 10 |  300 |   44 |   2 | 333 |     30
+
+--TEST verify the check constraint exists on the OSM chunk
 SELECT * FROM test.show_constraints('child_hyper_constr');
        Constraint        | Type | Columns | Index |              Expr               | Deferrable | Deferred | Validated 
 -------------------------+------+---------+-------+---------------------------------+------------+----------+-----------
@@ -1077,13 +1098,13 @@ CALL run_job(:deljob_id);
 NOTICE:  hypertable_drop_chunks_hook 
 CALL run_job(:deljob_id);
 NOTICE:  hypertable_drop_chunks_hook 
-SELECT chunk_name, range_start, range_end
+SELECT chunk_name
 FROM chunk_view
 WHERE hypertable_name = 'hyper_constr'
 ORDER BY chunk_name;
-     chunk_name     |            range_start            |             range_end              
---------------------+-----------------------------------+------------------------------------
- child_hyper_constr | Wed Dec 31 16:00:00.0001 1969 PST | Wed Dec 31 16:00:00.00011 1969 PST
+     chunk_name     
+--------------------
+ child_hyper_constr
 
 SELECT ts_undo_osm_hook();
  ts_undo_osm_hook 


### PR DESCRIPTION
Preserve filters for OSM chunks during primary dimension constraint
 pruning for fully covered chunks. Follow-up for PR 9127.

Reviewers:  This addresses OSM nightly regression failures.