### PR TITLE
Add aggregate expressions to Continuous Aggregate

### DIFF
--- a/.unreleased/pr_9202
+++ b/.unreleased/pr_9202
@@ -1,0 +1,1 @@
+Implements: #9202 Add function to add aggregate expressions to continuous aggregates

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -217,3 +217,12 @@ CREATE OR REPLACE PROCEDURE @extschema@.refresh_continuous_aggregate(
     options                  JSONB = NULL
 ) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh';
 
+-- Add an aggregate expression to a continuous aggregate.
+-- The aggregate will be computed and stored in the materialization hypertable.
+-- Example: add_continuous_aggregate_column('my_cagg', 'sum(value) AS total')
+CREATE OR REPLACE FUNCTION @extschema@.add_continuous_aggregate_column(
+    continuous_aggregate     REGCLASS,
+    column_or_expr           TEXT,
+    if_not_exists            BOOLEAN = FALSE
+) RETURNS VOID
+AS '@MODULE_PATHNAME@', 'ts_continuous_agg_add_column' LANGUAGE C VOLATILE STRICT;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS @extschema@.add_continuous_aggregate_column(REGCLASS, TEXT, BOOLEAN);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -95,6 +95,7 @@ CROSSMODULE_WRAPPER(continuous_agg_validate_query);
 CROSSMODULE_WRAPPER(continuous_agg_get_bucket_function);
 CROSSMODULE_WRAPPER(continuous_agg_get_bucket_function_info);
 CROSSMODULE_WRAPPER(continuous_agg_get_grouping_columns);
+CROSSMODULE_WRAPPER(continuous_agg_add_column);
 
 CROSSMODULE_WRAPPER(chunk_freeze_chunk);
 CROSSMODULE_WRAPPER(chunk_unfreeze_chunk);
@@ -345,6 +346,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.continuous_agg_get_bucket_function = error_no_default_fn_pg_community,
 	.continuous_agg_get_bucket_function_info = error_no_default_fn_pg_community,
 	.continuous_agg_get_grouping_columns = error_no_default_fn_pg_community,
+	.continuous_agg_add_column = error_no_default_fn_pg_community,
 
 	/* compression */
 	.compressed_data_send = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -116,6 +116,7 @@ typedef struct CrossModuleFunctions
 	PGFunction continuous_agg_get_bucket_function;
 	PGFunction continuous_agg_get_bucket_function_info;
 	PGFunction continuous_agg_get_grouping_columns;
+	PGFunction continuous_agg_add_column;
 
 	PGFunction compressed_data_send;
 	PGFunction compressed_data_recv;

--- a/tsl/src/continuous_aggs/CMakeLists.txt
+++ b/tsl/src/continuous_aggs/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/alter.c
     ${CMAKE_CURRENT_SOURCE_DIR}/common.c
     ${CMAKE_CURRENT_SOURCE_DIR}/create.c
     ${CMAKE_CURRENT_SOURCE_DIR}/finalize.c

