### PR TITLE
Remove mattablecolumninfo_init function

### DIFF
--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -92,20 +92,6 @@ caggtimebucketinfo_init(ContinuousAggTimeBucketInfo *src, int32 hypertable_id, O
 }
 
 /*
- * Initialize MaterializationHypertableColumnInfo.
- */
-void
-mattablecolumninfo_init(MaterializationHypertableColumnInfo *matcolinfo, List *grouplist)
-{
-	matcolinfo->matcollist = NIL;
-	matcolinfo->partial_seltlist = NIL;
-	matcolinfo->partial_grouplist = grouplist;
-	matcolinfo->mat_groupcolname_list = NIL;
-	matcolinfo->matpartcolno = -1;
-	matcolinfo->matpartcolname = NULL;
-}
-
-/*
  * Check if the supplied OID belongs to a valid bucket function
  * for continuous aggregates.
  */

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -115,8 +115,6 @@ extern Query *destroy_union_query(Query *q);
 extern void RemoveRangeTableEntries(Query *query);
 extern Query *build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *q1,
 								Query *q2, int materialize_htid);
-extern void mattablecolumninfo_init(MaterializationHypertableColumnInfo *matcolinfo,
-									List *grouplist);
 extern bool function_allowed_in_cagg_definition(Oid funcid);
 extern Oid get_watermark_function_oid(void);
 extern Oid cagg_get_boundary_converter_funcoid(Oid typoid);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -115,15 +115,6 @@ makeMaterializedTableName(char *buf, const char *prefix, int hypertable_id)
 	}
 }
 
-/* STATIC functions defined on the structs above. */
-static int32 mattablecolumninfo_create_materialization_table(
-	MaterializationHypertableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
-	ContinuousAggTimeBucketInfo *bucket_info, bool create_addl_index, char *tablespacename,
-	char *table_access_method, int64 matpartcol_interval, ObjectAddress *mataddress);
-static Query *
-mattablecolumninfo_get_partial_select_query(MaterializationHypertableColumnInfo *mattblinfo,
-											Query *userview_query);
-
 /*
  * Create a entry for the materialization table in table CONTINUOUS_AGGS.
  */
@@ -374,16 +365,15 @@ mattablecolumninfo_add_mattable_index(MaterializationHypertableColumnInfo *matco
  *    bucket_info: bucket information used for setting up the
  *                 hypertable partitioning (`chunk_interval_size`).
  *    tablespace_name: Name of the tablespace for the materialization table.
- *    table_access_method: Name of the table access method to use for the
- *        materialization table.
- *    mataddress: return the ObjectAddress RETURNS: hypertable id of the
- *        materialization table
+ *    mataddress: return the ObjectAddress
+ *
+ *  RETURNS: hypertable id of the materialization table
  */
 static int32
-mattablecolumninfo_create_materialization_table(
-	MaterializationHypertableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
-	ContinuousAggTimeBucketInfo *bucket_info, bool create_addl_index, char *const tablespacename,
-	char *const table_access_method, int64 matpartcol_interval, ObjectAddress *mataddress)
+create_materialization_table(MaterializationHypertableColumnInfo *matcolinfo, int32 hypertable_id,
+							 RangeVar *mat_rel, ContinuousAggTimeBucketInfo *bucket_info,
+							 bool create_addl_index, IntoClause *into, int64 matpartcol_interval,
+							 ObjectAddress *mataddress)
 {
 	Oid uid, saved_uid;
 	int sec_ctx;
@@ -409,8 +399,8 @@ mattablecolumninfo_create_materialization_table(
 	create->constraints = NIL;
 	create->options = NULL;
 	create->oncommit = ONCOMMIT_NOOP;
-	create->tablespacename = tablespacename;
-	create->accessMethod = table_access_method;
+	create->tablespacename = into->tableSpaceName;
+	create->accessMethod = into->accessMethod;
 	create->if_not_exists = false;
 
 	/*  Create the materialization table.  */
@@ -453,8 +443,7 @@ mattablecolumninfo_create_materialization_table(
  * the materialization columns and remove HAVING clause and ORDER BY.
  */
 static Query *
-mattablecolumninfo_get_partial_select_query(MaterializationHypertableColumnInfo *mattblinfo,
-											Query *userview_query)
+get_partial_select_query(MaterializationHypertableColumnInfo *mattblinfo, Query *userview_query)
 {
 	Query *partial_selquery = NULL;
 
@@ -606,7 +595,6 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 {
 	ObjectAddress mataddress;
 	char relnamebuf[NAMEDATALEN];
-	MaterializationHypertableColumnInfo mattblinfo;
 	FinalizeQueryInfo finalqinfo;
 	CatalogSecurityContext sec_ctx;
 	bool is_create_mattbl_index;
@@ -640,7 +628,8 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	 * No other modifications to panquery.
 	 */
 	fixup_userview_query_tlist(panquery, stmt->aliases);
-	mattablecolumninfo_init(&mattblinfo, copyObject(panquery->groupClause));
+	MaterializationHypertableColumnInfo mattblinfo = { .partial_grouplist =
+														   copyObject(panquery->groupClause) };
 	finalizequery_init(&finalqinfo, panquery, &mattblinfo);
 
 	/*
@@ -650,9 +639,6 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	stmt->options = NULL;
 
 	/*
-	 * Old format caggs are not supported anymore, there is no need to add
-	 * an internal chunk id column for materialized hypertable.
-	 *
 	 * Step 1: create the materialization table.
 	 */
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
@@ -662,15 +648,14 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	mat_rel = makeRangeVar(pstrdup(INTERNAL_SCHEMA_NAME), pstrdup(relnamebuf), -1);
 	is_create_mattbl_index =
 		DatumGetBool(with_clause_options[CreateMaterializedViewFlagCreateGroupIndexes].parsed);
-	mattablecolumninfo_create_materialization_table(&mattblinfo,
-													materialize_hypertable_id,
-													mat_rel,
-													bucket_info,
-													is_create_mattbl_index,
-													create_stmt->into->tableSpaceName,
-													create_stmt->into->accessMethod,
-													matpartcol_interval,
-													&mataddress);
+	create_materialization_table(&mattblinfo,
+								 materialize_hypertable_id,
+								 mat_rel,
+								 bucket_info,
+								 is_create_mattbl_index,
+								 create_stmt->into,
+								 matpartcol_interval,
+								 &mataddress);
 
 	/*
 	 * Step 2: Create view with select finalize from materialization table.
@@ -694,7 +679,7 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	/*
 	 * Step 3: create the internal view with select partialize(..).
 	 */
-	partial_selquery = mattablecolumninfo_get_partial_select_query(&mattblinfo, panquery);
+	partial_selquery = get_partial_select_query(&mattblinfo, panquery);
 
 	makeMaterializedTableName(relnamebuf, "_partial_view_%d", materialize_hypertable_id);
 	part_rel = makeRangeVar(pstrdup(INTERNAL_SCHEMA_NAME), pstrdup(relnamebuf), -1);


### PR DESCRIPTION
This function had only 1 caller and only assigned 1 value so move
it inline.

Disable-check: approval-count
Disable-check: force-changelog-file
