### PR TITLE
Propagate extended statistics to chunks (#2433)

### DIFF
--- a/.unreleased/pr_9237
+++ b/.unreleased/pr_9237
@@ -1,0 +1,1 @@
+Implements: #2433 Propagate CREATE/DROP/RENAME STATISTICS to hypertable chunks

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     chunk_adaptive.c
     chunk_constraint.c
     chunk_index.c
+    chunk_statistics.c
     chunk_insert_state.c
     chunk_scan.c
     chunk_tuple_routing.c

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -59,6 +59,7 @@
 #include "bgw_policy/chunk_stats.h"
 #include "cache.h"
 #include "chunk_index.h"
+#include "chunk_statistics.h"
 
 #include "cross_module_fn.h"
 #include "debug_assert.h"
@@ -986,6 +987,10 @@ chunk_create_table_constraints(const Hypertable *ht, const Chunk *chunk)
 								  chunk->fd.id,
 								  chunk->table_id,
 								  InvalidOid);
+		ts_chunk_extended_statistics_create_all(chunk->fd.hypertable_id,
+												chunk->hypertable_relid,
+												chunk->fd.id,
+												chunk->table_id);
 
 		chunk_set_replica_identity(chunk);
 	}

--- a/src/chunk_statistics.c
+++ b/src/chunk_statistics.c
@@ -1,0 +1,1005 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+#include <access/heapam.h>
+#include <access/htup_details.h>
+#include <catalog/indexing.h>
+#include <catalog/namespace.h>
+#include <catalog/pg_statistic_ext.h>
+#include <commands/defrem.h>
+#include <commands/tablecmds.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <nodes/nodes.h>
+#include <nodes/parsenodes.h>
+#include <nodes/readfuncs.h>
+#include <optimizer/optimizer.h>
+#include <parser/parse_node.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/memutils.h>
+#include <utils/regproc.h>
+#include <utils/rel.h>
+#include <utils/relcache.h>
+#include <utils/syscache.h>
+
+#include "compat/compat.h"
+#include "chunk.h"
+#include "chunk_statistics.h"
+#include "hypertable.h"
+#include "utils.h"
+
+/* Forward declarations */
+static CreateStatsStmt *build_chunk_extended_statistics_stmt(Chunk *chunk,
+															 Form_pg_statistic_ext stat_ext_form,
+															 HeapTuple stat_ext_tuple,
+															 Oid hypertable_relid, Oid chunk_relid);
+static List *convert_stxkeys_to_chunk_exprs(int2vector *stxkeys, Oid hypertable_relid,
+											Oid chunk_relid);
+static List *convert_stxkind_to_string_list(ArrayType *stxkind);
+static List *process_chunk_extended_statistics_exprs(HeapTuple stat_ext_tuple, List *chunk_exprs,
+													 Oid hypertable_relid, Oid chunk_relid);
+static char *chunk_extended_statistics_choose_name(const char *chunk_table_name,
+												   const char *stat_ext_name, Oid namespaceid);
+static bool compare_extended_statistics_columns(Form_pg_statistic_ext stat_ext_form1,
+												Form_pg_statistic_ext stat_ext_form2);
+static bool compare_extended_statistics_kinds(HeapTuple stat_ext_tuple1, HeapTuple stat_ext_tuple2);
+static bool compare_extended_statistics_expressions(HeapTuple stat_ext_tuple1,
+													HeapTuple stat_ext_tuple2);
+static bool compare_extended_statistics_name_pattern(const char *chunk_stat_name,
+													 const char *hypertable_stat_name);
+
+/*
+ * Create all extended statistics on a chunk, given the extended statistics
+ * that exist on the chunk's hypertable.
+ *
+ * Similar to ts_chunk_index_create_all() for indexes.
+ */
+void
+ts_chunk_extended_statistics_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id,
+										Oid chunk_relid)
+{
+	Relation hypertable_relation;
+	Relation chunk_relation;
+	List *extended_statistics_list;
+	ListCell *extended_statistics_cell;
+	const char chunk_relkind = get_rel_relkind(chunk_relid);
+
+	/* Foreign table chunks don't support extended statistics */
+	if (chunk_relkind == RELKIND_FOREIGN_TABLE)
+		return;
+
+	Assert(chunk_relkind == RELKIND_RELATION);
+
+	hypertable_relation = table_open(hypertable_relid, AccessShareLock);
+	chunk_relation = table_open(chunk_relid, ShareLock);
+
+	/*
+	 * Get all extended statistics on the hypertable.
+	 * RelationGetStatExtList() returns a list of OIDs for all extended
+	 * statistics objects defined on the relation, similar to how
+	 * RelationGetIndexList() works for indexes.
+	 */
+	extended_statistics_list = RelationGetStatExtList(hypertable_relation);
+
+	foreach (extended_statistics_cell, extended_statistics_list)
+	{
+		Oid stat_ext_oid = lfirst_oid(extended_statistics_cell);
+		HeapTuple stat_ext_tuple;
+		Form_pg_statistic_ext stat_ext_form;
+		Chunk *chunk;
+		CreateStatsStmt *chunk_stmt;
+
+		/* Get the extended statistics tuple from system cache */
+		stat_ext_tuple = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(stat_ext_oid));
+		if (!HeapTupleIsValid(stat_ext_tuple))
+			continue; /* Should not happen, but skip if it does */
+
+		stat_ext_form = (Form_pg_statistic_ext) GETSTRUCT(stat_ext_tuple);
+
+		/* Get chunk structure */
+		chunk = ts_chunk_get_by_relid(chunk_relid, true);
+		if (chunk == NULL)
+		{
+			ReleaseSysCache(stat_ext_tuple);
+			continue;
+		}
+
+		/* Build CreateStatsStmt node */
+		chunk_stmt = build_chunk_extended_statistics_stmt(chunk,
+														  stat_ext_form,
+														  stat_ext_tuple,
+														  hypertable_relid,
+														  chunk_relid);
+		if (chunk_stmt == NULL)
+		{
+			ReleaseSysCache(stat_ext_tuple);
+			continue;
+		}
+
+		/* Create extended statistics on chunk */
+		CreateStatistics(chunk_stmt, false);
+
+		ReleaseSysCache(stat_ext_tuple);
+	}
+
+	list_free(extended_statistics_list);
+	table_close(chunk_relation, NoLock);
+	table_close(hypertable_relation, AccessShareLock);
+}
+
+/*
+ * Build CreateStatsStmt node for creating extended statistics on a chunk.
+ *
+ * Returns: CreateStatsStmt node, or NULL if extended statistics cannot be created
+ *          (e.g., expressions present, invalid data).
+ */
+static CreateStatsStmt *
+build_chunk_extended_statistics_stmt(Chunk *chunk, Form_pg_statistic_ext stat_ext_form,
+									 HeapTuple stat_ext_tuple, Oid hypertable_relid,
+									 Oid chunk_relid)
+{
+	CreateStatsStmt *chunk_stmt;
+	List *chunk_exprs;
+	List *chunk_stat_ext_types;
+	RangeVar *chunk_range_var;
+	Datum datum;
+	bool isnull;
+	int2vector *stxkeys;
+	ArrayType *stxkind;
+
+	/* Get stxkeys (column numbers) */
+	datum = SysCacheGetAttr(STATEXTOID, stat_ext_tuple, Anum_pg_statistic_ext_stxkeys, &isnull);
+	if (isnull)
+		return NULL;
+	stxkeys = (int2vector *) DatumGetPointer(datum);
+
+	/* Convert stxkeys to chunk exprs */
+	chunk_exprs = convert_stxkeys_to_chunk_exprs(stxkeys, hypertable_relid, chunk_relid);
+	if (chunk_exprs == NULL)
+		return NULL; /* Column doesn't exist in chunk */
+
+	/* Get stxkind (statistics types) */
+	datum = SysCacheGetAttr(STATEXTOID, stat_ext_tuple, Anum_pg_statistic_ext_stxkind, &isnull);
+	if (isnull)
+	{
+		list_free_deep(chunk_exprs);
+		return NULL;
+	}
+	stxkind = DatumGetArrayTypeP(datum);
+
+	/*
+	 * Convert stxkind to string list.
+	 * NIL is valid when only expressions exist (stxkind = {e}).
+	 */
+	chunk_stat_ext_types = convert_stxkind_to_string_list(stxkind);
+
+	/* Process expression extended statistics if present */
+	chunk_exprs = process_chunk_extended_statistics_exprs(stat_ext_tuple,
+														  chunk_exprs,
+														  hypertable_relid,
+														  chunk_relid);
+
+	/* Create CreateStatsStmt node */
+	chunk_stmt = makeNode(CreateStatsStmt);
+
+	/* Build qualified name: schema.chunk_table_name_stat_ext_name */
+	char *chunk_stat_ext_name =
+		chunk_extended_statistics_choose_name(NameStr(chunk->fd.table_name),
+											  NameStr(stat_ext_form->stxname),
+											  get_rel_namespace(chunk_relid));
+	chunk_stmt->defnames =
+		list_make2(makeString(NameStr(chunk->fd.schema_name)), makeString(chunk_stat_ext_name));
+
+	/* Build RangeVar for chunk relation */
+	chunk_range_var =
+		makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0);
+
+	/* Set up CreateStatsStmt */
+	chunk_stmt->exprs = chunk_exprs;
+	chunk_stmt->stat_types = chunk_stat_ext_types;
+	chunk_stmt->relations = list_make1(chunk_range_var);
+	chunk_stmt->if_not_exists = true;
+
+	return chunk_stmt;
+}
+
+/*
+ * Convert hypertable's stxkeys (column numbers) to chunk's StatsElem list.
+ * Gets column names from hypertable and verifies they exist in chunk.
+ *
+ * Returns: List of StatsElem nodes with column names.
+ *          ERROR if any column doesn't exist in chunk.
+ */
+static List *
+convert_stxkeys_to_chunk_exprs(int2vector *stxkeys, Oid hypertable_relid, Oid chunk_relid)
+{
+	List *chunk_exprs = NIL;
+	int i;
+
+	for (i = 0; i < stxkeys->dim1; i++)
+	{
+		AttrNumber hypertable_attnum = stxkeys->values[i];
+		char *column_name;
+		AttrNumber chunk_attnum;
+		StatsElem *stats_elem;
+
+		/* Get column name from hypertable */
+		column_name = get_attname(hypertable_relid, hypertable_attnum, false);
+		if (column_name == NULL)
+		{
+			list_free_deep(chunk_exprs);
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column with attribute number %d does not exist in hypertable \"%s\"",
+							hypertable_attnum,
+							get_rel_name(hypertable_relid))));
+		}
+
+		/* Verify column exists in chunk by name */
+		chunk_attnum = get_attnum(chunk_relid, column_name);
+		if (chunk_attnum == InvalidAttrNumber)
+		{
+			list_free_deep(chunk_exprs);
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" of hypertable \"%s\" does not exist in chunk \"%s\"",
+							column_name,
+							get_rel_name(hypertable_relid),
+							get_rel_name(chunk_relid))));
+		}
+
+		/* Create StatsElem with hypertable's column name */
+		stats_elem = makeNode(StatsElem);
+		stats_elem->name = pstrdup(column_name);
+		stats_elem->expr = NULL;
+		chunk_exprs = lappend(chunk_exprs, stats_elem);
+	}
+
+	return chunk_exprs;
+}
+
+/*
+ * Convert stxkind char array to string list.
+ * Maps 'd' -> "ndistinct", 'f' -> "dependencies", 'm' -> "mcv".
+ * Skips 'e' (expressions) - PostgreSQL adds it automatically when expressions exist.
+ *
+ * Returns: List of strings. NIL is valid when only expressions exist (stxkind = {e}).
+ */
+static List *
+convert_stxkind_to_string_list(ArrayType *stxkind)
+{
+	List *chunk_stat_types = NIL;
+	char *kind_chars;
+	int num_kinds;
+	int i;
+
+	/* PostgreSQL guarantees stxkind is a valid 1-dimensional char array */
+	Assert(ARR_NDIM(stxkind) == 1);
+	Assert(!ARR_HASNULL(stxkind));
+
+	kind_chars = (char *) ARR_DATA_PTR(stxkind);
+	num_kinds = ARR_DIMS(stxkind)[0];
+
+	for (i = 0; i < num_kinds; i++)
+	{
+		char kind_char = kind_chars[i];
+		char *kind_str;
+
+		switch (kind_char)
+		{
+			case STATS_EXT_NDISTINCT:
+				kind_str = "ndistinct";
+				break;
+			case STATS_EXT_DEPENDENCIES:
+				kind_str = "dependencies";
+				break;
+			case STATS_EXT_MCV:
+				kind_str = "mcv";
+				break;
+			case STATS_EXT_EXPRESSIONS:
+				/*
+				 * Skip 'expressions' kind. PostgreSQL automatically adds it
+				 * when CREATE STATISTICS includes expressions. We cannot specify
+				 * it explicitly in SQL syntax, so we omit it from stat_types.
+				 * PostgreSQL will add it again for the chunk automatically.
+				 */
+				continue;
+			default:
+				/*
+				 * Skip unknown kinds for forward compatibility with future
+				 * PostgreSQL versions that may add new statistics kinds.
+				 */
+				continue;
+		}
+		chunk_stat_types = lappend(chunk_stat_types, makeString(kind_str));
+	}
+
+	/*
+	 * NIL is valid here - it means only expressions exist (stxkind = {e}).
+	 * PostgreSQL will handle stat_types = NIL correctly.
+	 */
+	return chunk_stat_types;
+}
+
+/*
+ * Process expression extended statistics and append to chunk_exprs.
+ * Parses pg_node_tree, maps attribute numbers, and creates StatsElem nodes.
+ *
+ * Returns: Updated chunk_exprs with expression elements appended,
+ *          or original chunk_exprs if no expressions present.
+ */
+static List *
+process_chunk_extended_statistics_exprs(HeapTuple stat_ext_tuple, List *chunk_exprs,
+										Oid hypertable_relid, Oid chunk_relid)
+{
+	Datum datum;
+	bool isnull;
+	char *expression_string;
+	List *expression_nodes;
+	List *variable_nodes = NIL;
+	ListCell *expression_cell;
+
+	/* Get stxexprs (expressions) */
+	datum = SysCacheGetAttr(STATEXTOID, stat_ext_tuple, Anum_pg_statistic_ext_stxexprs, &isnull);
+	if (isnull)
+		return chunk_exprs; /* No expressions, return as-is */
+
+	/* Convert pg_node_tree to C string and parse to Node tree */
+	expression_string = TextDatumGetCString(datum);
+	expression_nodes = (List *) stringToNode(expression_string);
+	pfree(expression_string);
+
+	/* Extract all Var nodes from the expression list */
+	if (expression_nodes != NIL)
+		variable_nodes = pull_var_clause((Node *) expression_nodes, 0);
+
+	/* Map attribute numbers from hypertable to chunk */
+	foreach (expression_cell, variable_nodes)
+	{
+		Var *variable_node = lfirst_node(Var, expression_cell);
+		/* ts_map_attno() will ERROR if column doesn't exist in chunk */
+		variable_node->varattno =
+			ts_map_attno(hypertable_relid, chunk_relid, variable_node->varattno);
+		variable_node->varattnosyn = variable_node->varattno;
+	}
+
+	/* Convert expressions to StatsElem nodes and append to chunk_exprs */
+	foreach (expression_cell, expression_nodes)
+	{
+		Node *expression_node = (Node *) lfirst(expression_cell);
+		StatsElem *stats_elem = makeNode(StatsElem);
+
+		stats_elem->name = NULL;			/* NULL for expressions */
+		stats_elem->expr = expression_node; /* Expression tree */
+
+		chunk_exprs = lappend(chunk_exprs, stats_elem);
+	}
+
+	return chunk_exprs;
+}
+
+/*
+ * Choose a unique name for chunk extended statistics object.
+ * Follows the same pattern as chunk_index_choose_name() in chunk_index.c.
+ *
+ * Pattern: chunk_table_name_stat_ext_name (e.g., "_hyper_1_1_chunk_stats_test_stat")
+ * If the name conflicts, appends a number (e.g., "_hyper_1_1_chunk_stats_test_stat_1")
+ */
+static char *
+chunk_extended_statistics_choose_name(const char *chunk_table_name, const char *stat_ext_name,
+									  Oid namespaceid)
+{
+	char buf[10];
+	char *label = NULL;
+	char *extended_statistics_name;
+	int n = 0;
+
+	for (;;)
+	{
+		/* makeObjectName will ensure the extended statistics name fits within a NAME type */
+		extended_statistics_name = makeObjectName(chunk_table_name, stat_ext_name, label);
+
+		/* Check if this name already exists in the namespace */
+		List *names = list_make2(makeString(get_namespace_name(namespaceid)),
+								 makeString(extended_statistics_name));
+		Oid existing_extended_statistics_oid = get_statistics_object_oid(names, true);
+		list_free_deep(names);
+
+		if (!OidIsValid(existing_extended_statistics_oid))
+			break;
+
+		/* Found a conflict, so try a new name component */
+		pfree(extended_statistics_name);
+		snprintf(buf, sizeof(buf), "%d", ++n);
+		label = buf;
+	}
+
+	return extended_statistics_name;
+}
+
+/*
+ * Create a specific extended statistics on a chunk by name.
+ *
+ * This function is called during DDL propagation when a new extended statistics
+ * is created on a hypertable and needs to be propagated to all existing chunks.
+ */
+void
+ts_chunk_extended_statistics_create_from_stat(Oid hypertable_relid, Oid chunk_relid,
+											  const char *stat_ext_name)
+{
+	Relation hypertable_relation;
+	Relation chunk_relation;
+	List *stat_ext_names;
+	Oid stat_ext_oid;
+	HeapTuple stat_ext_tuple;
+	Form_pg_statistic_ext stat_ext_form;
+	Chunk *chunk;
+	CreateStatsStmt *chunk_stmt;
+
+	/* Open relations */
+	hypertable_relation = table_open(hypertable_relid, AccessShareLock);
+	chunk_relation = table_open(chunk_relid, ShareLock);
+
+	/* Convert extended statistics name to qualified name list and get OID */
+#if PG16_LT
+	stat_ext_names = stringToQualifiedNameList(stat_ext_name);
+#else
+	stat_ext_names = stringToQualifiedNameList(stat_ext_name, NULL);
+#endif
+	stat_ext_oid = get_statistics_object_oid(stat_ext_names, false);
+
+	/* Get extended statistics metadata from system cache */
+	stat_ext_tuple = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(stat_ext_oid));
+	if (!HeapTupleIsValid(stat_ext_tuple))
+	{
+		list_free(stat_ext_names);
+		table_close(chunk_relation, NoLock);
+		table_close(hypertable_relation, AccessShareLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("extended statistics object \"%s\" does not exist", stat_ext_name)));
+	}
+
+	stat_ext_form = (Form_pg_statistic_ext) GETSTRUCT(stat_ext_tuple);
+
+	/* Get chunk structure */
+	chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	if (chunk == NULL)
+	{
+		ReleaseSysCache(stat_ext_tuple);
+		list_free(stat_ext_names);
+		table_close(chunk_relation, NoLock);
+		table_close(hypertable_relation, AccessShareLock);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("chunk with OID %u not found", chunk_relid)));
+	}
+
+	/* Build CreateStatsStmt for the chunk */
+	chunk_stmt = build_chunk_extended_statistics_stmt(chunk,
+													  stat_ext_form,
+													  stat_ext_tuple,
+													  hypertable_relid,
+													  chunk_relid);
+	if (chunk_stmt == NULL)
+	{
+		/* NULL means expression-only extended statistics, silently skip */
+		ReleaseSysCache(stat_ext_tuple);
+		list_free(stat_ext_names);
+		table_close(chunk_relation, NoLock);
+		table_close(hypertable_relation, AccessShareLock);
+		return;
+	}
+
+	/* Create extended statistics on chunk */
+	CreateStatistics(chunk_stmt, false);
+
+	/* Cleanup */
+	ReleaseSysCache(stat_ext_tuple);
+	list_free(stat_ext_names);
+	table_close(chunk_relation, NoLock);
+	table_close(hypertable_relation, AccessShareLock);
+}
+
+/*
+ * Find a chunk extended statistics that matches the structure of a hypertable
+ * extended statistics.
+ *
+ * This function searches through all extended statistics on the chunk and returns
+ * the OID of the first extended statistics that has the same structure as the
+ * hypertable extended statistics.
+ *
+ * Similar to ts_chunk_index_get_by_hypertable_indexrelid() for indexes.
+ *
+ * Returns InvalidOid if no matching extended statistics is found.
+ */
+Oid
+ts_chunk_extended_statistics_get_by_hypertable_relid(Oid chunk_relid, Oid hypertable_stat_ext_oid)
+{
+	ScanKeyData scan_key;
+	SysScanDesc extended_statistics_scan;
+	HeapTuple extended_statistics_tuple;
+	Relation extended_statistics_relation;
+	Oid matched_chunk_stat_ext_oid = InvalidOid;
+
+	/* Open pg_statistic_ext catalog for scanning */
+	extended_statistics_relation = table_open(StatisticExtRelationId, AccessShareLock);
+
+	/*
+	 * Initialize scan key to find all extended statistics on the chunk relation.
+	 * We're searching for: stxrelid = chunk_relid
+	 */
+	ScanKeyInit(&scan_key,
+				Anum_pg_statistic_ext_stxrelid,
+				BTEqualStrategyNumber,
+				F_OIDEQ,
+				ObjectIdGetDatum(chunk_relid));
+
+	/*
+	 * Begin index scan on pg_statistic_ext using StatisticExtRelidIndexId.
+	 * This uses the index on stxrelid for efficient lookup.
+	 */
+	extended_statistics_scan = systable_beginscan(extended_statistics_relation,
+												  StatisticExtRelidIndexId,
+												  true,
+												  NULL,
+												  1,
+												  &scan_key);
+
+	/* Iterate through all extended statistics on the chunk */
+	while (HeapTupleIsValid(extended_statistics_tuple = systable_getnext(extended_statistics_scan)))
+	{
+		Form_pg_statistic_ext chunk_stat_ext_form =
+			(Form_pg_statistic_ext) GETSTRUCT(extended_statistics_tuple);
+		Oid chunk_stat_ext_oid = chunk_stat_ext_form->oid;
+
+		/* Compare structure with hypertable extended statistics */
+		if (ts_extended_statistics_compare(chunk_stat_ext_oid, hypertable_stat_ext_oid))
+		{
+			matched_chunk_stat_ext_oid = chunk_stat_ext_oid;
+			break; /* Found first match, stop searching */
+		}
+	}
+
+	systable_endscan(extended_statistics_scan);
+	table_close(extended_statistics_relation, AccessShareLock);
+
+	return matched_chunk_stat_ext_oid;
+}
+
+/*
+ * Compare two extended statistics to determine if they have the same structure.
+ *
+ * Two extended statistics are considered structurally identical if they have:
+ * - Same stxkeys (column numbers)
+ * - Same stxkind (statistics types: d, f, m, e)
+ * - Same stxexprs (expressions, if any)
+ * - Matching name pattern (chunk statistics name contains hypertable statistics name)
+ *
+ * This function is similar to ts_indexing_compare() for indexes, but for
+ * extended statistics.
+ *
+ * Returns true if the extended statistics have identical structure, false otherwise.
+ */
+bool
+ts_extended_statistics_compare(Oid stat_ext_oid1, Oid stat_ext_oid2)
+{
+	HeapTuple stat_ext_tuple1;
+	HeapTuple stat_ext_tuple2;
+	Form_pg_statistic_ext stat_ext_form1;
+	Form_pg_statistic_ext stat_ext_form2;
+	bool columns_match;
+	bool kinds_match;
+	bool expressions_match;
+	bool name_pattern_match;
+
+	/* Fetch extended statistics tuples from system cache */
+	stat_ext_tuple1 = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(stat_ext_oid1));
+	if (!HeapTupleIsValid(stat_ext_tuple1))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("extended statistics with OID %u does not exist", stat_ext_oid1)));
+
+	stat_ext_tuple2 = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(stat_ext_oid2));
+	if (!HeapTupleIsValid(stat_ext_tuple2))
+	{
+		ReleaseSysCache(stat_ext_tuple1);
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("extended statistics with OID %u does not exist", stat_ext_oid2)));
+	}
+
+	/* Extract extended statistics form data */
+	stat_ext_form1 = (Form_pg_statistic_ext) GETSTRUCT(stat_ext_tuple1);
+	stat_ext_form2 = (Form_pg_statistic_ext) GETSTRUCT(stat_ext_tuple2);
+
+	/* Compare columns */
+	columns_match = compare_extended_statistics_columns(stat_ext_form1, stat_ext_form2);
+	if (!columns_match)
+	{
+		ReleaseSysCache(stat_ext_tuple1);
+		ReleaseSysCache(stat_ext_tuple2);
+		return false;
+	}
+
+	/* Compare extended statistics kinds */
+	kinds_match = compare_extended_statistics_kinds(stat_ext_tuple1, stat_ext_tuple2);
+	if (!kinds_match)
+	{
+		ReleaseSysCache(stat_ext_tuple1);
+		ReleaseSysCache(stat_ext_tuple2);
+		return false;
+	}
+
+	/* Compare expressions */
+	expressions_match = compare_extended_statistics_expressions(stat_ext_tuple1, stat_ext_tuple2);
+	if (!expressions_match)
+	{
+		ReleaseSysCache(stat_ext_tuple1);
+		ReleaseSysCache(stat_ext_tuple2);
+		return false;
+	}
+
+	/*
+	 * Compare name patterns to ensure chunk statistics matches hypertable statistics.
+	 * Chunk statistics are named: {chunk_prefix}_{hypertable_stat_name}[_{number}]
+	 * For example:
+	 *   Hypertable: multi_drop_stat1
+	 *   Chunk:      _hyper_5_12_chunk_multi_drop_stat1
+	 *   Chunk (dup): _hyper_5_12_chunk_multi_drop_stat1_1
+	 *
+	 * We check if stat1 (chunk) name contains "_{stat2_name}" pattern,
+	 * optionally followed by "_digits" suffix.
+	 */
+	name_pattern_match = compare_extended_statistics_name_pattern(NameStr(stat_ext_form1->stxname),
+																  NameStr(stat_ext_form2->stxname));
+	if (!name_pattern_match)
+	{
+		ReleaseSysCache(stat_ext_tuple1);
+		ReleaseSysCache(stat_ext_tuple2);
+		return false;
+	}
+
+	/* All checks passed - extended statistics are structurally identical */
+	ReleaseSysCache(stat_ext_tuple1);
+	ReleaseSysCache(stat_ext_tuple2);
+	return true;
+}
+
+/*
+ * Compare stxkeys (column numbers) of two extended statistics.
+ *
+ * Returns true if both extended statistics target the same columns in the same order.
+ */
+static bool
+compare_extended_statistics_columns(Form_pg_statistic_ext stat_ext_form1,
+									Form_pg_statistic_ext stat_ext_form2)
+{
+	int num_columns_stat_ext1;
+	int num_columns_stat_ext2;
+
+	num_columns_stat_ext1 = stat_ext_form1->stxkeys.dim1;
+	num_columns_stat_ext2 = stat_ext_form2->stxkeys.dim1;
+
+	/* Check if both extended statistics have the same number of columns */
+	if (num_columns_stat_ext1 != num_columns_stat_ext2)
+		return false;
+
+	/* Compare each column number */
+	for (int i = 0; i < num_columns_stat_ext1; i++)
+	{
+		if (stat_ext_form1->stxkeys.values[i] != stat_ext_form2->stxkeys.values[i])
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * Compare stxkind (statistics types) of two extended statistics.
+ *
+ * stxkind is an array of char values like {'d', 'f', 'm', 'e'} representing:
+ * - 'd': ndistinct
+ * - 'f': dependencies
+ * - 'm': mcv (most common values)
+ * - 'e': expressions
+ *
+ * Returns true if both extended statistics have the same types in the same order.
+ */
+static bool
+compare_extended_statistics_kinds(HeapTuple stat_ext_tuple1, HeapTuple stat_ext_tuple2)
+{
+	Datum stxkind_datum_stat_ext1;
+	Datum stxkind_datum_stat_ext2;
+	bool stxkind_isnull_stat_ext1;
+	bool stxkind_isnull_stat_ext2;
+	ArrayType *stxkind_array_stat_ext1;
+	ArrayType *stxkind_array_stat_ext2;
+	int num_kinds_stat_ext1;
+	int num_kinds_stat_ext2;
+	char *stxkind_data_stat_ext1;
+	char *stxkind_data_stat_ext2;
+
+	/* Fetch stxkind attribute from both extended statistics tuples */
+	stxkind_datum_stat_ext1 = SysCacheGetAttr(STATEXTOID,
+											  stat_ext_tuple1,
+											  Anum_pg_statistic_ext_stxkind,
+											  &stxkind_isnull_stat_ext1);
+	stxkind_datum_stat_ext2 = SysCacheGetAttr(STATEXTOID,
+											  stat_ext_tuple2,
+											  Anum_pg_statistic_ext_stxkind,
+											  &stxkind_isnull_stat_ext2);
+
+	/* Check if both are NULL or both are NOT NULL */
+	if (stxkind_isnull_stat_ext1 != stxkind_isnull_stat_ext2)
+		return false;
+
+	/* If both are NULL, they match */
+	if (stxkind_isnull_stat_ext1)
+		return true;
+
+	/* Both have stxkind, compare the arrays */
+	stxkind_array_stat_ext1 = DatumGetArrayTypeP(stxkind_datum_stat_ext1);
+	stxkind_array_stat_ext2 = DatumGetArrayTypeP(stxkind_datum_stat_ext2);
+
+	num_kinds_stat_ext1 = ARR_DIMS(stxkind_array_stat_ext1)[0];
+	num_kinds_stat_ext2 = ARR_DIMS(stxkind_array_stat_ext2)[0];
+
+	/* Check if both have the same number of kinds */
+	if (num_kinds_stat_ext1 != num_kinds_stat_ext2)
+		return false;
+
+	/* Compare each kind character */
+	stxkind_data_stat_ext1 = ARR_DATA_PTR(stxkind_array_stat_ext1);
+	stxkind_data_stat_ext2 = ARR_DATA_PTR(stxkind_array_stat_ext2);
+
+	for (int i = 0; i < num_kinds_stat_ext1; i++)
+	{
+		if (stxkind_data_stat_ext1[i] != stxkind_data_stat_ext2[i])
+			return false;
+	}
+
+	return true;
+}
+
+/*
+ * Compare stxexprs (expression trees) of two extended statistics.
+ *
+ * For expression extended statistics like:
+ *   CREATE STATISTICS stat ON (a + b), (c * 2) FROM table;
+ *
+ * Returns true if both extended statistics have identical expression trees.
+ */
+static bool
+compare_extended_statistics_expressions(HeapTuple stat_ext_tuple1, HeapTuple stat_ext_tuple2)
+{
+	Datum stxexprs_datum_stat_ext1;
+	Datum stxexprs_datum_stat_ext2;
+	bool stxexprs_isnull_stat_ext1;
+	bool stxexprs_isnull_stat_ext2;
+	List *expression_list_stat_ext1;
+	List *expression_list_stat_ext2;
+
+	/* Fetch stxexprs attribute from both extended statistics tuples */
+	stxexprs_datum_stat_ext1 = SysCacheGetAttr(STATEXTOID,
+											   stat_ext_tuple1,
+											   Anum_pg_statistic_ext_stxexprs,
+											   &stxexprs_isnull_stat_ext1);
+	stxexprs_datum_stat_ext2 = SysCacheGetAttr(STATEXTOID,
+											   stat_ext_tuple2,
+											   Anum_pg_statistic_ext_stxexprs,
+											   &stxexprs_isnull_stat_ext2);
+
+	/* Check if both are NULL or both are NOT NULL */
+	if (stxexprs_isnull_stat_ext1 != stxexprs_isnull_stat_ext2)
+		return false;
+
+	/* If both are NULL, they match */
+	if (stxexprs_isnull_stat_ext1)
+		return true;
+
+	/*
+	 * Parse and compare expression trees in a short-lived context so that
+	 * the allocated node trees are freed when we're done, avoiding transaction
+	 * memory buildup when comparing many extended statistics.
+	 */
+	{
+		MemoryContext old_ctx;
+		MemoryContext expr_ctx;
+		bool result;
+
+		expr_ctx = AllocSetContextCreate(CurrentMemoryContext,
+										 "compare extended statistics expressions",
+										 ALLOCSET_SMALL_SIZES);
+		old_ctx = MemoryContextSwitchTo(expr_ctx);
+
+		expression_list_stat_ext1 =
+			(List *) stringToNode(TextDatumGetCString(stxexprs_datum_stat_ext1));
+		expression_list_stat_ext2 =
+			(List *) stringToNode(TextDatumGetCString(stxexprs_datum_stat_ext2));
+
+		result = equal(expression_list_stat_ext1, expression_list_stat_ext2);
+
+		MemoryContextSwitchTo(old_ctx);
+		MemoryContextDelete(expr_ctx);
+
+		return result;
+	}
+}
+
+/*
+ * Compare name patterns to determine if chunk statistics matches hypertable statistics.
+ *
+ * Chunk statistics are named following the pattern:
+ *   {chunk_table_name}_{hypertable_stat_name}[_{number}]
+ *
+ * Examples:
+ *   Hypertable stat: multi_drop_stat1
+ *   Chunk stat:      _hyper_5_12_chunk_multi_drop_stat1
+ *   Chunk stat (dup): _hyper_5_12_chunk_multi_drop_stat1_1
+ *
+ * This function checks if chunk_stat_name contains "_{hypertable_stat_name}"
+ * pattern, optionally followed by "_{digits}" suffix for duplicate resolution.
+ *
+ * Returns true if the name pattern matches, false otherwise.
+ */
+static bool
+compare_extended_statistics_name_pattern(const char *chunk_stat_name,
+										 const char *hypertable_stat_name)
+{
+	const char *pattern_pos;
+	const char *suffix_pos;
+	size_t chunk_name_len;
+	size_t hypertable_name_len;
+
+	if (chunk_stat_name == NULL || hypertable_stat_name == NULL)
+		return false;
+
+	chunk_name_len = strlen(chunk_stat_name);
+	hypertable_name_len = strlen(hypertable_stat_name);
+
+	/* Chunk name must be longer than hypertable name (has prefix) */
+	if (chunk_name_len <= hypertable_name_len)
+		return false;
+
+	/* Find hypertable_stat_name within chunk_stat_name */
+	pattern_pos = strstr(chunk_stat_name, hypertable_stat_name);
+	if (pattern_pos == NULL)
+		return false;
+
+	/* Check if hypertable_stat_name is preceded by underscore */
+	if (pattern_pos == chunk_stat_name || *(pattern_pos - 1) != '_')
+		return false;
+
+	/* Check what comes after hypertable_stat_name */
+	suffix_pos = pattern_pos + hypertable_name_len;
+
+	/* If it's the end of string, it's a perfect match */
+	if (*suffix_pos == '\0')
+		return true;
+
+	/* If not the end, it must be "_digits" pattern (duplicate resolution) */
+	if (*suffix_pos != '_')
+		return false;
+
+	/* Skip the underscore */
+	suffix_pos++;
+
+	/* Verify that the rest is all digits */
+	while (*suffix_pos != '\0')
+	{
+		if (!isdigit((unsigned char) *suffix_pos))
+			return false;
+		suffix_pos++;
+	}
+
+	return true;
+}
+
+/*
+ * Get the relation OID that an extended statistics object belongs to.
+ *
+ * Given an extended statistics OID, returns the OID of the table that the
+ * extended statistics object is defined on (stxrelid from pg_statistic_ext).
+ *
+ * Returns InvalidOid if the extended statistics object doesn't exist.
+ */
+Oid
+ts_get_relation_from_extended_statistics(Oid stat_ext_oid)
+{
+	HeapTuple stat_ext_tuple;
+	Form_pg_statistic_ext stat_ext_form;
+	Oid relid;
+
+	/* Fetch extended statistics tuple from system cache */
+	stat_ext_tuple = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(stat_ext_oid));
+	if (!HeapTupleIsValid(stat_ext_tuple))
+		return InvalidOid;
+
+	stat_ext_form = (Form_pg_statistic_ext) GETSTRUCT(stat_ext_tuple);
+	relid = stat_ext_form->stxrelid;
+
+	ReleaseSysCache(stat_ext_tuple);
+
+	return relid;
+}
+
+/*
+ * Rename chunk extended statistics to match the new hypertable statistics name.
+ *
+ * This function is called when a hypertable extended statistics is renamed.
+ * It finds the corresponding chunk extended statistics and renames them to
+ * maintain naming consistency.
+ *
+ * Similar to ts_chunk_index_rename() for indexes.
+ */
+void
+ts_chunk_extended_statistics_rename(Hypertable *ht, Oid hypertable_stat_oid, const char *new_name)
+{
+	List *chunks = ts_chunk_get_by_hypertable_id(ht->fd.id);
+	ListCell *lc;
+
+	foreach (lc, chunks)
+	{
+		Chunk *chunk = lfirst(lc);
+		if (!OidIsValid(chunk->table_id))
+			continue;
+
+		/* Find matching extended statistics on chunk using structural comparison */
+		Oid chunk_stat_oid =
+			ts_chunk_extended_statistics_get_by_hypertable_relid(chunk->table_id,
+																 hypertable_stat_oid);
+
+		if (OidIsValid(chunk_stat_oid))
+		{
+			Oid chunk_schemaoid = get_namespace_oid(NameStr(chunk->fd.schema_name), false);
+			HeapTuple old_tuple;
+			HeapTuple new_tuple;
+			Relation catalog;
+			Datum values[Natts_pg_statistic_ext];
+			bool isnull[Natts_pg_statistic_ext];
+			bool replace[Natts_pg_statistic_ext] = { false };
+			NameData name_data;
+
+			/* Generate new name: {chunk_table_name}_{new_name} */
+			const char *chunk_new_name =
+				chunk_extended_statistics_choose_name(NameStr(chunk->fd.table_name),
+													  new_name,
+													  chunk_schemaoid);
+
+			/* Open pg_statistic_ext catalog */
+			catalog = table_open(StatisticExtRelationId, RowExclusiveLock);
+
+			/* Fetch the old tuple */
+			old_tuple = SearchSysCache1(STATEXTOID, ObjectIdGetDatum(chunk_stat_oid));
+			if (!HeapTupleIsValid(old_tuple))
+				elog(ERROR, "cache lookup failed for statistics object %u", chunk_stat_oid);
+
+			/* Deform the tuple */
+			heap_deform_tuple(old_tuple, RelationGetDescr(catalog), values, isnull);
+
+			/* Replace the name */
+			namestrcpy(&name_data, chunk_new_name);
+			values[AttrNumberGetAttrOffset(Anum_pg_statistic_ext_stxname)] =
+				NameGetDatum(&name_data);
+			replace[AttrNumberGetAttrOffset(Anum_pg_statistic_ext_stxname)] = true;
+
+			/* Create new tuple and update catalog */
+			new_tuple =
+				heap_modify_tuple(old_tuple, RelationGetDescr(catalog), values, isnull, replace);
+			CatalogTupleUpdate(catalog, &new_tuple->t_self, new_tuple);
+
+			/* Cleanup */
+			heap_freetuple(new_tuple);
+			ReleaseSysCache(old_tuple);
+			table_close(catalog, RowExclusiveLock);
+
+			/* Invalidate cache */
+			CommandCounterIncrement();
+		}
+	}
+}

--- a/src/chunk_statistics.h
+++ b/src/chunk_statistics.h
@@ -1,0 +1,71 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+
+typedef struct Chunk Chunk;
+typedef struct Hypertable Hypertable;
+
+/*
+ * Create all extended statistics on a chunk, given the extended statistics
+ * that exist on the chunk's hypertable.
+ *
+ * Similar to ts_chunk_index_create_all() for indexes.
+ */
+extern void ts_chunk_extended_statistics_create_all(int32 hypertable_id, Oid hypertable_relid,
+													int32 chunk_id, Oid chunk_relid);
+
+/*
+ * Create a specific extended statistics on a chunk by name.
+ *
+ * Used for DDL propagation (CREATE STATISTICS on hypertable).
+ */
+extern void ts_chunk_extended_statistics_create_from_stat(Oid hypertable_relid, Oid chunk_relid,
+														  const char *stat_ext_name);
+
+/*
+ * Find a chunk extended statistics that matches the structure of a hypertable
+ * extended statistics.
+ *
+ * This function searches through all extended statistics on the chunk and returns
+ * the OID of the first statistics that has the same structure as the hypertable
+ * extended statistics.
+ *
+ * Returns InvalidOid if no matching extended statistics is found.
+ */
+extern Oid ts_chunk_extended_statistics_get_by_hypertable_relid(Oid chunk_relid,
+																Oid hypertable_stat_ext_oid);
+
+/*
+ * Compare two extended statistics to determine if they have the same structure.
+ *
+ * Two extended statistics are considered structurally identical if they have:
+ * - Same stxkeys (column numbers)
+ * - Same stxkind (statistics types: d, f, m, e)
+ * - Same stxexprs (expressions, if any)
+ *
+ * Returns true if the extended statistics have identical structure, false otherwise.
+ */
+extern bool ts_extended_statistics_compare(Oid stat_ext_oid1, Oid stat_ext_oid2);
+
+/*
+ * Get the relation OID that an extended statistics object belongs to.
+ *
+ * Given an extended statistics OID, returns the OID of the table that the
+ * extended statistics object is defined on (stxrelid from pg_statistic_ext).
+ *
+ * Returns InvalidOid if the extended statistics object doesn't exist.
+ */
+extern Oid ts_get_relation_from_extended_statistics(Oid stat_ext_oid);
+
+/*
+ * Rename chunk extended statistics to match the new hypertable statistics name.
+ *
+ * Similar to ts_chunk_index_rename() for indexes.
+ */
+extern void ts_chunk_extended_statistics_rename(Hypertable *ht, Oid hypertable_stat_oid,
+												const char *new_name);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -16,6 +16,7 @@
 #include <catalog/pg_class_d.h>
 #include <catalog/pg_constraint.h>
 #include <catalog/pg_inherits.h>
+#include <catalog/pg_statistic_ext.h>
 #include <catalog/pg_trigger.h>
 #include <commands/alter.h>
 #include <commands/cluster.h>
@@ -59,28 +60,25 @@
 #include "annotations.h"
 #include "chunk.h"
 #include "chunk_index.h"
+#include "chunk_statistics.h"
 #include "copy.h"
 #include "cross_module_fn.h"
 #include "debug_assert.h"
 #include "debug_point.h"
-#include "dimension_vector.h"
 #include "errors.h"
 #include "event_trigger.h"
 #include "export.h"
 #include "extension.h"
 #include "extension_constants.h"
 #include "foreign_key.h"
-#include "hypercube.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
 #include "indexing.h"
 #include "license_guc.h"
 #include "partition_chunk.h"
-#include "partitioning.h"
 #include "process_utility.h"
 #include "scan_iterator.h"
 #include "time_utils.h"
-#include "trigger.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/chunk_column_stats.h"
@@ -1728,6 +1726,98 @@ process_drop_hypertable_index(ProcessUtilityArgs *args, DropStmt *stmt)
 	ts_cache_release(&hcache);
 }
 
