### PR TITLE
Move treewalker used by VectorAgg into expression_utils.c

### DIFF
--- a/src/expression_utils.h
+++ b/src/expression_utils.h
@@ -15,3 +15,7 @@ bool TSDLLEXPORT ts_extract_expr_args(Expr *expr, Var **var, Expr **arg_value, O
 
 TSDLLEXPORT List *ts_build_trivial_custom_output_targetlist(List *scan_targetlist);
 TSDLLEXPORT List *ts_resolve_outer_special_vars(List *agg_tlist, Plan *childplan);
+
+typedef Plan *(*ts_plan_tree_walkerfunc)(Plan *, void *);
+extern TSDLLEXPORT Plan *ts_plan_tree_walker(Plan *plan, ts_plan_tree_walkerfunc func,
+											 void *context);


### PR DESCRIPTION
This is in preparation to use the treewalker for ColumnarIndexScan.

Disable-check: force-changelog-file
Disable-check: approval-count