### PR TITLE
Fix bumping version in post release workflow

### DIFF
--- a/scripts/release/build_post_release_artefacts.sh
+++ b/scripts/release/build_post_release_artefacts.sh
@@ -51,5 +51,6 @@ echo "remove .unreleased files"
 
 # Set new previous version
 echo "Set new previous version version.config to ${PUBLISHED_VERSION}"
-sed -i '' -e "s/^previous_version = .*/previous_version = $PUBLISHED_VERSION/" version.config
+sed -i.bak "s/^previous_version = .*/previous_version = $PUBLISHED_VERSION/" version.config
+rm -f version.config.bak
 tail -n 1 version.config


### PR DESCRIPTION
Use both GNU and BSD sed compatible syntax to fix "can't read" errors in post release ceremony workflow