+/*
+ * Add chunk extended statistics to the drop list when dropping a hypertable
+ * extended statistics.
+ *
+ * When dropping an extended statistics object on a hypertable, we need to also
+ * drop the corresponding extended statistics on all chunks. This function finds
+ * matching chunk extended statistics using structural comparison and adds them
+ * to the drop list.
+ *
+ * Similar to process_drop_hypertable_index() for indexes.
+ */
+static void
+process_drop_hypertable_extended_statistics(ProcessUtilityArgs *args, DropStmt *stmt)
+{
+	Cache *hypertable_cache = ts_hypertable_cache_pin();
+	ListCell *object_cell;
+	List *chunk_stats_to_drop = NIL;
+
+	foreach (object_cell, stmt->objects)
+	{
+		List *stat_name_parts = lfirst(object_cell);
+		Oid hypertable_relid, extended_statistics_oid;
+		Hypertable *hypertable;
+
+		/* Get extended statistics OID */
+		extended_statistics_oid = get_statistics_object_oid(stat_name_parts, true);
+		if (!OidIsValid(extended_statistics_oid))
+			continue;
+
+		/* Get the table that this extended statistics object belongs to */
+		hypertable_relid = ts_get_relation_from_extended_statistics(extended_statistics_oid);
+		if (!OidIsValid(hypertable_relid))
+			continue;
+
+		/* Check if it's a hypertable */
+		hypertable = ts_hypertable_cache_get_entry(hypertable_cache,
+												   hypertable_relid,
+												   CACHE_FLAG_MISSING_OK);
+		if (hypertable)
+		{
+			List *chunks = ts_chunk_get_by_hypertable_id(hypertable->fd.id);
+			ListCell *chunk_cell;
+
+			foreach (chunk_cell, chunks)
+			{
+				Chunk *chunk = lfirst(chunk_cell);
+				if (!OidIsValid(chunk->table_id))
+					continue;
+
+				/* Find matching extended statistics on chunk using structural comparison */
+				Oid chunk_extended_statistics_oid =
+					ts_chunk_extended_statistics_get_by_hypertable_relid(chunk->table_id,
+																		 extended_statistics_oid);
+
+				if (OidIsValid(chunk_extended_statistics_oid))
+				{
+					HeapTuple chunk_stat_tuple;
+					Form_pg_statistic_ext chunk_stat_form;
+
+					/* Get chunk extended statistics metadata from pg_statistic_ext */
+					chunk_stat_tuple =
+						SearchSysCache1(STATEXTOID,
+										ObjectIdGetDatum(chunk_extended_statistics_oid));
+					if (!HeapTupleIsValid(chunk_stat_tuple))
+						continue; /* Should not happen, but skip if it does */
+
+					chunk_stat_form = (Form_pg_statistic_ext) GETSTRUCT(chunk_stat_tuple);
+
+					/* Get schema and statistics names */
+					char *schema_name = get_namespace_name(chunk_stat_form->stxnamespace);
+					char *extended_statistics_name = pstrdup(NameStr(chunk_stat_form->stxname));
+
+					/* Add to separate list (avoid modifying list being iterated) */
+					chunk_stats_to_drop = lappend(chunk_stats_to_drop,
+												  list_make2(makeString(schema_name),
+															 makeString(extended_statistics_name)));
+
+					ReleaseSysCache(chunk_stat_tuple);
+				}
+			}
+		}
+	}
+
+	/* Now append all chunk statistics to the drop list */
+	foreach (object_cell, chunk_stats_to_drop)
+	{
+		stmt->objects = lappend(stmt->objects, lfirst(object_cell));
+	}
+
+	ts_cache_release(&hypertable_cache);
+}
+
 /* Note that DROP TABLESPACE does not have a hook in event triggers so cannot go
  * through process_ddl_sql_drop */
 static DDLResult