--- a/tsl/src/continuous_aggs/alter.c
+++ b/tsl/src/continuous_aggs/alter.c
@@ -1,0 +1,654 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file contains the implementation for altering continuous aggregates,
+ * specifically adding aggregate expressions to an existing continuous aggregate.
+ */
+
+#include <postgres.h>
+
+#include "export.h"
+
+#include <access/table.h>
+#include <access/xact.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_proc.h>
+#include <commands/tablecmds.h>
+#include <commands/view.h>
+#include <fmgr.h>
+#include <lib/stringinfo.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <nodes/parsenodes.h>
+#include <parser/analyze.h>
+#include <parser/parse_expr.h>
+#include <parser/parse_node.h>
+#include <parser/parse_relation.h>
+#include <parser/parser.h>
+#include <storage/lmgr.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/rel.h>
+#include <utils/syscache.h>
+
+#include "alter.h"
+#include "common.h"
+#include "create.h"
+#include "debug_assert.h"
+#include "hypertable.h"
+#include "hypertable_cache.h"
+#include "ts_catalog/continuous_agg.h"
+
+/*
+ * Structure to hold parsed aggregate expression information
+ */
+typedef struct AggregateExprInfo
+{
+	char *column_alias;	  /* alias for the result column */
+	Oid result_type;	  /* return type of aggregate */
+	int32 result_typmod;  /* typmod of result type */
+	Oid result_collation; /* collation of result */
+	Aggref *aggref;		  /* the parsed Aggref node */
+	Oid source_relid;	  /* source relation OID used for parsing */
+} AggregateExprInfo;
+
+/*
+ * Walker function to collect column references from an expression
+ */
+static bool
+collect_column_walker(Node *node, List **column_names)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, ColumnRef))
+	{
+		ColumnRef *cref = castNode(ColumnRef, node);
+		/* Get the column name (last element of fields list) */
+		Node *field = llast(cref->fields);
+		if (IsA(field, String))
+		{
+			char *colname = strVal(field);
+			/* Add to list if not already present */
+			ListCell *lc;
+			bool found = false;
+			foreach (lc, *column_names)
+			{
+				if (strcmp(strVal(lfirst(lc)), colname) == 0)
+				{
+					found = true;
+					break;
+				}
+			}
+			if (!found)
+				*column_names = lappend(*column_names, makeString(colname));
+		}
+		return false;
+	}
+
+	return raw_expression_tree_walker(node, collect_column_walker, column_names);
+}
+
+/*
+ * Parse and validate an aggregate expression
+ *
+ * Returns an AggregateExprInfo structure with parsed information.
+ * Errors out if the expression is not a valid aggregate.
+ */
+static AggregateExprInfo *
+parse_aggregate_expression(const char *expr_str, Oid source_relid)
+{
+	StringInfoData query_str;
+	List *raw_parsetree_list;
+
+	/* Build a SELECT statement to parse the expression */
+	initStringInfo(&query_str);
+	appendStringInfo(&query_str, "SELECT %s", expr_str);
+
+	const MemoryContext oldcontext = CurrentMemoryContext;
+
+	PG_TRY();
+	{
+		/* Parse the query */
+		raw_parsetree_list = raw_parser(query_str.data, RAW_PARSE_DEFAULT);
+	}
+	PG_CATCH();
+	{
+		/* We do this fandango to avoid exhausting the error stack if we get
+		 * anything else but a syntax error, for example, an out of memory
+		 * error. */
+		ErrorData *edata;
+		MemoryContextSwitchTo(oldcontext);
+		edata = CopyErrorData();
+		FlushErrorState();
+		if (edata->sqlerrcode == ERRCODE_SYNTAX_ERROR)
+		{
+			edata->cursorpos = edata->internalpos = 0;
+			edata->detail = edata->message;
+			edata->message = psprintf("unable to parse the aggregate expression \"%s\"", expr_str);
+		}
+		ReThrowError(edata);
+	}
+	PG_END_TRY();
+
+	if (list_length(raw_parsetree_list) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("invalid aggregate expression: \"%s\"", expr_str)));
+
+	RawStmt *raw_stmt = linitial_node(RawStmt, raw_parsetree_list);
+	Assert(IsA(raw_stmt->stmt, SelectStmt));
+
+	SelectStmt *select_stmt = castNode(SelectStmt, raw_stmt->stmt);
+	if (list_length(select_stmt->targetList) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR), errmsg("only one aggregate expression allowed")));
+
+	ResTarget *res_target = linitial_node(ResTarget, select_stmt->targetList);
+
+	/* Check if it's a FuncCall (aggregate functions are parsed as FuncCall initially) */
+	if (!IsA(res_target->val, FuncCall))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("expression must be an aggregate function"),
+				 errhint("Use syntax like 'sum(column) AS alias' or 'avg(column)'.")));
+
+	FuncCall *func_call = castNode(FuncCall, res_target->val);
+
+	/* Get the number of arguments - special case for count(*) which has agg_star=true */
+	int nargs = func_call->agg_star ? 0 : list_length(func_call->args);
+
+	/* Look up the function to check if it's an aggregate */
+	List *funcname = func_call->funcname;
+	FuncCandidateList clist =
+		FuncnameGetCandidates(funcname, nargs, NIL, true, false, false, false);
+
+	if (clist == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("function \"%s\" does not exist", NameListToString(funcname))));
+
+	/* Find an aggregate function among candidates */
+	Oid funcoid = InvalidOid;
+	while (clist)
+	{
+		HeapTuple proc_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(clist->oid));
+		if (HeapTupleIsValid(proc_tuple))
+		{
+			Form_pg_proc proc_form = (Form_pg_proc) GETSTRUCT(proc_tuple);
+			if (proc_form->prokind == PROKIND_AGGREGATE)
+			{
+				funcoid = clist->oid;
+				ReleaseSysCache(proc_tuple);
+				break;
+			}
+			ReleaseSysCache(proc_tuple);
+		}
+		clist = clist->next;
+	}
+
+	if (!OidIsValid(funcoid))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not an aggregate function", NameListToString(funcname))));
+
+	/* Collect column references from the aggregate arguments */
+	List *column_names = NIL;
+	collect_column_walker((Node *) func_call->args, &column_names);
+
+	/* Validate that all referenced columns exist in source relation */
+	ListCell *lc;
+	foreach (lc, column_names)
+	{
+		char *colname = strVal(lfirst(lc));
+		AttrNumber attnum = get_attnum(source_relid, colname);
+		if (!AttributeNumberIsValid(attnum))
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" referenced in aggregate does not exist in source "
+							"relation",
+							colname)));
+	}
+
+	/* Now we need to transform the expression to get the Aggref and type info */
+	/* Create a ParseState with the source relation */
+	ParseState *pstate = make_parsestate(NULL);
+	Relation source_rel = table_open(source_relid, AccessShareLock);
+	ParseNamespaceItem *nsitem =
+		addRangeTableEntryForRelation(pstate, source_rel, AccessShareLock, NULL, false, true);
+
+	/* Add to namespace */
+	addNSItemToQuery(pstate, nsitem, true, true, true);
+
+	/* Transform the expression */
+	Node *transformed = transformExpr(pstate, res_target->val, EXPR_KIND_SELECT_TARGET);
+
+	/* Clean up */
+	table_close(source_rel, NoLock);
+	free_parsestate(pstate);
+
+	Assert(IsA(transformed, Aggref));
+
+	Aggref *aggref = castNode(Aggref, transformed);
+
+	/* Build the result structure */
+	AggregateExprInfo *info = palloc0(sizeof(AggregateExprInfo));
+	info->result_type = aggref->aggtype;
+	info->result_typmod = -1; /* aggregates typically don't have typmod */
+	info->result_collation = aggref->aggcollid;
+	info->aggref = aggref;
+	info->source_relid = source_relid;
+
+	/* Determine the column alias */
+	if (res_target->name != NULL)
+	{
+		/* User provided an explicit alias */
+		info->column_alias = res_target->name;
+	}
+	else
+	{
+		/* Generate alias from function name (use last element to skip schema qualification) */
+		info->column_alias = strVal(llast(func_call->funcname));
+	}
+
+	return info;
+}
+
+/*
+ * Check if a column name already exists in the query's targetList
+ */
+static bool
+column_exists_in_targetlist(Query *query, const char *column_name)
+{
+	ListCell *lc;
+
+	foreach (lc, query->targetList)
+	{
+		TargetEntry *tle = lfirst_node(TargetEntry, lc);
+		if (tle->resname && strcmp(tle->resname, column_name) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+/*
+ * Mutator function to adjust varno in Var nodes within an expression
+ */
+static Node *
+adjust_varno_mutator(Node *node, int *new_varno)
+{
+	if (node == NULL)
+		return NULL;
+
+	if (IsA(node, Var))
+	{
+		Var *var = copyObject(castNode(Var, node));
+		var->varno = *new_varno;
+		return (Node *) var;
+	}
+
+	return expression_tree_mutator(node, adjust_varno_mutator, new_varno);
+}
+
+/*
+ * Add an expression to a query's targetList, optionally adjusting Var nodes.
+ *
+ * If relid is valid, finds the varno for relid in the query's rtable and adjusts
+ * all Var nodes in the expression to use that varno. The input expression should
+ * use varno=0 as a placeholder in this case.
+ *
+ * If relid is InvalidOid, adds the expression as-is without adjustment.
+ */
+static void
+add_expr_to_query(Query *query, Oid relid, Expr *expr, char *column_name)
+{
+	if (OidIsValid(relid))
+	{
+		int varno = find_rte_index_for_relid(query, relid);
+		Assert(varno != 0);
+		expr = (Expr *) adjust_varno_mutator((Node *) expr, &varno);
+	}
+
+	TargetEntry *tle = makeTargetEntry(expr,
+									   list_length(query->targetList) + 1,
+									   column_name,
+									   false); /* not resjunk */
+	tle->ressortgroupref = 0;
+
+	query->targetList = lappend(query->targetList, tle);
+}
+
+/*
+ * Add a column to a relation (table or view) using ALTER TABLE/VIEW ADD COLUMN.
+ *
+ * For views, switches to the TimescaleDB internal user for the operation.
+ */
+static void
+add_column_to_relation(char *schema_name, char *rel_name, AggregateExprInfo *agg_info, bool is_view)
+{
+	int sec_ctx;
+	Oid uid, saved_uid;
+
+	/* Create column definition */
+	ColumnDef *coldef = makeColumnDef(agg_info->column_alias,
+									  agg_info->result_type,
+									  agg_info->result_typmod,
+									  agg_info->result_collation);
+
+	/* Create ALTER TABLE/VIEW ADD COLUMN command */
+	AlterTableCmd *cmd = makeNode(AlterTableCmd);
+	cmd->subtype = is_view ? AT_AddColumnToView : AT_AddColumn;
+	cmd->def = (Node *) coldef;
+	cmd->behavior = DROP_RESTRICT;
+	cmd->missing_ok = false;
+
+	AlterTableStmt stmt = {
+		.type = T_AlterTableStmt,
+		.relation = makeRangeVar(schema_name, rel_name, -1),
+		.cmds = list_make1(cmd),
+		.objtype = is_view ? OBJECT_VIEW : OBJECT_TABLE,
+		.missing_ok = false,
+	};
+
+	if (is_view)
+		SWITCH_TO_TS_USER(schema_name, uid, saved_uid, sec_ctx);
+
+	LOCKMODE lockmode = AlterTableGetLockLevel(stmt.cmds);
+	AlterTableUtilityContext atcontext = {
+		.relid = AlterTableLookupRelation(&stmt, lockmode),
+	};
+	AlterTable(&stmt, lockmode, &atcontext);
+	CommandCounterIncrement();
+
+	if (is_view)
+		RESTORE_USER(uid, saved_uid, sec_ctx);
+}
+
+/*
+ * Update a view's query definition to add a new aggregate expression.
+ */
+static void
+update_view_add_aggregate(Oid view_oid, char *view_schema, char *view_name,
+						  AggregateExprInfo *agg_info)
+{
+	int sec_ctx;
+	Oid uid, saved_uid;
+
+	/* Step 1: Get the view's query BEFORE adding the column */
+	Query *query = get_view_query_tree(view_oid);
+
+	/* Remove dummy RTEs for PG16+ */
+	RemoveRangeTableEntries(query);
+
+	/* Add the aggregate to the query */
+	add_expr_to_query(query,
+					  agg_info->source_relid,
+					  (Expr *) agg_info->aggref,
+					  agg_info->column_alias);
+
+	/* Step 2: Add the column to the view relation */
+	add_column_to_relation(view_schema, view_name, agg_info, true);
+
+	/* Step 3: Store the updated query */
+	SWITCH_TO_TS_USER(view_schema, uid, saved_uid, sec_ctx);
+	StoreViewQuery(view_oid, query, true);
+	CommandCounterIncrement();
+	RESTORE_USER(uid, saved_uid, sec_ctx);
+}
+
+/*
+ * Update the user view to include a new column.
+ *
+ * Handles both real-time mode (UNION ALL query with materialized + raw subqueries)
+ * and materialized-only mode (direct query on mat_ht).
+ */
+static void
+update_user_view_add_column(ContinuousAgg *cagg, Hypertable *mat_ht, AggregateExprInfo *agg_info)
+{
+	int sec_ctx;
+	Oid uid, saved_uid;
+
+	Oid user_view_oid = ts_get_relation_relid(NameStr(cagg->data.user_view_schema),
+											  NameStr(cagg->data.user_view_name),
+											  false);
+
+	/* Get the new attnum from the materialization hypertable after adding the column */
+	AttrNumber mat_attnum = get_attnum(mat_ht->main_table_relid, agg_info->column_alias);
+
+	Query *user_query = get_view_query_tree(user_view_oid);
+	RemoveRangeTableEntries(user_query);
+
+	if (user_query->setOperations)
+	{
+		/*
+		 * Real-time mode: UNION ALL query
+		 * Need to update both subqueries and the SetOperationStmt
+		 */
+		Assert(list_length(user_query->rtable) == 2);
+		RangeTblEntry *mat_rte = linitial(user_query->rtable);
+		RangeTblEntry *raw_rte = lsecond(user_query->rtable);
+
+		if (mat_rte->rtekind != RTE_SUBQUERY || raw_rte->rtekind != RTE_SUBQUERY)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("unexpected query structure in real-time continuous aggregate")));
+
+		/* Update materialized subquery (queries mat_ht) - always a simple column read
+		 * since data is pre-aggregated in the materialization hypertable */
+		Expr *mat_var = (Expr *) makeVar(0,
+										 mat_attnum,
+										 agg_info->result_type,
+										 agg_info->result_typmod,
+										 agg_info->result_collation,
+										 0);
+		add_expr_to_query(mat_rte->subquery,
+						  mat_ht->main_table_relid,
+						  mat_var,
+						  agg_info->column_alias);
+		mat_rte->eref->colnames =
+			lappend(mat_rte->eref->colnames, makeString(agg_info->column_alias));
+
+		/* Update raw subquery (queries source relation) - compute the aggregate on the fly */
+		add_expr_to_query(raw_rte->subquery,
+						  agg_info->source_relid,
+						  (Expr *) agg_info->aggref,
+						  agg_info->column_alias);
+		raw_rte->eref->colnames =
+			lappend(raw_rte->eref->colnames, makeString(agg_info->column_alias));
+
+		/* Update SetOperationStmt column type lists */
+		SetOperationStmt *setop = castNode(SetOperationStmt, user_query->setOperations);
+		setop->colTypes = lappend_int(setop->colTypes, agg_info->result_type);
+		setop->colTypmods = lappend_int(setop->colTypmods, agg_info->result_typmod);
+		setop->colCollations = lappend_int(setop->colCollations, agg_info->result_collation);
+
+		/* Add column to outer targetList (no GROUP BY for UNION ALL outer query) */
+		Expr *outer_var = (Expr *) makeVar(1, /* first RTE is always the UNION result */
+										   list_length(user_query->targetList) + 1,
+										   agg_info->result_type,
+										   agg_info->result_typmod,
+										   agg_info->result_collation,
+										   0);
+		add_expr_to_query(user_query, InvalidOid, outer_var, agg_info->column_alias);
+	}
+	else
+	{
+		/*
+		 * Materialized-only mode: Direct query on mat_ht
+		 * No GROUP BY needed since data is pre-aggregated
+		 */
+		Expr *var = (Expr *) makeVar(0,
+									 mat_attnum,
+									 agg_info->result_type,
+									 agg_info->result_typmod,
+									 agg_info->result_collation,
+									 0);
+		add_expr_to_query(user_query, mat_ht->main_table_relid, var, agg_info->column_alias);
+	}
+
+	/* Add the column to the user view relation */
+	add_column_to_relation(NameStr(cagg->data.user_view_schema),
+						   NameStr(cagg->data.user_view_name),
+						   agg_info,
+						   true);
+
+	/* Store the updated user view query */
+	SWITCH_TO_TS_USER(NameStr(cagg->data.user_view_schema), uid, saved_uid, sec_ctx);
+	StoreViewQuery(user_view_oid, user_query, true);
+	CommandCounterIncrement();
+	RESTORE_USER(uid, saved_uid, sec_ctx);
+}
+
+/*
+ * Main function to add an aggregate expression to a continuous aggregate
+ */
+Datum
+continuous_agg_add_column(PG_FUNCTION_ARGS)
+{
+	Oid cagg_relid = PG_GETARG_OID(0);
+	char *expr_str = text_to_cstring(PG_GETARG_TEXT_PP(1));
+	bool if_not_exists = PG_GETARG_BOOL(2);
+
+	/* Only the owner of the continuous aggregate can alter it */
+	ts_cagg_permissions_check(cagg_relid, GetUserId());
+
+	/*
+	 * Take an AccessExclusiveLock on the continuous aggregate relation to
+	 * prevent concurrent modifications. This ensures that two concurrent
+	 * add_continuous_aggregate_column calls are properly serialized.
+	 */
+	LockRelationOid(cagg_relid, AccessExclusiveLock);
+
+	/* Get the continuous aggregate */
+	ContinuousAgg *cagg = cagg_get_by_relid_or_fail(cagg_relid);
+
+	/* Get the raw hypertable */
+	Cache *hcache = ts_hypertable_cache_pin();
+	Hypertable *raw_ht = ts_hypertable_cache_get_entry_by_id(hcache, cagg->data.raw_hypertable_id);
+
+	if (raw_ht == NULL)
+	{
+		ts_cache_release(&hcache);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("could not find raw hypertable for continuous aggregate")));
+	}
+
+	/* Get the materialization hypertable */
+	Hypertable *mat_ht = ts_hypertable_cache_get_entry_by_id(hcache, cagg->data.mat_hypertable_id);
+	if (mat_ht == NULL)
+	{
+		ts_cache_release(&hcache);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not find materialization hypertable for continuous aggregate")));
+	}
+
+	/* Check if the materialization hypertable has compressed chunks */
+	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(mat_ht) ||
+		TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(mat_ht))
+	{
+		ts_cache_release(&hcache);
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot add aggregate to continuous aggregate with compression enabled"),
+				 errhint("Disable compression on the continuous aggregate first.")));
+	}
+
+	/*
+	 * Determine the source relation for the partial/direct views:
+	 * - For regular CAggs: the raw hypertable
+	 * - For hierarchical CAggs: the parent CAgg's user view
+	 */
+	Oid source_relid = raw_ht->main_table_relid;
+
+	if (ContinuousAggIsHierarchical(cagg))
+	{
+		/* Get the parent continuous aggregate */
+		ContinuousAgg *parent_cagg =
+			ts_continuous_agg_find_by_mat_hypertable_id(cagg->data.parent_mat_hypertable_id, false);
+
+		if (parent_cagg == NULL)
+		{
+			ts_cache_release(&hcache);
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("could not find parent continuous aggregate")));
+		}
+
+		/* Get the parent CAgg's user view OID */
+		source_relid = ts_get_relation_relid(NameStr(parent_cagg->data.user_view_schema),
+											 NameStr(parent_cagg->data.user_view_name),
+											 false);
+	}
+
+	/* Parse and validate the aggregate expression */
+	AggregateExprInfo *agg_info = parse_aggregate_expression(expr_str, source_relid);
+
+	/* Check if column already exists in the continuous aggregate */
+	Oid partial_view_oid = ts_get_relation_relid(NameStr(cagg->data.partial_view_schema),
+												 NameStr(cagg->data.partial_view_name),
+												 false);
+
+	Query *partial_query = get_view_query_tree(partial_view_oid);
+
+	if (column_exists_in_targetlist(partial_query, agg_info->column_alias))
+	{
+		ts_cache_release(&hcache);
+		if (if_not_exists)
+		{
+			ereport(NOTICE,
+					(errmsg("column \"%s\" already exists in continuous aggregate, skipping",
+							agg_info->column_alias)));
+			PG_RETURN_VOID();
+		}
+		ereport(ERROR,
+				(errcode(ERRCODE_DUPLICATE_COLUMN),
+				 errmsg("column \"%s\" already exists in continuous aggregate",
+						agg_info->column_alias)));
+	}
+
+	/*
+	 * Step 1: Add column to materialization hypertable
+	 * (aggregates are stored as computed values in mat_ht)
+	 */
+	add_column_to_relation(NameStr(mat_ht->fd.schema_name),
+						   NameStr(mat_ht->fd.table_name),
+						   agg_info,
+						   false);
+
+	/*
+	 * Step 2: Update partial view
+	 * The partial view queries the source relation (raw hypertable or parent CAgg's user view)
+	 */
+	update_view_add_aggregate(partial_view_oid,
+							  NameStr(cagg->data.partial_view_schema),
+							  NameStr(cagg->data.partial_view_name),
+							  agg_info);
+
+	/*
+	 * Step 3: Update direct view
+	 * The direct view also queries the source relation
+	 */
+	Oid direct_view_oid = ts_get_relation_relid(NameStr(cagg->data.direct_view_schema),
+												NameStr(cagg->data.direct_view_name),
+												false);
+	update_view_add_aggregate(direct_view_oid,
+							  NameStr(cagg->data.direct_view_schema),
+							  NameStr(cagg->data.direct_view_name),
+							  agg_info);
+
+	/*
+	 * Step 4: Update user view
+	 */
+	update_user_view_add_column(cagg, mat_ht, agg_info);
+
+	ts_cache_release(&hcache);
+
+	PG_RETURN_VOID();
+}

