### PR TITLE
Handle NULL values in continuous aggregate invalidation more gracefully

### DIFF
--- a/.unreleased/pr_9176
+++ b/.unreleased/pr_9176
@@ -1,0 +1,1 @@
+Fixes: #9176 Handle NULL values in continuous aggregate invalidation more gracefully

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -62,10 +62,8 @@ static HTAB *continuous_aggs_cache_hyper_inval_threshold_htab = NULL;
 
 static MemoryContext continuous_aggs_invalidation_mctx = NULL;
 
-static int64 tuple_get_time(Dimension *d, HeapTuple tuple, AttrNumber col, TupleDesc tupdesc);
 static inline void cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry,
 										  int32 hypertable_id, Oid chunk_relid);
-static inline void cache_update_entry(ContinuousAggsCacheInvalEntry *cache_entry, int64 timeval);
 static inline ContinuousAggsCacheInvalEntry *get_cache_inval_entry(int32 hypertable_id,
 																   Oid chunk_relid);
 static void cache_inval_cleanup(void);
@@ -106,25 +104,35 @@ cache_inval_init()
 					HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 }
 
-static int64
-tuple_get_time(Dimension *d, HeapTuple tuple, AttrNumber col, TupleDesc tupdesc)
+static void
+update_cache_from_tuple(ContinuousAggsCacheInvalEntry *cache_entry, HeapTuple tuple,
+						TupleDesc tupdesc)
 {
 	Datum datum;
 	bool isnull;
 	Oid dimtype;
-
-	datum = heap_getattr(tuple, col, tupdesc, &isnull);
-	/*
-	 * Since this is the value of the primary partitioning column and we require
-	 * partitioning columns to be NOT NULL we should never see a NULL here.
-	 */
-	Ensure(!isnull, "primary partition column cannot be NULL");
+	Dimension *d = &cache_entry->hypertable_open_dimension;
+	AttrNumber col = cache_entry->open_dimension_attno;
 
 	Assert(d->type == DIMENSION_TYPE_OPEN);
 
-	dimtype = ts_dimension_get_partition_type(d);
+	datum = heap_getattr(tuple, col, tupdesc, &isnull);
+	/*
+	 * Even though there are NOT NULL constraints on time columns checking these happens
+	 * after invalidation processing so we skip nulls here to allow for normal postgres
+	 * error handling for these NULL values.
+	 */
+	if (isnull)
+		return;
 
-	return ts_time_value_to_internal(datum, dimtype);
+	dimtype = ts_dimension_get_partition_type(d);
+	int64 timeval = ts_time_value_to_internal(datum, dimtype);
+
+	cache_entry->value_is_set = true;
+	if (timeval < cache_entry->lowest_modified_value)
+		cache_entry->lowest_modified_value = timeval;
+	if (timeval > cache_entry->greatest_modified_value)
+		cache_entry->greatest_modified_value = timeval;
 }
 
 static inline void
@@ -146,16 +154,6 @@ cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry, int32 hyperta
 	cache_entry->lowest_modified_value = INVAL_POS_INFINITY;
 	cache_entry->greatest_modified_value = INVAL_NEG_INFINITY;
 	ts_cache_release(&ht_cache);
-}
-
-static inline void
-cache_update_entry(ContinuousAggsCacheInvalEntry *cache_entry, int64 timeval)
-{
-	cache_entry->value_is_set = true;
-	if (timeval < cache_entry->lowest_modified_value)
-		cache_entry->lowest_modified_value = timeval;
-	if (timeval > cache_entry->greatest_modified_value)
-		cache_entry->greatest_modified_value = timeval;
 }
 
 static inline ContinuousAggsCacheInvalEntry *
