### PR TITLE
Refactor ColumnarIndexScan planning

### DIFF
--- a/.unreleased/pr_9267
+++ b/.unreleased/pr_9267
@@ -1,0 +1,1 @@
+Implements: #9267 Enable ColumnarIndexScan custom scan

--- a/src/guc.c
+++ b/src/guc.c
@@ -130,7 +130,7 @@ TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings = true;
 /* Enable of disable columnar scans for columnar-oriented storage engines. If
  * disabled, regular sequence scans will be used instead. */
 TSDLLEXPORT bool ts_guc_enable_columnarscan = true;
-TSDLLEXPORT bool ts_guc_enable_columnarindexscan = false;
+TSDLLEXPORT bool ts_guc_enable_columnarindexscan = true;
 TSDLLEXPORT int ts_guc_bgw_log_level = WARNING;
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 #if PG16_GE
@@ -1196,7 +1196,7 @@ _guc_init(void)
 							 "Enable experimental support for returning results directly from "
 							 "compression metadata without decompression",
 							 &ts_guc_enable_columnarindexscan,
-							 false,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
@@ -5,34 +5,11 @@
  */
 #pragma once
 
+#define COLUMNAR_INDEX_SCAN_NAME "ColumnarIndexScan"
+
 #include <postgres.h>
-#include <nodes/extensible.h>
-
-#include "nodes/columnar_scan/columnar_scan.h"
-
-typedef struct ColumnarIndexScanPath
-{
-	CustomPath custom_path;
-	const CompressionInfo *info;
-	List *aggregate_attnos; /* Chunk attnos of aggregate columns in target list order */
-	List *metadata_attnos;	/* Compressed chunk attnos for metadata in target list order */
-	List *aggregate_fnoids; /* Aggregate function OIDs in target list order */
-} ColumnarIndexScanPath;
-
-/*
- * Post-process a plan tree to fix Aggref references for ColumnarIndexScan.
- * This is needed when multiple aggregates reference the same column.
- */
-extern void ts_columnar_index_scan_fix_aggrefs(Plan *plan);
+#include <nodes/plannodes.h>
 
 extern void _columnar_index_scan_init(void);
-extern bool ts_is_columnar_index_scan_path(Path *path);
-extern bool ts_is_columnar_index_scan_plan(Plan *plan);
-
-extern ColumnarIndexScanPath *
-ts_columnar_index_scan_path_create(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
-								   const CompressionInfo *info, Path *compressed_path);
-extern Plan *columnar_index_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
-											 List *output_targetlist, List *clauses,
-											 List *custom_plans);
+extern Plan *try_insert_columnar_index_scan_node(Plan *plan, List *rtable);
 extern Node *columnar_index_scan_state_create(CustomScan *cscan);

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -36,7 +36,6 @@
 #include "debug_assert.h"
 #include "import/allpaths.h"
 #include "import/planner.h"
-#include "nodes/columnar_index_scan/columnar_index_scan.h"
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/columnar_scan/planner.h"
 #include "nodes/columnar_scan/qual_pushdown.h"
@@ -1369,22 +1368,6 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("debug: batch sorted merge is required but not possible at planning "
 						"time")));