--- a/tsl/src/continuous_aggs/alter.h
+++ b/tsl/src/continuous_aggs/alter.h
@@ -1,0 +1,11 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+#include <fmgr.h>
+
+extern Datum continuous_agg_add_column(PG_FUNCTION_ARGS);

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -134,6 +134,42 @@ RemoveRangeTableEntries(Query *query)
 }
 
 /*
+ * Find the RTE index (varno) for a given relation OID in the query's rtable.
+ * Returns 0 if not found.
+ */
+int
+find_rte_index_for_relid(Query *query, Oid relid)
+{
+	ListCell *lc;
+	int varno = 1;
+
+	foreach (lc, query->rtable)
+	{
+		RangeTblEntry *rte = lfirst_node(RangeTblEntry, lc);
+		if (rte->rtekind == RTE_RELATION && rte->relid == relid)
+			return varno;
+		varno++;
+	}
+
+	return 0; /* Not found */
+}
+
+/*
+ * Get a copy of the view's query tree.
+ *
+ * Opens the view relation, extracts and copies the query tree, then closes
+ * the relation. The returned Query is a deep copy that can be freely modified.
+ */
+Query *
+get_view_query_tree(Oid reloid)
+{
+	Relation view_rel = table_open(reloid, AccessShareLock);
+	Query *query = copyObject(get_view_query(view_rel));
+	table_close(view_rel, NoLock);
+	return query;
+}
+
+/*
  * Extract the final view from the UNION ALL query.
  *
  * q1 is the query on the materialization hypertable with the finalize call
@@ -1649,26 +1685,11 @@ build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *
 	 * If there is join in CAgg definition then adjust varno
 	 * to get time column from the hypertable in the join.
 	 */
