### PR TITLE
Disable autovacuum immediatelly for skipscan test

### DIFF
--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan-18.out
+++ b/tsl/test/expected/plan_skip_scan-18.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan_dagg-15.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-15.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan_dagg-16.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-16.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan_dagg-17.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-17.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan_dagg-18.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-18.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 \set TABLE skip_scan

--- a/tsl/test/expected/plan_skip_scan_notnull.out
+++ b/tsl/test/expected/plan_skip_scan_notnull.out
@@ -8,16 +8,25 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -35,6 +44,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -64,14 +76,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -105,9 +114,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- we want to run with analyze here so we can see counts in the nodes
 \set PREFIX 'EXPLAIN (analyze, buffers off, costs off, timing off, summary off)'
 -- test SkipScan NOT NULL mode

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -15,16 +15,25 @@ SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized resul
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -42,6 +51,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -71,14 +83,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -112,9 +121,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- run tests on normal table and diff results
 \set TABLE skip_scan
 \set PREFIX ''

--- a/tsl/test/expected/skip_scan_dagg.out
+++ b/tsl/test/expected/skip_scan_dagg.out
@@ -14,16 +14,25 @@ SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized resul
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan SET (autovacuum_enabled = off);
 INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
 INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
 INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
 ANALYZE skip_scan;
 CREATE TABLE skip_scan_nulls(time int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_nulls SET (autovacuum_enabled = off);
 CREATE INDEX ON skip_scan_nulls(time);
 INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
 ANALYZE skip_scan_nulls;
 -- create hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_ht SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable     
 ---------------------------
@@ -41,6 +50,9 @@ ANALYZE skip_scan_ht;
 ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
 -- create compressed hypertable with different physical layouts in the chunks
 CREATE TABLE skip_scan_htc(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htc SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htc', 'time', chunk_time_interval => 250, create_default_indexes => false);
      create_hypertable      
 ----------------------------
@@ -70,14 +82,11 @@ UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htc'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htc'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan set (autovacuum_enabled = off);
-alter table skip_scan_nulls set (autovacuum_enabled = off);
-alter table skip_scan_ht set (autovacuum_enabled = off);
-alter table skip_scan_htc set (autovacuum_enabled = off);
 -- create compressed hypertable with different physical layouts in the compressed chunks
 CREATE TABLE skip_scan_htcl(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+-- Turn off autovacuum to not trigger new vacuums that restores the
+-- adjusted statistics
+ALTER TABLE skip_scan_htcl SET (autovacuum_enabled = off);
 SELECT create_hypertable('skip_scan_htcl', 'time', chunk_time_interval => 250, create_default_indexes => false);
       create_hypertable      
 -----------------------------
@@ -111,9 +120,6 @@ ANALYZE skip_scan_htcl;
 -- adjust statistics so we get skipscan plans
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_htcl'::regclass;
 UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_htcl'::regclass);
--- Turn off autovacuum to not trigger new vacuums that restores the
--- adjusted statistics
-alter table skip_scan_htcl set (autovacuum_enabled = off);
 -- run tests on normal table and diff results
 \set TABLE skip_scan
 \set PREFIX ''


### PR DESCRIPTION
We disabled autovacuum after modifying the stats so there is potential for autovacuum to come in a short window to manage to update the modified stats. By disabling it right after table creation, it should help with test stability.

Failed test: https://github.com/timescale/timescaledb/actions/runs/21693503493/job/62558563876

Disable-check: force-changelog-file