-	}
-
-	/*
-	 * Try to create a ColumnarIndexScan path for the metadata-only optimization.
-	 */
-	{
-		ColumnarIndexScanPath *index_scan_path =
-			ts_columnar_index_scan_path_create(root,
-											   chunk,
-											   chunk_rel,
-											   compression_info,
-											   compressed_path);
-		if (index_scan_path)
-		{
-			decompressed_paths = lappend(decompressed_paths, index_scan_path);
-		}
 	}
 
 	/*

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -301,7 +301,9 @@ tsl_postprocess_plan(PlannedStmt *stmt)
 {
 	if (ts_guc_enable_columnarindexscan)
 	{
-		ts_columnar_index_scan_fix_aggrefs(stmt->planTree);
+		stmt->planTree = try_insert_columnar_index_scan_node(stmt->planTree, stmt->rtable);
+		stmt->subplans =
+			(List *) try_insert_columnar_index_scan_node((Plan *) stmt->subplans, stmt->rtable);
 	}
 
 	if (ts_guc_enable_vectorized_aggregation)

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -38,8 +38,10 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
+-- first run with hypertable with 1 fully compressed chunk
 -- get query plans
 \set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -51,155 +53,396 @@ SHOW timescaledb.enable_columnarindexscan;
 --------------------------------------
  on
 
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
 -- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 min aggregate that can use optimization
 :PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- simple query with 1 first aggregate that can use optimization
 :PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 :PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on same column
 :PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns
 :PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns but different order
 :PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on multiple columns
 :PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- test multiple group by columns
 :PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
--- order by does currently prevent optimization
-:PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
---- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: (device = ANY ('{d1,d2}'::text[]))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
 
 :PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
--- filter on non-segmentby prevents optimization
-:PREFIX SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         Vectorized Filter: ("time" <> 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization
---:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: device, tableoid
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: device, (min("time")), (max("time"))
+   Presorted Key: device
+   ->  Merge Append
+         Sort Key: device
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max("time"))
+               ->  GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
 -- group by on non-segmentby prevents optimization
 :PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
@@ -215,73 +458,18 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
--- no group by prevents optimization
-:PREFIX SELECT max(time) FROM metrics;
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
 --- QUERY PLAN ---
- Result
-   InitPlan 1 (returns $0)
-     ->  Limit
-           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-                 Filter: ("time" IS NOT NULL)
-                 ->  Sort
-                       Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
-                       ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column use optimization
-:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column with first/last
-:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- segmentby column at end of targetlist
-:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on different columns use optimization
-:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same non-time column use optimization
-:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on multiple columns
-:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- expression on aggregates (currently not optimized)
-:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
---- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
+ Aggregate
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregate on segmentby column does not use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -291,43 +479,606 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
--- aggregate on column without metadata does not use optimization
-:PREFIX SELECT device, min(value2) FROM metrics GROUP BY device;
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Vectorized Filter: (value > '10'::double precision)
+         ->  Seq Scan on compress_hyper_2_2_chunk
+               Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.device, metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
 --- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.device, metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with subquery (SubqueryScan)
 :PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
  Sort
    Sort Key: sub.device
    ->  Subquery Scan on sub
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Finalize HashAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
@@ -336,20 +1087,17 @@ SHOW timescaledb.enable_columnarindexscan;
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
-WITH agg_data AS (
-    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
-)
-SELECT * FROM agg_data ORDER BY device;
- device |           min_time           |           max_time           
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
@@ -360,11 +1108,17 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
  set_config 
@@ -378,34 +1132,291 @@ SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
 ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
+   Sort Key: metrics.device
    ->  Append
-         ->  GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                           Index Cond: (device = 'd1'::text)
-         ->  GroupAggregate
-               Group Key: _hyper_1_1_chunk_1.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
-                           Index Cond: (device = 'd2'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
 UNION ALL
 SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device, (min(_hyper_1_1_chunk."time")), (max(_hyper_1_1_chunk."time"))
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
    ->  Append
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Finalize HashAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+         ->  Finalize HashAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize HashAggregate
+                     Group Key: metrics.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                       ->  Seq Scan on compress_hyper_2_2_chunk
+                           ->  Partial HashAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Finalize HashAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk_1.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Seq Scan on _hyper_1_1_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 \set PREFIX ''
 \set ECHO errors
@@ -417,46 +1428,952 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 - off
 + on
  
-  device |             max              
-NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+  device | count 
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_3_chunk
 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.device, metrics.tableoid
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
 
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.value
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              | min | max 
---------+------------------------------+------------------------------+-----+-----
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   4 | 200
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   6 | 250
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
 
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -38,8 +38,10 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
+-- first run with hypertable with 1 fully compressed chunk
 -- get query plans
 \set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -51,155 +53,394 @@ SHOW timescaledb.enable_columnarindexscan;
 --------------------------------------
  on
 
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
 -- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 min aggregate that can use optimization
 :PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- simple query with 1 first aggregate that can use optimization
 :PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 :PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on same column
 :PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns
 :PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns but different order
 :PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on multiple columns
 :PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- test multiple group by columns
 :PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
--- order by does currently prevent optimization
-:PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
---- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: (device = ANY ('{d1,d2}'::text[]))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
 
 :PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
--- filter on non-segmentby prevents optimization
-:PREFIX SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         Vectorized Filter: ("time" <> 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization
---:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: device, tableoid
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: device, (min("time")), (max("time"))
+   Presorted Key: device
+   ->  Merge Append
+         Sort Key: device
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max("time"))
+               ->  GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
 -- group by on non-segmentby prevents optimization
 :PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
@@ -215,73 +456,18 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
--- no group by prevents optimization
-:PREFIX SELECT max(time) FROM metrics;
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
 --- QUERY PLAN ---
- Result
-   InitPlan 1 (returns $0)
-     ->  Limit
-           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-                 Filter: ("time" IS NOT NULL)
-                 ->  Sort
-                       Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
-                       ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column use optimization
-:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column with first/last
-:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- segmentby column at end of targetlist
-:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on different columns use optimization
-:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same non-time column use optimization
-:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on multiple columns
-:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- expression on aggregates (currently not optimized)
-:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
---- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
+ Aggregate
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregate on segmentby column does not use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -291,43 +477,609 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
--- aggregate on column without metadata does not use optimization
-:PREFIX SELECT device, min(value2) FROM metrics GROUP BY device;
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Vectorized Filter: (value > '10'::double precision)
+         ->  Seq Scan on compress_hyper_2_2_chunk
+               Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.device, metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
 --- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.device, metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with subquery (SubqueryScan)
 :PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
  Sort
    Sort Key: sub.device
    ->  Subquery Scan on sub
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Finalize HashAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
@@ -336,20 +1088,17 @@ SHOW timescaledb.enable_columnarindexscan;
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
-WITH agg_data AS (
-    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
-)
-SELECT * FROM agg_data ORDER BY device;
- device |           min_time           |           max_time           
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
@@ -360,11 +1109,17 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
  set_config 
@@ -378,32 +1133,291 @@ SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
 ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
+   Sort Key: metrics.device
    ->  Append
-         ->  GroupAggregate
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                           Index Cond: (device = 'd1'::text)
-         ->  GroupAggregate
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
-                           Index Cond: (device = 'd2'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
 UNION ALL
 SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device, (min(_hyper_1_1_chunk."time")), (max(_hyper_1_1_chunk."time"))
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
    ->  Append
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Finalize HashAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+         ->  Finalize HashAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize HashAggregate
+                     Group Key: metrics.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                       ->  Seq Scan on compress_hyper_2_2_chunk
+                           ->  Partial HashAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Finalize HashAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk_1.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 \set PREFIX ''
 \set ECHO errors
@@ -415,46 +1429,953 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 - off
 + on
  
-  device |             max              
-NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+  device | count 
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_3_chunk
 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.device, metrics.tableoid
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
 
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.value
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              | min | max 
---------+------------------------------+------------------------------+-----+-----
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   4 | 200
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   6 | 250
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
 
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -38,8 +38,10 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
+-- first run with hypertable with 1 fully compressed chunk
 -- get query plans
 \set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -51,155 +53,394 @@ SHOW timescaledb.enable_columnarindexscan;
 --------------------------------------
  on
 
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
 -- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 min aggregate that can use optimization
 :PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- simple query with 1 first aggregate that can use optimization
 :PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 :PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on same column
 :PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns
 :PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns but different order
 :PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on multiple columns
 :PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- test multiple group by columns
 :PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
--- order by does currently prevent optimization
-:PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
---- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: (device = ANY ('{d1,d2}'::text[]))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
 
 :PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
--- filter on non-segmentby prevents optimization
-:PREFIX SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         Vectorized Filter: ("time" <> 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization
---:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: device, tableoid
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: device, (min("time")), (max("time"))
+   Presorted Key: device
+   ->  Merge Append
+         Sort Key: device
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max("time"))
+               ->  GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
 -- group by on non-segmentby prevents optimization
 :PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
@@ -215,72 +456,18 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
--- no group by prevents optimization
-:PREFIX SELECT max(time) FROM metrics;
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
 --- QUERY PLAN ---
- Result
-   InitPlan 1
-     ->  Limit
-           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-                 ->  Sort
-                       Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
-                       ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column use optimization
-:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column with first/last
-:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- segmentby column at end of targetlist
-:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on different columns use optimization
-:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same non-time column use optimization
-:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on multiple columns
-:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- expression on aggregates (currently not optimized)
-:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
---- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
+ Aggregate
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregate on segmentby column does not use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -290,43 +477,717 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
--- aggregate on column without metadata does not use optimization
-:PREFIX SELECT device, min(value2) FROM metrics GROUP BY device;
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Vectorized Filter: (value > '10'::double precision)
+         ->  Seq Scan on compress_hyper_2_2_chunk
+               Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
 --- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with subquery (SubqueryScan)
 :PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: sub.device
-   ->  Subquery Scan on sub
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Seq Scan on compress_hyper_2_2_chunk
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Sort
+                                 Sort Key: compress_hyper_2_2_chunk.device
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
@@ -334,21 +1195,21 @@ SHOW timescaledb.enable_columnarindexscan;
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
-WITH agg_data AS (
-    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
-)
-SELECT * FROM agg_data ORDER BY device;
- device |           min_time           |           max_time           
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
@@ -358,12 +1219,21 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
  set_config 
@@ -377,32 +1247,328 @@ SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
 ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
+   Sort Key: metrics.device
    ->  Append
-         ->  GroupAggregate
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                           Index Cond: (device = 'd1'::text)
-         ->  GroupAggregate
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
-                           Index Cond: (device = 'd2'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
 UNION ALL
 SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 --- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Sort
+                                       Sort Key: compress_hyper_2_2_chunk.device
+                                       ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Sort
+                                 Sort Key: _hyper_1_1_chunk.device
+                                 ->  Seq Scan on _hyper_1_1_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Sort
+                                       Sort Key: compress_hyper_2_2_chunk_1.device
+                                       ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Sort
+                                 Sort Key: _hyper_1_1_chunk_1.device
+                                 ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device, (min(_hyper_1_1_chunk."time")), (max(_hyper_1_1_chunk."time"))
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                       ->  Sort
+                                             Sort Key: compress_hyper_2_2_chunk.device
+                                             ->  Seq Scan on compress_hyper_2_2_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Sort
+                                       Sort Key: _hyper_1_1_chunk.device
+                                       ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Sort
+                                 Sort Key: compress_hyper_2_2_chunk.device
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
    ->  Append
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk_1.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_2_2_chunk.device
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 \set PREFIX ''
 \set ECHO errors
@@ -414,46 +1580,953 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 - off
 + on
  
-  device |             max              
-NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+  device | count 
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_3_chunk
 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.device, metrics.tableoid
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
 
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.value
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              | min | max 
---------+------------------------------+------------------------------+-----+-----
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   4 | 200
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   6 | 250
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
 
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -38,8 +38,10 @@ SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
+-- first run with hypertable with 1 fully compressed chunk
 -- get query plans
 \set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
@@ -51,155 +53,394 @@ SHOW timescaledb.enable_columnarindexscan;
 --------------------------------------
  on
 
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
 -- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 min aggregate that can use optimization
 :PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- simple query with 1 first aggregate that can use optimization
 :PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 :PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on same column
 :PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns
 :PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- same aggregate on multiple columns but different order
 :PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- multiple aggregates on multiple columns
 :PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.sensor
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk.sensor
                ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- test multiple group by columns
 :PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
--- order by does currently prevent optimization
-:PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
---- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: (device = ANY ('{d1,d2}'::text[]))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
 
 :PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                     Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
--- filter on non-segmentby prevents optimization
-:PREFIX SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         Vectorized Filter: ("time" <> 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization
---:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: device, tableoid
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: device, (min("time")), (max("time"))
+   Presorted Key: device
+   ->  Merge Append
+         Sort Key: device
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max("time"))
+               ->  GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  GroupAggregate
+         Group Key: device
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
 -- group by on non-segmentby prevents optimization
 :PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
@@ -215,72 +456,18 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
--- no group by prevents optimization
-:PREFIX SELECT max(time) FROM metrics;
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
 --- QUERY PLAN ---
- Result
-   InitPlan 1
-     ->  Limit
-           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-                 ->  Sort
-                       Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
-                       ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column use optimization
-:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same column with first/last
-:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- segmentby column at end of targetlist
-:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on different columns use optimization
-:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on same non-time column use optimization
-:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- multiple aggregates on multiple columns
-:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
---- QUERY PLAN ---
- HashAggregate
-   Group Key: _hyper_1_1_chunk.device
-   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-         ->  Seq Scan on compress_hyper_2_2_chunk
-
--- expression on aggregates (currently not optimized)
-:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
---- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
+ Aggregate
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregate on segmentby column does not use optimization
 :PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
@@ -290,43 +477,717 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
--- aggregate on column without metadata does not use optimization
-:PREFIX SELECT device, min(value2) FROM metrics GROUP BY device;
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Vectorized Filter: (value > '10'::double precision)
+         ->  Seq Scan on compress_hyper_2_2_chunk
+               Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: (device = ANY ('{d1,d2}'::text[]))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                 Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.tableoid
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
 --- QUERY PLAN ---
- GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Sort
-         Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with subquery (SubqueryScan)
 :PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: sub.device
-   ->  Subquery Scan on sub
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Seq Scan on compress_hyper_2_2_chunk
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Sort
+                                 Sort Key: compress_hyper_2_2_chunk.device
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
@@ -334,21 +1195,21 @@ SHOW timescaledb.enable_columnarindexscan;
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
-
-WITH agg_data AS (
-    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
-)
-SELECT * FROM agg_data ORDER BY device;
- device |           min_time           |           max_time           
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Wed Jan 01 02:30:00 2025 PST
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
@@ -358,12 +1219,21 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk.device
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk.device
-         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-               ->  Seq Scan on compress_hyper_2_2_chunk
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
  set_config 
@@ -377,32 +1247,328 @@ SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
 ORDER BY device;
 --- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device
+   Sort Key: metrics.device
    ->  Append
-         ->  GroupAggregate
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
-                           Index Cond: (device = 'd1'::text)
-         ->  GroupAggregate
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
-                           Index Cond: (device = 'd2'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
 
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
 UNION ALL
 SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 --- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Sort
+                                       Sort Key: compress_hyper_2_2_chunk.device
+                                       ->  Seq Scan on compress_hyper_2_2_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Sort
+                                 Sort Key: _hyper_1_1_chunk.device
+                                 ->  Seq Scan on _hyper_1_1_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Sort
+                                       Sort Key: compress_hyper_2_2_chunk_1.device
+                                       ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Sort
+                                 Sort Key: _hyper_1_1_chunk_1.device
+                                 ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
  Sort
-   Sort Key: _hyper_1_1_chunk.device, (min(_hyper_1_1_chunk."time")), (max(_hyper_1_1_chunk."time"))
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                       ->  Sort
+                                             Sort Key: compress_hyper_2_2_chunk.device
+                                             ->  Seq Scan on compress_hyper_2_2_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: _hyper_1_1_chunk.device
+                                 ->  Sort
+                                       Sort Key: _hyper_1_1_chunk.device
+                                       ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Sort
+                                 Sort Key: compress_hyper_2_2_chunk.device
+                                 ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
    ->  Append
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  HashAggregate
-               Group Key: _hyper_1_1_chunk_1.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
-                     ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: compress_hyper_2_2_chunk.device
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 \set PREFIX ''
 \set ECHO errors
@@ -414,46 +1580,953 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 - off
 + on
  
-  device |             max              
-NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+  device | count 
              compress_chunk             
 ----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_3_chunk
 
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_4_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.device, metrics.tableoid
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              
---------+------------------------------+------------------------------
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
 
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
 --- QUERY PLAN ---
  Finalize HashAggregate
-   Group Key: metrics.device
+   Group Key: metrics.value
    ->  Append
          ->  Partial HashAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Partial HashAggregate
-               Group Key: _hyper_1_3_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
- device |             min              |             max              | min | max 
---------+------------------------------+------------------------------+-----+-----
- d1     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   4 | 200
- d2     | Wed Jan 01 00:00:00 2025 PST | Sat Feb 01 01:00:00 2025 PST |   6 | 250
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
 
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/compress_qualpushdown_saop.out
+++ b/tsl/test/expected/compress_qualpushdown_saop.out
@@ -569,12 +569,14 @@ select * from saop, arrays where segmentby = any(a);
                Sort Method: top-N heapsort 
                ->  Finalize HashAggregate (actual rows=23.00 loops=1)
                      Group Key: saop_1.segmentby
-                     ->  Append (actual rows=138.00 loops=1)
-                           ->  Custom Scan (VectorAgg) (actual rows=69.00 loops=1)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50001.00 loops=1)
+                     ->  Append (actual rows=46.00 loops=1)
+                           ->  Partial HashAggregate (actual rows=23.00 loops=1)
+                                 Group Key: segmentby
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk saop (actual rows=69.00 loops=1)
                                        ->  Seq Scan on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69.00 loops=1)
-                           ->  Custom Scan (VectorAgg) (actual rows=69.00 loops=1)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=50000.00 loops=1)
+                           ->  Partial HashAggregate (actual rows=23.00 loops=1)
+                                 Group Key: segmentby
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk saop (actual rows=69.00 loops=1)
                                        ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=69.00 loops=1)
    ->  Append (actual rows=4348.00 loops=10)
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=2174.00 loops=10)
@@ -606,12 +608,14 @@ select * from saop, arrays where with_minmax = any(a);
                            Sort Method: top-N heapsort 
                            ->  Finalize HashAggregate (actual rows=23.00 loops=1)
                                  Group Key: saop_1.segmentby
-                                 ->  Append (actual rows=138.00 loops=1)
-                                       ->  Custom Scan (VectorAgg) (actual rows=69.00 loops=1)
-                                             ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50001.00 loops=1)
+                                 ->  Append (actual rows=46.00 loops=1)
+                                       ->  Partial HashAggregate (actual rows=23.00 loops=1)
+                                             Group Key: segmentby
+                                             ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk saop (actual rows=69.00 loops=1)
                                                    ->  Seq Scan on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69.00 loops=1)
-                                       ->  Custom Scan (VectorAgg) (actual rows=69.00 loops=1)
-                                             ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=50000.00 loops=1)
+                                       ->  Partial HashAggregate (actual rows=23.00 loops=1)
+                                             Group Key: segmentby
+                                             ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk saop (actual rows=69.00 loops=1)
                                                    ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=69.00 loops=1)
 
 explain (analyze, buffers off, costs off, timing off, summary off)
@@ -634,12 +638,14 @@ select * from saop, arrays where with_bloom = any(a);
                            Sort Method: top-N heapsort 
                            ->  Finalize HashAggregate (actual rows=23.00 loops=1)
                                  Group Key: saop_1.segmentby
-                                 ->  Append (actual rows=138.00 loops=1)
-                                       ->  Custom Scan (VectorAgg) (actual rows=69.00 loops=1)
-                                             ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=50001.00 loops=1)
+                                 ->  Append (actual rows=46.00 loops=1)
+                                       ->  Partial HashAggregate (actual rows=23.00 loops=1)
+                                             Group Key: segmentby
+                                             ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk saop (actual rows=69.00 loops=1)
                                                    ->  Seq Scan on compress_hyper_2_3_chunk compress_hyper_2_3_chunk_1 (actual rows=69.00 loops=1)
-                                       ->  Custom Scan (VectorAgg) (actual rows=69.00 loops=1)
-                                             ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=50000.00 loops=1)
+                                       ->  Partial HashAggregate (actual rows=23.00 loops=1)
+                                             Group Key: segmentby
+                                             ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk saop (actual rows=69.00 loops=1)
                                                    ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1 (actual rows=69.00 loops=1)
 
 -- Array parameter of prepared statements.

--- a/tsl/test/expected/compress_unordered_sort.out
+++ b/tsl/test/expected/compress_unordered_sort.out
@@ -291,8 +291,8 @@ select device, sensor||'1', min(time), max(time) from metrics group by device, s
 :PREFIX select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 select device, sensor, min(time) from metrics group by device, sensor order by 1,2;
@@ -306,8 +306,8 @@ select device, sensor, min(time) from metrics group by device, sensor order by 1
 :PREFIX select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 select device, sensor, first(time,time) from metrics group by device, sensor order by 1,2;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -535,8 +535,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE prep_plan;
 --- QUERY PLAN ---
  Finalize Aggregate
    ->  Append
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_7_16_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_7_16_chunk plan_inval
                      ->  Seq Scan on compress_hyper_8_18_chunk
          ->  Partial Aggregate
                ->  Seq Scan on _hyper_7_17_chunk

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1301,8 +1301,9 @@ ORDER BY device_id;
    ->  Sort
          Sort Key: compression_insert.device_id
          ->  Append
-               ->  Custom Scan (VectorAgg)
-                     ->  Custom Scan (ColumnarScan) on _hyper_31_110_chunk
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_31_110_chunk.device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_31_110_chunk
                            ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_111_chunk
                ->  Partial GroupAggregate
                      Group Key: _hyper_31_110_chunk.device_id
@@ -1378,11 +1379,13 @@ ORDER BY device_id;
    Group Key: compression_insert.device_id
    ->  Merge Append
          Sort Key: compression_insert.device_id
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_110_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_110_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_111_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_112_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_31_112_chunk.device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_112_chunk
                      ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_113_chunk
          ->  Partial GroupAggregate
                Group Key: _hyper_31_112_chunk.device_id
@@ -1458,14 +1461,17 @@ ORDER BY device_id;
    Group Key: compression_insert.device_id
    ->  Merge Append
          Sort Key: compression_insert.device_id
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_110_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_110_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_111_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_112_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_112_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_113_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_114_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_31_114_chunk.device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_114_chunk
                      ->  Index Scan using compress_hyper_32_115_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_115_chunk
          ->  Partial GroupAggregate
                Group Key: _hyper_31_114_chunk.device_id
@@ -1541,17 +1547,21 @@ ORDER BY device_id;
    Group Key: compression_insert.device_id
    ->  Merge Append
          Sort Key: compression_insert.device_id
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_110_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_110_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_111_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_112_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_112_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_113_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_114_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_114_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_115_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_115_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_116_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_31_116_chunk.device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_116_chunk
                      ->  Index Scan using compress_hyper_32_117_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_117_chunk
          ->  Partial GroupAggregate
                Group Key: _hyper_31_116_chunk.device_id
@@ -1627,20 +1637,25 @@ ORDER BY device_id;
    Group Key: compression_insert.device_id
    ->  Merge Append
          Sort Key: compression_insert.device_id
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_110_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_110_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_111_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_111_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_112_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_112_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_113_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_113_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_114_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_114_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_115_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_115_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_116_chunk
+         ->  Partial GroupAggregate
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_116_chunk compression_insert
                      ->  Index Scan using compress_hyper_32_117_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_117_chunk
-         ->  Custom Scan (VectorAgg)
-               ->  Custom Scan (ColumnarScan) on _hyper_31_118_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_31_118_chunk.device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_31_118_chunk
                      ->  Index Scan using compress_hyper_32_119_chunk_device_id__ts_meta_min_1__ts_me_idx on compress_hyper_32_119_chunk
          ->  Partial GroupAggregate
                Group Key: _hyper_31_118_chunk.device_id

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -406,11 +406,10 @@ VACUUM ANALYZE mytab;
 SET enable_seqscan TO off;
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT count(*) FROM mytab where a = 2;
 --- QUERY PLAN ---
- Finalize Aggregate
-   ->  Custom Scan (VectorAgg)
-         ->  Custom Scan (ColumnarScan) on _hyper_11_12_chunk
-               ->  Index Scan using compress_hyper_12_13_chunk_a_c__ts_meta_min_1__ts_meta_max__idx on compress_hyper_12_13_chunk
-                     Index Cond: (a = 2)
+ Aggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_11_12_chunk mytab
+         ->  Index Scan using compress_hyper_12_13_chunk_a_c__ts_meta_min_1__ts_meta_max__idx on compress_hyper_12_13_chunk
+               Index Cond: (a = 2)
 
 SELECT count(*) FROM mytab where a = 2;
  count 

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -1505,13 +1505,13 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5.00 loops=1)
 
 -- test aggregate with GROUP BY
@@ -1527,8 +1527,9 @@ ORDER BY device_id;
    Group Key: metrics.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_15_chunk.device_id
                            Sort Method: quicksort 
@@ -1539,8 +1540,9 @@ ORDER BY device_id;
                      Sort Key: _hyper_1_2_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_16_chunk.device_id
                            Sort Method: quicksort 
@@ -1558,8 +1560,9 @@ ORDER BY device_id;
          Group Key: metrics.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_15_chunk.device_id
                                  Sort Method: quicksort 
@@ -1570,8 +1573,9 @@ ORDER BY device_id;
                            Sort Key: _hyper_1_2_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_16_chunk.device_id
                                  Sort Method: quicksort 
@@ -1920,13 +1924,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_5_15_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_15_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_1_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_15_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
@@ -1935,11 +1938,10 @@ WHERE device_id = 1;
                ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=672.00 loops=1)
                      Filter: (_hyper_1_2_chunk.device_id = 1)
                      Rows Removed by Filter: 2688
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_16_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_3_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_16_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                            Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
@@ -5305,14 +5307,14 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=9.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
@@ -5320,11 +5322,11 @@ FROM :TEST_TABLE;
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=2016.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
@@ -5342,20 +5344,23 @@ ORDER BY device_id;
    Group Key: metrics_space.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics_space.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_17_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_18_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_19_chunk.device_id
                            Sort Method: quicksort 
@@ -5369,14 +5374,16 @@ ORDER BY device_id;
          ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                Group Key: _hyper_2_9_chunk.device_id
                ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_20_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_21_chunk.device_id
                            Sort Method: quicksort 
@@ -5397,20 +5404,23 @@ ORDER BY device_id;
          Group Key: metrics_space.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics_space.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_17_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_18_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_19_chunk.device_id
                                  Sort Method: quicksort 
@@ -5424,14 +5434,16 @@ ORDER BY device_id;
                ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                      Group Key: _hyper_2_9_chunk.device_id
                      ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_20_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_21_chunk.device_id
                                  Sort Method: quicksort 
@@ -5795,13 +5807,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_6_17_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_17_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_17_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_17_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
@@ -5809,11 +5820,10 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672.00 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_20_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_20_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_20_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                            Index Cond: (compress_hyper_6_20_chunk.device_id = 1)

--- a/tsl/test/expected/transparent_decompression-16.out
+++ b/tsl/test/expected/transparent_decompression-16.out
@@ -1505,13 +1505,13 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5.00 loops=1)
 
 -- test aggregate with GROUP BY
@@ -1527,8 +1527,9 @@ ORDER BY device_id;
    Group Key: metrics.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_15_chunk.device_id
                            Sort Method: quicksort 
@@ -1539,8 +1540,9 @@ ORDER BY device_id;
                      Sort Key: _hyper_1_2_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_16_chunk.device_id
                            Sort Method: quicksort 
@@ -1558,8 +1560,9 @@ ORDER BY device_id;
          Group Key: metrics.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_15_chunk.device_id
                                  Sort Method: quicksort 
@@ -1570,8 +1573,9 @@ ORDER BY device_id;
                            Sort Key: _hyper_1_2_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_16_chunk.device_id
                                  Sort Method: quicksort 
@@ -1920,13 +1924,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_5_15_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_15_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_1_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_15_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
@@ -1935,11 +1938,10 @@ WHERE device_id = 1;
                ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=672.00 loops=1)
                      Filter: (_hyper_1_2_chunk.device_id = 1)
                      Rows Removed by Filter: 2688
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_16_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_3_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_16_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                            Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
@@ -5312,14 +5314,14 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=9.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
@@ -5327,11 +5329,11 @@ FROM :TEST_TABLE;
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=2016.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
@@ -5349,20 +5351,23 @@ ORDER BY device_id;
    Group Key: metrics_space.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics_space.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_17_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_18_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_19_chunk.device_id
                            Sort Method: quicksort 
@@ -5376,14 +5381,16 @@ ORDER BY device_id;
          ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                Group Key: _hyper_2_9_chunk.device_id
                ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_20_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_21_chunk.device_id
                            Sort Method: quicksort 
@@ -5404,20 +5411,23 @@ ORDER BY device_id;
          Group Key: metrics_space.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics_space.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_17_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_18_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_19_chunk.device_id
                                  Sort Method: quicksort 
@@ -5431,14 +5441,16 @@ ORDER BY device_id;
                ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                      Group Key: _hyper_2_9_chunk.device_id
                      ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_20_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_21_chunk.device_id
                                  Sort Method: quicksort 
@@ -5802,13 +5814,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_6_17_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_17_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_17_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_17_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
@@ -5816,11 +5827,10 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672.00 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_20_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_20_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_20_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                            Index Cond: (compress_hyper_6_20_chunk.device_id = 1)

--- a/tsl/test/expected/transparent_decompression-17.out
+++ b/tsl/test/expected/transparent_decompression-17.out
@@ -1505,13 +1505,13 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5.00 loops=1)
 
 -- test aggregate with GROUP BY
@@ -1527,8 +1527,9 @@ ORDER BY device_id;
    Group Key: metrics.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_15_chunk.device_id
                            Sort Method: quicksort 
@@ -1539,8 +1540,9 @@ ORDER BY device_id;
                      Sort Key: _hyper_1_2_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_16_chunk.device_id
                            Sort Method: quicksort 
@@ -1558,8 +1560,9 @@ ORDER BY device_id;
          Group Key: metrics.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_15_chunk.device_id
                                  Sort Method: quicksort 
@@ -1570,8 +1573,9 @@ ORDER BY device_id;
                            Sort Key: _hyper_1_2_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_16_chunk.device_id
                                  Sort Method: quicksort 
@@ -1920,13 +1924,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_5_15_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_15_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_1_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_15_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
@@ -1935,11 +1938,10 @@ WHERE device_id = 1;
                ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=672.00 loops=1)
                      Filter: (_hyper_1_2_chunk.device_id = 1)
                      Rows Removed by Filter: 2688
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_16_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_3_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_16_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                            Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
@@ -5312,14 +5314,14 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=9.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
@@ -5327,11 +5329,11 @@ FROM :TEST_TABLE;
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=2016.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
@@ -5349,20 +5351,23 @@ ORDER BY device_id;
    Group Key: metrics_space.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics_space.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_17_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_18_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_19_chunk.device_id
                            Sort Method: quicksort 
@@ -5376,14 +5381,16 @@ ORDER BY device_id;
          ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                Group Key: _hyper_2_9_chunk.device_id
                ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_20_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_21_chunk.device_id
                            Sort Method: quicksort 
@@ -5404,20 +5411,23 @@ ORDER BY device_id;
          Group Key: metrics_space.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics_space.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_17_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_18_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_19_chunk.device_id
                                  Sort Method: quicksort 
@@ -5431,14 +5441,16 @@ ORDER BY device_id;
                ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                      Group Key: _hyper_2_9_chunk.device_id
                      ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_20_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_21_chunk.device_id
                                  Sort Method: quicksort 
@@ -5802,13 +5814,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_6_17_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_17_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_17_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_17_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
@@ -5816,11 +5827,10 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672.00 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_20_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_20_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_20_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                            Index Cond: (compress_hyper_6_20_chunk.device_id = 1)

--- a/tsl/test/expected/transparent_decompression-18.out
+++ b/tsl/test/expected/transparent_decompression-18.out
@@ -1524,13 +1524,13 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5.00 loops=1)
 
 -- test aggregate with GROUP BY
@@ -1546,8 +1546,9 @@ ORDER BY device_id;
    Group Key: metrics.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_15_chunk.device_id
                            Sort Method: quicksort 
@@ -1558,8 +1559,9 @@ ORDER BY device_id;
                      Sort Key: _hyper_1_2_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                      ->  Sort (actual rows=5.00 loops=1)
                            Sort Key: compress_hyper_5_16_chunk.device_id
                            Sort Method: quicksort 
@@ -1577,8 +1579,9 @@ ORDER BY device_id;
          Group Key: metrics.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=3600.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_15_chunk.device_id
                                  Sort Method: quicksort 
@@ -1589,8 +1592,9 @@ ORDER BY device_id;
                            Sort Key: _hyper_1_2_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on _hyper_1_2_chunk (actual rows=3360.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=5.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1680.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=5.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics (actual rows=5.00 loops=1)
                            ->  Sort (actual rows=5.00 loops=1)
                                  Sort Key: compress_hyper_5_16_chunk.device_id
                                  Sort Method: quicksort 
@@ -1939,13 +1943,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_5_15_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_15_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_1_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_15_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
@@ -1954,11 +1957,10 @@ WHERE device_id = 1;
                ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=672.00 loops=1)
                      Filter: (_hyper_1_2_chunk.device_id = 1)
                      Rows Removed by Filter: 2688
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_5_16_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_1_3_chunk metrics (actual rows=1.00 loops=1)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_5_16_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                            Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
@@ -5420,14 +5422,14 @@ FROM :TEST_TABLE;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=9.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
@@ -5435,11 +5437,11 @@ FROM :TEST_TABLE;
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=2016.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3.00 loops=1)
          ->  Partial Aggregate (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
@@ -5457,20 +5459,23 @@ ORDER BY device_id;
    Group Key: metrics_space.device_id
    ->  Merge Append (actual rows=15.00 loops=1)
          Sort Key: metrics_space.device_id
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_17_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_18_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_19_chunk.device_id
                            Sort Method: quicksort 
@@ -5484,14 +5489,16 @@ ORDER BY device_id;
          ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                Group Key: _hyper_2_9_chunk.device_id
                ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_6_20_chunk.device_id
                            Sort Method: quicksort 
                            ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+         ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+               Group Key: device_id
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                      ->  Sort (actual rows=3.00 loops=1)
                            Sort Key: compress_hyper_6_21_chunk.device_id
                            Sort Method: quicksort 
@@ -5512,20 +5519,23 @@ ORDER BY device_id;
          Group Key: metrics_space.device_id
          ->  Merge Append (actual rows=15.00 loops=1)
                Sort Key: metrics_space.device_id
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_17_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=2160.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_5_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_18_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_6_chunk (actual rows=720.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_6_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_19_chunk.device_id
                                  Sort Method: quicksort 
@@ -5539,14 +5549,16 @@ ORDER BY device_id;
                ->  Partial GroupAggregate (actual rows=1.00 loops=1)
                      Group Key: _hyper_2_9_chunk.device_id
                      ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=672.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
                            ->  Sort (actual rows=1.00 loops=1)
                                  Sort Key: compress_hyper_6_20_chunk.device_id
                                  Sort Method: quicksort 
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
-               ->  Custom Scan (VectorAgg) (actual rows=3.00 loops=1)
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+               ->  Partial GroupAggregate (actual rows=3.00 loops=1)
+                     Group Key: device_id
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_2_11_chunk metrics_space (actual rows=3.00 loops=1)
                            ->  Sort (actual rows=3.00 loops=1)
                                  Sort Key: compress_hyper_6_21_chunk.device_id
                                  Sort Method: quicksort 
@@ -5910,13 +5922,12 @@ FROM :TEST_TABLE
 WHERE device_id = 1;
 --- QUERY PLAN ---
  Finalize Aggregate (actual rows=1.00 loops=1)
-   Output: count(*)
+   Output: sum(compress_hyper_6_17_chunk._ts_meta_count)
    ->  Append (actual rows=3.00 loops=1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_17_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_4_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_17_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_17_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
@@ -5924,11 +5935,10 @@ WHERE device_id = 1;
                Output: PARTIAL count(*)
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=672.00 loops=1)
                      Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         ->  Custom Scan (VectorAgg) (actual rows=1.00 loops=1)
-               Output: (PARTIAL count(*))
-               Grouping Policy: all compressed batches
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Bulk Decompression: false
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               Output: PARTIAL sum(compress_hyper_6_20_chunk._ts_meta_count)
+               ->  Custom Scan (ColumnarIndexScan) on _timescaledb_internal._hyper_2_10_chunk metrics_space (actual rows=1.00 loops=1)
+                     Output: compress_hyper_6_20_chunk._ts_meta_count
                      ->  Index Scan using compress_hyper_6_20_chunk_device_id_device_id_peer__ts_meta_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1.00 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                            Index Cond: (compress_hyper_6_20_chunk.device_id = 1)

--- a/tsl/test/expected/vector_agg_byte.out
+++ b/tsl/test/expected/vector_agg_byte.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+set timescaledb.enable_columnarindexscan = off;
 -- Tests for grouping by single-byte data types. Only bool for now, because char
 -- lacks a vectorized representation.
 create table groupbyte(ts int, b bool, x text, i int)

--- a/tsl/test/expected/vector_agg_default.out
+++ b/tsl/test/expected/vector_agg_default.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+set timescaledb.enable_columnarindexscan = off;
 -- Uncomment these two settings to run this test with hypercore TAM
 --set timescaledb.default_hypercore_use_access_method=true;
 --set enable_indexscan=off;

--- a/tsl/test/expected/vector_agg_expr.out
+++ b/tsl/test/expected/vector_agg_expr.out
@@ -3,6 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Expressions in vectorized aggregation.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+set timescaledb.enable_columnarindexscan = off;
 \pset null $
 create function always_null(x int4) returns int4 as $$ select null::int4 $$
 language sql strict immutable parallel safe;

--- a/tsl/test/expected/vector_agg_planning-15.out
+++ b/tsl/test/expected/vector_agg_planning-15.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_columnarindexscan = off;
 SET max_parallel_workers_per_gather = 0;
 \set EXPLAIN 'EXPLAIN (costs off, timing off)'
 CREATE TABLE metrics(time timestamptz not null, device text, value float) WITH (tsdb.hypertable);

--- a/tsl/test/expected/vector_agg_planning-16.out
+++ b/tsl/test/expected/vector_agg_planning-16.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_columnarindexscan = off;
 SET max_parallel_workers_per_gather = 0;
 \set EXPLAIN 'EXPLAIN (costs off, timing off)'
 CREATE TABLE metrics(time timestamptz not null, device text, value float) WITH (tsdb.hypertable);

--- a/tsl/test/expected/vector_agg_planning-17.out
+++ b/tsl/test/expected/vector_agg_planning-17.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_columnarindexscan = off;
 SET max_parallel_workers_per_gather = 0;
 \set EXPLAIN 'EXPLAIN (costs off, timing off)'
 CREATE TABLE metrics(time timestamptz not null, device text, value float) WITH (tsdb.hypertable);

--- a/tsl/test/expected/vector_agg_planning-18.out
+++ b/tsl/test/expected/vector_agg_planning-18.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_columnarindexscan = off;
 SET max_parallel_workers_per_gather = 0;
 \set EXPLAIN 'EXPLAIN (costs off, timing off)'
 CREATE TABLE metrics(time timestamptz not null, device text, value float) WITH (tsdb.hypertable);

--- a/tsl/test/expected/vectorized_aggregation.out
+++ b/tsl/test/expected/vectorized_aggregation.out
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set EXPLAIN 'EXPLAIN (VERBOSE, BUFFERS OFF, COSTS OFF)'
+SET timescaledb.enable_columnarindexscan TO OFF;
 CREATE TABLE testtable (
 time timestamptz NOT NULL,
 segment_by_value integer,

--- a/tsl/test/sql/columnar_index_scan.sql.in
+++ b/tsl/test/sql/columnar_index_scan.sql.in
@@ -39,8 +39,11 @@ INSERT INTO metrics VALUES
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
 
+-- first run with hypertable with 1 fully compressed chunk
+
 -- get query plans
 \set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 
@@ -62,21 +65,70 @@ SET timescaledb.enable_columnarindexscan = on;
 -- compare optimized vs non-optimized results
 :DIFF_CMD
 
--- test with multiple chunks to verify Append/MergeAppend handling
+-- make initial chunk partial
+INSERT INTO metrics VALUES
+('2025-01-01 00:00:00 PST', 'd1', 'A', 1.0, 1.1),
+('2025-01-01 00:00:00 PST', 'd3', 'A', 50.0, 50.1),
+('2025-01-01 00:00:00 PST', 'd3', 'B', 52.0, 52.1);
+
+-- second run with hypertable with 1 partial chunk
+
+-- get query plans
+\set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+
+\set PREFIX ''
+\set ECHO errors
+
+-- get query results with columnar index scan disabled
+SET timescaledb.enable_columnarindexscan = off;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+-- get query results with columnar index scan enabled
+SET timescaledb.enable_columnarindexscan = on;
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+-- compare optimized vs non-optimized results
+:DIFF_CMD
+
+-- create a second chunk
 INSERT INTO metrics VALUES
 ('2025-02-01 00:00:00 PST', 'd1', 'A', 100.0, 100.1),
 ('2025-02-01 01:00:00 PST', 'd1', 'B', 200.0, 200.1),
 ('2025-02-01 00:00:00 PST', 'd2', 'A', 150.0, 150.1),
 ('2025-02-01 01:00:00 PST', 'd2', 'C', 250.0, 250.1);
 
-SELECT compress_chunk(c) FROM show_chunks('metrics') c;
+SELECT compress_chunk(c) FROM show_chunks('metrics') c LIMIT 1 OFFSET 1;
 
+-- third run with hypertable with 1 partial and 1 fully compressed chunk
+
+-- get query plans
 \set PREFIX 'EXPLAIN (costs off)'
--- query across multiple chunks with ColumnarIndexScan
-:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
-SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
 
--- multiple aggregates across multiple chunks
-:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
-SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+\set PREFIX ''
+\set ECHO errors
+
+-- get query results with columnar index scan disabled
+SET timescaledb.enable_columnarindexscan = off;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+-- get query results with columnar index scan enabled
+SET timescaledb.enable_columnarindexscan = on;
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+-- compare optimized vs non-optimized results
+:DIFF_CMD
 

--- a/tsl/test/sql/include/columnar_index_scan_query.sql
+++ b/tsl/test/sql/include/columnar_index_scan_query.sql
@@ -5,6 +5,15 @@
 -- canary for test diff
 SHOW timescaledb.enable_columnarindexscan;
 
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+
 -- simple query with 1 max aggregate that can use optimization
 :PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
 
@@ -37,25 +46,24 @@ SHOW timescaledb.enable_columnarindexscan;
 -- test multiple group by columns
 :PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
 
--- order by does currently prevent optimization
-:PREFIX SELECT device, max(time) FROM metrics GROUP BY device ORDER BY device;
-
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 :PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
 
--- filter on non-segmentby prevents optimization
-:PREFIX SELECT device, max(time) FROM metrics WHERE time <> '2025-01-01'  GROUP BY device;
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
 
 -- tableoid doesnt prevent optimization
---:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
-
--- group by on non-segmentby prevents optimization
-:PREFIX SELECT max(time) FROM metrics GROUP BY value;
-:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
-
--- no group by prevents optimization
-:PREFIX SELECT max(time) FROM metrics;
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
 
 -- multiple aggregates on same column use optimization
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
@@ -75,14 +83,8 @@ SHOW timescaledb.enable_columnarindexscan;
 -- multiple aggregates on multiple columns
 :PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
 
--- expression on aggregates (currently not optimized)
+-- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
-
--- aggregate on segmentby column does not use optimization
-:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
-
--- aggregate on column without metadata does not use optimization
-:PREFIX SELECT device, min(value2) FROM metrics GROUP BY device;
 
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
@@ -94,11 +96,6 @@ SHOW timescaledb.enable_columnarindexscan;
 
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
-    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
-)
-SELECT * FROM agg_data ORDER BY device;
-
-WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
@@ -117,4 +114,50 @@ ORDER BY device;
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
 UNION ALL
 SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+
+-- currently unoptimized queries
+
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+
+-- first/last with different arg1 and arg2
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
 

--- a/tsl/test/sql/vector_agg_byte.sql
+++ b/tsl/test/sql/vector_agg_byte.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+set timescaledb.enable_columnarindexscan = off;
+
 -- Tests for grouping by single-byte data types. Only bool for now, because char
 -- lacks a vectorized representation.
 

--- a/tsl/test/sql/vector_agg_default.sql
+++ b/tsl/test/sql/vector_agg_default.sql
@@ -4,6 +4,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+set timescaledb.enable_columnarindexscan = off;
+
 -- Uncomment these two settings to run this test with hypercore TAM
 --set timescaledb.default_hypercore_use_access_method=true;
 --set enable_indexscan=off;

--- a/tsl/test/sql/vector_agg_expr.sql
+++ b/tsl/test/sql/vector_agg_expr.sql
@@ -6,6 +6,8 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+set timescaledb.enable_columnarindexscan = off;
+
 \pset null $
 
 create function always_null(x int4) returns int4 as $$ select null::int4 $$

--- a/tsl/test/sql/vector_agg_planning.sql.in
+++ b/tsl/test/sql/vector_agg_planning.sql.in
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timescaledb.enable_columnarindexscan = off;
 SET max_parallel_workers_per_gather = 0;
 \set EXPLAIN 'EXPLAIN (costs off, timing off)'
 

--- a/tsl/test/sql/vectorized_aggregation.sql
+++ b/tsl/test/sql/vectorized_aggregation.sql
@@ -4,6 +4,8 @@
 
 \set EXPLAIN 'EXPLAIN (VERBOSE, BUFFERS OFF, COSTS OFF)'
 
+SET timescaledb.enable_columnarindexscan TO OFF;
+
 CREATE TABLE testtable (
 time timestamptz NOT NULL,
 segment_by_value integer,


### PR DESCRIPTION
Do ColumnarIndexScan plan generation after postgres planning so we
dont have to work against setrefs. This commit also changes the
plan structure for this node. The node will be below a partial
aggregate node instead of replacing it.

New plan structure:

```
 Finalize Aggregate
   Filter: (sum(compress_hyper_2_5_chunk._ts_meta_count) > 1)
   ->  Append
         ->  Partial Aggregate
               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                     ->  Seq Scan on compress_hyper_2_5_chunk
         ->  Partial Aggregate
               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_9_chunk
                     ->  Seq Scan on compress_hyper_2_42_chunk
         ->  Partial Aggregate
               ->  Seq Scan on _hyper_1_9_chunk
```
This patch also adds count(*) as supported aggregate and adds
support for HAVING clause.