@@ -2134,6 +2224,9 @@ process_drop_start(ProcessUtilityArgs *args)
 		case OBJECT_INDEX:
 			process_drop_hypertable_index(args, stmt);
 			break;
+		case OBJECT_STATISTIC_EXT:
+			process_drop_hypertable_extended_statistics(args, stmt);
+			break;
 		case OBJECT_MATVIEW:
 			process_drop_continuous_aggregates(args, stmt);
 			break;
@@ -2414,6 +2507,23 @@ process_rename_index(ProcessUtilityArgs *args, Cache *hcache, Oid relid, RenameS
 	}
 }
 
+static void
+process_rename_extended_statistics(ProcessUtilityArgs *args, Cache *hcache, Oid relid,
+								   RenameStmt *stmt)
+{
+	Oid tablerelid = ts_get_relation_from_extended_statistics(relid);
+	Hypertable *ht;
+
+	if (!OidIsValid(tablerelid))
+		return;
+
+	ht = ts_hypertable_cache_get_entry(hcache, tablerelid, CACHE_FLAG_MISSING_OK);
+	if (ht)
+	{
+		ts_chunk_extended_statistics_rename(ht, relid, stmt->newname);
+	}
+}
+
 /* Visit all internal catalog tables with a schema column to check for applicable rename */
 static void
 process_rename_schema(RenameStmt *stmt)
