### PR TITLE
Fix error in bloom filter lookup with anonymous record

### DIFF
--- a/.unreleased/record-bloom
+++ b/.unreleased/record-bloom
@@ -1,0 +1,1 @@
+Fixes: #9256 Error "record type has no extended hash function" on some queries using a sparse bloom filter index on a column of composite type.

--- a/tsl/src/nodes/columnar_scan/qual_pushdown.c
+++ b/tsl/src/nodes/columnar_scan/qual_pushdown.c
@@ -488,7 +488,7 @@ pushdown_op_to_segment_meta_bloom1(QualPushdownContext *context, OpExpr *orig_op
 	 * same result for both types, so we don't need any type conversion here.
 	 * The only special case is composite types. The right-hand constant would
 	 * have the anonymous type "record" and would be compared polymorphically
-	 * at rutime with the record_eq() function. However, this type doesn't have
+	 * at runtime with the record_eq() function. However, this type doesn't have
 	 * an extended hash function. Just refuse to work with it.
 	 */
 	const Oid compared_type = exprType((Node *) pushed_down_rightop);

--- a/tsl/test/expected/compress_bloom_sparse-15.out
+++ b/tsl/test/expected/compress_bloom_sparse-15.out
@@ -850,6 +850,14 @@ select * from bloom_composite where x = (2, 3)::ctype;
          Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
 
 explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::record)
+   Rows Removed by Filter: 1
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
 select * from bloom_composite where x = (3, 4)::ctype;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compress_bloom_sparse-15.out
+++ b/tsl/test/expected/compress_bloom_sparse-15.out
@@ -821,9 +821,47 @@ select count(*) from arraybloom where value = array[7248::int];
 -------
      1
 
+-- Test a composite type
+create type ctype as (a int, b int);
+create table bloom_composite(ts int, x ctype) with (tsdb.hypertable,
+    tsdb.partition_column = 'ts', tsdb.compress, tsdb.compress_orderby = 'ts',
+    tsdb.sparse_index = 'bloom(x)')
+;
+insert into bloom_composite values (1, row(2, 3)::ctype);
+select count(compress_chunk(x)) from show_chunks('bloom_composite') x;
+ count 
+-------
+     1
+
+vacuum full analyze bloom_composite;
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::record)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=0.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(3,4)'::ctype)
+         Rows Removed by Filter: 1
+
 -- Cleanup
 drop table bloom;
 drop table corner;
 drop table badtable;
 drop table byref;
 drop table arraybloom;
+drop table bloom_composite;

--- a/tsl/test/expected/compress_bloom_sparse-16.out
+++ b/tsl/test/expected/compress_bloom_sparse-16.out
@@ -850,6 +850,14 @@ select * from bloom_composite where x = (2, 3)::ctype;
          Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
 
 explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::record)
+   Rows Removed by Filter: 1
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
 select * from bloom_composite where x = (3, 4)::ctype;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compress_bloom_sparse-16.out
+++ b/tsl/test/expected/compress_bloom_sparse-16.out
@@ -821,9 +821,47 @@ select count(*) from arraybloom where value = array[7248::int];
 -------
      1
 
+-- Test a composite type
+create type ctype as (a int, b int);
+create table bloom_composite(ts int, x ctype) with (tsdb.hypertable,
+    tsdb.partition_column = 'ts', tsdb.compress, tsdb.compress_orderby = 'ts',
+    tsdb.sparse_index = 'bloom(x)')
+;
+insert into bloom_composite values (1, row(2, 3)::ctype);
+select count(compress_chunk(x)) from show_chunks('bloom_composite') x;
+ count 
+-------
+     1
+
+vacuum full analyze bloom_composite;
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::record)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=0.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(3,4)'::ctype)
+         Rows Removed by Filter: 1
+
 -- Cleanup
 drop table bloom;
 drop table corner;
 drop table badtable;
 drop table byref;
 drop table arraybloom;
+drop table bloom_composite;

--- a/tsl/test/expected/compress_bloom_sparse-17.out
+++ b/tsl/test/expected/compress_bloom_sparse-17.out
@@ -850,6 +850,14 @@ select * from bloom_composite where x = (2, 3)::ctype;
          Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
 
 explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::record)
+   Rows Removed by Filter: 1
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
 select * from bloom_composite where x = (3, 4)::ctype;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compress_bloom_sparse-17.out
+++ b/tsl/test/expected/compress_bloom_sparse-17.out
@@ -821,9 +821,47 @@ select count(*) from arraybloom where value = array[7248::int];
 -------
      1
 
