### PR TITLE
Fix shellcheck ci check

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -2,16 +2,10 @@
 name: Shellcheck
 "on":
   pull_request:
-    paths:
-      - '**.sh'
-      - .github/workflows/shellcheck.yaml
   push:
     branches:
       - main
       - ?.*.x
-    paths:
-      - '**.sh'
-      - .github/workflows/shellcheck.yaml
 jobs:
   check_paths:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove the top-level filter from the workflow since path filtering
is now handled below.