-	varno = list_length(q2->rtable);
-
-	if (list_length(q2->rtable) > 1)
-	{
-		int nvarno = 1;
-		foreach (lc2, q2->rtable)
-		{
-			RangeTblEntry *rte = lfirst_node(RangeTblEntry, lc2);
-			if (rte->rtekind == RTE_RELATION)
-			{
-				/* look for hypertable or parent hypertable in RangeTableEntry list */
-				if (rte->relid == tbinfo->htoid || rte->relid == tbinfo->htoidparent)
-				{
-					varno = nvarno;
-					break;
-				}
-			}
-			nvarno++;
-		}
-	}
+	varno = find_rte_index_for_relid(q2, tbinfo->htoid);
+	if (varno == 0)
+		varno = find_rte_index_for_relid(q2, tbinfo->htoidparent);
+	if (varno == 0)
+		varno = list_length(q2->rtable);
 
 	q2_quals = build_union_query_quals(materialize_htid,
 									   q2_partcoltype,
@@ -1791,9 +1812,7 @@ cagg_get_by_relid_or_fail(const Oid cagg_relid)
 ContinuousAggBucketFunction *
 ts_cagg_get_bucket_function_info(Oid view_oid)
 {
-	Relation view_rel = relation_open(view_oid, AccessShareLock);
-	Query *query = copyObject(get_view_query(view_rel));
-	relation_close(view_rel, NoLock);
+	Query *query = get_view_query_tree(view_oid);
 
 	Assert(query != NULL);
 	Assert(query->commandType == CMD_SELECT);

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -121,6 +121,8 @@ extern Oid cagg_get_boundary_converter_funcoid(Oid typoid);
 
 extern ContinuousAgg *cagg_get_by_relid_or_fail(const Oid cagg_relid);
 extern List *cagg_find_groupingcols(ContinuousAgg *agg, Hypertable *mat_ht);
+extern int find_rte_index_for_relid(Query *query, Oid relid);
+extern Query *get_view_query_tree(Oid reloid);
 
 static inline int64
 cagg_get_time_min(const ContinuousAgg *cagg)

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -905,20 +905,14 @@ cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 	Oid user_view_oid = ts_get_relation_relid(NameStr(agg->data.user_view_schema),
 											  NameStr(agg->data.user_view_name),
 											  false);
-	Relation user_view_rel = relation_open(user_view_oid, AccessShareLock);
-	Query *user_query = copyObject(get_view_query(user_view_rel));
-	/* Keep lock until end of transaction. */
-	relation_close(user_view_rel, NoLock);
+	Query *user_query = get_view_query_tree(user_view_oid);
 	RemoveRangeTableEntries(user_query);
 
 	/* Direct view query of the original user view definition at CAGG creation. */
 	Oid direct_view_oid = ts_get_relation_relid(NameStr(agg->data.direct_view_schema),
 												NameStr(agg->data.direct_view_name),
 												false);
-	Relation direct_view_rel = relation_open(direct_view_oid, AccessShareLock);
-	Query *direct_query = copyObject(get_view_query(direct_view_rel));
-	/* Keep lock until end of transaction. */
-	relation_close(direct_view_rel, NoLock);
+	Query *direct_query = get_view_query_tree(direct_view_oid);
 	RemoveRangeTableEntries(direct_query);
 
 	ContinuousAggTimeBucketInfo timebucket_exprinfo =

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -28,6 +28,7 @@
 #include "compression/create.h"
 #include "compression/recompress.h"
 #include "compression/sparse_index_bloom1.h"
+#include "continuous_aggs/alter.h"
 #include "continuous_aggs/create.h"
 #include "continuous_aggs/insert.h"
 #include "continuous_aggs/invalidation.h"
@@ -142,6 +143,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.continuous_agg_get_bucket_function = continuous_agg_get_bucket_function,
 	.continuous_agg_get_bucket_function_info = continuous_agg_get_bucket_function_info,
 	.continuous_agg_get_grouping_columns = continuous_agg_get_grouping_columns,
+	.continuous_agg_add_column = continuous_agg_add_column,
 
 	/* Compression */
 	.compressed_data_decompress_forward = tsl_compressed_data_decompress_forward,

--- a/tsl/test/expected/cagg_alter-15.out
+++ b/tsl/test/expected/cagg_alter-15.out
@@ -1,0 +1,672 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for add_continuous_aggregate_column function (aggregate expressions only)
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Create test hypertable
+CREATE TABLE test_ht (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    category TEXT
+) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- Insert test data
+INSERT INTO test_ht VALUES
+    ('2020-01-01 00:00:00', 1, 20.0, 50.0, 'indoor'),
+    ('2020-01-01 01:00:00', 1, 22.0, 55.0, 'indoor'),
+    ('2020-01-01 02:00:00', 1, 21.0, 52.0, 'indoor'),
+    ('2020-01-01 00:00:00', 2, 25.0, 60.0, 'outdoor'),
+    ('2020-01-01 01:00:00', 2, 28.0, 65.0, 'outdoor'),
+    ('2020-01-01 02:00:00', 2, 26.0, 62.0, 'outdoor'),
+    ('2020-01-02 00:00:00', 1, 19.0, 48.0, 'indoor'),
+    ('2020-01-02 01:00:00', 2, 30.0, 70.0, 'outdoor');
+-- Create a materialized-only CAgg with basic aggregation
+CREATE MATERIALIZED VIEW test_cagg_mat
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Create a real-time CAgg
+CREATE MATERIALIZED VIEW test_cagg_rt
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Show initial state
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_3.bucket,
+    _materialized_hypertable_3.device_id,
+    _materialized_hypertable_3.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Add SUM aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify column was added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_3.bucket,
+    _materialized_hypertable_3.device_id,
+    _materialized_hypertable_3.avg_temp,
+    _materialized_hypertable_3.sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+-- Add MAX aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'max(temperature) AS max_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Add MIN aggregate to real-time CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'min(temperature) AS min_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify columns were added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+ max_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_3.bucket,
+    _materialized_hypertable_3.device_id,
+    _materialized_hypertable_3.avg_temp,
+    _materialized_hypertable_3.sum_temp,
+    _materialized_hypertable_3.max_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+-- Verify aggregates are computed correctly
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp 
+------------------------------+-----------+------------------+----------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30
+
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp 
+------------------------------+-----------+------------------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30
+
+-- Add aggregate with different column (humidity)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'avg(humidity) AS avg_humidity');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and check
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity 
+------------------------------+-----------+------------------+----------+----------+--------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |             
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |             
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |             
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |             
+
+-- Error tests
+\set ON_ERROR_STOP 0
+-- NULL arguments (STRICT function returns NULL for any NULL input)
+SELECT add_continuous_aggregate_column(NULL, 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- function does not exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'missing_func(temperature) AS bad');
+ERROR:  function "missing_func" does not exist
+-- function is not an aggregate
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'round(temperature)');
+ERROR:  "round" is not an aggregate function
+-- syntax error in aggregate expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature AS bad_syntax');
+ERROR:  unable to parse the aggregate expression "sum(temperature AS bad_syntax"
+-- multiple aggregates in single expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature), avg(temperature)');
+ERROR:  only one aggregate expression allowed
+-- multiple SQL statements (SQL injection attempt)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature); SELECT 1;');
+ERROR:  invalid aggregate expression: "sum(temperature); SELECT 1;"
+-- aggregate already exists (same alias)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ERROR:  column "sum_temp" already exists in continuous aggregate
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', true);
+NOTICE:  column "sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- column referenced in aggregate doesn't exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+-- Error - expression must be an aggregate function (simple column)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'category');
+ERROR:  expression must be an aggregate function
+-- Error - window function is not allowed
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'row_number() OVER () AS rn');
+ERROR:  "row_number" is not an aggregate function
+-- not a continuous aggregate
+CREATE TABLE regular_table (id INT, data TEXT);
+SELECT add_continuous_aggregate_column('regular_table', 'sum(id) AS total');
+ERROR:  relation "regular_table" is not a continuous aggregate
+-- permission denied: non-owner cannot alter the continuous aggregate
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp2');
+ERROR:  must be owner of continuous aggregate "test_cagg_mat"
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 1
+DROP TABLE regular_table;
+-- Add COUNT aggregate (no column argument)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(*) AS row_count');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |          
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |          
+
+-- Test adding aggregate without explicit alias (uses function name)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'sum(humidity)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding schema-qualified aggregate without explicit alias (should use function name, not schema)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'pg_catalog.count(*)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify they were added with auto-generated aliases
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+ sum       | double precision         |           |          |         | plain   | 
+ count     | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with double-quoted alias containing special characters
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'max(humidity) AS "weird and insane column name, but still valid on Postgres!"');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify it was added with the special alias
+\d+ test_cagg_rt
+                                                           View "public.test_cagg_rt"
+                           Column                           |           Type           | Collation | Nullable | Default | Storage | Description 
+------------------------------------------------------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket                                                     | timestamp with time zone |           |          |         | plain   | 
+ device_id                                                  | integer                  |           |          |         | plain   | 
+ avg_temp                                                   | double precision         |           |          |         | plain   | 
+ min_temp                                                   | double precision         |           |          |         | plain   | 
+ sum                                                        | double precision         |           |          |         | plain   | 
+ count                                                      | bigint                   |           |          |         | plain   | 
+ weird and insane column name, but still valid on Postgres! | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count,
+    _materialized_hypertable_4."weird and insane column name, but still valid on Postgres!"
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count,
+    max(test_ht.humidity) AS "weird and insane column name, but still valid on Postgres!"
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with DISTINCT
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(DISTINCT device_id) AS distinct_devices');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding aggregate with FILTER clause
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) FILTER (WHERE temperature > 20) AS sum_temp_gt20');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Create and test a custom aggregate
+CREATE AGGREGATE custom_sum (float8) (
+    sfunc = float8pl,
+    stype = float8,
+    initcond = '0'
+);
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'custom_sum(temperature) AS custom_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify all new aggregates
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count | distinct_devices | sum_temp_gt20 | custom_sum_temp 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------+------------------+---------------+-----------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |           |                  |               |                
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |           |                  |               |                
+
+-- Test adding aggregate with ORDER BY (string_agg)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'string_agg(category, '','' ORDER BY category) AS categories');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt" is already up-to-date
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+
+-- Insert new data and check real-time aggregation works
+INSERT INTO test_ht VALUES
+    ('2020-01-03 00:00:00', 1, 23.0, 56.0, 'indoor'),
+    ('2020-01-03 01:00:00', 2, 32.0, 72.0, 'outdoor');
+-- Real-time CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+ Thu Jan 02 16:00:00 2020 PST |         1 |               23 |       23 |  56 |     1 |                                                         56 | indoor
+ Thu Jan 02 16:00:00 2020 PST |         2 |               32 |       32 |  72 |     1 |                                                         72 | outdoor
+
+-- =====================================================
+-- Hierarchical continuous aggregate tests
+-- =====================================================
+-- Create a second-level materialized-only CAgg on top of test_cagg_mat
+CREATE MATERIALIZED VIEW test_cagg_level2
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_mat
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667
+
+\d+ test_cagg_level2
+                                View "public.test_cagg_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_5.bucket,
+    _materialized_hypertable_5.device_id,
+    _materialized_hypertable_5.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Error - aggregate references column that doesn't exist in parent CAgg
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+\set ON_ERROR_STOP 1
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_level2
+                                   View "public.test_cagg_level2"
+     Column     |           Type           | Collation | Nullable | Default | Storage | Description 
+----------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket         | timestamp with time zone |           |          |         | plain   | 
+ device_id      | integer                  |           |          |         | plain   | 
+ avg_temp       | double precision         |           |          |         | plain   | 
+ total_sum_temp | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_5.bucket,
+    _materialized_hypertable_5.device_id,
+    _materialized_hypertable_5.avg_temp,
+    _materialized_hypertable_5.total_sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_level2" is already up-to-date
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | total_sum_temp 
+------------------------------+-----------+------------------+----------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20 |               
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667 |               
+
+-- Error - aggregate already exists
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ERROR:  column "total_sum_temp" already exists in continuous aggregate
+\set ON_ERROR_STOP 1
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp', true);
+NOTICE:  column "total_sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- =====================================================
+-- Hierarchical CAgg with real-time mode
+-- =====================================================
+-- Create a second-level real-time CAgg on top of test_cagg_rt
+CREATE MATERIALIZED VIEW test_cagg_rt_level2
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_rt
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444
+
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt_level2', 'max(min_temp) AS max_of_min');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket     | timestamp with time zone |           |          |         | plain   | 
+ device_id  | integer                  |           |          |         | plain   | 
+ avg_temp   | double precision         |           |          |         | plain   | 
+ max_of_min | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp,
+    _materialized_hypertable_6.max_of_min
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp,
+    max(test_cagg_rt.min_temp) AS max_of_min
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt_level2" is already up-to-date
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- Insert new data to test real-time aggregation in hierarchical CAgg
+INSERT INTO test_ht VALUES
+    ('2020-01-04 00:00:00', 1, 18.0, 45.0, 'indoor'),
+    ('2020-01-04 01:00:00', 2, 35.0, 75.0, 'outdoor');
+-- Real-time hierarchical CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- =====================================================
+-- Tests for CAgg with compression enabled
+-- =====================================================
+-- Create a new CAgg for compression tests
+CREATE MATERIALIZED VIEW test_cagg_compress
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh to materialize data
+CALL refresh_continuous_aggregate('test_cagg_compress', NULL, NULL);
+-- Enable compression on the CAgg
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress);
+NOTICE:  defaulting compress_orderby to bucket,device_id
+-- Error - cannot add column to CAgg with compression enabled
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Compress the chunks
+SELECT compress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Error - still cannot add column after chunks are compressed
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Decompress all chunks
+SELECT decompress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Disable compression
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress = false);
+-- Now we should be able to add a column
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_compress
+                               View "public.test_cagg_compress"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _materialized_hypertable_7.device_id,
+    _materialized_hypertable_7.avg_temp,
+    _materialized_hypertable_7.sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_7;
+
+SET client_min_messages TO WARNING;
+-- Cleanup compression test CAgg
+DROP MATERIALIZED VIEW test_cagg_compress;
+-- Cleanup
+DROP MATERIALIZED VIEW test_cagg_rt_level2;
+DROP MATERIALIZED VIEW test_cagg_level2;
+DROP MATERIALIZED VIEW test_cagg_mat;
+DROP MATERIALIZED VIEW test_cagg_rt;
+DROP TABLE test_ht;
+RESET client_min_messages;