+-- Test a composite type
+create type ctype as (a int, b int);
+create table bloom_composite(ts int, x ctype) with (tsdb.hypertable,
+    tsdb.partition_column = 'ts', tsdb.compress, tsdb.compress_orderby = 'ts',
+    tsdb.sparse_index = 'bloom(x)')
+;
+insert into bloom_composite values (1, row(2, 3)::ctype);
+select count(compress_chunk(x)) from show_chunks('bloom_composite') x;
+ count 
+-------
+     1
+
+vacuum full analyze bloom_composite;
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::record)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=0.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(3,4)'::ctype)
+         Rows Removed by Filter: 1
+
 -- Cleanup
 drop table bloom;
 drop table corner;
 drop table badtable;
 drop table byref;
 drop table arraybloom;
+drop table bloom_composite;

--- a/tsl/test/expected/compress_bloom_sparse-18.out
+++ b/tsl/test/expected/compress_bloom_sparse-18.out
@@ -850,6 +850,14 @@ select * from bloom_composite where x = (2, 3)::ctype;
          Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
 
 explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::record)
+   Rows Removed by Filter: 1
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
 select * from bloom_composite where x = (3, 4)::ctype;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compress_bloom_sparse-18.out
+++ b/tsl/test/expected/compress_bloom_sparse-18.out
@@ -821,9 +821,47 @@ select count(*) from arraybloom where value = array[7248::int];
 -------
      1
 
+-- Test a composite type
+create type ctype as (a int, b int);
+create table bloom_composite(ts int, x ctype) with (tsdb.hypertable,
+    tsdb.partition_column = 'ts', tsdb.compress, tsdb.compress_orderby = 'ts',
+    tsdb.sparse_index = 'bloom(x)')
+;
+insert into bloom_composite values (1, row(2, 3)::ctype);
+select count(compress_chunk(x)) from show_chunks('bloom_composite') x;
+ count 
+-------
+     1
+
+vacuum full analyze bloom_composite;
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::record)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=1.00 loops=1)
+   Filter: (x = '(2,3)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=1.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(2,3)'::ctype)
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4)::ctype;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_11_13_chunk (actual rows=0.00 loops=1)
+   Filter: (x = '(3,4)'::ctype)
+   ->  Seq Scan on compress_hyper_12_14_chunk (actual rows=0.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_x, '(3,4)'::ctype)
+         Rows Removed by Filter: 1
+
 -- Cleanup
 drop table bloom;
 drop table corner;
 drop table badtable;
 drop table byref;
 drop table arraybloom;
+drop table bloom_composite;

--- a/tsl/test/sql/compress_bloom_sparse.sql.in
+++ b/tsl/test/sql/compress_bloom_sparse.sql.in
@@ -450,6 +450,9 @@ explain (analyze, buffers off, costs off, timing off, summary off)
 select * from bloom_composite where x = (2, 3)::ctype;
 
 explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4);
+
+explain (analyze, buffers off, costs off, timing off, summary off)
 select * from bloom_composite where x = (3, 4)::ctype;
 
 

--- a/tsl/test/sql/compress_bloom_sparse.sql.in
+++ b/tsl/test/sql/compress_bloom_sparse.sql.in
@@ -429,10 +429,35 @@ select count(*) from arraybloom where value = array[7248::int];
 select count(*) from arraybloom where value = array[7248::int];
 
 
+-- Test a composite type
+create type ctype as (a int, b int);
+
+create table bloom_composite(ts int, x ctype) with (tsdb.hypertable,
+    tsdb.partition_column = 'ts', tsdb.compress, tsdb.compress_orderby = 'ts',
+    tsdb.sparse_index = 'bloom(x)')
+;
+
+insert into bloom_composite values (1, row(2, 3)::ctype);
+
+select count(compress_chunk(x)) from show_chunks('bloom_composite') x;
+
+vacuum full analyze bloom_composite;
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3);
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (2, 3)::ctype;
+
+explain (analyze, buffers off, costs off, timing off, summary off)
+select * from bloom_composite where x = (3, 4)::ctype;
+
+
 -- Cleanup
 drop table bloom;
 drop table corner;
 drop table badtable;
 drop table byref;
 drop table arraybloom;
+drop table bloom_composite;
 


### PR DESCRIPTION
Currently we support the composite types in sparse bloom filter indexes, but a lookup like `x = (2, 3)` fails with an error about the record type lacking an extended hash function. Don't pushdown in this case and require an explicit conversion like `x = (2, 3)::my_composite_type`.