### PR TITLE
conn_ssl.c: guard old openssl API functions

### DIFF
--- a/.unreleased/pr_9277
+++ b/.unreleased/pr_9277
@@ -1,0 +1,2 @@
+Fixes: #9277 Fix SSL-related build errors
+Thanks: @tureba for fixing SSL-related build errors

--- a/src/net/conn_ssl.c
+++ b/src/net/conn_ssl.c
@@ -267,14 +267,20 @@ extern void _conn_ssl_fini(void);
 void
 _conn_ssl_init(void)
 {
+#if (OPENSSL_VERSION_NUMBER < 0x1010000fL)
+	/* OpenSSL < 1.1.0 requires explicit initialization */
 	SSL_library_init();
 	/* Always returns 1 */
 	SSL_load_error_strings();
+#endif
 	ts_connection_register(CONNECTION_SSL, &ssl_ops);
 }
 
 void
 _conn_ssl_fini(void)
 {
+#if (OPENSSL_VERSION_NUMBER < 0x1010000fL)
+	/* OpenSSL < 1.1.0 requires explicit cleanup */
 	ERR_free_strings();
+#endif
 }


### PR DESCRIPTION
The openssl functions SSL_library_init(), SSL_load_error_strings(), and ERR_free_strings() were deprecated in openssl 1.1.0, and shouldn't be called on newer versions. In some runtime library versions, the symbols may not even exist in the library anymore, leading to errors like:

  ERROR:  could not load library "/usr/pgsql-18/lib/timescaledb-2.25.1.so":
    /usr/pgsql-18/lib/timescaledb-2.25.1.so: undefined symbol: SSL_library_init
    
This should cover issue #9274 

Disable-check: force-changelog-file