--- a/tsl/test/expected/cagg_alter-16.out
+++ b/tsl/test/expected/cagg_alter-16.out
@@ -1,0 +1,672 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for add_continuous_aggregate_column function (aggregate expressions only)
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Create test hypertable
+CREATE TABLE test_ht (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    category TEXT
+) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- Insert test data
+INSERT INTO test_ht VALUES
+    ('2020-01-01 00:00:00', 1, 20.0, 50.0, 'indoor'),
+    ('2020-01-01 01:00:00', 1, 22.0, 55.0, 'indoor'),
+    ('2020-01-01 02:00:00', 1, 21.0, 52.0, 'indoor'),
+    ('2020-01-01 00:00:00', 2, 25.0, 60.0, 'outdoor'),
+    ('2020-01-01 01:00:00', 2, 28.0, 65.0, 'outdoor'),
+    ('2020-01-01 02:00:00', 2, 26.0, 62.0, 'outdoor'),
+    ('2020-01-02 00:00:00', 1, 19.0, 48.0, 'indoor'),
+    ('2020-01-02 01:00:00', 2, 30.0, 70.0, 'outdoor');
+-- Create a materialized-only CAgg with basic aggregation
+CREATE MATERIALIZED VIEW test_cagg_mat
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Create a real-time CAgg
+CREATE MATERIALIZED VIEW test_cagg_rt
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Show initial state
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Add SUM aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify column was added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+-- Add MAX aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'max(temperature) AS max_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Add MIN aggregate to real-time CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'min(temperature) AS min_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify columns were added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+ max_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp,
+    max_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+-- Verify aggregates are computed correctly
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp 
+------------------------------+-----------+------------------+----------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30
+
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp 
+------------------------------+-----------+------------------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30
+
+-- Add aggregate with different column (humidity)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'avg(humidity) AS avg_humidity');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and check
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity 
+------------------------------+-----------+------------------+----------+----------+--------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |             
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |             
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |             
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |             
+
+-- Error tests
+\set ON_ERROR_STOP 0
+-- NULL arguments (STRICT function returns NULL for any NULL input)
+SELECT add_continuous_aggregate_column(NULL, 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- function does not exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'missing_func(temperature) AS bad');
+ERROR:  function "missing_func" does not exist
+-- function is not an aggregate
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'round(temperature)');
+ERROR:  "round" is not an aggregate function
+-- syntax error in aggregate expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature AS bad_syntax');
+ERROR:  unable to parse the aggregate expression "sum(temperature AS bad_syntax"
+-- multiple aggregates in single expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature), avg(temperature)');
+ERROR:  only one aggregate expression allowed
+-- multiple SQL statements (SQL injection attempt)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature); SELECT 1;');
+ERROR:  invalid aggregate expression: "sum(temperature); SELECT 1;"
+-- aggregate already exists (same alias)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ERROR:  column "sum_temp" already exists in continuous aggregate
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', true);
+NOTICE:  column "sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- column referenced in aggregate doesn't exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+-- Error - expression must be an aggregate function (simple column)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'category');
+ERROR:  expression must be an aggregate function
+-- Error - window function is not allowed
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'row_number() OVER () AS rn');
+ERROR:  "row_number" is not an aggregate function
+-- not a continuous aggregate
+CREATE TABLE regular_table (id INT, data TEXT);
+SELECT add_continuous_aggregate_column('regular_table', 'sum(id) AS total');
+ERROR:  relation "regular_table" is not a continuous aggregate
+-- permission denied: non-owner cannot alter the continuous aggregate
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp2');
+ERROR:  must be owner of continuous aggregate "test_cagg_mat"
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 1
+DROP TABLE regular_table;
+-- Add COUNT aggregate (no column argument)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(*) AS row_count');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |          
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |          
+
+-- Test adding aggregate without explicit alias (uses function name)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'sum(humidity)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding schema-qualified aggregate without explicit alias (should use function name, not schema)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'pg_catalog.count(*)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify they were added with auto-generated aliases
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+ sum       | double precision         |           |          |         | plain   | 
+ count     | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with double-quoted alias containing special characters
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'max(humidity) AS "weird and insane column name, but still valid on Postgres!"');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify it was added with the special alias
+\d+ test_cagg_rt
+                                                           View "public.test_cagg_rt"
+                           Column                           |           Type           | Collation | Nullable | Default | Storage | Description 
+------------------------------------------------------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket                                                     | timestamp with time zone |           |          |         | plain   | 
+ device_id                                                  | integer                  |           |          |         | plain   | 
+ avg_temp                                                   | double precision         |           |          |         | plain   | 
+ min_temp                                                   | double precision         |           |          |         | plain   | 
+ sum                                                        | double precision         |           |          |         | plain   | 
+ count                                                      | bigint                   |           |          |         | plain   | 
+ weird and insane column name, but still valid on Postgres! | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count,
+    _materialized_hypertable_4."weird and insane column name, but still valid on Postgres!"
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count,
+    max(test_ht.humidity) AS "weird and insane column name, but still valid on Postgres!"
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with DISTINCT
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(DISTINCT device_id) AS distinct_devices');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding aggregate with FILTER clause
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) FILTER (WHERE temperature > 20) AS sum_temp_gt20');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Create and test a custom aggregate
+CREATE AGGREGATE custom_sum (float8) (
+    sfunc = float8pl,
+    stype = float8,
+    initcond = '0'
+);
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'custom_sum(temperature) AS custom_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify all new aggregates
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count | distinct_devices | sum_temp_gt20 | custom_sum_temp 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------+------------------+---------------+-----------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |           |                  |               |                
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |           |                  |               |                
+
+-- Test adding aggregate with ORDER BY (string_agg)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'string_agg(category, '','' ORDER BY category) AS categories');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt" is already up-to-date
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+
+-- Insert new data and check real-time aggregation works
+INSERT INTO test_ht VALUES
+    ('2020-01-03 00:00:00', 1, 23.0, 56.0, 'indoor'),
+    ('2020-01-03 01:00:00', 2, 32.0, 72.0, 'outdoor');
+-- Real-time CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+ Thu Jan 02 16:00:00 2020 PST |         1 |               23 |       23 |  56 |     1 |                                                         56 | indoor
+ Thu Jan 02 16:00:00 2020 PST |         2 |               32 |       32 |  72 |     1 |                                                         72 | outdoor
+
+-- =====================================================
+-- Hierarchical continuous aggregate tests
+-- =====================================================
+-- Create a second-level materialized-only CAgg on top of test_cagg_mat
+CREATE MATERIALIZED VIEW test_cagg_level2
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_mat
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667
+
+\d+ test_cagg_level2
+                                View "public.test_cagg_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Error - aggregate references column that doesn't exist in parent CAgg
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+\set ON_ERROR_STOP 1
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_level2
+                                   View "public.test_cagg_level2"
+     Column     |           Type           | Collation | Nullable | Default | Storage | Description 
+----------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket         | timestamp with time zone |           |          |         | plain   | 
+ device_id      | integer                  |           |          |         | plain   | 
+ avg_temp       | double precision         |           |          |         | plain   | 
+ total_sum_temp | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    total_sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_level2" is already up-to-date
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | total_sum_temp 
+------------------------------+-----------+------------------+----------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20 |               
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667 |               
+
+-- Error - aggregate already exists
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ERROR:  column "total_sum_temp" already exists in continuous aggregate
+\set ON_ERROR_STOP 1
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp', true);
+NOTICE:  column "total_sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- =====================================================
+-- Hierarchical CAgg with real-time mode
+-- =====================================================
+-- Create a second-level real-time CAgg on top of test_cagg_rt
+CREATE MATERIALIZED VIEW test_cagg_rt_level2
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_rt
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444
+
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt_level2', 'max(min_temp) AS max_of_min');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket     | timestamp with time zone |           |          |         | plain   | 
+ device_id  | integer                  |           |          |         | plain   | 
+ avg_temp   | double precision         |           |          |         | plain   | 
+ max_of_min | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp,
+    _materialized_hypertable_6.max_of_min
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp,
+    max(test_cagg_rt.min_temp) AS max_of_min
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt_level2" is already up-to-date
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- Insert new data to test real-time aggregation in hierarchical CAgg
+INSERT INTO test_ht VALUES
+    ('2020-01-04 00:00:00', 1, 18.0, 45.0, 'indoor'),
+    ('2020-01-04 01:00:00', 2, 35.0, 75.0, 'outdoor');
+-- Real-time hierarchical CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- =====================================================
+-- Tests for CAgg with compression enabled
+-- =====================================================
+-- Create a new CAgg for compression tests
+CREATE MATERIALIZED VIEW test_cagg_compress
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh to materialize data
+CALL refresh_continuous_aggregate('test_cagg_compress', NULL, NULL);
+-- Enable compression on the CAgg
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress);
+NOTICE:  defaulting compress_orderby to bucket,device_id
+-- Error - cannot add column to CAgg with compression enabled
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Compress the chunks
+SELECT compress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Error - still cannot add column after chunks are compressed
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Decompress all chunks
+SELECT decompress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Disable compression
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress = false);
+-- Now we should be able to add a column
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_compress
+                               View "public.test_cagg_compress"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_7;
+
+SET client_min_messages TO WARNING;
+-- Cleanup compression test CAgg
+DROP MATERIALIZED VIEW test_cagg_compress;
+-- Cleanup
+DROP MATERIALIZED VIEW test_cagg_rt_level2;
+DROP MATERIALIZED VIEW test_cagg_level2;
+DROP MATERIALIZED VIEW test_cagg_mat;
+DROP MATERIALIZED VIEW test_cagg_rt;
+DROP TABLE test_ht;
+RESET client_min_messages;

--- a/tsl/test/expected/cagg_alter-17.out
+++ b/tsl/test/expected/cagg_alter-17.out
@@ -1,0 +1,672 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for add_continuous_aggregate_column function (aggregate expressions only)
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Create test hypertable
+CREATE TABLE test_ht (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    category TEXT
+) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- Insert test data
+INSERT INTO test_ht VALUES
+    ('2020-01-01 00:00:00', 1, 20.0, 50.0, 'indoor'),
+    ('2020-01-01 01:00:00', 1, 22.0, 55.0, 'indoor'),
+    ('2020-01-01 02:00:00', 1, 21.0, 52.0, 'indoor'),
+    ('2020-01-01 00:00:00', 2, 25.0, 60.0, 'outdoor'),
+    ('2020-01-01 01:00:00', 2, 28.0, 65.0, 'outdoor'),
+    ('2020-01-01 02:00:00', 2, 26.0, 62.0, 'outdoor'),
+    ('2020-01-02 00:00:00', 1, 19.0, 48.0, 'indoor'),
+    ('2020-01-02 01:00:00', 2, 30.0, 70.0, 'outdoor');
+-- Create a materialized-only CAgg with basic aggregation
+CREATE MATERIALIZED VIEW test_cagg_mat
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Create a real-time CAgg
+CREATE MATERIALIZED VIEW test_cagg_rt
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Show initial state
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Add SUM aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify column was added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+-- Add MAX aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'max(temperature) AS max_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Add MIN aggregate to real-time CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'min(temperature) AS min_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify columns were added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+ max_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp,
+    max_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+-- Verify aggregates are computed correctly
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp 
+------------------------------+-----------+------------------+----------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30
+
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp 
+------------------------------+-----------+------------------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30
+
+-- Add aggregate with different column (humidity)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'avg(humidity) AS avg_humidity');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and check
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity 
+------------------------------+-----------+------------------+----------+----------+--------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |             
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |             
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |             
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |             
+
+-- Error tests
+\set ON_ERROR_STOP 0
+-- NULL arguments (STRICT function returns NULL for any NULL input)
+SELECT add_continuous_aggregate_column(NULL, 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- function does not exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'missing_func(temperature) AS bad');
+ERROR:  function "missing_func" does not exist
+-- function is not an aggregate
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'round(temperature)');
+ERROR:  "round" is not an aggregate function
+-- syntax error in aggregate expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature AS bad_syntax');
+ERROR:  unable to parse the aggregate expression "sum(temperature AS bad_syntax"
+-- multiple aggregates in single expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature), avg(temperature)');
+ERROR:  only one aggregate expression allowed
+-- multiple SQL statements (SQL injection attempt)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature); SELECT 1;');
+ERROR:  invalid aggregate expression: "sum(temperature); SELECT 1;"
+-- aggregate already exists (same alias)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ERROR:  column "sum_temp" already exists in continuous aggregate
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', true);
+NOTICE:  column "sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- column referenced in aggregate doesn't exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+-- Error - expression must be an aggregate function (simple column)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'category');
+ERROR:  expression must be an aggregate function
+-- Error - window function is not allowed
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'row_number() OVER () AS rn');
+ERROR:  "row_number" is not an aggregate function
+-- not a continuous aggregate
+CREATE TABLE regular_table (id INT, data TEXT);
+SELECT add_continuous_aggregate_column('regular_table', 'sum(id) AS total');
+ERROR:  relation "regular_table" is not a continuous aggregate
+-- permission denied: non-owner cannot alter the continuous aggregate
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp2');
+ERROR:  must be owner of continuous aggregate "test_cagg_mat"
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 1
+DROP TABLE regular_table;
+-- Add COUNT aggregate (no column argument)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(*) AS row_count');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |          
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |          
+
+-- Test adding aggregate without explicit alias (uses function name)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'sum(humidity)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding schema-qualified aggregate without explicit alias (should use function name, not schema)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'pg_catalog.count(*)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify they were added with auto-generated aliases
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+ sum       | double precision         |           |          |         | plain   | 
+ count     | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with double-quoted alias containing special characters
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'max(humidity) AS "weird and insane column name, but still valid on Postgres!"');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify it was added with the special alias
+\d+ test_cagg_rt
+                                                           View "public.test_cagg_rt"
+                           Column                           |           Type           | Collation | Nullable | Default | Storage | Description 
+------------------------------------------------------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket                                                     | timestamp with time zone |           |          |         | plain   | 
+ device_id                                                  | integer                  |           |          |         | plain   | 
+ avg_temp                                                   | double precision         |           |          |         | plain   | 
+ min_temp                                                   | double precision         |           |          |         | plain   | 
+ sum                                                        | double precision         |           |          |         | plain   | 
+ count                                                      | bigint                   |           |          |         | plain   | 
+ weird and insane column name, but still valid on Postgres! | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count,
+    _materialized_hypertable_4."weird and insane column name, but still valid on Postgres!"
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count,
+    max(test_ht.humidity) AS "weird and insane column name, but still valid on Postgres!"
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with DISTINCT
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(DISTINCT device_id) AS distinct_devices');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding aggregate with FILTER clause
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) FILTER (WHERE temperature > 20) AS sum_temp_gt20');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Create and test a custom aggregate
+CREATE AGGREGATE custom_sum (float8) (
+    sfunc = float8pl,
+    stype = float8,
+    initcond = '0'
+);
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'custom_sum(temperature) AS custom_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify all new aggregates
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count | distinct_devices | sum_temp_gt20 | custom_sum_temp 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------+------------------+---------------+-----------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |           |                  |               |                
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |           |                  |               |                
+
+-- Test adding aggregate with ORDER BY (string_agg)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'string_agg(category, '','' ORDER BY category) AS categories');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt" is already up-to-date
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+
+-- Insert new data and check real-time aggregation works
+INSERT INTO test_ht VALUES
+    ('2020-01-03 00:00:00', 1, 23.0, 56.0, 'indoor'),
+    ('2020-01-03 01:00:00', 2, 32.0, 72.0, 'outdoor');
+-- Real-time CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+ Thu Jan 02 16:00:00 2020 PST |         1 |               23 |       23 |  56 |     1 |                                                         56 | indoor
+ Thu Jan 02 16:00:00 2020 PST |         2 |               32 |       32 |  72 |     1 |                                                         72 | outdoor
+
+-- =====================================================
+-- Hierarchical continuous aggregate tests
+-- =====================================================
+-- Create a second-level materialized-only CAgg on top of test_cagg_mat
+CREATE MATERIALIZED VIEW test_cagg_level2
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_mat
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667
+
+\d+ test_cagg_level2
+                                View "public.test_cagg_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Error - aggregate references column that doesn't exist in parent CAgg
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+\set ON_ERROR_STOP 1
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_level2
+                                   View "public.test_cagg_level2"
+     Column     |           Type           | Collation | Nullable | Default | Storage | Description 
+----------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket         | timestamp with time zone |           |          |         | plain   | 
+ device_id      | integer                  |           |          |         | plain   | 
+ avg_temp       | double precision         |           |          |         | plain   | 
+ total_sum_temp | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    total_sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_level2" is already up-to-date
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | total_sum_temp 
+------------------------------+-----------+------------------+----------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20 |               
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667 |               
+
+-- Error - aggregate already exists
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ERROR:  column "total_sum_temp" already exists in continuous aggregate
+\set ON_ERROR_STOP 1
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp', true);
+NOTICE:  column "total_sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- =====================================================
+-- Hierarchical CAgg with real-time mode
+-- =====================================================
+-- Create a second-level real-time CAgg on top of test_cagg_rt
+CREATE MATERIALIZED VIEW test_cagg_rt_level2
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_rt
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444
+
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt_level2', 'max(min_temp) AS max_of_min');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket     | timestamp with time zone |           |          |         | plain   | 
+ device_id  | integer                  |           |          |         | plain   | 
+ avg_temp   | double precision         |           |          |         | plain   | 
+ max_of_min | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp,
+    _materialized_hypertable_6.max_of_min
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp,
+    max(test_cagg_rt.min_temp) AS max_of_min
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt_level2" is already up-to-date
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- Insert new data to test real-time aggregation in hierarchical CAgg
+INSERT INTO test_ht VALUES
+    ('2020-01-04 00:00:00', 1, 18.0, 45.0, 'indoor'),
+    ('2020-01-04 01:00:00', 2, 35.0, 75.0, 'outdoor');
+-- Real-time hierarchical CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- =====================================================
+-- Tests for CAgg with compression enabled
+-- =====================================================
+-- Create a new CAgg for compression tests
+CREATE MATERIALIZED VIEW test_cagg_compress
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh to materialize data
+CALL refresh_continuous_aggregate('test_cagg_compress', NULL, NULL);
+-- Enable compression on the CAgg
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress);
+NOTICE:  defaulting compress_orderby to bucket,device_id
+-- Error - cannot add column to CAgg with compression enabled
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Compress the chunks
+SELECT compress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Error - still cannot add column after chunks are compressed
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Decompress all chunks
+SELECT decompress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Disable compression
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress = false);
+-- Now we should be able to add a column
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_compress
+                               View "public.test_cagg_compress"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_7;
+
+SET client_min_messages TO WARNING;
+-- Cleanup compression test CAgg
+DROP MATERIALIZED VIEW test_cagg_compress;
+-- Cleanup
+DROP MATERIALIZED VIEW test_cagg_rt_level2;
+DROP MATERIALIZED VIEW test_cagg_level2;
+DROP MATERIALIZED VIEW test_cagg_mat;
+DROP MATERIALIZED VIEW test_cagg_rt;
+DROP TABLE test_ht;
+RESET client_min_messages;

