### PR TITLE
Run all check on main regardless of the changed paths

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -29,7 +29,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -37,7 +37,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -11,7 +11,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -11,7 +11,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -10,7 +10,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.shell == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.shell == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -12,7 +12,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -41,7 +41,10 @@ jobs:
   check_paths:
     runs-on: ubuntu-latest
     outputs:
-      run_ci: ${{ steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run_ci: >-
+        ${{ github.event_name == 'push'
+          || (steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+         }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
Having all checks run on main provides a useful baseline for debugging the CI failures.