@@ -2555,8 +2665,14 @@ process_rename(ProcessUtilityArgs *args)
 	Oid relid = InvalidOid;
 	Cache *hcache;
 
-	/* Only get the relid if it exists for this stmt */
-	if (NULL != stmt->relation)
+	/* Get the relid based on object type */
+	if (stmt->renameType == OBJECT_STATISTIC_EXT && stmt->object != NULL)
+	{
+		relid = get_statistics_object_oid(castNode(List, stmt->object), true);
+		if (!OidIsValid(relid))
+			return DDL_CONTINUE;
+	}
+	else if (NULL != stmt->relation)
 	{
 		relid = RangeVarGetRelid(stmt->relation, NoLock, true);
 		if (!OidIsValid(relid))
@@ -2575,6 +2691,9 @@ process_rename(ProcessUtilityArgs *args)
 			break;
 		case OBJECT_INDEX:
 			process_rename_index(args, hcache, relid, stmt);
+			break;
+		case OBJECT_STATISTIC_EXT:
+			process_rename_extended_statistics(args, hcache, relid, stmt);
 			break;
 		case OBJECT_TABCONSTRAINT:
 		case OBJECT_TRIGGER:
@@ -3581,6 +3700,147 @@ process_index_start(ProcessUtilityArgs *args)
 	DEBUG_WAITPOINT("process_index_start_indexing_done");
 
 	return DDL_DONE;
+}
+
+/*
+ * Argument for CREATE STATISTICS (extended statistics) chunk propagation callback
+ */
+typedef struct CreateExtendedStatisticsChunkArg
+{
+	Oid hypertable_relid;
+	const char *extended_statistics_name;
+} CreateExtendedStatisticsChunkArg;
+
+/*
+ * Callback for foreach_chunk to create extended statistics on a single chunk.
+ */
+static void process_create_extended_statistics_chunk(Hypertable *hypertable, Oid chunk_relid,
+													 void *arg);
+
+/*
+ * Handle CREATE STATISTICS (extended statistics) on a hypertable.
+ *
+ * Propagates the extended statistics to all chunks of the hypertable.
+ * Pattern follows process_index_start.
+ */
+static DDLResult
+process_create_extended_statistics_start(ProcessUtilityArgs *args)
+{
+	CreateStatsStmt *stmt = (CreateStatsStmt *) args->parsetree;
+	RangeVar *relation;
+	Cache *hypertable_cache;
+	Hypertable *hypertable;
+	ContinuousAgg *continuous_agg = NULL;
+	CreateExtendedStatisticsChunkArg chunk_arg;
+
+	Assert(IsA(stmt, CreateStatsStmt));
+
+	/* CREATE STATISTICS (extended) supports only single table */
+	if (stmt->relations == NIL || list_length(stmt->relations) != 1)
+		return DDL_CONTINUE;
+
+	/* Skip non-plain-relation FROM clauses (subqueries, VALUES, functions, JOINs,
+	 * TABLESAMPLE, XMLTABLE, JSON_TABLE, etc.) — let PostgreSQL handle them. */
+	if (!IsA(linitial(stmt->relations), RangeVar))
+		return DDL_CONTINUE;
+
+	relation = linitial_node(RangeVar, stmt->relations);
+
+	hypertable_cache = ts_hypertable_cache_pin();
+	hypertable = ts_hypertable_cache_get_entry_rv(hypertable_cache, relation);
+
+	if (!hypertable)
+	{
+		/* Check if the relation is a Continuous Aggregate */
+		continuous_agg = ts_continuous_agg_find_by_rv(relation);
+
+		if (continuous_agg)
+		{
+			hypertable = ts_hypertable_get_by_id(continuous_agg->data.mat_hypertable_id);
+		}
+
+		if (!hypertable)
+		{
+			ts_cache_release(&hypertable_cache);
+			return DDL_CONTINUE;
+		}
+
+		/* Replace relation with materialization hypertable */
+		stmt->relations = list_make1(makeRangeVar(NameStr(hypertable->fd.schema_name),
+												  NameStr(hypertable->fd.table_name),
+												  -1));
+	}
+
+	ts_hypertable_permissions_check_by_id(hypertable->fd.id);
+
+	/* Check if extended statistics already exists (for IF NOT EXISTS handling) */
+#if PG16_LT
+	List *stat_ext_names = stringToQualifiedNameList(NameListToString(stmt->defnames));
+#else
+	List *stat_ext_names = stringToQualifiedNameList(NameListToString(stmt->defnames), NULL);
+#endif
+	Oid stat_ext_oid_before = get_statistics_object_oid(stat_ext_names, true);
+	list_free(stat_ext_names);
+
+	/* Create extended statistics on hypertable (PostgreSQL default handling) */
+	prev_ProcessUtility(args);
+
+	/* Propagate to all existing chunks only if extended statistics was newly created */
+	if (!OidIsValid(stat_ext_oid_before))
+	{
+		chunk_arg.hypertable_relid = hypertable->main_table_relid;
+		chunk_arg.extended_statistics_name = NameListToString(stmt->defnames);
+
+		CatalogSecurityContext security_context;
+		Relation hypertable_rel = table_open(hypertable->main_table_relid, AccessShareLock);
+		Oid hypertable_owner = hypertable_rel->rd_rel->relowner;
+		table_close(hypertable_rel, AccessShareLock);
+
+		GetUserIdAndSecContext(&security_context.saved_uid,
+							   &security_context.saved_security_context);
+		if (security_context.saved_uid != hypertable_owner)
+			SetUserIdAndSecContext(hypertable_owner,
+								   security_context.saved_security_context |
+									   SECURITY_LOCAL_USERID_CHANGE);
+
+		foreach_chunk(hypertable, process_create_extended_statistics_chunk, &chunk_arg);
+
+		/* Restore original user */
+		if (security_context.saved_uid != hypertable_owner)
+			SetUserIdAndSecContext(security_context.saved_uid,
+								   security_context.saved_security_context);
+	}
+
+	ts_cache_release(&hypertable_cache);
+
+	return DDL_DONE;
+}
+
+/*
+ * Callback for foreach_chunk to create extended statistics on a single chunk.
+ */
+static void
+process_create_extended_statistics_chunk(Hypertable *hypertable, Oid chunk_relid, void *arg)
+{
+	CreateExtendedStatisticsChunkArg *chunk_arg = (CreateExtendedStatisticsChunkArg *) arg;
+	Chunk *chunk;
+
+	/* Skip inheritance children that are not TimescaleDB chunks */
+	chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	if (chunk == NULL)
+		return;
+
+	/* OSM (tiered) chunks don't support extended statistics */
+	if (IS_OSM_CHUNK(chunk))
+	{
+		ereport(NOTICE, (errmsg("skipping extended statistics creation for tiered data")));
+		return;
+	}
+
+	/* Create the specific extended statistics on this chunk */
+	ts_chunk_extended_statistics_create_from_stat(chunk_arg->hypertable_relid,
+												  chunk_relid,
+												  chunk_arg->extended_statistics_name);
 }
 
 static int
