### PR TITLE
Remove continuous_agg_migrate_plan tables

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -507,36 +507,6 @@ CREATE INDEX compression_chunk_size_idx ON _timescaledb_catalog.compression_chun
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.compression_chunk_size', '');
 
-CREATE TABLE _timescaledb_catalog.continuous_agg_migrate_plan (
-  mat_hypertable_id integer NOT NULL,
-  start_ts TIMESTAMPTZ NOT NULL DEFAULT pg_catalog.now(),
-  end_ts TIMESTAMPTZ,
-  user_view_definition TEXT,
-  -- table constraints
-  CONSTRAINT continuous_agg_migrate_plan_pkey PRIMARY KEY (mat_hypertable_id)
-);
-
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_agg_migrate_plan', '');
-
-CREATE TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step (
-  mat_hypertable_id integer NOT NULL,
-  step_id serial NOT NULL,
-  status TEXT NOT NULL DEFAULT 'NOT STARTED', -- NOT STARTED, STARTED, FINISHED, CANCELED
-  start_ts TIMESTAMPTZ,
-  end_ts TIMESTAMPTZ,
-  type TEXT NOT NULL,
-  config JSONB,
-  -- table constraints
-  CONSTRAINT continuous_agg_migrate_plan_step_pkey PRIMARY KEY (mat_hypertable_id, step_id),
-  CONSTRAINT continuous_agg_migrate_plan_step_mat_hypertable_id_fkey FOREIGN KEY (mat_hypertable_id) REFERENCES _timescaledb_catalog.continuous_agg_migrate_plan (mat_hypertable_id) ON DELETE CASCADE,
-  CONSTRAINT continuous_agg_migrate_plan_step_check CHECK (start_ts <= end_ts),
-  CONSTRAINT continuous_agg_migrate_plan_step_check2 CHECK (type IN ('CREATE NEW CAGG', 'DISABLE POLICIES', 'COPY POLICIES', 'ENABLE POLICIES', 'SAVE WATERMARK', 'REFRESH NEW CAGG', 'COPY DATA', 'OVERRIDE CAGG', 'DROP OLD CAGG'))
-);
-
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_agg_migrate_plan_step', '');
-
-SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.continuous_agg_migrate_plan_step', 'step_id'), '');
-
 CREATE TABLE _timescaledb_catalog.chunk_rewrite (
   chunk_relid REGCLASS NOT NULL,
   new_relid REGCLASS NOT NULL,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -80,3 +80,11 @@ GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
 GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
 -- end rebuild _timescaledb_catalog.chunk table --
 
+-- drop the catalog tables for continuous aggregate migration plans
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq;
+DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step;
+DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan;
+

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -189,8 +189,6 @@ SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_
  _timescaledb_catalog  | compression_chunk_size
  _timescaledb_catalog  | compression_settings
  _timescaledb_catalog  | continuous_agg
- _timescaledb_catalog  | continuous_agg_migrate_plan
- _timescaledb_catalog  | continuous_agg_migrate_plan_step
  _timescaledb_catalog  | continuous_aggs_bucket_function
  _timescaledb_catalog  | continuous_aggs_hypertable_invalidation_log
  _timescaledb_catalog  | continuous_aggs_invalidation_threshold


### PR DESCRIPTION
These are left over from when the procedure to convert continuous
aggregate from partial format to new format were removed.

Disable-check: force-changelog-file