--- a/tsl/test/expected/cagg_alter-18.out
+++ b/tsl/test/expected/cagg_alter-18.out
@@ -1,0 +1,672 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for add_continuous_aggregate_column function (aggregate expressions only)
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Create test hypertable
+CREATE TABLE test_ht (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    category TEXT
+) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- Insert test data
+INSERT INTO test_ht VALUES
+    ('2020-01-01 00:00:00', 1, 20.0, 50.0, 'indoor'),
+    ('2020-01-01 01:00:00', 1, 22.0, 55.0, 'indoor'),
+    ('2020-01-01 02:00:00', 1, 21.0, 52.0, 'indoor'),
+    ('2020-01-01 00:00:00', 2, 25.0, 60.0, 'outdoor'),
+    ('2020-01-01 01:00:00', 2, 28.0, 65.0, 'outdoor'),
+    ('2020-01-01 02:00:00', 2, 26.0, 62.0, 'outdoor'),
+    ('2020-01-02 00:00:00', 1, 19.0, 48.0, 'indoor'),
+    ('2020-01-02 01:00:00', 2, 30.0, 70.0, 'outdoor');
+-- Create a materialized-only CAgg with basic aggregation
+CREATE MATERIALIZED VIEW test_cagg_mat
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Create a real-time CAgg
+CREATE MATERIALIZED VIEW test_cagg_rt
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Show initial state
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Add SUM aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify column was added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+-- Add MAX aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'max(temperature) AS max_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Add MIN aggregate to real-time CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'min(temperature) AS min_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify columns were added
+\d+ test_cagg_mat
+                                  View "public.test_cagg_mat"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+ max_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp,
+    max_temp
+   FROM _timescaledb_internal._materialized_hypertable_3;
+
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+-- Verify aggregates are computed correctly
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp 
+------------------------------+-----------+------------------+----------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30
+
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp 
+------------------------------+-----------+------------------+----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30
+
+-- Add aggregate with different column (humidity)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'avg(humidity) AS avg_humidity');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and check
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity 
+------------------------------+-----------+------------------+----------+----------+--------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |             
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |             
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |             
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |             
+
+-- Error tests
+\set ON_ERROR_STOP 0
+-- NULL arguments (STRICT function returns NULL for any NULL input)
+SELECT add_continuous_aggregate_column(NULL, 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', NULL);
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- function does not exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'missing_func(temperature) AS bad');
+ERROR:  function "missing_func" does not exist
+-- function is not an aggregate
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'round(temperature)');
+ERROR:  "round" is not an aggregate function
+-- syntax error in aggregate expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature AS bad_syntax');
+ERROR:  unable to parse the aggregate expression "sum(temperature AS bad_syntax"
+-- multiple aggregates in single expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature), avg(temperature)');
+ERROR:  only one aggregate expression allowed
+-- multiple SQL statements (SQL injection attempt)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature); SELECT 1;');
+ERROR:  invalid aggregate expression: "sum(temperature); SELECT 1;"
+-- aggregate already exists (same alias)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+ERROR:  column "sum_temp" already exists in continuous aggregate
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', true);
+NOTICE:  column "sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- column referenced in aggregate doesn't exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+-- Error - expression must be an aggregate function (simple column)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'category');
+ERROR:  expression must be an aggregate function
+-- Error - window function is not allowed
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'row_number() OVER () AS rn');
+ERROR:  "row_number" is not an aggregate function
+-- not a continuous aggregate
+CREATE TABLE regular_table (id INT, data TEXT);
+SELECT add_continuous_aggregate_column('regular_table', 'sum(id) AS total');
+ERROR:  relation "regular_table" is not a continuous aggregate
+-- permission denied: non-owner cannot alter the continuous aggregate
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp2');
+ERROR:  must be owner of continuous aggregate "test_cagg_mat"
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 1
+DROP TABLE regular_table;
+-- Add COUNT aggregate (no column argument)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(*) AS row_count');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |          
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |          
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |          
+
+-- Test adding aggregate without explicit alias (uses function name)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'sum(humidity)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding schema-qualified aggregate without explicit alias (should use function name, not schema)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'pg_catalog.count(*)');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify they were added with auto-generated aliases
+\d+ test_cagg_rt
+                                  View "public.test_cagg_rt"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ min_temp  | double precision         |           |          |         | plain   | 
+ sum       | double precision         |           |          |         | plain   | 
+ count     | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with double-quoted alias containing special characters
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'max(humidity) AS "weird and insane column name, but still valid on Postgres!"');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify it was added with the special alias
+\d+ test_cagg_rt
+                                                           View "public.test_cagg_rt"
+                           Column                           |           Type           | Collation | Nullable | Default | Storage | Description 
+------------------------------------------------------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket                                                     | timestamp with time zone |           |          |         | plain   | 
+ device_id                                                  | integer                  |           |          |         | plain   | 
+ avg_temp                                                   | double precision         |           |          |         | plain   | 
+ min_temp                                                   | double precision         |           |          |         | plain   | 
+ sum                                                        | double precision         |           |          |         | plain   | 
+ count                                                      | bigint                   |           |          |         | plain   | 
+ weird and insane column name, but still valid on Postgres! | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_4.bucket,
+    _materialized_hypertable_4.device_id,
+    _materialized_hypertable_4.avg_temp,
+    _materialized_hypertable_4.min_temp,
+    _materialized_hypertable_4.sum,
+    _materialized_hypertable_4.count,
+    _materialized_hypertable_4."weird and insane column name, but still valid on Postgres!"
+   FROM _timescaledb_internal._materialized_hypertable_4
+  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, test_ht."time") AS bucket,
+    test_ht.device_id,
+    avg(test_ht.temperature) AS avg_temp,
+    min(test_ht.temperature) AS min_temp,
+    sum(test_ht.humidity) AS sum,
+    count(*) AS count,
+    max(test_ht.humidity) AS "weird and insane column name, but still valid on Postgres!"
+   FROM test_ht
+  WHERE test_ht."time" >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(4)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, test_ht."time")), test_ht.device_id;
+
+-- Test adding aggregate with DISTINCT
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(DISTINCT device_id) AS distinct_devices');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Test adding aggregate with FILTER clause
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) FILTER (WHERE temperature > 20) AS sum_temp_gt20');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Create and test a custom aggregate
+CREATE AGGREGATE custom_sum (float8) (
+    sfunc = float8pl,
+    stype = float8,
+    initcond = '0'
+);
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'custom_sum(temperature) AS custom_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify all new aggregates
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_mat" is already up-to-date
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | sum_temp | max_temp | avg_humidity | row_count | distinct_devices | sum_temp_gt20 | custom_sum_temp 
+------------------------------+-----------+------------------+----------+----------+--------------+-----------+------------------+---------------+-----------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       63 |       22 |              |           |                  |               |                
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       79 |       28 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |       19 |              |           |                  |               |                
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |       30 |              |           |                  |               |                
+
+-- Test adding aggregate with ORDER BY (string_agg)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'string_agg(category, '','' ORDER BY category) AS categories');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt" is already up-to-date
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+
+-- Insert new data and check real-time aggregation works
+INSERT INTO test_ht VALUES
+    ('2020-01-03 00:00:00', 1, 23.0, 56.0, 'indoor'),
+    ('2020-01-03 01:00:00', 2, 32.0, 72.0, 'outdoor');
+-- Real-time CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | min_temp | sum | count | weird and insane column name, but still valid on Postgres! | categories 
+------------------------------+-----------+------------------+----------+-----+-------+------------------------------------------------------------+------------
+ Tue Dec 31 16:00:00 2019 PST |         1 |               21 |       20 |     |       |                                                            | 
+ Tue Dec 31 16:00:00 2019 PST |         2 | 26.3333333333333 |       25 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         1 |               19 |       19 |     |       |                                                            | 
+ Wed Jan 01 16:00:00 2020 PST |         2 |               30 |       30 |     |       |                                                            | 
+ Thu Jan 02 16:00:00 2020 PST |         1 |               23 |       23 |  56 |     1 |                                                         56 | indoor
+ Thu Jan 02 16:00:00 2020 PST |         2 |               32 |       32 |  72 |     1 |                                                         72 | outdoor
+
+-- =====================================================
+-- Hierarchical continuous aggregate tests
+-- =====================================================
+-- Create a second-level materialized-only CAgg on top of test_cagg_mat
+CREATE MATERIALIZED VIEW test_cagg_level2
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_mat
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667
+
+\d+ test_cagg_level2
+                                View "public.test_cagg_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Error - aggregate references column that doesn't exist in parent CAgg
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(nonexistent) AS bad');
+ERROR:  column "nonexistent" referenced in aggregate does not exist in source relation
+\set ON_ERROR_STOP 1
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_level2
+                                   View "public.test_cagg_level2"
+     Column     |           Type           | Collation | Nullable | Default | Storage | Description 
+----------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket         | timestamp with time zone |           |          |         | plain   | 
+ device_id      | integer                  |           |          |         | plain   | 
+ avg_temp       | double precision         |           |          |         | plain   | 
+ total_sum_temp | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    total_sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_5;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_level2" is already up-to-date
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | total_sum_temp 
+------------------------------+-----------+------------------+----------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               20 |               
+ Sun Dec 29 16:00:00 2019 PST |         2 | 28.1666666666667 |               
+
+-- Error - aggregate already exists
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+ERROR:  column "total_sum_temp" already exists in continuous aggregate
+\set ON_ERROR_STOP 1
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp', true);
+NOTICE:  column "total_sum_temp" already exists in continuous aggregate, skipping
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- =====================================================
+-- Hierarchical CAgg with real-time mode
+-- =====================================================
+-- Create a second-level real-time CAgg on top of test_cagg_rt
+CREATE MATERIALIZED VIEW test_cagg_rt_level2
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_rt
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+-- Show initial state
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     
+------------------------------+-----------+------------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444
+
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt_level2', 'max(min_temp) AS max_of_min');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_rt_level2
+                               View "public.test_cagg_rt_level2"
+   Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket     | timestamp with time zone |           |          |         | plain   | 
+ device_id  | integer                  |           |          |         | plain   | 
+ avg_temp   | double precision         |           |          |         | plain   | 
+ max_of_min | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.device_id,
+    _materialized_hypertable_6.avg_temp,
+    _materialized_hypertable_6.max_of_min
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 7 days'::interval, test_cagg_rt.bucket) AS bucket,
+    test_cagg_rt.device_id,
+    avg(test_cagg_rt.avg_temp) AS avg_temp,
+    max(test_cagg_rt.min_temp) AS max_of_min
+   FROM test_cagg_rt
+  WHERE test_cagg_rt.bucket >= COALESCE(_timescaledb_functions.to_timestamp(_timescaledb_functions.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 7 days'::interval, test_cagg_rt.bucket)), test_cagg_rt.device_id;
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+NOTICE:  continuous aggregate "test_cagg_rt_level2" is already up-to-date
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- Insert new data to test real-time aggregation in hierarchical CAgg
+INSERT INTO test_ht VALUES
+    ('2020-01-04 00:00:00', 1, 18.0, 45.0, 'indoor'),
+    ('2020-01-04 01:00:00', 2, 35.0, 75.0, 'outdoor');
+-- Real-time hierarchical CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+            bucket            | device_id |     avg_temp     | max_of_min 
+------------------------------+-----------+------------------+------------
+ Sun Dec 29 16:00:00 2019 PST |         1 |               21 |           
+ Sun Dec 29 16:00:00 2019 PST |         2 | 29.4444444444444 |           
+
+-- =====================================================
+-- Tests for CAgg with compression enabled
+-- =====================================================
+-- Create a new CAgg for compression tests
+CREATE MATERIALIZED VIEW test_cagg_compress
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+-- Refresh to materialize data
+CALL refresh_continuous_aggregate('test_cagg_compress', NULL, NULL);
+-- Enable compression on the CAgg
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress);
+NOTICE:  defaulting compress_orderby to bucket,device_id
+-- Error - cannot add column to CAgg with compression enabled
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Compress the chunks
+SELECT compress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Error - still cannot add column after chunks are compressed
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ERROR:  cannot add aggregate to continuous aggregate with compression enabled
+\set ON_ERROR_STOP 1
+-- Decompress all chunks
+SELECT decompress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_7_7_chunk
+
+-- Disable compression
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress = false);
+-- Now we should be able to add a column
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+ add_continuous_aggregate_column 
+---------------------------------
+ 
+
+-- Verify the column was added
+\d+ test_cagg_compress
+                               View "public.test_cagg_compress"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ device_id | integer                  |           |          |         | plain   | 
+ avg_temp  | double precision         |           |          |         | plain   | 
+ sum_temp  | double precision         |           |          |         | plain   | 
+View definition:
+ SELECT bucket,
+    device_id,
+    avg_temp,
+    sum_temp
+   FROM _timescaledb_internal._materialized_hypertable_7;
+
+SET client_min_messages TO WARNING;
+-- Cleanup compression test CAgg
+DROP MATERIALIZED VIEW test_cagg_compress;
+-- Cleanup
+DROP MATERIALIZED VIEW test_cagg_rt_level2;
+DROP MATERIALIZED VIEW test_cagg_level2;
+DROP MATERIALIZED VIEW test_cagg_mat;
+DROP MATERIALIZED VIEW test_cagg_rt;
+DROP TABLE test_ht;
+RESET client_min_messages;