@@ -5498,6 +5758,9 @@ process_ddl_command_start(ProcessUtilityArgs *args)
 			break;
 		case T_CreateTrigStmt:
 			handler = process_create_trigger_start;
+			break;
+		case T_CreateStatsStmt:
+			handler = process_create_extended_statistics_start;
 			break;
 		case T_RuleStmt:
 			handler = process_create_rule_start;

--- a/test/expected/create_statistics.out
+++ b/test/expected/create_statistics.out
@@ -1,0 +1,338 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- =============================================
+-- Test: CREATE STATISTICS propagation to chunks
+-- Complete test coverage for Issue #2433
+-- =============================================
+\set ON_ERROR_STOP 0
+-- =============================================
+-- Setup: Create schemas and tables
+-- =============================================
+-- =============================================
+-- Test Group 1: Basic CREATE STATISTICS Propagation
+-- =============================================
+-- Setup: Main test table
+CREATE TABLE stats_test (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER,
+    temp FLOAT,
+    humidity FLOAT,
+    location TEXT
+);
+SELECT create_hypertable('stats_test', 'time', chunk_time_interval => INTERVAL '1 day');
+    create_hypertable    
+-------------------------
+ (1,public,stats_test,t)
+
+-- Insert data to create 3 chunks
+INSERT INTO stats_test VALUES
+    ('2024-01-01 00:00:00', 1, 20.5, 65.0, 'room_a'),
+    ('2024-01-02 00:00:00', 2, 21.0, 70.0, 'room_b'),
+    ('2024-01-03 00:00:00', 3, 19.5, 68.0, 'room_c');
+-- Verify 3 chunks created
+SELECT count(*) AS chunk_count FROM show_chunks('stats_test');
+ chunk_count 
+-------------
+           3
+
+-- =============================================
+-- Test 1: Basic CREATE STATISTICS propagation
+-- =============================================
+SELECT '=== Test 1: Basic CREATE STATISTICS ===' AS test_name;
+                test_name                
+-----------------------------------------
+ === Test 1: Basic CREATE STATISTICS ===
+
+CREATE STATISTICS stats_test_stat ON device_id, temp FROM stats_test;
+-- Should have 4 statistics: 1 on hypertable + 3 on chunks
+SELECT count(*) AS stat_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%stats_test_stat%';
+ stat_count 
+------------
+          4
+
+-- =============================================
+-- Test 2: CREATE STATISTICS IF NOT EXISTS
+-- =============================================
+SELECT '=== Test 2: IF NOT EXISTS ===' AS test_name;
+           test_name           
+-------------------------------
+ === Test 2: IF NOT EXISTS ===
+
+-- Should produce NOTICE, not error
+CREATE STATISTICS IF NOT EXISTS stats_test_stat ON device_id, temp FROM stats_test;
+NOTICE:  statistics object "stats_test_stat" already exists, skipping
+-- Count should remain the same
+SELECT count(*) AS stat_count_after_if_not_exists
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%stats_test_stat%';
+ stat_count_after_if_not_exists 
+--------------------------------
+                              4
+
+-- =============================================
+-- Test 3: Multiple column statistics with specific kinds
+-- =============================================
+SELECT '=== Test 3: Statistics with kinds (ndistinct, dependencies, mcv) ===' AS test_name;
+                              test_name                               
+----------------------------------------------------------------------
+ === Test 3: Statistics with kinds (ndistinct, dependencies, mcv) ===
+
+CREATE STATISTICS stats_test_ndistinct (ndistinct) ON device_id, temp FROM stats_test;
+CREATE STATISTICS stats_test_deps (dependencies) ON device_id, temp FROM stats_test;
+CREATE STATISTICS stats_test_mcv (mcv) ON device_id, temp FROM stats_test;
+-- Each should have 4 entries
+SELECT s.stxname, count(*) AS count
+FROM pg_statistic_ext s
+WHERE s.stxname IN ('stats_test_ndistinct', 'stats_test_deps', 'stats_test_mcv')
+   OR s.stxname LIKE '_hyper_%stats_test_ndistinct%'
+   OR s.stxname LIKE '_hyper_%stats_test_deps%'
+   OR s.stxname LIKE '_hyper_%stats_test_mcv%'
+GROUP BY s.stxname
+ORDER BY s.stxname;
+                stxname                | count 
+---------------------------------------+-------
+ _hyper_1_1_chunk_stats_test_deps      |     1
+ _hyper_1_1_chunk_stats_test_mcv       |     1
+ _hyper_1_1_chunk_stats_test_ndistinct |     1
+ _hyper_1_2_chunk_stats_test_deps      |     1
+ _hyper_1_2_chunk_stats_test_mcv       |     1
+ _hyper_1_2_chunk_stats_test_ndistinct |     1
+ _hyper_1_3_chunk_stats_test_deps      |     1
+ _hyper_1_3_chunk_stats_test_mcv       |     1
+ _hyper_1_3_chunk_stats_test_ndistinct |     1
+ stats_test_deps                       |     1
+ stats_test_mcv                        |     1
+ stats_test_ndistinct                  |     1
+
+-- =============================================
+-- Test 4: New chunk gets statistics automatically
+-- =============================================
+SELECT '=== Test 4: New chunk propagation ===' AS test_name;
+               test_name               
+---------------------------------------
+ === Test 4: New chunk propagation ===
+
+-- Insert data to create a NEW chunk (4th day)
+INSERT INTO stats_test VALUES ('2024-01-04 00:00:00', 4, 22.0, 72.0, 'room_d');
+-- Verify 4 chunks now exist
+SELECT count(*) AS chunk_count_after FROM show_chunks('stats_test');
+ chunk_count_after 
+-------------------
+                 4
+
+-- Statistics should now be on 5 objects (1 hypertable + 4 chunks)
+SELECT count(*) AS after_new_chunk
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%stats_test_stat%';
+ after_new_chunk 
+-----------------
+               5
+
+-- =============================================
+-- Test 5: Multiple statistics on new chunk
+-- =============================================
+SELECT '=== Test 5: Multiple statistics on new chunk ===' AS test_name;
+                    test_name                     
+--------------------------------------------------
+ === Test 5: Multiple statistics on new chunk ===
+
+-- All statistics (stats_test_stat, ndistinct, deps, mcv) should be on new chunk
+-- Use show_chunks() to get the OID of the most recently created chunk
+SELECT count(*) AS stats_on_new_chunk
+FROM pg_statistic_ext s
+WHERE s.stxrelid = (
+    SELECT show_chunks FROM show_chunks('stats_test')
+    ORDER BY show_chunks DESC
+    LIMIT 1
+);
+ stats_on_new_chunk 
+--------------------
+                  4
+
+-- =============================================
+-- Test 6: Empty hypertable then insert
+-- =============================================
+SELECT '=== Test 6: Empty hypertable ===' AS test_name;
+            test_name             
+----------------------------------
+ === Test 6: Empty hypertable ===
+
+CREATE TABLE empty_stats_test (
+    time TIMESTAMPTZ NOT NULL,
+    val1 INTEGER,
+    val2 INTEGER
+);
+SELECT create_hypertable('empty_stats_test', 'time', chunk_time_interval => INTERVAL '1 day');
+       create_hypertable       
+-------------------------------
+ (2,public,empty_stats_test,t)
+
+-- Create statistics on empty table (no chunks yet)
+CREATE STATISTICS empty_stat ON val1, val2 FROM empty_stats_test;
+-- Should only be on hypertable (1)
+SELECT count(*) AS empty_stat_before
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%empty_stat%';
+ empty_stat_before 
+-------------------
+                 1
+
+-- Now insert data
+INSERT INTO empty_stats_test VALUES ('2024-01-01 00:00:00', 1, 2);
+-- Statistics should now be on 2 objects (1 hypertable + 1 chunk)
+SELECT count(*) AS empty_stat_after_insert
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%empty_stat%';
+ empty_stat_after_insert 
+-------------------------
+                       2
+
+-- =============================================
+-- Test Group 2: DROP STATISTICS Propagation
+-- =============================================
+-- =============================================
+-- Test 7: Basic DROP STATISTICS propagation
+-- =============================================
+SELECT '=== Test 7: DROP STATISTICS ===' AS test_name;
+            test_name            
+---------------------------------
+ === Test 7: DROP STATISTICS ===
+
+-- Create a statistics to drop
+CREATE STATISTICS drop_test_stat ON device_id, humidity FROM stats_test;
+SELECT count(*) AS before_drop
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%drop_test_stat%';
+ before_drop 
+-------------
+           5
+
+-- Drop it
+DROP STATISTICS drop_test_stat;
+-- All should be gone (hypertable + all chunks)
+SELECT count(*) AS after_drop
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%drop_test_stat%';
+ after_drop 
+------------
+          0
+
+-- =============================================
+-- Test 8: DROP one of multiple statistics
+-- =============================================
+SELECT '=== Test 8: Drop one of multiple ===' AS test_name;
+              test_name               
+--------------------------------------
+ === Test 8: Drop one of multiple ===
+
+-- Create two statistics
+CREATE STATISTICS multi_drop_stat1 ON device_id, temp FROM stats_test;
+CREATE STATISTICS multi_drop_stat2 ON device_id, humidity FROM stats_test;
+-- Count both
+SELECT count(*) AS before_partial_drop
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%multi_drop_stat%';
+ before_partial_drop 
+---------------------
+                  10
+
+-- Drop only one
+DROP STATISTICS multi_drop_stat1;
+-- Only stat2 should remain
+SELECT count(*) AS after_partial_drop
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%multi_drop_stat%';
+ after_partial_drop 
+--------------------
+                  5
+
+-- Verify stat2 still exists
+SELECT count(*) AS stat2_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%multi_drop_stat2%';
+ stat2_count 
+-------------
+           5
+
+-- Cleanup
+DROP STATISTICS multi_drop_stat2;
+-- =============================================
+-- Test Group 3: RENAME STATISTICS Propagation
+-- =============================================
+-- =============================================
+-- Test 9: Basic RENAME STATISTICS propagation
+-- =============================================
+SELECT '=== Test 9: RENAME STATISTICS ===' AS test_name;
+             test_name             
+-----------------------------------
+ === Test 9: RENAME STATISTICS ===
+
+CREATE STATISTICS rename_test_stat ON device_id, temp FROM stats_test;
+-- Rename the statistics
+ALTER STATISTICS rename_test_stat RENAME TO renamed_stat;
+-- Old name should have 0
+SELECT count(*) AS old_name_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%rename_test_stat%';
+ old_name_count 
+----------------
+              0
+
+-- New name should have all (hypertable + chunks)
+SELECT count(*) AS new_name_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%renamed_stat%';
+ new_name_count 
+----------------
+              5
+
+-- Cleanup
+DROP STATISTICS renamed_stat;
+-- =============================================
+-- Test Group 4: Expression and Edge Cases
+-- =============================================
+-- =============================================
+-- Test 10: Expression in CREATE STATISTICS
+-- =============================================
+SELECT '=== Test 10: Expression in CREATE STATISTICS ===' AS test_name;
+                    test_name                     
+--------------------------------------------------
+ === Test 10: Expression in CREATE STATISTICS ===
+
+-- Create statistics with expression
+CREATE STATISTICS stats_test_expr ON (device_id + temp), humidity FROM stats_test;
+-- Expression statistics should be propagated to all chunks
+SELECT
+    stxrelid::regclass AS table_name,
+    stxname AS statistics_name,
+    stxkind AS stat_types
+FROM pg_statistic_ext
+WHERE stxname LIKE '%stats_test_expr%'
+ORDER BY stxrelid;
+               table_name               |         statistics_name          | stat_types 
+----------------------------------------+----------------------------------+------------
+ stats_test                             | stats_test_expr                  | {d,f,m,e}
+ _timescaledb_internal._hyper_1_1_chunk | _hyper_1_1_chunk_stats_test_expr | {d,f,m,e}
+ _timescaledb_internal._hyper_1_2_chunk | _hyper_1_2_chunk_stats_test_expr | {d,f,m,e}
+ _timescaledb_internal._hyper_1_3_chunk | _hyper_1_3_chunk_stats_test_expr | {d,f,m,e}
+ _timescaledb_internal._hyper_1_4_chunk | _hyper_1_4_chunk_stats_test_expr | {d,f,m,e}
+
+-- =============================================
+-- Cleanup
+-- =============================================
+SELECT '=== Cleanup ===' AS test_name;
+    test_name    
+-----------------
+ === Cleanup ===
+
+-- Drop test tables
+DROP TABLE IF EXISTS stats_test CASCADE;
+DROP TABLE IF EXISTS empty_stats_test CASCADE;
+SELECT '=== All tests completed ===' AS test_name;
+          test_name          
+-----------------------------
+ === All tests completed ===
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_FILES
     cluster.sql
     create_chunks.sql
     create_hypertable.sql
