### PR TITLE
Clean up orphaned entries in continuous aggregate invalidaton logs

### DIFF
--- a/.unreleased/pr_9215
+++ b/.unreleased/pr_9215
@@ -1,2 +1,2 @@
-Fixes: #9215 Fix off by one error in sort optimization
+Fixes: #9215 Add missing handling for em_parent to sort_transform
 Thanks: @emapple for reporting a crash in a query with nested joins and subqueries

--- a/.unreleased/pr_9223
+++ b/.unreleased/pr_9223
@@ -1,0 +1,1 @@
+Fixes: #9223 Clean up orphaned entries in continuous aggregate invalidaton logs


### PR DESCRIPTION
With 2.25.0 we rebuild the continuous aggregate catalog table which
readds the foreign key constraints leading to verification of those
constraints by postgres which is normally skipped in our internal
functions as we use a lower-level API. This commit adds cleanup
to get rid of orphaned entries in the log tables.

Disable-check: force-changelog-file