--- a/tsl/test/isolation/expected/cagg_alter.out
+++ b/tsl/test/isolation/expected/cagg_alter.out
@@ -1,0 +1,59 @@
+Parsed test spec with 4 sessions
+
+starting permutation: l1_lock s1_add_column l1_unlock s1_add_column_commit s3_select
+step l1_lock: 
+    BEGIN;
+    LOCK TABLE cagg_test IN ACCESS SHARE MODE;
+
+step s1_add_column: 
+    BEGIN;
+    SELECT add_continuous_aggregate_column('cagg_test', 'sum(humidity) AS sum_humidity');
+ <waiting ...>
+step l1_unlock: 
+    ROLLBACK;
+
+step s1_add_column: <... completed>
+add_continuous_aggregate_column
+-------------------------------
+                               
+
+step s1_add_column_commit: 
+    COMMIT;
+
+step s3_select: 
+    SELECT * FROM cagg_test ORDER BY bucket, device;
+
+bucket|device|avg_temp|sum_humidity
+------+------+--------+------------
+
+
+starting permutation: s1_add_column s2_add_column s1_add_column_commit s2_add_column_commit s3_select
+step s1_add_column: 
+    BEGIN;
+    SELECT add_continuous_aggregate_column('cagg_test', 'sum(humidity) AS sum_humidity');
+
+add_continuous_aggregate_column
+-------------------------------
+                               
+
+step s2_add_column: 
+    BEGIN;
+    SELECT add_continuous_aggregate_column('cagg_test', 'max(pressure) AS max_pressure');
+ <waiting ...>
+step s1_add_column_commit: 
+    COMMIT;
+
+step s2_add_column: <... completed>
+add_continuous_aggregate_column
+-------------------------------
+                               
+
+step s2_add_column_commit: 
+    COMMIT;
+
+step s3_select: 
+    SELECT * FROM cagg_test ORDER BY bucket, device;
+
+bucket|device|avg_temp|sum_humidity|max_pressure
+------+------+--------+------------+------------
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -16,6 +16,7 @@ list(
   TEST_FILES
   compression_ddl_iso.spec
   compression_conflicts_iso.spec
+  cagg_alter.spec
   cagg_insert.spec
   cagg_multi_iso.spec
   deadlock_drop_chunks_compress.spec

--- a/tsl/test/isolation/specs/cagg_alter.spec
+++ b/tsl/test/isolation/specs/cagg_alter.spec
@@ -1,0 +1,97 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# Test that concurrent add_continuous_aggregate_column calls are properly
+# serialized via AccessExclusiveLock on the continuous aggregate relation.
+
+setup
+{
+    SELECT _timescaledb_functions.stop_background_workers();
+
+    CREATE TABLE temperature (
+        time TIMESTAMPTZ NOT NULL,
+        device INT,
+        temperature FLOAT,
+        humidity FLOAT,
+        pressure FLOAT
+    ) WITH (tsdb.hypertable);
+
+    CREATE MATERIALIZED VIEW cagg_test
+        WITH (timescaledb.continuous, timescaledb.materialized_only = true)
+    AS SELECT time_bucket('1 day', time) AS bucket, device,
+              avg(temperature) AS avg_temp
+    FROM temperature
+    GROUP BY 1, 2 WITH NO DATA;
+}
+
+teardown
+{
+    DROP TABLE temperature CASCADE;
+}
+
+# Session that holds an AccessExclusiveLock on the cagg to simulate
+# a concurrent add_continuous_aggregate_column in progress.
+session "L1"
+setup
+{
+    SET lock_timeout = '5s';
+}
+step "l1_lock"
+{
+    BEGIN;
+    LOCK TABLE cagg_test IN ACCESS SHARE MODE;
+}
+step "l1_unlock"
+{
+    ROLLBACK;
+}
+
+# Session 1: add sum(humidity)
+session "S1"
+setup
+{
+    SET lock_timeout = '5s';
+}
+step "s1_add_column"
+{
+    BEGIN;
+    SELECT add_continuous_aggregate_column('cagg_test', 'sum(humidity) AS sum_humidity');
+}
+step "s1_add_column_commit"
+{
+    COMMIT;
+}
+
+# Session 2: add max(pressure)
+session "S2"
+setup
+{
+    SET lock_timeout = '5s';
+}
+step "s2_add_column"
+{
+    BEGIN;
+    SELECT add_continuous_aggregate_column('cagg_test', 'max(pressure) AS max_pressure');
+}
+step "s2_add_column_commit"
+{
+    COMMIT;
+}
+
+# Session to verify the final state
+session "S3"
+step "s3_select"
+{
+    SELECT * FROM cagg_test ORDER BY bucket, device;
+}
+
+# Test 1: add_continuous_aggregate_column blocks when cagg is locked.
+# L1 holds AccessExclusiveLock, S1 blocks waiting for it, then proceeds
+# after L1 releases the lock.
+permutation "l1_lock" "s1_add_column" "l1_unlock" "s1_add_column_commit" "s3_select"
+
+# Test 2: Two concurrent add_continuous_aggregate_column calls serialize.
+# S1 takes AccessExclusiveLock, S2 blocks until S1 completes.
+# Both columns should be present in the final view.
+permutation "s1_add_column" "s2_add_column" "s1_add_column_commit" "s2_add_column_commit" "s3_select"

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -187,6 +187,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  ts_now_mock()
  add_columnstore_policy(regclass,"any",boolean,interval,timestamp with time zone,text,interval)
  add_compression_policy(regclass,"any",boolean,interval,timestamp with time zone,text,interval)
+ add_continuous_aggregate_column(regclass,text,boolean)
  add_continuous_aggregate_policy(regclass,"any","any",interval,boolean,timestamp with time zone,text,boolean,integer,integer,boolean)
  add_dimension(regclass,_timescaledb_internal.dimension_info,boolean)
  add_dimension(regclass,name,integer,anyelement,regproc,boolean)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -86,6 +86,7 @@ set(TEST_FILES
     vectorized_aggregation.sql)
 
 set(TEST_TEMPLATES
+    cagg_alter.sql.in
     cagg_query.sql.in
     cagg_query_using_merge.sql.in
     cagg_union_view.sql.in

--- a/tsl/test/sql/cagg_alter.sql.in
+++ b/tsl/test/sql/cagg_alter.sql.in
@@ -1,0 +1,332 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Tests for add_continuous_aggregate_column function (aggregate expressions only)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+-- Create test hypertable
+CREATE TABLE test_ht (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER NOT NULL,
+    temperature DOUBLE PRECISION,
+    humidity DOUBLE PRECISION,
+    category TEXT
+) WITH (tsdb.hypertable);
+
+-- Insert test data
+INSERT INTO test_ht VALUES
+    ('2020-01-01 00:00:00', 1, 20.0, 50.0, 'indoor'),
+    ('2020-01-01 01:00:00', 1, 22.0, 55.0, 'indoor'),
+    ('2020-01-01 02:00:00', 1, 21.0, 52.0, 'indoor'),
+    ('2020-01-01 00:00:00', 2, 25.0, 60.0, 'outdoor'),
+    ('2020-01-01 01:00:00', 2, 28.0, 65.0, 'outdoor'),
+    ('2020-01-01 02:00:00', 2, 26.0, 62.0, 'outdoor'),
+    ('2020-01-02 00:00:00', 1, 19.0, 48.0, 'indoor'),
+    ('2020-01-02 01:00:00', 2, 30.0, 70.0, 'outdoor');
+
+-- Create a materialized-only CAgg with basic aggregation
+CREATE MATERIALIZED VIEW test_cagg_mat
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+
+-- Create a real-time CAgg
+CREATE MATERIALIZED VIEW test_cagg_rt
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+
+-- Show initial state
+\d+ test_cagg_mat
+\d+ test_cagg_rt
+
+-- Add SUM aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+
+-- Verify column was added
+\d+ test_cagg_mat
+
+-- Add MAX aggregate to materialized-only CAgg
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'max(temperature) AS max_temp');
+
+-- Add MIN aggregate to real-time CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'min(temperature) AS min_temp');
+
+-- Verify columns were added
+\d+ test_cagg_mat
+\d+ test_cagg_rt
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+
+-- Verify aggregates are computed correctly
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+
+-- Add aggregate with different column (humidity)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'avg(humidity) AS avg_humidity');
+
+-- Refresh and check
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+
+-- Error tests
+\set ON_ERROR_STOP 0
+-- NULL arguments (STRICT function returns NULL for any NULL input)
+SELECT add_continuous_aggregate_column(NULL, 'sum(temperature) AS sum_temp');
+SELECT add_continuous_aggregate_column('test_cagg_mat', NULL);
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', NULL);
+
+-- function does not exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'missing_func(temperature) AS bad');
+
+-- function is not an aggregate
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'round(temperature)');
+
+-- syntax error in aggregate expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature AS bad_syntax');
+
+-- multiple aggregates in single expression
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature), avg(temperature)');
+
+-- multiple SQL statements (SQL injection attempt)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature); SELECT 1;');
+
+-- aggregate already exists (same alias)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp');
+
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp', true);
+
+-- column referenced in aggregate doesn't exist
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(nonexistent) AS bad');
+
+-- Error - expression must be an aggregate function (simple column)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'category');
+
+-- Error - window function is not allowed
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'row_number() OVER () AS rn');
+
+-- not a continuous aggregate
+CREATE TABLE regular_table (id INT, data TEXT);
+SELECT add_continuous_aggregate_column('regular_table', 'sum(id) AS total');
+
+-- permission denied: non-owner cannot alter the continuous aggregate
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) AS sum_temp2');
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 1
+DROP TABLE regular_table;
+
+-- Add COUNT aggregate (no column argument)
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(*) AS row_count');
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+
+-- Test adding aggregate without explicit alias (uses function name)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'sum(humidity)');
+
+-- Test adding schema-qualified aggregate without explicit alias (should use function name, not schema)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'pg_catalog.count(*)');
+
+-- Verify they were added with auto-generated aliases
+\d+ test_cagg_rt
+
+-- Test adding aggregate with double-quoted alias containing special characters
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'max(humidity) AS "weird and insane column name, but still valid on Postgres!"');
+
+-- Verify it was added with the special alias
+\d+ test_cagg_rt
+
+-- Test adding aggregate with DISTINCT
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'count(DISTINCT device_id) AS distinct_devices');
+
+-- Test adding aggregate with FILTER clause
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'sum(temperature) FILTER (WHERE temperature > 20) AS sum_temp_gt20');
+
+-- Create and test a custom aggregate
+CREATE AGGREGATE custom_sum (float8) (
+    sfunc = float8pl,
+    stype = float8,
+    initcond = '0'
+);
+SELECT add_continuous_aggregate_column('test_cagg_mat', 'custom_sum(temperature) AS custom_sum_temp');
+
+-- Refresh and verify all new aggregates
+CALL refresh_continuous_aggregate('test_cagg_mat', NULL, NULL);
+SELECT * FROM test_cagg_mat ORDER BY bucket, device_id;
+
+-- Test adding aggregate with ORDER BY (string_agg)
+SELECT add_continuous_aggregate_column('test_cagg_rt', 'string_agg(category, '','' ORDER BY category) AS categories');
+
+-- Refresh and verify
+CALL refresh_continuous_aggregate('test_cagg_rt', NULL, NULL);
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+
+-- Insert new data and check real-time aggregation works
+INSERT INTO test_ht VALUES
+    ('2020-01-03 00:00:00', 1, 23.0, 56.0, 'indoor'),
+    ('2020-01-03 01:00:00', 2, 32.0, 72.0, 'outdoor');
+
+-- Real-time CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt ORDER BY bucket, device_id;
+
+-- =====================================================
+-- Hierarchical continuous aggregate tests
+-- =====================================================
+
+-- Create a second-level materialized-only CAgg on top of test_cagg_mat
+CREATE MATERIALIZED VIEW test_cagg_level2
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_mat
+GROUP BY 1, 2
+WITH NO DATA;
+
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+
+-- Show initial state
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+\d+ test_cagg_level2
+
+-- Error - aggregate references column that doesn't exist in parent CAgg
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(nonexistent) AS bad');
+\set ON_ERROR_STOP 1
+
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+
+-- Verify the column was added
+\d+ test_cagg_level2
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_level2', NULL, NULL);
+SELECT * FROM test_cagg_level2 ORDER BY bucket, device_id;
+
+-- Error - aggregate already exists
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp');
+\set ON_ERROR_STOP 1
+
+-- if_not_exists=true should not error
+SELECT add_continuous_aggregate_column('test_cagg_level2', 'sum(sum_temp) AS total_sum_temp', true);
+
+-- =====================================================
+-- Hierarchical CAgg with real-time mode
+-- =====================================================
+
+-- Create a second-level real-time CAgg on top of test_cagg_rt
+CREATE MATERIALIZED VIEW test_cagg_rt_level2
+    WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS SELECT
+    time_bucket('7 days', bucket) AS bucket,
+    device_id,
+    avg(avg_temp) AS avg_temp
+FROM test_cagg_rt
+GROUP BY 1, 2
+WITH NO DATA;
+
+-- Refresh level 2
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+
+-- Show initial state
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+\d+ test_cagg_rt_level2
+
+-- Add aggregate using column from parent CAgg
+SELECT add_continuous_aggregate_column('test_cagg_rt_level2', 'max(min_temp) AS max_of_min');
+
+-- Verify the column was added
+\d+ test_cagg_rt_level2
+
+-- Refresh and check data
+CALL refresh_continuous_aggregate('test_cagg_rt_level2', NULL, NULL);
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+
+-- Insert new data to test real-time aggregation in hierarchical CAgg
+INSERT INTO test_ht VALUES
+    ('2020-01-04 00:00:00', 1, 18.0, 45.0, 'indoor'),
+    ('2020-01-04 01:00:00', 2, 35.0, 75.0, 'outdoor');
+
+-- Real-time hierarchical CAgg should show new data without refresh
+SELECT * FROM test_cagg_rt_level2 ORDER BY bucket, device_id;
+
+-- =====================================================
+-- Tests for CAgg with compression enabled
+-- =====================================================
+
+-- Create a new CAgg for compression tests
+CREATE MATERIALIZED VIEW test_cagg_compress
+    WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day', time) AS bucket,
+    device_id,
+    avg(temperature) AS avg_temp
+FROM test_ht
+GROUP BY 1, 2
+WITH NO DATA;
+
+-- Refresh to materialize data
+CALL refresh_continuous_aggregate('test_cagg_compress', NULL, NULL);
+
+-- Enable compression on the CAgg
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress);
+
+-- Error - cannot add column to CAgg with compression enabled
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+\set ON_ERROR_STOP 1
+
+-- Compress the chunks
+SELECT compress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+
+-- Error - still cannot add column after chunks are compressed
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+\set ON_ERROR_STOP 1
+
+-- Decompress all chunks
+SELECT decompress_chunk(chunk) FROM show_chunks('test_cagg_compress') chunk;
+
+-- Disable compression
+ALTER MATERIALIZED VIEW test_cagg_compress SET (timescaledb.compress = false);
+
+-- Now we should be able to add a column
+SELECT add_continuous_aggregate_column('test_cagg_compress', 'sum(temperature) AS sum_temp');
+
+-- Verify the column was added
+\d+ test_cagg_compress
+
+SET client_min_messages TO WARNING;
+
+-- Cleanup compression test CAgg
+DROP MATERIALIZED VIEW test_cagg_compress;
+
+-- Cleanup
+DROP MATERIALIZED VIEW test_cagg_rt_level2;
+DROP MATERIALIZED VIEW test_cagg_level2;
+DROP MATERIALIZED VIEW test_cagg_mat;
+DROP MATERIALIZED VIEW test_cagg_rt;
+DROP TABLE test_ht;
+
+RESET client_min_messages;


### PR DESCRIPTION
Implements `add_continuous_aggregate_column()` SQL function that allows adding new aggregate expressions to existing Continuous Aggregates without recreating them.

The function updates all internal CAgg structures:
* Materialization hypertable (adds column for storing computed values)
* Partial and Direct views (adds aggregate computation)
* User view (adds column reference or aggregate for real-time mode)

Usage examples:
```sql
-- Add aggregate with explicit alias
SELECT add_continuous_aggregate_column('my_cagg', 'sum(value) AS total');

-- Add aggregate without alias (uses function name)
SELECT add_continuous_aggregate_column('my_cagg', 'avg(temperature)');

-- Skip if column already exists
SELECT add_continuous_aggregate_column('my_cagg', 'max(value) AS peak', true);
```

Limitations:
* Cannot add aggregates to CAggs with compression enabled
* Only single aggregate expressions allowed per call
* Column name must not already exist in the CAgg