+    create_statistics.sql
     create_table.sql
     create_table_with.sql
     constraint.sql

--- a/tsl/test/expected/create_statistics_tsl.out
+++ b/tsl/test/expected/create_statistics_tsl.out
@@ -1,0 +1,121 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- These tests verify Apache-licensed CREATE STATISTICS propagation behavior
+-- on Continuous Aggregates and compressed chunks; they live under TSL tests
+-- only because they need TSL to create those objects (CA, compression).
+-- =============================================
+-- Test 11: CREATE STATISTICS on Continuous Aggregate
+-- =============================================
+SELECT '=== Test 11: Continuous Aggregate propagation ===' AS test_name;
+                     test_name                     
+---------------------------------------------------
+ === Test 11: Continuous Aggregate propagation ===
+
+CREATE TABLE ca_stats_src (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER,
+    temp FLOAT
+);
+SELECT create_hypertable('ca_stats_src', 'time', chunk_time_interval => INTERVAL '1 day');
+     create_hypertable     
+---------------------------
+ (1,public,ca_stats_src,t)
+
+INSERT INTO ca_stats_src VALUES
+    ('2024-01-01 00:00:00', 1, 20.0),
+    ('2024-01-02 00:00:00', 2, 21.0),
+    ('2024-01-03 00:00:00', 3, 19.0);
+CREATE MATERIALIZED VIEW ca_stats_daily
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', time) AS bucket,
+       device_id,
+       avg(temp) AS avg_temp
+FROM ca_stats_src
+GROUP BY 1, 2
+WITH NO DATA;
+CALL refresh_continuous_aggregate('ca_stats_daily', NULL, NULL);
+CREATE STATISTICS ca_stat ON device_id, avg_temp FROM ca_stats_daily;
+-- Stats must be on materialization hypertable + its chunks only (1 + N chunks)
+SELECT count(*) AS ca_stat_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%ca_stat%';
+ ca_stat_count 
+---------------
+             2
+
+-- All such stats must be on the materialization hypertable or its chunks
+SELECT s.stxrelid::regclass AS table_name, s.stxname
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%ca_stat%'
+ORDER BY s.stxrelid;
+                    table_name                    |         stxname          
+--------------------------------------------------+--------------------------
+ _timescaledb_internal._materialized_hypertable_2 | ca_stat
+ _timescaledb_internal._hyper_2_4_chunk           | _hyper_2_4_chunk_ca_stat
+
+-- =============================================
+-- Test 12: Compressed chunk skip (no stats on compressed chunk tables)
+-- =============================================
+SELECT '=== Test 12: Compressed chunk skip ===' AS test_name;
+               test_name                
+----------------------------------------
+ === Test 12: Compressed chunk skip ===
+
+CREATE TABLE comp_skip (
+    time TIMESTAMPTZ NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+SELECT create_hypertable('comp_skip', 'time', chunk_time_interval => INTERVAL '1 day');
+   create_hypertable    
+------------------------
+ (3,public,comp_skip,t)
+
+ALTER TABLE comp_skip SET (timescaledb.compress);
+INSERT INTO comp_skip VALUES
+    ('2024-01-01 00:00:00', 10, 100),
+    ('2024-01-02 00:00:00', 20, 200);
+-- Compress one chunk so we have one compressed chunk table
+SELECT compress_chunk(c) FROM show_chunks('comp_skip') c LIMIT 1;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+CREATE STATISTICS comp_skip_stat ON a, b FROM comp_skip;
+-- Verify chunk tables: 3 (2 uncompressed + 1 compressed for the one we compressed)
+SELECT count(*) AS chunk_table_count
+FROM _timescaledb_catalog.chunk c
+WHERE c.hypertable_id IN (
+    (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'comp_skip' LIMIT 1),
+    (SELECT compressed_hypertable_id FROM _timescaledb_catalog.hypertable WHERE table_name = 'comp_skip' LIMIT 1)
+);
+ chunk_table_count 
+-------------------
+                 3
+
+-- Total relations: 1 ht + 3 chunk tables = 4. Stat only on ht + 2 uncompressed chunks → expect 3.
+SELECT count(*) AS comp_skip_stat_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%comp_skip_stat%';
+ comp_skip_stat_count 
+----------------------
+                    3
+
+-- =============================================
+-- Cleanup
+-- =============================================
+SELECT '=== Cleanup ===' AS test_name;
+    test_name    
+-----------------
+ === Cleanup ===
+
+DROP MATERIALIZED VIEW IF EXISTS ca_stats_daily;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_4_chunk
+DROP TABLE IF EXISTS ca_stats_src CASCADE;
+DROP TABLE IF EXISTS comp_skip CASCADE;
+SELECT '=== All tests completed ===' AS test_name;
+          test_name          
+-----------------------------
+ === All tests completed ===
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -56,6 +56,7 @@ set(TEST_FILES
     compression_uuid.sql
     compression_trigger.sql
     create_table_with.sql
+    create_statistics_tsl.sql
     decompress_index.sql
     merge_compress.sql
     move.sql

--- a/tsl/test/sql/create_statistics_tsl.sql
+++ b/tsl/test/sql/create_statistics_tsl.sql
@@ -1,0 +1,93 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- These tests verify Apache-licensed CREATE STATISTICS propagation behavior
+-- on Continuous Aggregates and compressed chunks; they live under TSL tests
+-- only because they need TSL to create those objects (CA, compression).
+
+-- =============================================
+-- Test 11: CREATE STATISTICS on Continuous Aggregate
+-- =============================================
+SELECT '=== Test 11: Continuous Aggregate propagation ===' AS test_name;
+
+CREATE TABLE ca_stats_src (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INTEGER,
+    temp FLOAT
+);
+SELECT create_hypertable('ca_stats_src', 'time', chunk_time_interval => INTERVAL '1 day');
+INSERT INTO ca_stats_src VALUES
+    ('2024-01-01 00:00:00', 1, 20.0),
+    ('2024-01-02 00:00:00', 2, 21.0),
+    ('2024-01-03 00:00:00', 3, 19.0);
+
+CREATE MATERIALIZED VIEW ca_stats_daily
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', time) AS bucket,
+       device_id,
+       avg(temp) AS avg_temp
+FROM ca_stats_src
+GROUP BY 1, 2
+WITH NO DATA;
+
+CALL refresh_continuous_aggregate('ca_stats_daily', NULL, NULL);
+
+CREATE STATISTICS ca_stat ON device_id, avg_temp FROM ca_stats_daily;
+
+-- Stats must be on materialization hypertable + its chunks only (1 + N chunks)
+SELECT count(*) AS ca_stat_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%ca_stat%';
+
+-- All such stats must be on the materialization hypertable or its chunks
+SELECT s.stxrelid::regclass AS table_name, s.stxname
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%ca_stat%'
+ORDER BY s.stxrelid;
+
+-- =============================================
+-- Test 12: Compressed chunk skip (no stats on compressed chunk tables)
+-- =============================================
+SELECT '=== Test 12: Compressed chunk skip ===' AS test_name;
+
+CREATE TABLE comp_skip (
+    time TIMESTAMPTZ NOT NULL,
+    a INTEGER,
+    b INTEGER
+);
+SELECT create_hypertable('comp_skip', 'time', chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE comp_skip SET (timescaledb.compress);
+
+INSERT INTO comp_skip VALUES
+    ('2024-01-01 00:00:00', 10, 100),
+    ('2024-01-02 00:00:00', 20, 200);
+
+-- Compress one chunk so we have one compressed chunk table
+SELECT compress_chunk(c) FROM show_chunks('comp_skip') c LIMIT 1;
+
+CREATE STATISTICS comp_skip_stat ON a, b FROM comp_skip;
+
+-- Verify chunk tables: 3 (2 uncompressed + 1 compressed for the one we compressed)
+SELECT count(*) AS chunk_table_count
+FROM _timescaledb_catalog.chunk c
+WHERE c.hypertable_id IN (
+    (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'comp_skip' LIMIT 1),
+    (SELECT compressed_hypertable_id FROM _timescaledb_catalog.hypertable WHERE table_name = 'comp_skip' LIMIT 1)
+);
+
+-- Total relations: 1 ht + 3 chunk tables = 4. Stat only on ht + 2 uncompressed chunks → expect 3.
+SELECT count(*) AS comp_skip_stat_count
+FROM pg_statistic_ext s
+WHERE s.stxname LIKE '%comp_skip_stat%';
+
+-- =============================================
+-- Cleanup
+-- =============================================
+SELECT '=== Cleanup ===' AS test_name;
+
+DROP MATERIALIZED VIEW IF EXISTS ca_stats_daily;
+DROP TABLE IF EXISTS ca_stats_src CASCADE;
+DROP TABLE IF EXISTS comp_skip CASCADE;
+
+SELECT '=== All tests completed ===' AS test_name;


### PR DESCRIPTION
Closes #2433.

When CREATE STATISTICS is run on a hypertable, extended statistics were not propagated to chunks, so ANALYZE on chunks did not build the same statistics. This change adds process utility hooks for CREATE STATISTICS, DROP STATISTICS, and RENAME STATISTICS so that these operations are applied to all (non-OSM) chunks. New chunks get statistics created via ts_chunk_extended_statistics_create_all in chunk.c. Structure comparison is used to match statistics (no metadata table). Owner of chunk statistics is set to the hypertable owner.