### PR TITLE
Make compression_hypertable independent of telemetry setting

### DIFF
--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -58,11 +58,6 @@ CREATE OPERATOR CLASS customtype_ops
   DEFAULT
   FOR TYPE customtype
   USING hash AS OPERATOR 1 =;
-SELECT count(delete_job(job_id)) from timescaledb_information.jobs ;
- count 
--------
-     2
-
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');

--- a/tsl/test/sql/compression_hypertable.sql
+++ b/tsl/test/sql/compression_hypertable.sql
@@ -45,8 +45,6 @@ CREATE OPERATOR CLASS customtype_ops
   FOR TYPE customtype
   USING hash AS OPERATOR 1 =;
 
-SELECT count(delete_job(job_id)) from timescaledb_information.jobs ;
-
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 CREATE TABLE test1 ("Time" timestamptz, i integer, b bigint, t text);


### PR DESCRIPTION
When telemetry is disabled there would be 1 less job being deleted
during the test. Since we disable bgw scheduler in normal tests
there is no need to delete jobs for this test.


Fixes #9218 