@@ -198,25 +196,14 @@ continuous_agg_dml_invalidate(int32 hypertable_id, Relation chunk_rel, HeapTuple
 {
 	ContinuousAggsCacheInvalEntry *cache_entry =
 		get_cache_inval_entry(hypertable_id, chunk_rel->rd_id);
-	int64 timeval;
 
-	timeval = tuple_get_time(&cache_entry->hypertable_open_dimension,
-							 chunk_tuple,
-							 cache_entry->open_dimension_attno,
-							 RelationGetDescr(chunk_rel));
-
-	cache_update_entry(cache_entry, timeval);
+	update_cache_from_tuple(cache_entry, chunk_tuple, RelationGetDescr(chunk_rel));
 
 	if (!update)
 		return;
 
 	/* on update we need to invalidate the new time value as well as the old one */
-	timeval = tuple_get_time(&cache_entry->hypertable_open_dimension,
-							 chunk_newtuple,
-							 cache_entry->open_dimension_attno,
-							 RelationGetDescr(chunk_rel));
-
-	cache_update_entry(cache_entry, timeval);
+	update_cache_from_tuple(cache_entry, chunk_newtuple, RelationGetDescr(chunk_rel));
 }
 
 static inline void

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1288,11 +1288,11 @@ EXPLAIN (costs off,timing off,summary off) SELECT FROM direct_compress_insert;
    ->  Custom Scan (ColumnarScan) on _hyper_18_61_chunk
          ->  Seq Scan on compress_hyper_19_62_chunk
 
+RESET timescaledb.enable_direct_compress_insert;
 -- test direct compress copy invalidation
 CREATE TABLE direct_compress_copy(time timestamptz) WITH (tsdb.hypertable);
 NOTICE:  using column "time" as partitioning column
 INSERT INTO direct_compress_copy SELECT '2025-01-01';
-WARNING:  disabling direct compress because of too small batch size
 CREATE MATERIALIZED VIEW cagg_copy WITH (tsdb.continuous) AS SELECT time_bucket('1day', time) FROM direct_compress_copy GROUP BY 1;
 NOTICE:  refreshing continuous aggregate "cagg_copy"
 SET timescaledb.enable_direct_compress_copy = true;
@@ -1334,6 +1334,7 @@ EXPLAIN (costs off,timing off,summary off) SELECT FROM direct_compress_copy;
    ->  Custom Scan (ColumnarScan) on _hyper_21_69_chunk
          ->  Seq Scan on compress_hyper_22_70_chunk
 
+RESET timescaledb.enable_direct_compress_copy;
 -- test direct compress invalidation with custom partitioning function (not supported atm)
 CREATE OR REPLACE FUNCTION f_month(timestamptz) returns int language sql AS $$ SELECT 12 * extract(year from $1) + extract(month from $1);$$ immutable;
 CREATE TABLE part_cagg (time timestamptz);
@@ -1346,3 +1347,21 @@ SELECT create_hypertable('part_cagg', 'time', time_partitioning_func => 'f_month
 CREATE MATERIALIZED VIEW part_cagg1 WITH (tsdb.continuous) AS SELECT time_bucket('1day', time) FROM part_cagg GROUP BY 1;
 ERROR:  custom partitioning functions not supported with continuous aggregates
 \set ON_ERROR_STOP 1
+-- test UPDATE invalidation
+CREATE TABLE inval_update(time timestamptz) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO inval_update SELECT '2025-01-01';
+CREATE MATERIALIZED VIEW cagg_inval_update WITH (tsdb.continuous) AS SELECT time_bucket('1day', time) FROM inval_update GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_inval_update"
+-- check setting to NULL is handled gracefully
+\set ON_ERROR_STOP 0
+UPDATE inval_update SET time = NULL WHERE time = '2025-01-01';
+ERROR:  null value in column "time" of relation "_hyper_25_71_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+UPDATE inval_update SET time = '2025-01-01 00:00:23' WHERE time = '2025-01-01';
+-- should have 1 entries now
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) start, _timescaledb_functions.to_timestamp(greatest_modified_value) end from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log WHERE hypertable_id = 25 ORDER BY 1,2;
+         start          |          end           
+------------------------+------------------------
+ 2025-01-01 00:00:00+00 | 2025-01-01 00:00:23+00
+


### PR DESCRIPTION
Even though there are NOT NULL constraints on dimension columns checking
these happens after invalidation processing. To allow for normal postgres
error handling to happen in these cases we skip NULL values during
continuous aggregate invalidation processing.
