### PR TITLE
First cut of the composite bloom changes

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -328,7 +328,7 @@ jobs:
       if: always() && contains(matrix.name, 'Flaky')
       run: |
         ! jq 'select(
-                (.state_code == "XX000" and .error_severity != "LOG")
+                (.state_code == "XX000" and .error_severity != "LOG" and (.message | test("TestFailure") | not))
                 or (.message | test("resource was not closed"))
             ) | [.message, .func_name,  .statement] | @tsv
         ' -r postmaster.json | grep .

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       PG_SRC_DIR: pgbuild
       PG_INSTALL_DIR: postgresql
-      CODE_PATHS: src/ tsl/src/
+      CODE_PATHS: src/ tsl/src/ test/src tsl/test/src
 
     steps:
     - name: Checkout TimescaleDB

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     uuid.c
     agg_bookend.c
+    bmslist_utils.c
     func_cache.c
     cache.c
     cache_invalidate.c

--- a/src/bmslist_utils.c
+++ b/src/bmslist_utils.c
@@ -1,0 +1,95 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include "bmslist_utils.h"
+
+TsBmsList
+ts_bmslist_create(void)
+{
+	/* Create a new empty list is NULL */
+	return NIL;
+}
+
+TsBmsList
+ts_bmslist_add_member(TsBmsList bmslist, const int *items, int num_items)
+{
+	Assert(items != NULL);
+	Assert(num_items > 0);
+
+	if (items == NULL || num_items == 0)
+		return bmslist;
+
+	/* Create a new Bitmapset for the items */
+	int first_item = items[0];
+	Bitmapset *set = bms_make_singleton(first_item);
+	for (int i = 1; i < num_items; i++)
+	{
+		int item = items[i];
+		set = bms_add_member(set, item);
+	}
+
+	/* Add the new set to the list */
+	return lappend(bmslist, set);
+}
+
+TsBmsList
+ts_bmslist_add_set(TsBmsList bmslist, Bitmapset *set)
+{
+	Assert(set != NULL);
+	return lappend(bmslist, set);
+}
+
+bool
+ts_bmslist_contains_items(TsBmsList bmslist, const int *items, int num_items)
+{
+	bool result = false;
+
+	Assert(items != NULL);
+	Assert(num_items > 0);
+
+	if (items == NULL || num_items == 0)
+		return false;
+
+	/* Create a new Bitmapset for the items */
+	int first_item = items[0];
+	Bitmapset *set = bms_make_singleton(first_item);
+	for (int i = 1; i < num_items; i++)
+	{
+		int item = items[i];
+		set = bms_add_member(set, item);
+	}
+
+	result = ts_bmslist_contains_set(bmslist, set);
+
+	bms_free(set);
+	return result;
+}
+
+bool
+ts_bmslist_contains_set(TsBmsList bmslist, Bitmapset *set)
+{
+	ListCell *lc;
+	Assert(set != NULL);
+
+	if (set == NULL)
+		return false;
+
+	foreach (lc, bmslist)
+	{
+		Bitmapset *item = (Bitmapset *) lfirst(lc);
+		if (bms_equal(item, set))
+			return true;
+	}
+
+	return false;
+}
+
+void
+ts_bmslist_free(TsBmsList bmslist)
+{
+	list_free_deep(bmslist);
+}

--- a/src/bmslist_utils.h
+++ b/src/bmslist_utils.h
@@ -1,0 +1,37 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+/*
+ * Utility functions to simplify working with lists of Bitmapsets.
+ * It builds on the Bitmapset and List implementations in Postgres.
+ * It is merely a convenience layer on top of the Postgres functionality.
+ */
+
+#include "nodes/bitmapset.h"
+#include "nodes/pg_list.h"
+#include "postgres.h"
+
+#include "export.h"
+
+typedef List *TsBmsList;
+
+/* Just a wrapper around the List type */
+extern TSDLLEXPORT TsBmsList ts_bmslist_create(void);
+
+/* Convert the items to a Bitmapset and add it to the list. It doesn't verify if
+ * the items are already in the list, so it may add duplicates. */
+extern TSDLLEXPORT TsBmsList ts_bmslist_add_member(TsBmsList bmslist, const int *items,
+												   int num_items);
+extern TSDLLEXPORT TsBmsList ts_bmslist_add_set(TsBmsList bmslist, Bitmapset *set);
+
+/* Checks if the list contains the given items or set. */
+extern TSDLLEXPORT bool ts_bmslist_contains_items(TsBmsList bmslist, const int *items,
+												  int num_items);
+extern TSDLLEXPORT bool ts_bmslist_contains_set(TsBmsList bmslist, Bitmapset *set);
+
+/* Frees the list and all the Bitmapsets it contains. */
+extern TSDLLEXPORT void ts_bmslist_free(TsBmsList bmslist);

--- a/src/foreach_ptr.h
+++ b/src/foreach_ptr.h
@@ -1,0 +1,33 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <compat/compat.h>
+#include <postgres.h>
+#include <nodes/pg_list.h>
+
+#ifdef PG17_LT
+/* In PG16 foreach_ptr is not available, this is a straight copy of the
+ * Postgres code that defines foreach_ptr and foreach_internal.
+ *
+ * Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ */
+
+#ifndef foreach_ptr
+#define foreach_ptr(type, var, lst) foreach_internal(type, *, var, lst, lfirst)
+#endif
+
+#ifndef foreach_internal
+#define foreach_internal(type, pointer, var, lst, func)                                            \
+	for (type pointer var = 0, pointer var##__outerloop = (type pointer) 1; var##__outerloop;      \
+		 var##__outerloop = 0)                                                                     \
+		for (ForEachState var##__state = { (lst), 0 };                                             \
+			 (var##__state.l != NIL && var##__state.i < var##__state.l->length &&                  \
+			  (var = (type pointer) func(&var##__state.l->elements[var##__state.i]), true));       \
+			 var##__state.i++)
+#endif
+#endif /* PG17_LT */

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -15,6 +15,8 @@ extern TSDLLEXPORT void ts_jsonb_add_null(JsonbParseState *state, const char *ke
 extern TSDLLEXPORT void ts_jsonb_add_bool(JsonbParseState *state, const char *key, bool boolean);
 extern TSDLLEXPORT void ts_jsonb_add_str(JsonbParseState *state, const char *key,
 										 const char *value);
+extern TSDLLEXPORT void ts_jsonb_add_str_array(JsonbParseState *state, const char *key,
+											   const char **values, int num_values);
 extern TSDLLEXPORT void ts_jsonb_add_interval(JsonbParseState *state, const char *key,
 											  Interval *interval);
 extern TSDLLEXPORT void ts_jsonb_add_int32(JsonbParseState *state, const char *key,
@@ -33,9 +35,6 @@ extern TSDLLEXPORT int32 ts_jsonb_get_int32_field(const Jsonb *json, const char 
 												  bool *field_found);
 extern TSDLLEXPORT int64 ts_jsonb_get_int64_field(const Jsonb *json, const char *key,
 												  bool *field_found);
-extern TSDLLEXPORT bool ts_jsonb_equal(Jsonb *left, Jsonb *right);
-extern TSDLLEXPORT Jsonb *ts_jsonb_replace_key_value_str_field(Jsonb *jb, const char *key,
-															   const char *old, const char *new,
-															   bool *replaced);
+extern TSDLLEXPORT bool ts_jsonb_equal(const Jsonb *left, const Jsonb *right);
 extern TSDLLEXPORT bool ts_jsonb_has_key_value_str_field(Jsonb *jb, const char *key,
 														 const char *value);

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -8,12 +8,14 @@
 #include <parser/parse_func.h>
 #include <utils/builtins.h>
 
+#include "foreach_ptr.h"
 #include "jsonb_utils.h"
 #include "scan_iterator.h"
 #include "scanner.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/compression_settings.h"
+#include <common/md5.h>
 #include <utils/palloc.h>
 
 TSDLLEXPORT const char *ts_sparse_index_type_names[] = { "bloom", "minmax" };
@@ -22,6 +24,7 @@ TSDLLEXPORT const char *ts_sparse_index_common_keys[] = { "type", "column", "sou
 static ScanTupleResult compression_settings_tuple_update(TupleInfo *ti, void *data);
 static HeapTuple compression_settings_formdata_make_tuple(const FormData_compression_settings *fd,
 														  TupleDesc desc);
+static Bitmapset *resolve_columns_to_attnos(List *column_names, Oid relid);
 
 /*
  * Compare two compression settings for equality
@@ -211,7 +214,6 @@ compression_settings_get(Oid relid, bool by_compress_relid)
 	settings = palloc0(sizeof(CompressionSettings));
 	compression_settings_fill_from_tuple(settings, ti);
 	ts_scan_iterator_close(&iterator);
-
 	return settings;
 }
 
@@ -302,21 +304,51 @@ compression_settings_rename_column(CompressionSettings *settings, const char *ol
 {
 	Jsonb *replacejsonb = NULL;
 	bool replaced = false;
+
 	settings->fd.segmentby = ts_array_replace_text(settings->fd.segmentby, old, new);
 	settings->fd.orderby = ts_array_replace_text(settings->fd.orderby, old, new);
 
-	/* jsonb filed can not be mutated inplace, a new copy will be created */
-	if (settings->fd.index &&
-		ts_jsonb_has_key_value_str_field(settings->fd.index,
-										 ts_sparse_index_common_keys[SparseIndexKeyCol],
-										 old))
+	replacejsonb = settings->fd.index;
+	if (replacejsonb)
 	{
-		replacejsonb =
-			ts_jsonb_replace_key_value_str_field(settings->fd.index,
-												 ts_sparse_index_common_keys[SparseIndexKeyCol],
-												 old,
-												 new,
-												 &replaced);
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(replacejsonb);
+		if (parsed_settings)
+		{
+			foreach_ptr(SparseIndexSettingsObject, obj, parsed_settings->objects)
+			{
+				Assert(obj != NULL);
+				if (!obj)
+					continue;
+
+				foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+				{
+					Assert(pair != NULL);
+					if (!pair)
+						continue;
+
+					ListCell *value_cell = NULL;
+					foreach (value_cell, pair->values)
+					{
+						const char *value = (const char *) lfirst(value_cell);
+						Assert(value != NULL);
+						if (!value)
+							continue;
+
+						if (strcmp(value, old) == 0)
+						{
+							value_cell->ptr_value =
+								ts_sparse_index_settings_pstrdup(parsed_settings, new);
+							replaced = true;
+						}
+					}
+				}
+			}
+			if (replaced)
+			{
+				replacejsonb = ts_convert_from_sparse_index_settings(parsed_settings);
+			}
+			ts_free_sparse_index_settings(parsed_settings);
+		}
 	}
 
 	settings->fd.index = replaced ? replacejsonb : settings->fd.index;
@@ -375,8 +407,11 @@ ts_compression_settings_update(CompressionSettings *settings)
 				ts_contains_sparse_index_config(settings,
 												TextDatumGetCString(datum),
 												ts_sparse_index_type_names
-													[_SparseIndexTypeEnumBloom]))
+													[_SparseIndexTypeEnumBloom],
+												/* skip_column_arrays = */ true))
 			{
+				/* disallow single column bloom index on orderby columns, composite bloom is
+				 * allowed, that is why we set 'skip_column_arrays' to true */
 				ereport(ERROR,
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("the orderby column \"%s\" cannot have a bloom sparse index ",
@@ -399,8 +434,12 @@ ts_compression_settings_update(CompressionSettings *settings)
 			{
 				if (ts_contains_sparse_index_config(settings,
 													TextDatumGetCString(datum),
-													ts_sparse_index_type_names[i]))
+													ts_sparse_index_type_names[i],
+													/* skip_column_arrays = */ false))
 				{
+					/* segmentby columns cannot have sparse indexes of any type, including composite
+					 * bloom that is why we set 'skip_column_arrays' to false, which will look
+					 * inside column name arrays, so composite bloom filters are checked too */
 					ereport(ERROR,
 							(errcode(ERRCODE_SYNTAX_ERROR),
 							 errmsg("the segmentby column \"%s\" can not have sparse "
@@ -504,86 +543,117 @@ compression_settings_tuple_update(TupleInfo *ti, void *data)
 }
 
 void
-ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state, SparseIndexConfig *config)
+ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state, SparseIndexConfigBase *config)
 {
+	MinmaxIndexColumnConfig *minmax_config = NULL;
+	BloomFilterConfig *bloom_config = NULL;
+
 	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
 	ts_jsonb_add_str(parse_state,
 					 ts_sparse_index_common_keys[SparseIndexKeyType],
-					 ts_sparse_index_type_names[config->base.type]); /* type */
+					 ts_sparse_index_type_names[config->type]); /* type */
+	switch (config->type)
+	{
+		case _SparseIndexTypeEnumMinmax:
+			minmax_config = (MinmaxIndexColumnConfig *) config;
+			ts_jsonb_add_str(parse_state,
+							 ts_sparse_index_common_keys[SparseIndexKeyCol],
+							 minmax_config->col); /* column */
+			break;
+		case _SparseIndexTypeEnumBloom:
+			bloom_config = (BloomFilterConfig *) config;
 
-	ts_jsonb_add_str(parse_state,
-					 ts_sparse_index_common_keys[SparseIndexKeyCol],
-					 config->base.col); /* column */
+			if (bloom_config->num_columns > 1)
+			{
+				/* add the column names as an array */
+				const char *column_names[MAX_BLOOM_FILTER_COLUMNS] = { 0 };
+				for (int i = 0; i < bloom_config->num_columns; i++)
+				{
+					column_names[i] = bloom_config->columns[i].name;
+				}
 
+				ts_jsonb_add_str_array(parse_state,
+									   ts_sparse_index_common_keys[SparseIndexKeyCol],
+									   column_names,
+									   bloom_config->num_columns);
+			}
+			else
+			{
+				ts_jsonb_add_str(parse_state,
+								 ts_sparse_index_common_keys[SparseIndexKeyCol],
+								 bloom_config->columns[0].name); /* column */
+			}
+			break;
+
+		default:
+			elog(ERROR, "invalid sparse index type: %d", config->type);
+	};
 	ts_jsonb_add_str(parse_state,
 					 ts_sparse_index_common_keys[SparseIndexKeySource],
-					 ts_sparse_index_source_names[config->base.source]); /* source */
+					 ts_sparse_index_source_names[config->source]); /* source */
 	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
 }
 
-static Jsonb *
-find_sparse_index_config(Jsonb *jsonb, const char *attname, const char *sparse_index_type)
-{
-	Oid fnargtypes[] = { JSONBOID, TEXTOID, TEXTOID };
-	FmgrInfo flinfo;
-	LOCAL_FCINFO(fcinfo, 3);
-	Datum result_datum;
-	if (jsonb == NULL || JB_ROOT_COUNT(jsonb) == 0)
-		return NULL;
-	else if (attname == NULL)
-		elog(ERROR, "sparse index attname is null");
-
-	bool valid_type = false;
-	for (int i = 0; i < _SparseIndexTypeEnumMax; i++)
-	{
-		if (strcmp(ts_sparse_index_type_names[i], sparse_index_type) == 0)
-		{
-			valid_type = true;
-			break;
-		}
-	}
-	if (!valid_type)
-		elog(ERROR, "\"%s\" is not a valid sparse index configuration type", sparse_index_type);
-
-	List *funcname =
-		list_make2(makeString(FUNCTIONS_SCHEMA_NAME), makeString("jsonb_get_matching_index_entry"));
-
-	Oid fnoid =
-		LookupFuncName(funcname, sizeof(fnargtypes) / sizeof(fnargtypes[0]), fnargtypes, false);
-
-	if (!OidIsValid(fnoid))
-		elog(ERROR,
-			 "function %s.%s does not exist",
-			 FUNCTIONS_SCHEMA_NAME,
-			 "jsonb_get_matching_index_entry");
-
-	fmgr_info(fnoid, &flinfo);
-	InitFunctionCallInfoData(*fcinfo, &flinfo, 3, InvalidOid, NULL, NULL);
-
-	FC_SET_ARG(fcinfo, 0, JsonbPGetDatum(jsonb));
-	FC_SET_ARG(fcinfo, 1, CStringGetTextDatum(attname));
-	FC_SET_ARG(fcinfo, 2, CStringGetTextDatum(sparse_index_type));
-
-	result_datum = FunctionCallInvoke(fcinfo);
-
-	if (fcinfo->isnull)
-		return NULL;
-
-	return DatumGetJsonbP(result_datum);
-}
-
-static bool
-contains_sparse_index_config(Jsonb *jsonb, const char *attname, const char *sparse_index_type)
-{
-	return (find_sparse_index_config(jsonb, attname, sparse_index_type) != NULL);
-}
-
-/* checks if given attribute has a sparse index of given type */
 bool
 ts_contains_sparse_index_config(CompressionSettings *settings, const char *attname,
-								const char *sparse_index_type)
+								const char *sparse_index_type, bool skip_column_arrays)
 {
-	return contains_sparse_index_config(settings->fd.index, attname, sparse_index_type);
+	bool result = false;
+	if (settings == NULL || settings->fd.index == NULL || attname == NULL)
+		return false;
+
+	SparseIndexSettings *parsed = ts_convert_to_sparse_index_settings(settings->fd.index);
+
+	if (parsed == NULL)
+	{
+		return false;
+	}
+
+	foreach_ptr(SparseIndexSettingsObject, obj, parsed->objects)
+	{
+		const char *index_type = NULL;
+		bool attname_found = false;
+		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+		{
+			if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol]) == 0)
+			{
+				if (skip_column_arrays && list_length(pair->values) > 1)
+				{
+					continue;
+				}
+
+				foreach_ptr(const char, value, pair->values)
+				{
+					if (strcmp(value, attname) == 0)
+					{
+						attname_found = true;
+						break;
+					}
+				}
+			}
+			if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyType]) == 0)
+			{
+				index_type = (const char *) lfirst(list_head(pair->values));
+				if (strcmp(index_type, sparse_index_type) != 0)
+				{
+					break;
+				}
+				else if (attname_found)
+				{
+					result = true;
+					break;
+				}
+			}
+			if (attname_found && index_type != NULL)
+			{
+				result = strcmp(index_type, sparse_index_type) == 0;
+				break;
+			}
+		}
+	}
+
+	ts_free_sparse_index_settings(parsed);
+	return result;
 }
 
 /* adds orderby sparse index settings into fd.index */
@@ -634,11 +704,11 @@ ts_add_orderby_sparse_index(CompressionSettings *settings)
 			continue;
 		}
 
-		SparseIndexConfig config;
+		MinmaxIndexColumnConfig config;
 		config.base.type = _SparseIndexTypeEnumMinmax;
-		config.base.col = TextDatumGetCString(datum);
+		config.col = TextDatumGetCString(datum);
 		config.base.source = _SparseIndexSourceEnumOrderby;
-		ts_convert_sparse_index_config_to_jsonb(parse_state, &config);
+		ts_convert_sparse_index_config_to_jsonb(parse_state, (SparseIndexConfigBase *) &config);
 	}
 
 	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
@@ -694,4 +764,605 @@ ts_remove_orderby_sparse_index(CompressionSettings *settings)
 		elog(LOG, "orderby settings existed, but no orderby sparse index was removed");
 
 	return has_object ? JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL)) : NULL;
+}
+
+int
+ts_qsort_attrnumber_cmp(const void *a, const void *b)
+{
+	SparseIndexColumn *col_a = (SparseIndexColumn *) a;
+	SparseIndexColumn *col_b = (SparseIndexColumn *) b;
+
+	return ((int) (col_a->attnum)) - ((int) (col_b->attnum));
+}
+
+SparseIndexSettings *
+ts_convert_to_sparse_index_settings(Jsonb *jsonb)
+{
+	enum ParseState
+	{
+		PARSE_STATE_INIT,
+		PARSE_STATE_KEY,
+		PARSE_STATE_VALUE,
+		PARSE_STATE_ARRAY_ENTRIES
+	};
+
+	MemoryContext tmp_context, new_context;
+	enum ParseState state = PARSE_STATE_INIT;
+	JsonbValue jsonb_value;
+	JsonbIterator *it;
+	JsonbIteratorToken r;
+	int num_arrays = 0;
+
+	Assert(jsonb != NULL);
+
+	if (jsonb == NULL)
+		return NULL;
+
+	if (JB_ROOT_IS_SCALAR(jsonb))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("cannot convert scalar to SparseIndexSettings")));
+
+	if (JB_ROOT_COUNT(jsonb) == 0)
+		return NULL;
+
+	it = JsonbIteratorInit(&jsonb->root);
+
+	new_context = AllocSetContextCreate(CurrentMemoryContext,
+										"SparseIndexSettings",
+										ALLOCSET_DEFAULT_MINSIZE,
+										ALLOCSET_DEFAULT_INITSIZE,
+										ALLOCSET_DEFAULT_MAXSIZE);
+
+	SparseIndexSettings *parsed_settings =
+		MemoryContextAllocZero(new_context, sizeof(SparseIndexSettings));
+
+	parsed_settings->objects = NIL;
+	parsed_settings->context = new_context;
+
+	while ((r = JsonbIteratorNext(&it, &jsonb_value, false)) != WJB_DONE)
+	{
+		switch (state)
+		{
+			case PARSE_STATE_INIT:
+				if (r == WJB_END_OBJECT || r == WJB_END_ARRAY)
+				{
+					/* Ignore*/
+				}
+				else if (r == WJB_BEGIN_OBJECT)
+				{
+					SparseIndexSettingsObject *current_object = NULL;
+
+					/* If the previous object has no pairs, reuse its space for the new object */
+					if (list_length(parsed_settings->objects) > 0)
+					{
+						current_object = llast(parsed_settings->objects);
+						if (list_length(current_object->pairs) > 0)
+						{
+							/* We can't reuse the previous object, so we need to create a new one */
+							current_object = NULL;
+						}
+					}
+
+					if (current_object == NULL)
+					{
+						/* Create a new object */
+						tmp_context = MemoryContextSwitchTo(parsed_settings->context);
+						current_object = palloc0(sizeof(SparseIndexSettingsObject));
+						parsed_settings->objects =
+							lappend(parsed_settings->objects, current_object);
+						MemoryContextSwitchTo(tmp_context);
+					}
+					state = PARSE_STATE_KEY;
+				}
+				else if (r == WJB_KEY)
+				{
+					Ensure(jsonb_value.type == jbvString,
+						   "Jsonb value is of type \"%s\", but expected of type string, in state "
+						   "INIT",
+						   JsonbTypeName(&jsonb_value));
+
+					SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
+					Assert(current_object != NULL);
+					tmp_context = MemoryContextSwitchTo(parsed_settings->context);
+					char *tmp_str =
+						pnstrdup(jsonb_value.val.string.val, jsonb_value.val.string.len);
+					SparseIndexSettingsPair *current_pair =
+						palloc0(sizeof(SparseIndexSettingsPair));
+					current_object->pairs = lappend(current_object->pairs, current_pair);
+					current_pair->key = tmp_str;
+					current_pair->values = NIL;
+					MemoryContextSwitchTo(tmp_context);
+					state = PARSE_STATE_VALUE;
+				}
+				else if (r == WJB_BEGIN_ARRAY)
+				{
+					num_arrays++;
+					/* We can ignore one begin array, but more than one is not allowed as we don't
+					 * support nested arrays */
+					if (num_arrays > 1)
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+								 errmsg("Jsonb value is of type \"%s\", but expected of type begin "
+										"object or end object, in state INIT",
+										JsonbTypeName(&jsonb_value))));
+				}
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("Jsonb value is of type \"%s\", but expected of type begin "
+									"object or end object, in state INIT",
+									JsonbTypeName(&jsonb_value))));
+				}
+				break;
+
+			case PARSE_STATE_KEY:
+				if (r == WJB_KEY)
+				{
+					Ensure(jsonb_value.type == jbvString,
+						   "Jsonb value is of type \"%s\", but expected of type string, in state "
+						   "KEY",
+						   JsonbTypeName(&jsonb_value));
+
+					SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
+					Assert(current_object != NULL);
+					tmp_context = MemoryContextSwitchTo(parsed_settings->context);
+					char *tmp_str =
+						pnstrdup(jsonb_value.val.string.val, jsonb_value.val.string.len);
+					SparseIndexSettingsPair *current_pair =
+						palloc0(sizeof(SparseIndexSettingsPair));
+					current_object->pairs = lappend(current_object->pairs, current_pair);
+					current_pair->key = tmp_str;
+					current_pair->values = NIL;
+					MemoryContextSwitchTo(tmp_context);
+					state = PARSE_STATE_VALUE;
+				}
+				else if (r == WJB_END_OBJECT)
+				{
+					state = PARSE_STATE_INIT;
+				}
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("Jsonb value is of type \"%s\", but expected of type key or "
+									"end object, in state KEY",
+									JsonbTypeName(&jsonb_value))));
+				}
+				break;
+
+			case PARSE_STATE_VALUE:
+				if (r == WJB_VALUE)
+				{
+					SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
+					Assert(current_object != NULL);
+
+					Ensure(jsonb_value.type == jbvString,
+						   "Jsonb value is of type \"%s\", but expected of type string, in state "
+						   "VALUE",
+						   JsonbTypeName(&jsonb_value));
+
+					tmp_context = MemoryContextSwitchTo(parsed_settings->context);
+					char *tmp_str =
+						pnstrdup(jsonb_value.val.string.val, jsonb_value.val.string.len);
+					SparseIndexSettingsPair *current_pair = llast(current_object->pairs);
+
+					/* The pair should have been created in the KEY state, but no values should have
+					 * been added yet */
+					Assert(current_pair != NULL);
+					Assert(current_pair->values == NIL);
+
+					current_pair->values = lappend(current_pair->values, tmp_str);
+					MemoryContextSwitchTo(tmp_context);
+					state = PARSE_STATE_KEY;
+				}
+				else if (r == WJB_BEGIN_ARRAY)
+				{
+#ifdef USE_ASSERT_CHECKING
+					SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
+					Assert(current_object != NULL);
+
+					/* The pair list should have been created in the key state */
+					Assert(list_length(current_object->pairs) > 0);
+
+					SparseIndexSettingsPair *current_pair = llast(current_object->pairs);
+					Assert(current_pair != NULL);
+					/* The values list should be empty when we arrive to the array start */
+					Assert(current_pair->values == NIL);
+#endif
+					state = PARSE_STATE_ARRAY_ENTRIES;
+				}
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("Jsonb value is of type \"%s\", but expected of type value or "
+									"array, in state VALUE",
+									JsonbTypeName(&jsonb_value))));
+				}
+				break;
+
+			case PARSE_STATE_ARRAY_ENTRIES:
+				if (r == WJB_ELEM)
+				{
+					SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
+					Assert(current_object != NULL);
+
+					SparseIndexSettingsPair *current_pair = llast(current_object->pairs);
+					Assert(current_pair != NULL);
+
+					Ensure(jsonb_value.type == jbvString,
+						   "Jsonb value is of type \"%s\", but expected of type string, in state "
+						   "ARRAY_ENTRIES",
+						   JsonbTypeName(&jsonb_value));
+
+					tmp_context = MemoryContextSwitchTo(parsed_settings->context);
+					char *tmp_str =
+						pnstrdup(jsonb_value.val.string.val, jsonb_value.val.string.len);
+					current_pair->values = lappend(current_pair->values, tmp_str);
+					MemoryContextSwitchTo(tmp_context);
+					/* state remains ARRAY_ENTRIES */
+				}
+				else if (r == WJB_END_ARRAY)
+				{
+					state = PARSE_STATE_INIT;
+				}
+				else
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("Jsonb value is of type \"%s\", but expected of type elem or "
+									"end array, in state ARRAY_ENTRIES",
+									JsonbTypeName(&jsonb_value))));
+				}
+				break;
+		}
+	}
+
+	/* If the last object has no pairs, remove it */
+	if (list_length(parsed_settings->objects) > 0)
+	{
+		SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
+		Assert(current_object != NULL);
+		if (list_length(current_object->pairs) == 0)
+		{
+			parsed_settings->objects = list_delete_last(parsed_settings->objects);
+		}
+	}
+
+	/* If there are no objects, free the parsed settings */
+	if (list_length(parsed_settings->objects) == 0)
+	{
+		ts_free_sparse_index_settings(parsed_settings);
+		parsed_settings = NULL;
+	}
+	return parsed_settings;
+}
+
+Jsonb *
+ts_convert_from_sparse_index_settings(SparseIndexSettings *settings)
+{
+	JsonbParseState *parse_state = NULL;
+
+	Assert(settings != NULL);
+	if (settings == NULL)
+		return NULL;
+
+	if (list_length(settings->objects) == 0)
+		return NULL;
+
+	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+	foreach_ptr(SparseIndexSettingsObject, obj, settings->objects)
+	{
+		pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+		Assert(list_length(obj->pairs) > 0);
+		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+		{
+			Assert(pair->key != NULL);
+			Assert(list_length(pair->values) > 0);
+			JsonbValue key = { .type = jbvString,
+							   .val = {
+								   .string = { .val = pair->key, .len = strlen(pair->key) } } };
+			pushJsonbValue(&parse_state, WJB_KEY, &key);
+
+			if (list_length(pair->values) == 1)
+			{
+				const char *value = (const char *) lfirst(list_head(pair->values));
+				Assert(value != NULL);
+				int len = strlen(value);
+				Assert(len > 0);
+				JsonbValue value_jsonb = {
+					.type = jbvString, .val = { .string = { .val = pstrdup(value), .len = len } }
+				};
+				pushJsonbValue(&parse_state, WJB_VALUE, &value_jsonb);
+			}
+			else
+			{
+				pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+				foreach_ptr(const char, value, pair->values)
+				{
+					Assert(value != NULL);
+					int len = strlen(value);
+					Assert(len > 0);
+					JsonbValue value_jsonb = { .type = jbvString,
+											   .val = { .string = { .val = pstrdup(value),
+																	.len = len } } };
+					pushJsonbValue(&parse_state, WJB_ELEM, &value_jsonb);
+				}
+				pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL);
+			}
+		}
+		pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	}
+	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
+}
+
+void
+ts_free_sparse_index_settings(SparseIndexSettings *settings)
+{
+	if (settings == NULL)
+		return;
+
+	if (settings->context != NULL)
+		MemoryContextDelete(settings->context);
+}
+
+const char *
+ts_sparse_index_settings_to_cstring(const SparseIndexSettings *settings)
+{
+	StringInfoData buf;
+	int i = 0, j = 0, k = 0;
+
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "[");
+
+	foreach_ptr(SparseIndexSettingsObject, obj, settings->objects)
+	{
+		if (i > 0)
+			appendStringInfo(&buf, ", ");
+		appendStringInfo(&buf, "{");
+
+		j = 0;
+		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+		{
+			if (j > 0)
+				appendStringInfo(&buf, ", ");
+			escape_json(&buf, pair->key);
+			appendStringInfo(&buf, ": ");
+
+			if (list_length(pair->values) == 1)
+			{
+				escape_json(&buf, (const char *) lfirst(list_head(pair->values)));
+			}
+			else
+			{
+				k = 0;
+				appendStringInfo(&buf, "[");
+				foreach_ptr(const char, value, pair->values)
+				{
+					if (k > 0)
+						appendStringInfo(&buf, ", ");
+					escape_json(&buf, value);
+					k++;
+				}
+				appendStringInfo(&buf, "]");
+			}
+			j++;
+		}
+		appendStringInfo(&buf, "}");
+		i++;
+	}
+
+	appendStringInfo(&buf, "]");
+	return buf.data;
+}
+
+char *
+ts_sparse_index_settings_pstrdup(SparseIndexSettings *settings, const char *str)
+{
+	Assert(settings != NULL);
+	Assert(str != NULL);
+	Assert(settings->context != NULL);
+
+	MemoryContext old_context = MemoryContextSwitchTo(settings->context);
+	char *new_str = pstrdup(str);
+	MemoryContextSwitchTo(old_context);
+	return new_str;
+}
+
+/* returns a list of PerColumnCompressionSettings objects */
+List *
+ts_get_per_column_compression_settings(const SparseIndexSettings *settings)
+{
+	if (settings == NULL)
+		return NIL;
+
+	List *result_settings = NIL;
+	int obj_id = 0;
+
+	foreach_ptr(SparseIndexSettingsObject, obj, settings->objects)
+	{
+		const char *index_type = NULL;
+		SparseIndexSettingsPair *column_names_pair = NULL;
+
+		Assert(obj != NULL);
+
+		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+		{
+			if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyType]) == 0)
+			{
+				Assert(list_length(pair->values) > 0);
+				index_type = (const char *) lfirst(list_head(pair->values));
+			}
+			else if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol]) == 0)
+			{
+				column_names_pair = pair;
+			}
+		}
+
+		/* we may have an empty object, that is the default */
+		if (index_type != NULL && column_names_pair != NULL)
+		{
+			/* find the column names and iterate over them */
+			int num_columns = list_length(column_names_pair->values);
+			foreach_ptr(const char, column_name, column_names_pair->values)
+			{
+				Assert(column_name != NULL);
+
+				PerColumnCompressionSettings *per_column_setting = NULL;
+				/* check if the column name is already in the list */
+				foreach_ptr(PerColumnCompressionSettings, tmp, result_settings)
+				{
+					if (strcmp(tmp->column_name, column_name) == 0)
+					{
+						per_column_setting = tmp;
+						break;
+					}
+				}
+
+				/* if no object is found, create a new one */
+				if (per_column_setting == NULL)
+				{
+					per_column_setting = palloc0(sizeof(PerColumnCompressionSettings));
+					per_column_setting->column_name = column_name;
+					per_column_setting->minmax_obj_id = -1;
+					per_column_setting->single_bloom_obj_id = -1;
+					per_column_setting->composite_bloom_index_obj_ids = NULL;
+					result_settings = lappend(result_settings, per_column_setting);
+				}
+
+				if (strcmp(index_type, ts_sparse_index_type_names[_SparseIndexTypeEnumMinmax]) == 0)
+				{
+					Assert(num_columns == 1);
+					per_column_setting->minmax_obj_id = obj_id;
+				}
+				else if (strcmp(index_type,
+								ts_sparse_index_type_names[_SparseIndexTypeEnumBloom]) == 0)
+				{
+					if (num_columns == 1)
+					{
+						per_column_setting->single_bloom_obj_id = obj_id;
+					}
+					else if (num_columns > 1)
+					{
+						if (per_column_setting->composite_bloom_index_obj_ids == NULL)
+						{
+							per_column_setting->composite_bloom_index_obj_ids =
+								bms_make_singleton(obj_id);
+						}
+						else
+						{
+							per_column_setting->composite_bloom_index_obj_ids =
+								bms_add_member(per_column_setting->composite_bloom_index_obj_ids,
+											   obj_id);
+						}
+					}
+				}
+			}
+		}
+		obj_id++;
+	}
+	return result_settings;
+}
+
+PerColumnCompressionSettings *
+ts_get_per_column_compression_settings_by_column_name(List *per_column_settings,
+													  const char *column_name)
+{
+	Assert(column_name != NULL);
+
+	ListCell *per_column_setting_cell = NULL;
+	foreach (per_column_setting_cell, per_column_settings)
+	{
+		PerColumnCompressionSettings *tmp =
+			(PerColumnCompressionSettings *) lfirst(per_column_setting_cell);
+		if (strcmp(tmp->column_name, column_name) == 0)
+		{
+			return tmp;
+		}
+	}
+	return NULL;
+}
+
+List *
+ts_get_column_names_from_parsed_object(SparseIndexSettingsObject *obj)
+{
+	Assert(obj != NULL);
+	foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+	{
+		if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol] /* "column" */) == 0)
+		{
+			return pair->values;
+		}
+	}
+	return NULL;
+}
+
+static Bitmapset *
+resolve_columns_to_attnos(List *column_names, Oid relid)
+{
+	Assert(column_names != NULL);
+	Assert(OidIsValid(relid));
+
+	Bitmapset *result = NULL;
+	ListCell *name_cell = NULL;
+
+	foreach (name_cell, column_names)
+	{
+		const char *name = (const char *) lfirst(name_cell);
+		AttrNumber attno = get_attnum(relid, name);
+		if (AttributeNumberIsValid(attno))
+		{
+			result = bms_add_member(result, attno);
+		}
+		else
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("column \"%s\" of relation \"%ld\" does not exist",
+							name,
+							(long) relid)));
+		}
+	}
+	return result;
+}
+
+/*
+ * Resolve the column names in the parsed settings to attribute numbers for the given relation
+ * and return a list of bitmapsets corresponding to each object in the parsed settings.
+ */
+TsBmsList
+ts_resolve_columns_to_attnos_from_parsed_settings(SparseIndexSettings *settings, Oid relid)
+{
+	Assert(settings != NULL);
+	Assert(OidIsValid(relid));
+
+	TsBmsList result = NIL;
+	foreach_ptr(SparseIndexSettingsObject, obj, settings->objects)
+	{
+		List *column_names = ts_get_column_names_from_parsed_object(obj);
+		Bitmapset *attnos = resolve_columns_to_attnos(column_names, relid);
+		result = lappend(result, attnos);
+	}
+
+	return result;
+}
+
+List *
+ts_get_values_by_key_from_parsed_object(SparseIndexSettingsObject *obj, const char *key)
+{
+	Assert(obj != NULL);
+	Assert(key != NULL);
+
+	List *result = NIL;
+	foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+	{
+		if (strcmp(pair->key, key) == 0)
+		{
+			result = pair->values;
+			return result;
+		}
+	}
+	return NIL;
 }

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -8,6 +8,7 @@
 #include <postgres.h>
 #include <catalog/pg_type.h>
 
+#include "bmslist_utils.h"
 #include "ts_catalog/catalog.h"
 
 typedef struct CompressionSettings
@@ -42,17 +43,88 @@ extern TSDLLEXPORT const char *ts_sparse_index_type_names[];
 extern TSDLLEXPORT const char *ts_sparse_index_source_names[];
 extern TSDLLEXPORT const char *ts_sparse_index_common_keys[];
 
-typedef struct SparseIndexBase
+typedef struct SparseIndexConfigBase
 {
 	SparseIndexTypeEnum type;
-	char *col;
 	SparseIndexSourceEnum source;
-} SparseIndexBase;
+} SparseIndexConfigBase;
 
-typedef struct SparseIndexConfig
+typedef struct MinmaxIndexColumnConfig
 {
-	SparseIndexBase base;
-} SparseIndexConfig;
+	SparseIndexConfigBase base;
+	const char *col;
+} MinmaxIndexColumnConfig;
+
+typedef struct SparseIndexColumn
+{
+	/* composite bloom indexes will have multiple SparseIndexColumn entries and
+	 * they will be sorted by the attribute number */
+	AttrNumber attnum;
+	const char *name;
+	Oid type;
+} SparseIndexColumn;
+
+#define MAX_BLOOM_FILTER_COLUMNS 8
+
+typedef struct BloomFilterConfig
+{
+	SparseIndexConfigBase base;
+	int num_columns;
+	SparseIndexColumn *columns;
+} BloomFilterConfig;
+
+/*
+ * The SparseIndexSettings structure is used to parse the compression
+ * settings from the JSONB structure.
+ * With this we can turn the stored JSONB into this structure, modify it and
+ * turn it back into JSONB and we can avoid the messy and error prone JSONB
+ * manipulation.
+ *
+ * The structure is a list of objects, each object is a list of pairs, each
+ * pair is a key and a list of values. This allows us to store and manipulate
+ * JSONB structures like this:
+ *
+ * [
+ *   {"type": "bloom", "column": "big1", "source": "config"},
+ *   {"type": "bloom", "column": ["value", "big1", "big2"], "source": "config"},
+ *   {"type": "bloom", "column": ["o", "big2"], "source": "config"},
+ *   {"type": "minmax", "column": "ts", "source": "orderby"}
+ * ]
+ *
+ * Notice that the "column" key can have a string or an array of strings as value.
+ */
+typedef struct SparseIndexSettingsPair
+{
+	char *key;
+	List *values; /* List of strings */
+} SparseIndexSettingsPair;
+typedef struct SparseIndexSettingsObject
+{
+	List *pairs; /* List of SparseIndexSettingsPair */
+} SparseIndexSettingsObject;
+
+typedef struct SparseIndexSettings
+{
+	MemoryContext context;
+	List *objects; /* List of SparseIndexSettingsObject */
+} SparseIndexSettings;
+
+typedef struct PerColumnCompressionSettings
+{
+	const char *column_name;
+
+	/* the index of the minmax index object that the column participates in, -1 if not present */
+	int minmax_obj_id;
+
+	/* the index of the single bloom index object that the column participates in, -1 if not present
+	 */
+	int single_bloom_obj_id;
+
+	/* the object ids of the composite bloom index objects that the column participates in */
+	Bitmapset *composite_bloom_index_obj_ids;
+} PerColumnCompressionSettings;
+
+TSDLLEXPORT int ts_qsort_attrnumber_cmp(const void *a, const void *b);
 
 TSDLLEXPORT CompressionSettings *
 ts_compression_settings_create(Oid relid, Oid compress_relid, ArrayType *segmentby,
@@ -74,10 +146,31 @@ TSDLLEXPORT int ts_compression_settings_update(CompressionSettings *settings);
 TSDLLEXPORT void ts_compression_settings_rename_column_cascade(Oid parent_relid, const char *old,
 															   const char *new);
 TSDLLEXPORT void ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state,
-														 SparseIndexConfig *config);
+														 SparseIndexConfigBase *config);
+
 TSDLLEXPORT
 bool ts_contains_sparse_index_config(CompressionSettings *settings, const char *attname,
-									 const char *sparse_index_type);
+									 const char *sparse_index_type, bool skip_column_arrays);
 TSDLLEXPORT Jsonb *ts_add_orderby_sparse_index(CompressionSettings *settings);
 
 TSDLLEXPORT Jsonb *ts_remove_orderby_sparse_index(CompressionSettings *settings);
+
+extern TSDLLEXPORT SparseIndexSettings *ts_convert_to_sparse_index_settings(Jsonb *jsonb);
+extern TSDLLEXPORT Jsonb *ts_convert_from_sparse_index_settings(SparseIndexSettings *settings);
+extern TSDLLEXPORT void ts_free_sparse_index_settings(SparseIndexSettings *settings);
+extern TSDLLEXPORT const char *
+ts_sparse_index_settings_to_cstring(const SparseIndexSettings *settings);
+extern TSDLLEXPORT char *ts_sparse_index_settings_pstrdup(SparseIndexSettings *settings,
+														  const char *str);
+extern TSDLLEXPORT List *
+ts_get_per_column_compression_settings(const SparseIndexSettings *settings);
+extern TSDLLEXPORT PerColumnCompressionSettings *
+ts_get_per_column_compression_settings_by_column_name(List *per_column_settings,
+													  const char *column_name);
+extern TSDLLEXPORT List *ts_get_column_names_from_parsed_object(SparseIndexSettingsObject *obj);
+
+extern TSDLLEXPORT TsBmsList
+ts_resolve_columns_to_attnos_from_parsed_settings(SparseIndexSettings *settings, Oid relid);
+
+extern TSDLLEXPORT List *ts_get_values_by_key_from_parsed_object(SparseIndexSettingsObject *obj,
+																 const char *key);

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -13,6 +13,7 @@
 #include <commands/trigger.h>
 #include <fmgr.h>
 #include <parser/parser.h>
+#include <port.h>
 #include <storage/lmgr.h>
 #include <utils/builtins.h>
 #include <utils/elog.h>
@@ -20,6 +21,7 @@
 #include <utils/typcache.h>
 
 #include "compat/compat.h"
+#include "bmslist_utils.h"
 #include "cross_module_fn.h"
 #include "debug_assert.h"
 #include "guc.h"
@@ -405,39 +407,24 @@ sparse_index_type_with_clause_parse(const char *parse, const WithClauseDefinitio
 	return _SparseIndexTypeEnumMax;
 }
 
-static void
-parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_details,
-						  Hypertable *hypertable, ArrayType **collist)
+static SparseIndexColumn
+parse_sparse_index_column(Hypertable *hypertable, FuncCall *sparse_index_details, int index,
+						  SparseIndexTypeEnum type)
 {
-	Oid coltypid;
-	char *colname;
-	AttrNumber col_attno;
-	TypeCacheEntry *type_cache;
-	/* extract type */
-	SparseIndexConfig config;
-	config.base.type =
-		sparse_index_type_with_clause_parse(NameListToString(sparse_index_details->funcname),
-											sparse_index_with_clause_def,
-											TS_ARRAY_LEN(sparse_index_with_clause_def));
-	config.base.source = _SparseIndexSourceEnumConfig;
+	SparseIndexColumn column;
+	Assert(index >= 0);
+	Assert(list_length(sparse_index_details->args) > index);
 
-	if (list_length(sparse_index_details->args) != 1)
-	{
+	if (index >= list_length(sparse_index_details->args) || index >= MAX_BLOOM_FILTER_COLUMNS)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("sparse index \"%s\" can only have one column",
-						ts_sparse_index_type_names[config.base.type])));
-	}
+				 errmsg("sparse index %s has too many columns", ts_sparse_index_type_names[type])));
 
-	/* validate and extract column */
-	Node *arg = list_nth(sparse_index_details->args, 0);
-
+	Node *arg = list_nth(sparse_index_details->args, index);
 	if (!IsA(arg, ColumnRef))
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("sparse index %s's first option must reference a valid "
-						"column.",
-						ts_sparse_index_type_names[config.base.type])));
+				 errmsg("sparse index column reference must reference a valid column name")));
 
 	ColumnRef *cf = (ColumnRef *) arg;
 	if (list_length(cf->fields) != 1 || !IsA(linitial(cf->fields), String))
@@ -447,35 +434,99 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 				 errdetail(
 					 "Wildcard or qualified references like '*' or 'table.col' are not allowed.")));
 
-	colname = strVal(linitial(cf->fields));
-	col_attno = get_attnum(hypertable->main_table_relid, colname);
-	if (col_attno == InvalidAttrNumber)
+	column.name = strVal(linitial(cf->fields));
+	column.attnum = get_attnum(hypertable->main_table_relid, column.name);
+	if (column.attnum == InvalidAttrNumber)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("column \"%s\" does not exist", colname),
+				 errmsg("column \"%s\" does not exist", column.name),
 				 errhint("The sparse index %s option must reference a valid "
 						 "column.",
-						 ts_sparse_index_type_names[config.base.type])));
+						 ts_sparse_index_type_names[type])));
 	}
 
 	/* get normalized column name */
-	colname = get_attname(hypertable->main_table_relid, col_attno, false);
-	coltypid = get_atttype(hypertable->main_table_relid, col_attno);
+	column.name = get_attname(hypertable->main_table_relid, column.attnum, false);
+	column.type = get_atttype(hypertable->main_table_relid, column.attnum);
 
-	/*
-	 * Note: currently only one sparse index per column is supported.
-	 */
-	if (ts_array_is_member(*collist, colname))
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("duplicate column name \"%s\"", colname),
-				 errhint("The sparse index option must reference distinct "
-						 "column.")));
-	*collist = ts_array_add_element_text(*collist, pstrdup(colname));
+	return column;
+}
+
+static const char *
+column_name_list_as_string(BloomFilterConfig *config)
+{
+	StringInfoData buf;
+	initStringInfo(&buf);
+	appendStringInfo(&buf, "(");
+	for (int i = 0; i < config->num_columns; i++)
+	{
+		appendStringInfo(&buf, "'%s'", config->columns[i].name);
+		if (i < config->num_columns - 1)
+			appendStringInfo(&buf, ",");
+	}
+	appendStringInfo(&buf, ")");
+	return buf.data;
+}
+
+/* parses the individual sparse index config entities. being called once for each sparse index
+ * config entity in the list. */
+static void
+parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_details,
+						  Hypertable *hypertable, TsBmsList *sparse_index_columns)
+{
+	TypeCacheEntry *type_cache;
+	MinmaxIndexColumnConfig minmax_config;
+	BloomFilterConfig bloom_config;
+	SparseIndexConfigBase config;
+	SparseIndexConfigBase *config_ptr = &config;
+	SparseIndexColumn first_column;
+
+	config.type =
+		sparse_index_type_with_clause_parse(NameListToString(sparse_index_details->funcname),
+											sparse_index_with_clause_def,
+											TS_ARRAY_LEN(sparse_index_with_clause_def));
+	config.source = _SparseIndexSourceEnumConfig;
+	int num_columns = list_length(sparse_index_details->args);
+
+	if (num_columns != 1)
+	{
+		if (num_columns > 1 && config.type == _SparseIndexTypeEnumBloom)
+		{
+			/* This will be enabled once all composite bloom index functionality is rolled out */
+#if 0
+			if (!ts_guc_enable_composite_bloom_indexes)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("composite bloom indexes are disabled"),
+						 errhint("Set timescaledb.enable_composite_bloom_indexes = true")));
+#else
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("composite bloom indexes are not supported")));
+#endif
+
+			if (num_columns > MAX_BLOOM_FILTER_COLUMNS)
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("bloom index has too many columns: %d > max %d",
+								num_columns,
+								MAX_BLOOM_FILTER_COLUMNS)));
+		}
+		else
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					 errmsg("minmax index can only have one column")));
+		}
+	}
+
+	/* parse the first column separately because we only need one for minmax */
+	first_column = parse_sparse_index_column(hypertable, sparse_index_details, 0, config.type);
+	Bitmapset *attnums_bitmap = bms_make_singleton(first_column.attnum);
 
 	/* extract custom sparse index type config */
-	switch (config.base.type)
+	switch (config.type)
 	{
 		case _SparseIndexTypeEnumBloom:
 			if (!ts_guc_enable_sparse_index_bloom)
@@ -487,21 +538,73 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 								 "bloom filter indexes from \"sparse_index\" configuration of the "
 								 "hypertable.")));
 			}
-			/*
-			 * The column type must be hashable. For some types we use our own hash functions
-			 * which have better characteristics.
-			 */
-			FmgrInfo *finfo = NULL;
-			if (ts_cm_functions->bloom1_get_hash_function(coltypid, &finfo) == NULL)
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_FUNCTION),
-						 errmsg("invalid bloom filter column type %s", format_type_be(coltypid)),
-						 errdetail("Could not identify a hashing function for the type.")));
 
-			config.base.col = colname;
+			bloom_config.base = config;
+			config_ptr = (SparseIndexConfigBase *) &bloom_config;
+			bloom_config.num_columns = num_columns;
+
+			bloom_config.columns = palloc(num_columns * sizeof(SparseIndexColumn));
+			bloom_config.columns[0] = first_column;
+			for (int i = 1; i < num_columns; i++)
+			{
+				bloom_config.columns[i] =
+					parse_sparse_index_column(hypertable, sparse_index_details, i, config.type);
+				attnums_bitmap = bms_add_member(attnums_bitmap, bloom_config.columns[i].attnum);
+				if (bms_num_members(attnums_bitmap) <= i)
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("duplicate column name ('%s') in composite bloom index "
+									"configuration: %s",
+									bloom_config.columns[i].name,
+									column_name_list_as_string(&bloom_config)),
+							 errhint(
+								 "The sparse index option must reference distinct column set.")));
+			}
+
+			if (ts_bmslist_contains_set(*sparse_index_columns, attnums_bitmap))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate sparse index configuration %s",
+								column_name_list_as_string(&bloom_config)),
+						 errhint("The sparse index option must reference distinct column set.")));
+			}
+			*sparse_index_columns = ts_bmslist_add_set(*sparse_index_columns, attnums_bitmap);
+
+			for (int i = 0; i < num_columns; i++)
+			{
+				/*
+				 * The column type must be hashable. For some types we use our own hash functions
+				 * which have better characteristics.
+				 */
+				FmgrInfo *finfo = NULL;
+				if (ts_cm_functions->bloom1_get_hash_function(bloom_config.columns[i].type,
+															  &finfo) == NULL)
+					ereport(ERROR,
+							(errcode(ERRCODE_UNDEFINED_FUNCTION),
+							 errmsg("invalid bloom filter column type %s",
+									format_type_be(bloom_config.columns[i].type)),
+							 errdetail("Could not identify a hashing function for the type.")));
+			}
+
+			/* the convention is that the column names are sorted by attribute number */
+			qsort(bloom_config.columns,
+				  num_columns,
+				  sizeof(SparseIndexColumn),
+				  ts_qsort_attrnumber_cmp);
 			break;
+
 		case _SparseIndexTypeEnumMinmax:
-			type_cache = lookup_type_cache(coltypid, TYPECACHE_LT_OPR);
+			if (ts_bmslist_contains_set(*sparse_index_columns, attnums_bitmap))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate column name \"%s\"", first_column.name),
+						 errhint("The sparse index option must reference distinct "
+								 "column.")));
+			}
+			*sparse_index_columns = ts_bmslist_add_set(*sparse_index_columns, attnums_bitmap);
+			type_cache = lookup_type_cache(first_column.type, TYPECACHE_LT_OPR);
 
 			/*
 			 * a comparison operator is required for min max operations
@@ -509,18 +612,21 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 			if (!OidIsValid(type_cache->lt_opr))
 				ereport(ERROR,
 						(errcode(ERRCODE_UNDEFINED_FUNCTION),
-						 errmsg("invalid minmax column type %s", format_type_be(coltypid)),
+						 errmsg("invalid minmax column type %s", format_type_be(first_column.type)),
 						 errdetail("Could not identify a less-than operator for the type.")));
 
-			config.base.col = colname;
+			minmax_config.base = config;
+			config_ptr = (SparseIndexConfigBase *) &minmax_config;
+			minmax_config.col = first_column.name;
 			break;
+
 		default:
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("Invalid sparse index type")));
 	}
 
-	ts_convert_sparse_index_config_to_jsonb(parse_state, &config);
+	ts_convert_sparse_index_config_to_jsonb(parse_state, config_ptr);
 }
 
 static Jsonb *
@@ -590,11 +696,12 @@ parse_sparse_index_config_list(char *inpstr, Hypertable *hypertable)
 
 	/* json format will be
 	 * [{"type": "bloom", "source":"config", "column": "u"},
-	 * {"type": "minmax","source":"config", "column": "ts"}]
+	 * {"type": "minmax","source":"config", "column": "ts"},
+	 * {"type": "bloom", "source":"config", "column": ["age", "gender"]}]
 	 */
 	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
 
-	ArrayType *collist = NULL;
+	TsBmsList sparse_index_columns = ts_bmslist_create();
 	foreach (lc, select->targetList)
 	{
 		ResTarget *target = lfirst_node(ResTarget, lc);
@@ -604,10 +711,10 @@ parse_sparse_index_config_list(char *inpstr, Hypertable *hypertable)
 
 		FuncCall *fc = (FuncCall *) target->val;
 
-		parse_sparse_index_config(parse_state, fc, hypertable, &collist);
+		parse_sparse_index_config(parse_state, fc, hypertable, &sparse_index_columns);
 	}
 
-	pfree(collist);
+	ts_bmslist_free(sparse_index_columns);
 	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
 }
 

--- a/test/expected/c_unit_tests.out
+++ b/test/expected/c_unit_tests.out
@@ -10,6 +10,12 @@ CREATE OR REPLACE FUNCTION test.adts() RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_adts' LANGUAGE C VOLATILE;
 CREATE OR REPLACE FUNCTION test.time_utils() RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_time_utils' LANGUAGE C;
+CREATE OR REPLACE FUNCTION test.bmslist_utils() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_bmslist_utils' LANGUAGE C;
+CREATE OR REPLACE FUNCTION test.jsonb_utils() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_jsonb_utils' LANGUAGE C;
+CREATE OR REPLACE FUNCTION test.compression_settings() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_compression_settings' LANGUAGE C;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT test.time_to_internal_conversion();
  time_to_internal_conversion 
@@ -29,5 +35,20 @@ SELECT test.adts();
 SELECT test.time_utils();
  time_utils 
 ------------
+ 
+
+SELECT test.bmslist_utils();
+ bmslist_utils 
+---------------
+ 
+
+SELECT test.jsonb_utils();
+ jsonb_utils 
+-------------
+ 
+
+SELECT test.compression_settings();
+ compression_settings 
+----------------------
  
 

--- a/test/expected/test_utils.out
+++ b/test/expected/test_utils.out
@@ -15,12 +15,16 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- failing conditions
 \set ON_ERROR_STOP 0
 SELECT test.condition();
+WARNING:  TestFailure in ts_test_utils_condition() at line:43
 ERROR:  TestFailure | (true_value == false_value)
 SELECT test.int64_eq();
+WARNING:  TestFailure in ts_test_utils_int64_eq() at line:53
 ERROR:  TestFailure | (big == small) [32532978 == 3242234]
 SELECT test.ptr_eq();
+WARNING:  TestFailure in ts_test_utils_ptr_eq() at line:67
 ERROR:  TestFailure | (true_ptr == false_ptr)
 SELECT test.double_eq();
+WARNING:  TestFailure in ts_test_utils_double_eq() at line:78
 ERROR:  TestFailure | (big_double == small_double) [923423478.324200 == 324.300000]
 \set ON_ERROR_STOP 1
 -- Test debug points

--- a/test/sql/c_unit_tests.sql
+++ b/test/sql/c_unit_tests.sql
@@ -14,9 +14,23 @@ AS :MODULE_PATHNAME, 'ts_test_adts' LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION test.time_utils() RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_time_utils' LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION test.bmslist_utils() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_bmslist_utils' LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION test.jsonb_utils() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_jsonb_utils' LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION test.compression_settings() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_compression_settings' LANGUAGE C;
+
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 SELECT test.time_to_internal_conversion();
 SELECT test.interval_to_internal_conversion();
 SELECT test.adts();
 SELECT test.time_utils();
+SELECT test.bmslist_utils();
+SELECT test.jsonb_utils();
+SELECT test.compression_settings();
+

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -2,6 +2,9 @@ set(SOURCES
     adt_tests.c
     metadata.c
     symbol_conflict.c
+    test_compression_settings.c
+    test_bmslist_utils.c
+    test_jsonb_utils.c
     test_scanner.c
     test_time_to_internal.c
     test_time_utils.c

--- a/test/src/test_bmslist_utils.c
+++ b/test/src/test_bmslist_utils.c
@@ -1,0 +1,59 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include "bmslist_utils.h"
+#include "test_utils.h"
+#include <fmgr.h>
+#include <funcapi.h>
+#include <ts_catalog/compression_settings.h>
+
+static void
+test_empty_bmslist_contains_items(void)
+{
+	TsBmsList bmslist = ts_bmslist_create();
+	int items[] = { 1, 2, 3 };
+	bool result = ts_bmslist_contains_items(bmslist, items, 3);
+	TestAssertBoolEq(result, false);
+}
+
+static void
+test_non_empty_bmslist_contains_items(void)
+{
+	TsBmsList bmslist = ts_bmslist_create();
+	int items[] = { 1, 2, 3 };
+	bmslist = ts_bmslist_add_member(bmslist, items, 1);
+	bmslist = ts_bmslist_add_member(bmslist, items, 2);
+	bmslist = ts_bmslist_add_member(bmslist, items, 3);
+
+	bool result = ts_bmslist_contains_items(bmslist, items, 3);
+	TestAssertBoolEq(result, true);
+
+	result = ts_bmslist_contains_items(bmslist, items, 2);
+	TestAssertBoolEq(result, true);
+
+	result = ts_bmslist_contains_items(bmslist, items, 1);
+	TestAssertBoolEq(result, true);
+
+	items[0] = 4;
+	result = ts_bmslist_contains_items(bmslist, items, 3);
+	TestAssertBoolEq(result, false);
+
+	result = ts_bmslist_contains_items(bmslist, items, 2);
+	TestAssertBoolEq(result, false);
+
+	result = ts_bmslist_contains_items(bmslist, items, 1);
+	TestAssertBoolEq(result, false);
+
+	ts_bmslist_free(bmslist);
+}
+
+TS_TEST_FN(ts_test_bmslist_utils)
+{
+	test_empty_bmslist_contains_items();
+	test_non_empty_bmslist_contains_items();
+	PG_RETURN_VOID();
+}

--- a/test/src/test_compression_settings.c
+++ b/test/src/test_compression_settings.c
@@ -1,0 +1,346 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include "foreach_ptr.h"
+#include <fmgr.h>
+#include <funcapi.h>
+#include <ts_catalog/compression_settings.h>
+#include <utils/jsonb.h>
+
+/* Include test_utils.h after all other headers */
+#include <test_utils.h>
+
+#define TestAssertParsedCompressionSettingsEqCstring(a, b)                                         \
+	do                                                                                             \
+	{                                                                                              \
+		SparseIndexSettings *a_ps = (a);                                                           \
+		Assert(a_ps != NULL);                                                                      \
+		const char *a_i = (a) == NULL ? "<null>" : ts_sparse_index_settings_to_cstring(a_ps);      \
+		const char *b_i = (b) == NULL ? "<null>" : (b);                                            \
+		if (strcmp(a_i, b_i) != 0)                                                                 \
+			TestFailure("(%s == %s)", a_i, b_i);                                                   \
+	} while (0)
+
+static void
+test_alter_table_rename_column_effect_jsonb()
+{
+	const char *jsonb_str =
+		"[{\"type\": \"bloom\", \"column\": \"big1\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": \"big2\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": \"value\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": [\"value\", \"big1\", \"big2\"], \"source\": "
+		"\"config\"}, "
+		"{\"type\": \"bloom\", \"column\": [\"o\", \"big2\"], \"source\": \"config\"}, "
+		"{\"type\": \"minmax\", \"column\": \"ts\", \"source\": \"orderby\"}]";
+
+	const char *jsonb_str_expected =
+		"[{\"type\": \"bloom\", \"column\": \"big1\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": \"xxl\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": \"value\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": [\"value\", \"big1\", \"xxl\"], \"source\": "
+		"\"config\"}, "
+		"{\"type\": \"bloom\", \"column\": [\"o\", \"xxl\"], \"source\": \"config\"}, "
+		"{\"type\": \"minmax\", \"column\": \"ts\", \"source\": \"orderby\"}]";
+
+	Jsonb *jb = cstring_to_jsonb(jsonb_str);
+	SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+
+	TestAssertInt64Eq(list_length(parsed_settings->objects), 6);
+	foreach_ptr(SparseIndexSettingsObject, obj, parsed_settings->objects)
+	{
+		Assert(obj != NULL);
+		TestAssertInt64Eq(list_length(obj->pairs), 3);
+
+		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+		{
+			Assert(pair != NULL);
+			if (strcmp(pair->key, "column") != 0)
+			{
+				continue;
+			}
+			ListCell *value_cell = NULL;
+			foreach (value_cell, pair->values)
+			{
+				const char *value = (const char *) lfirst(value_cell);
+				Assert(value != NULL);
+				if (strcmp(value, "big2") == 0)
+				{
+					/* Replace the value with the new one, allocate from the parsed settings context
+					 */
+					value_cell->ptr_value =
+						ts_sparse_index_settings_pstrdup(parsed_settings, "xxl");
+				}
+			}
+		}
+	}
+
+	Jsonb *result = ts_convert_from_sparse_index_settings(parsed_settings);
+	TestAssertJsonbEqCstring(result, jsonb_str_expected);
+	TestAssertParsedCompressionSettingsEqCstring(parsed_settings, jsonb_str_expected);
+
+	/* test the per column settings */
+	List *per_column_settings = ts_get_per_column_compression_settings(parsed_settings);
+	Assert(per_column_settings != NIL);
+	TestAssertInt64Eq(list_length(per_column_settings), 5);
+	PerColumnCompressionSettings *per_column_setting = NULL;
+	{
+		per_column_setting =
+			(PerColumnCompressionSettings *) lfirst(list_head(per_column_settings));
+		Assert(per_column_setting != NULL);
+		TestAssertCStringEq(per_column_setting->column_name, "big1");
+		TestAssertInt64Eq(per_column_setting->single_bloom_obj_id, 0);
+		TestAssertInt64Eq(per_column_setting->minmax_obj_id, -1);
+		/* only part of a single composite bloom index */
+		TestAssertInt64Eq(bms_num_members(per_column_setting->composite_bloom_index_obj_ids), 1);
+		TestAssertBoolEq(bms_is_member(3, per_column_setting->composite_bloom_index_obj_ids), true);
+	}
+
+	{
+		per_column_setting = (PerColumnCompressionSettings *) lsecond(per_column_settings);
+		Assert(per_column_setting != NULL);
+		TestAssertCStringEq(per_column_setting->column_name, "xxl");
+		TestAssertInt64Eq(per_column_setting->single_bloom_obj_id, 1);
+		TestAssertInt64Eq(per_column_setting->minmax_obj_id, -1);
+		/* part of two composite bloom indices */
+		TestAssertInt64Eq(bms_num_members(per_column_setting->composite_bloom_index_obj_ids), 2);
+		TestAssertBoolEq(bms_is_member(3, per_column_setting->composite_bloom_index_obj_ids), true);
+		TestAssertBoolEq(bms_is_member(4, per_column_setting->composite_bloom_index_obj_ids), true);
+	}
+
+	{
+		per_column_setting = (PerColumnCompressionSettings *) lthird(per_column_settings);
+		Assert(per_column_setting != NULL);
+		TestAssertCStringEq(per_column_setting->column_name, "value");
+		TestAssertInt64Eq(per_column_setting->single_bloom_obj_id, 2);
+		TestAssertInt64Eq(per_column_setting->minmax_obj_id, -1);
+		/* part of a single composite bloom index */
+		TestAssertInt64Eq(bms_num_members(per_column_setting->composite_bloom_index_obj_ids), 1);
+		TestAssertBoolEq(bms_is_member(3, per_column_setting->composite_bloom_index_obj_ids), true);
+	}
+
+	{
+		per_column_setting = (PerColumnCompressionSettings *) lfourth(per_column_settings);
+		Assert(per_column_setting != NULL);
+		TestAssertCStringEq(per_column_setting->column_name, "o");
+		TestAssertInt64Eq(per_column_setting->single_bloom_obj_id, -1);
+		TestAssertInt64Eq(per_column_setting->minmax_obj_id, -1);
+		/* part of a single composite bloom index */
+		TestAssertInt64Eq(bms_num_members(per_column_setting->composite_bloom_index_obj_ids), 1);
+		TestAssertBoolEq(bms_is_member(4, per_column_setting->composite_bloom_index_obj_ids), true);
+	}
+
+	{
+		per_column_setting = (PerColumnCompressionSettings *) lfifth(per_column_settings);
+		Assert(per_column_setting != NULL);
+		TestAssertCStringEq(per_column_setting->column_name, "ts");
+		TestAssertInt64Eq(per_column_setting->single_bloom_obj_id, -1);
+		TestAssertInt64Eq(per_column_setting->minmax_obj_id, 5);
+		TestAssertPtrEq(per_column_setting->composite_bloom_index_obj_ids, NULL);
+	}
+
+	pfree(result);
+	ts_free_sparse_index_settings(parsed_settings);
+	pfree(jb);
+}
+
+static void
+test_alter_table_drop_column_effect_jsonb()
+{
+	const char *jsonb_str =
+		"[{\"type\": \"bloom\", \"column\": \"big1\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": \"big2\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": \"value\", \"source\": \"config\"}, "
+		"{\"type\": \"bloom\", \"column\": [\"value\", \"big1\", \"big2\"], \"source\": "
+		"\"config\"}, "
+		"{\"type\": \"bloom\", \"column\": [\"o\", \"big2\"], \"source\": \"config\"}, "
+		"{\"type\": \"minmax\", \"column\": \"ts\", \"source\": \"orderby\"}]";
+
+	const char *jsonb_str_expected =
+		"[{\"type\": \"bloom\", \"column\": \"big1\", \"source\": \"config\"}, "
+		/* DROP: "{\"type\": \"bloom\", \"column\": \"big2\", \"source\": \"config\"}, " */
+		"{\"type\": \"bloom\", \"column\": \"value\", \"source\": \"config\"}, "
+		/* DROP: "{\"type\": \"bloom\", \"column\": [\"value\", \"big1\", \"big2\"], \"source\":
+		   \"config\"}, */
+		/* DROP: "{\"type\": \"bloom\", \"column\": [\"o\", \"big2\"], \"source\": \"config\"}, " */
+		"{\"type\": \"minmax\", \"column\": \"ts\", \"source\": \"orderby\"}]";
+
+	Jsonb *jb = cstring_to_jsonb(jsonb_str);
+	SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+
+	TestAssertInt64Eq(list_length(parsed_settings->objects), 6);
+	ListCell *obj_cell = NULL;
+	foreach (obj_cell, parsed_settings->objects)
+	{
+		SparseIndexSettingsObject *obj = (SparseIndexSettingsObject *) lfirst(obj_cell);
+		Assert(obj != NULL);
+		TestAssertInt64Eq(list_length(obj->pairs), 3);
+		bool to_remove = false;
+		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+		{
+			Assert(pair != NULL);
+			if (strcmp(pair->key, "column") != 0)
+			{
+				continue;
+			}
+			foreach_ptr(const char, value, pair->values)
+			{
+				Assert(value != NULL);
+				if (strcmp(value, "big2") == 0)
+				{
+					to_remove = true;
+					break;
+				}
+			}
+			if (to_remove)
+			{
+				break;
+			}
+		}
+		if (to_remove)
+		{
+			/* Remove the object from the list of objects */
+			parsed_settings->objects = foreach_delete_current(parsed_settings->objects, obj_cell);
+		}
+	}
+
+	TestAssertInt64Eq(list_length(parsed_settings->objects), 3);
+	Jsonb *result = ts_convert_from_sparse_index_settings(parsed_settings);
+	TestAssertJsonbEqCstring(result, jsonb_str_expected);
+	TestAssertParsedCompressionSettingsEqCstring(parsed_settings, jsonb_str_expected);
+	ts_free_sparse_index_settings(parsed_settings);
+	pfree(result);
+	pfree(jb);
+}
+
+static void
+test_convert_to_sparse_index_settings()
+{
+	{
+		/* Objects with a single pair are converted to SparseIndexSettings */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": \"value\"}");
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		TestAssertInt64Eq(list_length(parsed_settings->objects), 1);
+		TestAssertParsedCompressionSettingsEqCstring(parsed_settings, "[{\"key\": \"value\"}]");
+		Jsonb *result = ts_convert_from_sparse_index_settings(parsed_settings);
+		TestAssertJsonbEqCstring(result, "[{\"key\": \"value\"}]");
+		/* per column should be empty because there is no column and no index type */
+		List *per_column_settings = ts_get_per_column_compression_settings(parsed_settings);
+		TestAssertPtrEq(per_column_settings, NIL);
+		ts_free_sparse_index_settings(parsed_settings);
+		pfree(jb);
+		pfree(result);
+	}
+
+	{
+		/* Objects with an array value are converted to SparseIndexSettings */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": [\"value\", \"value2\"]}");
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		TestAssertInt64Eq(list_length(parsed_settings->objects), 1);
+		TestAssertParsedCompressionSettingsEqCstring(parsed_settings,
+													 "[{\"key\": [\"value\", \"value2\"]}]");
+		Jsonb *result = ts_convert_from_sparse_index_settings(parsed_settings);
+		TestAssertJsonbEqCstring(result, "[{\"key\": [\"value\", \"value2\"]}]");
+		ts_free_sparse_index_settings(parsed_settings);
+		pfree(jb);
+		pfree(result);
+	}
+
+	{
+		/* Objects with multiple pairs are converted to SparseIndexSettings */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": [\"value\", \"value2\"], \"key2\": \"value3\"}");
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		TestAssertInt64Eq(list_length(parsed_settings->objects), 1);
+		TestAssertParsedCompressionSettingsEqCstring(parsed_settings,
+													 "[{\"key\": [\"value\", \"value2\"], "
+													 "\"key2\": \"value3\"}]");
+		Jsonb *result = ts_convert_from_sparse_index_settings(parsed_settings);
+		TestAssertJsonbEqCstring(result,
+								 "[{\"key\": [\"value\", \"value2\"], \"key2\": \"value3\"}]");
+		ts_free_sparse_index_settings(parsed_settings);
+		pfree(jb);
+		pfree(result);
+	}
+
+	{
+		/* Empty objects are converted to NULL */
+		Jsonb *jb = cstring_to_jsonb("{}");
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		TestAssertPtrEq(parsed_settings, NULL);
+		pfree(jb);
+	}
+
+	{
+		/* Empty arrays are ignored and converted to NULL */
+		Jsonb *jb = cstring_to_jsonb("[]");
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		TestAssertPtrEq(parsed_settings, NULL);
+		pfree(jb);
+	}
+
+	{
+		/* Empty objects are ignored */
+		Jsonb *jb = cstring_to_jsonb("[{}, {\"key\": \"value\"}, {}, {}]");
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		TestAssertInt64Eq(list_length(parsed_settings->objects), 1);
+		TestAssertParsedCompressionSettingsEqCstring(parsed_settings, "[{\"key\": \"value\"}]");
+		Jsonb *result = ts_convert_from_sparse_index_settings(parsed_settings);
+		TestAssertJsonbEqCstring(result, "[{\"key\": \"value\"}]");
+		ts_free_sparse_index_settings(parsed_settings);
+		pfree(jb);
+		pfree(result);
+	}
+
+	{
+		/* Unexpected nesting of objects return an error */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": [{\"key2\": \"value2\"}]}");
+		TestEnsureError(ts_convert_to_sparse_index_settings(jb));
+		pfree(jb);
+	}
+
+	{
+		/* Unexpected nesting of objects return an error */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": {\"key2\": \"value2\"}}");
+		TestEnsureError(ts_convert_to_sparse_index_settings(jb));
+		pfree(jb);
+	}
+
+	{
+		/* Unexpected nesting of objects return an error */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": [{\"key2\": \"value2\"}, {\"key3\": \"value3\"}]}");
+		TestEnsureError(ts_convert_to_sparse_index_settings(jb));
+		pfree(jb);
+	}
+
+	{
+		/* Unexpected nesting of arrays return an error */
+		Jsonb *jb = cstring_to_jsonb("{\"key\": [[\"value2\", \"value3\"]]}");
+		TestEnsureError(ts_convert_to_sparse_index_settings(jb));
+		pfree(jb);
+	}
+
+	{
+		/* Unexpected nesting of arrays return an error */
+		Jsonb *jb = cstring_to_jsonb("[[{\"key\": [\"value2\", \"value3\"]}]]");
+		TestEnsureError(ts_convert_to_sparse_index_settings(jb));
+		pfree(jb);
+	}
+
+	{
+		/* Unexpected nesting of arrays return an error */
+		Jsonb *jb = cstring_to_jsonb("[{\"key\": [\"value2\", [\"value3\"]]}]");
+		TestEnsureError(ts_convert_to_sparse_index_settings(jb));
+		pfree(jb);
+	}
+}
+
+TS_TEST_FN(ts_test_compression_settings)
+{
+	test_alter_table_rename_column_effect_jsonb();
+	test_alter_table_drop_column_effect_jsonb();
+	test_convert_to_sparse_index_settings();
+	PG_RETURN_VOID();
+}

--- a/test/src/test_jsonb_utils.c
+++ b/test/src/test_jsonb_utils.c
@@ -1,0 +1,255 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include "jsonb_utils.h"
+#include "test_utils.h"
+#include "ts_catalog/compression_settings.h"
+#include "utils/jsonb.h"
+#include <fmgr.h>
+#include <funcapi.h>
+
+// Declare jsonb_in explicitly
+extern Datum jsonb_in(PG_FUNCTION_ARGS);
+
+const char *
+jsonb_to_cstring(Jsonb *jsonb)
+{
+	StringInfoData buf;
+	initStringInfo(&buf);
+	JsonbToCString(&buf, &jsonb->root, 0);
+	return buf.data;
+}
+
+Jsonb *
+cstring_to_jsonb(const char *cstring)
+{
+	Datum jsonb_datum = DirectFunctionCall1(jsonb_in, CStringGetDatum(cstring));
+	Jsonb *jsonb = DatumGetJsonbP(jsonb_datum);
+	return jsonb;
+}
+
+static void
+test_get_str_field()
+{
+	{
+		/* Empty JSONB  doesn't have the key */
+		Jsonb *jb = cstring_to_jsonb("{}");
+		TestAssertCStringEq(ts_jsonb_get_str_field(jb, "key"), NULL);
+		TestAssertJsonbEqCstring(jb, "{}");
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, string value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": \"value\" }");
+		TestAssertCStringEq(ts_jsonb_get_str_field(jb, "key"), "value");
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, integer value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": 1 }");
+		TestAssertCStringEq(ts_jsonb_get_str_field(jb, "key"), "1");
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, empty object value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": {} }");
+		TestAssertCStringEq(ts_jsonb_get_str_field(jb, "key"), "{}");
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, array value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": [1, 2, 3] }");
+		TestAssertCStringEq(ts_jsonb_get_str_field(jb, "key"), "[1, 2, 3]");
+		pfree(jb);
+	}
+}
+
+static void
+test_get_bool_field()
+{
+	{
+		/* JSONB with missing key */
+		Jsonb *jb = cstring_to_jsonb("{ \"something_else\": {} }");
+		bool found;
+		TestAssertBoolEq(ts_jsonb_get_bool_field(jb, "key", &found), false);
+		TestAssertBoolEq(found, false);
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, true value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": true }");
+		bool found;
+		TestAssertBoolEq(ts_jsonb_get_bool_field(jb, "key", &found), true);
+		TestAssertBoolEq(found, true);
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, false value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": false }");
+		bool found;
+		TestAssertBoolEq(ts_jsonb_get_bool_field(jb, "key", &found), false);
+		TestAssertBoolEq(found, true);
+		pfree(jb);
+	}
+}
+
+static void
+test_has_key_value_str_field()
+{
+	{
+		/* JSONB with missing key */
+		Jsonb *jb = cstring_to_jsonb("{ \"something_else\": {} }");
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "key", "value"), false);
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, string value */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": \"value\" }");
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "key", "value"), true);
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, array value, only string key=value pairs should be matched */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": [\"value\", \"value2\"] }");
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "key", "value"), false);
+		pfree(jb);
+	}
+
+	{
+		/* JSONB with the key, array value, only string key=value pairs should be matched */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": [\"value2\", \"value\"] }");
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "key", "value"), false);
+		pfree(jb);
+	}
+
+	{
+		/* Key value pair nested in an object */
+		Jsonb *jb = cstring_to_jsonb("{ \"key\": [\"value\", \"value2\"], \"x\": {\"y\": \"z\", "
+									 "\"key\": \"value\"}, \"z\": [{\"key\": \"value\"}] }");
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "key", "value"), true);
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "y", "z"), true);
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "z", "value"), false);
+		TestAssertBoolEq(ts_jsonb_has_key_value_str_field(jb, "z", "key"), false);
+		pfree(jb);
+	}
+}
+
+static void
+test_contains_sparse_index_config()
+{
+	{
+		/* Single column bloom filter */
+		CompressionSettings settings = {
+			.fd = { .index = cstring_to_jsonb(
+						"{\"type\": \"bloom\", \"column\": \"big1\", \"source\": \"config\"}") }
+		};
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "bloom",
+														 false /* skip_column_arrays */),
+						 true);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "bloom",
+														 true /* skip_column_arrays */),
+						 true);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "no_such_type",
+														 true /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "no_such_type",
+														 false /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "non_existent",
+														 "bloom",
+														 false /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "non_existent",
+														 "bloom",
+														 true /* skip_column_arrays */),
+						 false);
+	}
+
+	{
+		/* Composite bloom filter */
+		CompressionSettings settings = { .fd = { .index = cstring_to_jsonb(
+													 "{\"type\": \"bloom\", \"column\": [\"big1\", "
+													 "\"big2\"], \"source\": \"config\"}") } };
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "bloom",
+														 true /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "bloom",
+														 false /* skip_column_arrays */),
+						 true);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big2",
+														 "bloom",
+														 true /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big2",
+														 "bloom",
+														 false /* skip_column_arrays */),
+						 true);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "no_such_type",
+														 true /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big1",
+														 "no_such_type",
+														 false /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big2",
+														 "no_such_type",
+														 true /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "big2",
+														 "no_such_type",
+														 false /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "non_existent",
+														 "bloom",
+														 true /* skip_column_arrays */),
+						 false);
+		TestAssertBoolEq(ts_contains_sparse_index_config(&settings,
+														 "non_existent",
+														 "bloom",
+														 false /* skip_column_arrays */),
+						 false);
+	}
+}
+
+TS_TEST_FN(ts_test_jsonb_utils)
+{
+	test_get_str_field();
+	test_get_bool_field();
+	test_has_key_value_str_field();
+	test_contains_sparse_index_config();
+	PG_RETURN_VOID();
+}

--- a/test/src/test_utils.h
+++ b/test/src/test_utils.h
@@ -29,6 +29,7 @@ strip_path(const char *filename)
 #define TestFailure(fmt, ...)                                                                      \
 	do                                                                                             \
 	{                                                                                              \
+		elog(WARNING, "TestFailure in %s() at line:%d", __func__, __LINE__);                       \
 		elog(ERROR, "TestFailure | " fmt "", ##__VA_ARGS__);                                       \
 		pg_unreachable();                                                                          \
 	} while (0)
@@ -51,6 +52,15 @@ strip_path(const char *filename)
 			TestFailure("(%s == %s)", #a, #b);                                                     \
 	} while (0)
 
+#define TestAssertCStringEq(a, b)                                                                  \
+	do                                                                                             \
+	{                                                                                              \
+		const char *a_i = (a) == NULL ? "<null>" : (a);                                            \
+		const char *b_i = (b) == NULL ? "<null>" : (b);                                            \
+		if (strcmp(a_i, b_i) != 0)                                                                 \
+			TestFailure("(%s == %s) [%s == %s]", #a, #b, a_i, b_i);                                \
+	} while (0)
+
 #define TestAssertDoubleEq(a, b)                                                                   \
 	do                                                                                             \
 	{                                                                                              \
@@ -58,6 +68,17 @@ strip_path(const char *filename)
 		double b_i = (b);                                                                          \
 		if (a_i != b_i)                                                                            \
 			TestFailure("(%s == %s) [%f == %f]", #a, #b, a_i, b_i);                                \
+	} while (0)
+
+#define TestAssertBoolEq(a, b)                                                                     \
+	do                                                                                             \
+	{                                                                                              \
+		const char *a_i = (a) ? "true" : "false";                                                  \
+		const char *b_i = (b) ? "true" : "false";                                                  \
+		bool a_bool = (a);                                                                         \
+		bool b_bool = (b);                                                                         \
+		if (a_bool != b_bool)                                                                      \
+			TestFailure("(%s == %s) [%s == %s]", #a, #b, a_i, b_i);                                \
 	} while (0)
 
 #define TestEnsureError(a)                                                                         \
@@ -94,3 +115,18 @@ strip_path(const char *filename)
 #define TS_TEST_FN(name)                                                                           \
 	TS_FUNCTION_INFO_V1(name);                                                                     \
 	Datum name(PG_FUNCTION_ARGS)
+
+#ifdef __JSONB_H__
+extern const char *jsonb_to_cstring(Jsonb *jsonb);
+extern Jsonb *cstring_to_jsonb(const char *cstring);
+
+#define TestAssertJsonbEqCstring(a, b)                                                             \
+	do                                                                                             \
+	{                                                                                              \
+		Jsonb *a_j = (a);                                                                          \
+		const char *a_i = (a) == NULL ? "<null>" : jsonb_to_cstring(a_j);                          \
+		const char *b_i = (b) == NULL ? "<null>" : (b);                                            \
+		if (strcmp(a_i, b_i) != 0)                                                                 \
+			TestFailure("(%s == %s)", a_i, b_i);                                                   \
+	} while (0)
+#endif

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -45,6 +45,7 @@
 #include "create.h"
 #include "custom_type_cache.h"
 #include "dimension.h"
+#include "foreach_ptr.h"
 #include "guc.h"
 #include "hypertable_cache.h"
 #include "jsonb_utils.h"
@@ -59,9 +60,9 @@
 
 #include "bgw_policy/compression_api.h"
 
+#ifdef USE_ASSERT_CHECKING
 static const char *sparse_index_types[] = { "min", "max" };
 
-#ifdef USE_ASSERT_CHECKING
 static bool
 is_sparse_index_type(const char *type)
 {
@@ -157,34 +158,75 @@ column_segment_max_name(int16 column_index)
  * in this case we disambiguate them with their md5 hash.
  */
 char *
-compressed_column_metadata_name_v2(const char *metadata_type, const char *column_name)
+compressed_column_metadata_name_v2(const char *metadata_type, const char **column_names,
+								   int num_columns)
 {
 	Assert(is_sparse_index_type(metadata_type));
 	Assert(strlen(metadata_type) <= 6);
+	Assert(column_names != NULL);
+	Assert(num_columns > 0);
+	Assert(num_columns <= MAX_BLOOM_FILTER_COLUMNS);
 
-	const int len = strlen(column_name);
-	Assert(len < NAMEDATALEN);
+	int len = 0;
+	StringInfoData buf = { 0 };
+	initStringInfo(&buf);
+
+	for (int i = 0; i < num_columns; i++)
+	{
+		Assert(column_names[i] != NULL);
+#ifdef USE_ASSERT_CHECKING
+		int col_len = strlen(column_names[i]);
+#endif
+		Assert(col_len > 0 && col_len < NAMEDATALEN);
+		if (i > 0)
+			appendStringInfoChar(&buf, '_');
+		appendStringInfo(&buf, "%s", column_names[i]);
+	}
+
+	len = buf.len;
 
 	/*
 	 * We have to fit the name into NAMEDATALEN - 1 which is 63 bytes:
-	 * 12 (_ts_meta_v2_) + 6 (metadata_type) + 1 (_) + x (column_name) + 1 (_) + 4 (hash) = 63;
-	 * x = 63 - 24 = 39.
+	 * 12 (_ts_meta_v2_) + 6 (metadata_type) + [1 (_) + x (column_name)]x num_columns  + 1 (_) + 4
+	 * (hash) = 63; x = 63 - 24 = 39.
 	 */
+
 	char *result;
 	if (len > 39)
 	{
 		const char *errstr = NULL;
 		char hash[33];
-		Ensure(pg_md5_hash(column_name, len, hash, &errstr), "md5 computation failure");
-
-		result = psprintf("_ts_meta_v2_%.6s_%.4s_%.39s", metadata_type, hash, column_name);
+		Ensure(pg_md5_hash(buf.data, len, hash, &errstr), "md5 computation failure");
+		result = psprintf("_ts_meta_v2_%.6s_%.4s_%.39s", metadata_type, hash, buf.data);
 	}
 	else
 	{
-		result = psprintf("_ts_meta_v2_%.6s_%.39s", metadata_type, column_name);
+		result = psprintf("_ts_meta_v2_%.6s_%.39s", metadata_type, buf.data);
 	}
 	Assert(strlen(result) < NAMEDATALEN);
 	return result;
+}
+
+char *
+compressed_column_metadata_name_list_v2(const char *metadata_type, List *column_names_list)
+{
+	int num_column_names = list_length(column_names_list);
+	Ensure(num_column_names > 0, "list of column names must be non-empty");
+	Ensure(num_column_names <= MAX_BLOOM_FILTER_COLUMNS,
+		   "list of column names must be less than or equal to %d, got %d",
+		   MAX_BLOOM_FILTER_COLUMNS,
+		   num_column_names);
+
+	const char *column_names[MAX_BLOOM_FILTER_COLUMNS];
+	ListCell *cell = NULL;
+	int i = 0;
+	foreach (cell, column_names_list)
+	{
+		column_names[i] = (const char *) lfirst(cell);
+		i++;
+	}
+
+	return compressed_column_metadata_name_v2(metadata_type, column_names, num_column_names);
 }
 
 int
@@ -204,7 +246,8 @@ compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_
 		return get_attnum(compressed_reloid, metadata_name);
 	}
 
-	char *metadata_name = compressed_column_metadata_name_v2(metadata_type, attname);
+	char *metadata_name =
+		compressed_column_metadata_name_v2(metadata_type, (const char **) &attname, 1);
 	return get_attnum(compressed_reloid, metadata_name);
 }
 
@@ -266,28 +309,64 @@ should_create_bloom_sparse_index(Oid atttypid, TypeCacheEntry *type, Oid src_rel
 	return true;
 }
 
+/*
+ * Create a column definition for a sparse index column. The attributes passed is a
+ * List of Form_pg_attribute elements. Min and max indices only use
+ * the first element. Bloom filters may use multiple columns.
+ */
 static ColumnDef *
-create_sparse_index_column_def(Form_pg_attribute attr, const char *metadata_type)
+create_sparse_index_column_def(List *attributes, const char *metadata_type)
 {
 	Assert(is_sparse_index_type(metadata_type));
 	ColumnDef *column_def = NULL;
+	List *column_names = NIL;
+
+	/* At least one valid attribute must be present */
+	Assert(attributes != NULL);
+	Assert(list_length(attributes) > 0);
+	Assert(list_length(attributes) <= MAX_BLOOM_FILTER_COLUMNS);
 
 	const bool is_bloom = strcmp(metadata_type, bloom1_column_prefix) == 0;
+
+	{
+		/* Populate the column names array */
+		ListCell *cell = NULL;
+		int i = 0;
+		foreach (cell, attributes)
+		{
+			Form_pg_attribute attr = (Form_pg_attribute) lfirst(cell);
+			Ensure(i < MAX_BLOOM_FILTER_COLUMNS,
+				   "too many columns for bloom filter, got %d, max %d, name: %s",
+				   i + 1,
+				   MAX_BLOOM_FILTER_COLUMNS,
+				   NameStr(attr->attname));
+			column_names = lappend(column_names, NameStr(attr->attname));
+			i++;
+		}
+	}
 
 	if (is_bloom)
 	{
 		/*
-		 * The type must be hashable. For some types we use our own hash functions
+		 * The types must be hashable. For some types we use our own hash functions
 		 * which have better characteristics.
 		 */
-		FmgrInfo *finfo = NULL;
-		if (bloom1_get_hash_function(attr->atttypid, &finfo) == NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-					 errmsg("invalid bloom filter column type %s", format_type_be(attr->atttypid)),
-					 errdetail("Could not identify a hashing function for the type.")));
+		ListCell *cell = NULL;
+		foreach (cell, attributes)
+		{
+			Form_pg_attribute attr = (Form_pg_attribute) lfirst(cell);
+			FmgrInfo *finfo = NULL;
+			if (bloom1_get_hash_function(attr->atttypid, &finfo) == NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_FUNCTION),
+						 errmsg("invalid bloom filter column type %s, name: %s",
+								format_type_be(attr->atttypid),
+								NameStr(attr->attname)),
+						 errdetail("Could not identify a hashing function for the type.")));
+		}
+
 		column_def =
-			makeColumnDef(compressed_column_metadata_name_v2(metadata_type, NameStr(attr->attname)),
+			makeColumnDef(compressed_column_metadata_name_list_v2(metadata_type, column_names),
 						  ts_custom_type_cache_get(CUSTOM_TYPE_BLOOM1)->type_oid,
 						  /* typmod = */ -1,
 						  /* collation = */ 0);
@@ -300,6 +379,7 @@ create_sparse_index_column_def(Form_pg_attribute attr, const char *metadata_type
 	}
 	else /* either min or max */
 	{
+		Form_pg_attribute attr = (Form_pg_attribute) lfirst(list_head(attributes));
 		TypeCacheEntry *type = lookup_type_cache(attr->atttypid, TYPECACHE_LT_OPR);
 
 		/*
@@ -312,7 +392,7 @@ create_sparse_index_column_def(Form_pg_attribute attr, const char *metadata_type
 					 errdetail("Could not identify a less-than operator for the type.")));
 
 		column_def =
-			makeColumnDef(compressed_column_metadata_name_v2(metadata_type, NameStr(attr->attname)),
+			makeColumnDef(compressed_column_metadata_name_list_v2(metadata_type, column_names),
 						  attr->atttypid,
 						  attr->atttypmod,
 						  attr->attcollation);
@@ -340,10 +420,27 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 	ArrayType *segmentby = settings->fd.segmentby;
 	List *compressed_column_defs = NIL;
 	List *segmentby_column_defs = NIL;
+	Jsonb *sparse_cfg = settings->fd.index;
+	SparseIndexSettings *parsed_settings =
+		sparse_cfg ? ts_convert_to_sparse_index_settings(sparse_cfg) : NULL;
+	Bitmapset *all_composite_bloom_obj_ids = NULL;
+	List *per_column_settings = ts_get_per_column_compression_settings(parsed_settings);
 
 	Relation rel = table_open(src_reloid, AccessShareLock);
 
 	TupleDesc tupdesc = rel->rd_att;
+
+	int num_sparse_index_objects =
+		parsed_settings != NULL ? list_length(parsed_settings->objects) : 0;
+	List **composite_attr_lists = NULL;
+	if (num_sparse_index_objects > 0)
+	{
+		/* Allocate an array of Lists that contain Form_pg_attribute elements for each sparse index
+		 * configuration object. Minmax and single bloom filter configuration objects will have a
+		 * single element list.
+		 */
+		composite_attr_lists = palloc0(sizeof(List *) * num_sparse_index_objects);
+	}
 
 	for (int attoffset = 0; attoffset < tupdesc->natts; attoffset++)
 	{
@@ -367,6 +464,52 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 														  attr->atttypmod,
 														  attr->attcollation));
 			continue;
+		}
+
+		PerColumnCompressionSettings *per_column_setting =
+			per_column_settings ?
+				ts_get_per_column_compression_settings_by_column_name(per_column_settings,
+																	  NameStr(attr->attname)) :
+				NULL;
+
+		if (per_column_setting != NULL && composite_attr_lists != NULL)
+		{
+			if (per_column_setting->minmax_obj_id != -1 &&
+				per_column_setting->minmax_obj_id < num_sparse_index_objects)
+			{
+				/* Minmax index configuration objects will have a single element list */
+				Assert(list_length(composite_attr_lists[per_column_setting->minmax_obj_id]) == 0);
+				composite_attr_lists[per_column_setting->minmax_obj_id] =
+					lappend(composite_attr_lists[per_column_setting->minmax_obj_id], attr);
+			}
+
+			if (per_column_setting->single_bloom_obj_id != -1 &&
+				per_column_setting->single_bloom_obj_id < num_sparse_index_objects)
+			{
+				/* Single bloom filter configuration objects will have a single element list */
+				Assert(list_length(composite_attr_lists[per_column_setting->single_bloom_obj_id]) ==
+					   0);
+				composite_attr_lists[per_column_setting->single_bloom_obj_id] =
+					lappend(composite_attr_lists[per_column_setting->single_bloom_obj_id], attr);
+			}
+
+			if (per_column_setting->composite_bloom_index_obj_ids != NULL)
+			{
+				/* The bitmapset tells which sparse index configuration objects the current
+				 * column participates in. Iterate over the bitmapset and add an entry
+				 * to the composite_attr_lists. */
+				int i = -1;
+				while ((i = bms_next_member(per_column_setting->composite_bloom_index_obj_ids,
+											i)) >= 0)
+				{
+					composite_attr_lists[i] = lappend(composite_attr_lists[i], attr);
+				}
+
+				/* capture all composite bloom index objects */
+				all_composite_bloom_obj_ids =
+					bms_union(all_composite_bloom_obj_ids,
+							  per_column_setting->composite_bloom_index_obj_ids);
+			}
 		}
 
 		/*
@@ -405,17 +548,12 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 			def->storage = TYPSTORAGE_PLAIN;
 			compressed_column_defs = lappend(compressed_column_defs, def);
 		}
-		else if (settings->fd.index)
+		else if (per_column_setting != NULL && composite_attr_lists != NULL)
 		{
 			/* check sparse index columndefs is applicable */
-			bool is_bloom = ts_contains_sparse_index_config(settings,
-															NameStr(attr->attname),
-															ts_sparse_index_type_names
-																[_SparseIndexTypeEnumBloom]);
-			bool is_minmax = ts_contains_sparse_index_config(settings,
-															 NameStr(attr->attname),
-															 ts_sparse_index_type_names
-																 [_SparseIndexTypeEnumMinmax]);
+			bool is_bloom = per_column_setting->single_bloom_obj_id != -1;
+			bool is_minmax = per_column_setting->minmax_obj_id != -1;
+
 			/*
 			 * We allow only one sparse index per column. Columns used in the ORDER BY
 			 * clause implicitly have a minmax index and adding a bloom filter on them is not
@@ -444,7 +582,9 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 				 * Add bloom filter sparse index for this column.
 				 */
 				ColumnDef *bloom_column_def =
-					create_sparse_index_column_def(attr, bloom1_column_prefix);
+					create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			->single_bloom_obj_id],
+												   bloom1_column_prefix);
 
 				compressed_column_defs = lappend(compressed_column_defs, bloom_column_def);
 			}
@@ -453,10 +593,15 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 				/*
 				 * Add minmax sparse index for this column.
 				 */
-				ColumnDef *def = create_sparse_index_column_def(attr, "min");
+				ColumnDef *def =
+					create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			->minmax_obj_id],
+												   "min");
 				compressed_column_defs = lappend(compressed_column_defs, def);
 
-				def = create_sparse_index_column_def(attr, "max");
+				def = create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			  ->minmax_obj_id],
+													 "max");
 				compressed_column_defs = lappend(compressed_column_defs, def);
 			}
 		}
@@ -465,6 +610,24 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 													   compresseddata_oid,
 													   /* typmod = */ -1,
 													   /* collOid = */ InvalidOid));
+	}
+
+	/* add the composite bloom columns */
+	if (composite_attr_lists != NULL && per_column_settings != NULL)
+	{
+		/* iterate over the all_composite_bloom_obj_ids bitmapset */
+		int i = -1;
+		while ((i = bms_next_member(all_composite_bloom_obj_ids, i)) >= 0)
+		{
+			Assert(i < num_sparse_index_objects);
+			Assert(composite_attr_lists[i] != NULL);
+			List *attr_list = composite_attr_lists[i];
+			if (attr_list != NULL)
+			{
+				ColumnDef *def = create_sparse_index_column_def(attr_list, bloom1_column_prefix);
+				compressed_column_defs = lappend(compressed_column_defs, def);
+			}
+		}
 	}
 
 	/*
@@ -870,20 +1033,90 @@ add_column_to_compression_table(Oid relid, CompressionSettings *settings, Column
 	modify_compressed_toast_table_storage(settings, list_make1(coldef), relid);
 }
 
-/* Drop column from internal compression table */
+/* Drop column from internal compression table, drop the bloom filter columns as well and
+ * update the compression settings for the chunk */
 static void
-drop_column_from_compression_table(Oid relid, char *name)
+drop_column_from_compression_table(CompressionSettings *comp_settings, char *name)
 {
+	Oid relid = comp_settings->fd.compress_relid;
 	AlterTableCmd *cmd;
+	List *cmds = NIL;
+	Jsonb *jb = comp_settings->fd.index;
 
 	/* create altertable stmt to drop column from the compressed hypertable */
 	cmd = makeNode(AlterTableCmd);
 	cmd->subtype = AT_DropColumn;
 	cmd->name = name;
 	cmd->missing_ok = true;
+	cmds = list_make1(cmd);
+
+	if (jb)
+	{
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		if (parsed_settings)
+		{
+			bool removed_any = false;
+
+			ListCell *obj_cell = NULL;
+			foreach (obj_cell, parsed_settings->objects)
+			{
+				bool removed = false;
+				const char *bloom_column_name = NULL;
+				SparseIndexSettingsObject *obj = (SparseIndexSettingsObject *) lfirst(obj_cell);
+				foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+				{
+					if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol]) != 0)
+					{
+						continue;
+					}
+					foreach_ptr(const char, value, pair->values)
+					{
+						if (strcmp(value, name) == 0)
+						{
+							removed = true;
+							Assert(list_length(pair->values) <= MAX_BLOOM_FILTER_COLUMNS);
+
+							bloom_column_name =
+								compressed_column_metadata_name_list_v2(bloom1_column_prefix,
+																		pair->values);
+							Assert(bloom_column_name != NULL);
+							break;
+						}
+					}
+					if (removed)
+					{
+						break;
+					}
+				}
+				/* if the column was removed, we need to remove the object from the list */
+				if (removed)
+				{
+					removed_any = true;
+					if (bloom_column_name)
+					{
+						cmd = makeNode(AlterTableCmd);
+						cmd->subtype = AT_DropColumn;
+						cmd->name = pstrdup(bloom_column_name);
+						cmd->missing_ok = true;
+						cmds = lappend(cmds, cmd);
+					}
+					parsed_settings->objects =
+						foreach_delete_current(parsed_settings->objects, obj_cell);
+				}
+			}
+
+			if (removed_any)
+			{
+				jb = ts_convert_from_sparse_index_settings(parsed_settings);
+				comp_settings->fd.index = jb;
+				ts_compression_settings_update(comp_settings);
+			}
+			ts_free_sparse_index_settings(parsed_settings);
+		}
+	}
 
 	/* alter the table and drop column */
-	ts_alter_table_with_event_trigger(relid, NULL, list_make1(cmd), true);
+	ts_alter_table_with_event_trigger(relid, NULL, cmds, true);
 }
 
 static bool
@@ -1332,7 +1565,7 @@ static Jsonb *
 compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings *settings)
 {
 	bool has_object = false;
-	Bitmapset *sparse_index_columns = NULL;
+	TsBmsList sparse_index_columns = ts_bmslist_create();
 	JsonbParseState *parse_state = NULL;
 
 	/*
@@ -1379,9 +1612,11 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 		{
 			char *attname;
 			Oid atttypid;
-			SparseIndexConfig config;
+			MinmaxIndexColumnConfig minmax_config;
+			BloomFilterConfig bloom_config;
+			SparseIndexConfigBase *config = NULL;
 			TypeCacheEntry *type;
-			const AttrNumber attno = index_info->ii_IndexAttrNumbers[i];
+			const int attno = index_info->ii_IndexAttrNumbers[i];
 			if (attno == InvalidAttrNumber)
 			{
 				continue;
@@ -1390,7 +1625,7 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 			/* do not create sparse index for orderby columns */
 			if (ts_array_is_member(settings->fd.orderby, attname) ||
 				ts_array_is_member(settings->fd.segmentby, attname) ||
-				bms_is_member(attno, sparse_index_columns))
+				ts_bmslist_contains_items(sparse_index_columns, &attno, 1))
 				continue;
 
 			atttypid = get_atttype(ht->main_table_relid, attno);
@@ -1400,22 +1635,34 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 			/* construct sparse index config */
 			if (ts_guc_enable_sparse_index_bloom &&
 				should_create_bloom_sparse_index(atttypid, type, ht->main_table_relid))
-				config.base.type = _SparseIndexTypeEnumBloom;
+			{
+				config = &bloom_config.base;
+				config->type = _SparseIndexTypeEnumBloom;
+				bloom_config.num_columns = 1;
+				bloom_config.columns = palloc(1 * sizeof(SparseIndexColumn));
+				bloom_config.columns[0].attnum = attno;
+				bloom_config.columns[0].name = attname;
+				bloom_config.columns[0].type = atttypid;
+			}
 			else if (OidIsValid(type->lt_opr))
-				config.base.type = _SparseIndexTypeEnumMinmax;
+			{
+				config = &minmax_config.base;
+				config->type = _SparseIndexTypeEnumMinmax;
+				minmax_config.col = attname;
+			}
 			else
 				continue;
 
-			config.base.col = attname;
-			config.base.source = _SparseIndexSourceEnumDefault;
+			config->source = _SparseIndexSourceEnumDefault;
 
 			/* convert to json object */
-			ts_convert_sparse_index_config_to_jsonb(parse_state, &config);
-			sparse_index_columns = bms_add_member(sparse_index_columns, attno);
+			ts_convert_sparse_index_config_to_jsonb(parse_state, config);
+			sparse_index_columns = ts_bmslist_add_member(sparse_index_columns, &attno, 1);
 			has_object = true;
 		}
 	}
 	table_close(rel, AccessShareLock);
+	ts_bmslist_free(sparse_index_columns);
 	return has_object ? JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL)) : NULL;
 }
 
@@ -1615,7 +1862,9 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 
 	CompressionSettings *settings = ts_compression_settings_get(ht->main_table_relid);
+	Jsonb *jb = settings->fd.index;
 
+	/* check if the column is a segmentby or orderby column */
 	if (settings && (ts_array_is_member(settings->fd.segmentby, name) ||
 					 ts_array_is_member(settings->fd.orderby, name)))
 		ereport(ERROR,
@@ -1625,11 +1874,16 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 
 	List *chunks = ts_chunk_get_by_hypertable_id(ht->fd.compressed_hypertable_id);
 	ListCell *lc;
+	int num_chunks = list_length(chunks);
+	CompressionSettings **chunk_settings = palloc(sizeof(CompressionSettings *) * num_chunks);
+
+	int i = 0;
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
 		CompressionSettings *settings =
 			ts_compression_settings_get_by_compress_relid(chunk->table_id);
+		chunk_settings[i++] = settings;
 		if (ts_array_is_member(settings->fd.segmentby, name) ||
 			ts_array_is_member(settings->fd.orderby, name))
 			ereport(ERROR,
@@ -1640,10 +1894,60 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 
 	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
-		foreach (lc, chunks)
+		for (int i = 0; i < num_chunks; i++)
 		{
-			Chunk *chunk = lfirst(lc);
-			drop_column_from_compression_table(chunk->table_id, name);
+			CompressionSettings *comp_settings = chunk_settings[i];
+			drop_column_from_compression_table(comp_settings, name);
+		}
+	}
+
+	/* update the compression settings for the main table */
+	if (jb)
+	{
+		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
+		if (parsed_settings)
+		{
+			bool removed_any = false;
+			ListCell *obj_cell = NULL;
+			foreach (obj_cell, parsed_settings->objects)
+			{
+				bool removed = false;
+				SparseIndexSettingsObject *obj = (SparseIndexSettingsObject *) lfirst(obj_cell);
+				Assert(obj != NULL);
+				foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+				{
+					if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol]) != 0)
+					{
+						continue;
+					}
+					foreach_ptr(const char, value, pair->values)
+					{
+						if (strcmp(value, name) == 0)
+						{
+							removed = true;
+							break;
+						}
+					}
+					if (removed)
+					{
+						break;
+					}
+				}
+				/* if the column was removed, we need to remove the object from the list */
+				if (removed)
+				{
+					removed_any = true;
+					parsed_settings->objects =
+						foreach_delete_current(parsed_settings->objects, obj_cell);
+				}
+			}
+			if (removed_any)
+			{
+				jb = ts_convert_from_sparse_index_settings(parsed_settings);
+				settings->fd.index = jb;
+				ts_compression_settings_update(settings);
+			}
+			ts_free_sparse_index_settings(parsed_settings);
 		}
 	}
 }
@@ -1661,6 +1965,12 @@ tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt)
 	Assert(stmt->relationType == OBJECT_TABLE && stmt->renameType == OBJECT_COLUMN);
 	Assert(TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
 
+	struct RenameFromTo
+	{
+		char *from;
+		char *to;
+	};
+
 	if (strncmp(stmt->newname,
 				COMPRESSION_COLUMN_METADATA_PREFIX,
 				strlen(COMPRESSION_COLUMN_METADATA_PREFIX)) == 0)
@@ -1677,7 +1987,9 @@ tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt)
 	RenameStmt *compressed_col_stmt = (RenameStmt *) copyObject(stmt);
 	RenameStmt *compressed_index_stmt = (RenameStmt *) copyObject(stmt);
 	List *chunks = ts_chunk_get_by_hypertable_id(ht->fd.compressed_hypertable_id);
+	CompressionSettings *ht_settings = NULL;
 	ListCell *lc;
+
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
@@ -1685,21 +1997,132 @@ tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt)
 			makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), -1);
 		ExecRenameStmt(compressed_col_stmt);
 
-		compressed_index_stmt->relation = compressed_col_stmt->relation;
-		for (size_t i = 0; i < sizeof(sparse_index_types) / sizeof(sparse_index_types[0]); i++)
+		List *rename_from_to = NIL;
+		CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+		if (!settings || settings->fd.index == NULL)
 		{
-			char *old_index_name =
-				compressed_column_metadata_name_v2(sparse_index_types[i], stmt->subname);
-			if (get_attnum(chunk->table_id, old_index_name) == InvalidAttrNumber)
+			/* only lookup ht settings if we haven't already */
+			if (!ht_settings)
 			{
-				continue;
+				ht_settings = ts_compression_settings_get(ht->main_table_relid);
+			}
+			settings = ht_settings;
+		}
+
+		/* check the minmax and single bloom index columns no matter what the compression settings
+		 * says */
+		{
+			/* handle minmax index */
+			struct RenameFromTo *from_to =
+				(struct RenameFromTo *) palloc(sizeof(struct RenameFromTo));
+			from_to->from =
+				compressed_column_metadata_name_v2("min", (const char **) &stmt->subname, 1);
+			from_to->to =
+				compressed_column_metadata_name_v2("min", (const char **) &stmt->newname, 1);
+			rename_from_to = lappend(rename_from_to, from_to);
+			from_to = (struct RenameFromTo *) palloc(sizeof(struct RenameFromTo));
+			from_to->from =
+				compressed_column_metadata_name_v2("max", (const char **) &stmt->subname, 1);
+			from_to->to =
+				compressed_column_metadata_name_v2("max", (const char **) &stmt->newname, 1);
+			rename_from_to = lappend(rename_from_to, from_to);
+		}
+
+		{
+			/* handle single bloom index */
+			struct RenameFromTo *from_to =
+				(struct RenameFromTo *) palloc(sizeof(struct RenameFromTo));
+			from_to->from = compressed_column_metadata_name_v2(bloom1_column_prefix,
+															   (const char **) &stmt->subname,
+															   1);
+			from_to->to = compressed_column_metadata_name_v2(bloom1_column_prefix,
+															 (const char **) &stmt->newname,
+															 1);
+			rename_from_to = lappend(rename_from_to, from_to);
+		}
+
+		if (settings && settings->fd.index != NULL)
+		{
+			SparseIndexSettings *parsed_settings =
+				ts_convert_to_sparse_index_settings(settings->fd.index);
+			List *per_column_settings = ts_get_per_column_compression_settings(parsed_settings);
+			PerColumnCompressionSettings *per_column_setting =
+				per_column_settings ?
+					ts_get_per_column_compression_settings_by_column_name(per_column_settings,
+																		  stmt->subname) :
+					NULL;
+
+			if (per_column_setting != NULL)
+			{
+				if (per_column_setting->composite_bloom_index_obj_ids != NULL)
+				{
+					/* one column may participate in multiple composite bloom indices, so we need to
+					 * handle all of them */
+					int i = -1;
+					struct RenameFromTo *from_to = NULL;
+
+					while ((i = bms_next_member(per_column_setting->composite_bloom_index_obj_ids,
+												i)) >= 0)
+					{
+						SparseIndexSettingsObject *obj =
+							(SparseIndexSettingsObject *) list_nth(parsed_settings->objects, i);
+						Assert(obj != NULL);
+						List *column_names = ts_get_column_names_from_parsed_object(obj);
+						Assert(column_names != NULL);
+						Assert(list_length(column_names) > 1);
+						Assert(list_length(column_names) <= MAX_BLOOM_FILTER_COLUMNS);
+						char *new_name[MAX_BLOOM_FILTER_COLUMNS] = { NULL };
+						int j = 0;
+						ListCell *cell = NULL;
+						foreach (cell, column_names)
+						{
+							const char *column_name = (const char *) lfirst(cell);
+							if (strcmp(column_name, stmt->subname) == 0)
+							{
+								new_name[j] = stmt->newname;
+							}
+							else
+							{
+								new_name[j] = pstrdup(column_name);
+							}
+							j++;
+						}
+						/* handle composite bloom index */
+						from_to = (struct RenameFromTo *) palloc(sizeof(struct RenameFromTo));
+						from_to->from =
+							compressed_column_metadata_name_list_v2(bloom1_column_prefix,
+																	column_names);
+						from_to->to = compressed_column_metadata_name_v2(bloom1_column_prefix,
+																		 (const char **) new_name,
+																		 list_length(column_names));
+						rename_from_to = lappend(rename_from_to, from_to);
+					}
+				}
+			}
+			ts_free_sparse_index_settings(parsed_settings);
+		}
+
+		compressed_index_stmt->relation = compressed_col_stmt->relation;
+		if (rename_from_to != NULL)
+		{
+			ListCell *cell = NULL;
+			foreach (cell, rename_from_to)
+			{
+				struct RenameFromTo *from_to = (struct RenameFromTo *) lfirst(cell);
+				Assert(from_to != NULL);
+				Assert(from_to->from != NULL);
+				Assert(from_to->to != NULL);
+				if (get_attnum(chunk->table_id, from_to->from) == InvalidAttrNumber)
+				{
+					continue;
+				}
+
+				compressed_index_stmt->subname = from_to->from;
+				compressed_index_stmt->newname = from_to->to;
+				ExecRenameStmt(compressed_index_stmt);
 			}
 
-			char *new_index_name =
-				compressed_column_metadata_name_v2(sparse_index_types[i], stmt->newname);
-			compressed_index_stmt->subname = old_index_name;
-			compressed_index_stmt->newname = new_index_name;
-			ExecRenameStmt(compressed_index_stmt);
+			list_free_deep(rename_from_to);
 		}
 	}
 }

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -26,7 +26,9 @@ Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid tabl
 
 char *column_segment_min_name(int16 column_index);
 char *column_segment_max_name(int16 column_index);
-char *compressed_column_metadata_name_v2(const char *metadata_type, const char *column_name);
+char *compressed_column_metadata_name_v2(const char *metadata_type, const char **column_names,
+										 int num_columns);
+char *compressed_column_metadata_name_list_v2(const char *metadata_type, List *column_names_list);
 
 typedef struct CompressionSettings CompressionSettings;
 int compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_reloid,

--- a/tsl/test/expected/compress_compbloom_config.out
+++ b/tsl/test/expected/compress_compbloom_config.out
@@ -1,0 +1,179 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-------------------------------------------------------------------
+-- Config tests
+-------------------------------------------------------------------
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+CREATE VIEW compressedcols AS select relname,attname,c.oid as reloid,attnum from pg_attribute a, pg_class c where c.oid=a.attrelid and relname like '%compress_hyper_%chunk' order by c.oid asc, a.attnum asc;
+CREATE TABLE t(a int, b int, c int, d int, e int, f int, g int, h int, i int);
+SELECT create_hypertable('t', 'a');
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+
+-- Should succeed (8 columns max)
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
+where relid = 't'::regclass and index is not null order by 1,2;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+-------+----------------+-----------+---------+--------------+--------------------+-------
+
+-- Should fail (9 columns)
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h","i")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+-- The ordering of bloom columns in the composite bloom index should be determined by the order of the columns in the CREATE TABLE statement
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f","e","d","c","b")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
+where relid = 't'::regclass and index is not null order by 1,2;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+-------+----------------+-----------+---------+--------------+--------------------+-------
+
+-- Creating two composite bloom indexes with the same columns in different orders should fail
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f"),bloom("f","g","h")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+-- Creating a composite bloom index with the same columns should fail
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress_index = 'bloom("a","b","a")');
+ERROR:  cannot set sparse index option without orderby option
+ALTER TABLE t SET (timescaledb.compress_index = 'bloom("g","g")');
+ERROR:  cannot set sparse index option without orderby option
+\set ON_ERROR_STOP 1
+DROP TABLE t CASCADE;
+-- Creating a composite bloom index based on a primary key, and create the same manually again
+CREATE TABLE u(a int, b int, c int, d int, PRIMARY KEY (a, b, c));
+SELECT create_hypertable('u', 'a');
+ create_hypertable 
+-------------------
+ (2,public,u,t)
+
+ALTER TABLE u SET (timescaledb.compress, timescaledb.compress_orderby = 'b');
+select index from settings where relid = 'u'::regclass and index is not null order by 1;
+ index 
+-------
+
+INSERT INTO u VALUES (1, 2, 3, 4), (5, 6, 7, 8);
+select count(compress_chunk(x)) from show_chunks('u') x;
+ count 
+-------
+     1
+
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                  index                                                                                  
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_2_1_chunk | _timescaledb_internal.compress_hyper_3_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+
+-- Check the auto generated compressed columns
+select relname,attname from compressedcols order by 1,2;
+         relname          |       attname        
+--------------------------+----------------------
+ compress_hyper_3_2_chunk | _ts_meta_count
+ compress_hyper_3_2_chunk | _ts_meta_max_1
+ compress_hyper_3_2_chunk | _ts_meta_max_2
+ compress_hyper_3_2_chunk | _ts_meta_min_1
+ compress_hyper_3_2_chunk | _ts_meta_min_2
+ compress_hyper_3_2_chunk | regress-test-bloom_c
+ compress_hyper_3_2_chunk | a
+ compress_hyper_3_2_chunk | b
+ compress_hyper_3_2_chunk | c
+ compress_hyper_3_2_chunk | cmax
+ compress_hyper_3_2_chunk | cmin
+ compress_hyper_3_2_chunk | ctid
+ compress_hyper_3_2_chunk | d
+ compress_hyper_3_2_chunk | tableoid
+ compress_hyper_3_2_chunk | xmax
+ compress_hyper_3_2_chunk | xmin
+
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE u SET (timescaledb.compress_index = 'bloom("a","b","c")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                  index                                                                                  
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_2_1_chunk | _timescaledb_internal.compress_hyper_3_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+
+-- Also in a different order
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE u SET (timescaledb.compress_index = 'bloom("c","b","a")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                  index                                                                                  
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_2_1_chunk | _timescaledb_internal.compress_hyper_3_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+
+DROP TABLE u CASCADE;
+-------------------------------------------------------------------
+-- Long column names tests
+-------------------------------------------------------------------
+CREATE TABLE v(a_01234567890123456789 int, b_01234567890123456789 int, c_01234567890123456789 int, d_01234567890123456789 int, e_01234567890123456789 int, f_01234567890123456789 int, g_01234567890123456789 int, h_01234567890123456789 int, i_01234567890123456789 int, primary key (a_01234567890123456789, b_01234567890123456789, c_01234567890123456789, d_01234567890123456789, e_01234567890123456789));
+SELECT create_hypertable('v', 'a_01234567890123456789');
+ create_hypertable 
+-------------------
+ (4,public,v,t)
+
+ALTER TABLE v SET (timescaledb.compress, timescaledb.compress_orderby = 'b_01234567890123456789');
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
+-------+----------------+-----------+---------+--------------+--------------------+-------
+
+INSERT INTO v VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9);
+select count(compress_chunk(x)) from show_chunks('v') x;
+ count 
+-------
+     1
+
+-- Check the auto generated composite bloom index configuration and column names
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+                 relid                  |                 compress_relid                 | segmentby |                     orderby                     | orderby_desc | orderby_nullsfirst |                                                                                                                                                                                             index                                                                                                                                                                                              
+----------------------------------------+------------------------------------------------+-----------+-------------------------------------------------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal.compress_hyper_5_4_chunk |           | {b_01234567890123456789,a_01234567890123456789} | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c_01234567890123456789", "source": "default"}, {"type": "bloom", "column": "d_01234567890123456789", "source": "default"}, {"type": "bloom", "column": "e_01234567890123456789", "source": "default"}, {"type": "minmax", "column": "b_01234567890123456789", "source": "orderby"}, {"type": "minmax", "column": "a_01234567890123456789", "source": "orderby"}]
+
+select relname,attname from compressedcols order by 1,2;
+         relname          |                  attname                  
+--------------------------+-------------------------------------------
+ compress_hyper_5_4_chunk | _ts_meta_count
+ compress_hyper_5_4_chunk | _ts_meta_max_1
+ compress_hyper_5_4_chunk | _ts_meta_max_2
+ compress_hyper_5_4_chunk | _ts_meta_min_1
+ compress_hyper_5_4_chunk | _ts_meta_min_2
+ compress_hyper_5_4_chunk | regress-test-bloom_c_01234567890123456789
+ compress_hyper_5_4_chunk | regress-test-bloom_d_01234567890123456789
+ compress_hyper_5_4_chunk | regress-test-bloom_e_01234567890123456789
+ compress_hyper_5_4_chunk | a_01234567890123456789
+ compress_hyper_5_4_chunk | b_01234567890123456789
+ compress_hyper_5_4_chunk | c_01234567890123456789
+ compress_hyper_5_4_chunk | cmax
+ compress_hyper_5_4_chunk | cmin
+ compress_hyper_5_4_chunk | ctid
+ compress_hyper_5_4_chunk | d_01234567890123456789
+ compress_hyper_5_4_chunk | e_01234567890123456789
+ compress_hyper_5_4_chunk | f_01234567890123456789
+ compress_hyper_5_4_chunk | g_01234567890123456789
+ compress_hyper_5_4_chunk | h_01234567890123456789
+ compress_hyper_5_4_chunk | i_01234567890123456789
+ compress_hyper_5_4_chunk | tableoid
+ compress_hyper_5_4_chunk | xmax
+ compress_hyper_5_4_chunk | xmin
+
+-- Make sure the duplicate column detection works for long column names
+\set ON_ERROR_STOP 0
+ALTER TABLE v SET (timescaledb.compress_index = 'bloom("a_01234567890123456789","b_01234567890123456789","c_01234567890123456789","a_01234567890123456789")');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+DROP TABLE v CASCADE;

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -2,9 +2,14 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
 CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
 -- Test configurable sparse indexes settings
-create table test_settings(x int, value text, u uuid, ts timestamp);
+create table test_settings(
+  x int, value text, u uuid, ts timestamp, d real, b bigint, age int, gender text, city text,
+  long1_01234567890123456789 text, long2_01234567890123456789 text, long3_01234567890123456789 text);
 select create_hypertable('test_settings', 'x');
 WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
      create_hypertable      
@@ -66,7 +71,7 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), bloom(count(u))');
-ERROR:  sparse index bloom's first option must reference a valid column.
+ERROR:  sparse index column reference must reference a valid column name
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = '"u", minmax("u")');
@@ -100,24 +105,11 @@ alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), minmax("u")');
 ERROR:  duplicate column name "u"
--- multiple columns
-alter table test_settings set (timescaledb.compress,
-    timescaledb.compress_orderby = 'x',
-    timescaledb.compress_index = 'bloom("u,ts")');
-ERROR:  column "u,ts" does not exist
-alter table test_settings set (timescaledb.compress,
-    timescaledb.compress_orderby = 'x',
-    timescaledb.compress_index = 'bloom(u,ts)');
-ERROR:  sparse index "bloom" can only have one column
-alter table test_settings set (timescaledb.compress,
-    timescaledb.compress_orderby = 'x',
-    timescaledb.compress_index = 'bloom(u,abc)');
-ERROR:  sparse index "bloom" can only have one column
 -- duplicate column
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), bloom("u")');
-ERROR:  duplicate column name "u"
+ERROR:  duplicate sparse index configuration ('u')
 -- invalid column
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
@@ -135,6 +127,94 @@ alter table test_settings set (timescaledb.compress,
     timescaledb.compress_index = 'bloom("u")');
 ERROR:  Creating bloom sparse index is disabled
 reset timescaledb.enable_sparse_index_bloom;
+\set ON_ERROR_STOP 1
+-- valid composite bloom filter cases:
+-- two columns
+-- TODO : remove after composite blooms rolled out
+\set ON_ERROR_STOP 0
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u","ts")');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u",ts)');
+ERROR:  composite bloom indexes are not supported
+-- three columns
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,value)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u","ts","value")');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u",ts,"value")');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(long1_01234567890123456789,long2_01234567890123456789,long3_01234567890123456789)');
+ERROR:  composite bloom indexes are not supported
+-- more than 3 columns
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,value,d)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,value,d,b)');
+ERROR:  composite bloom indexes are not supported
+-- partial overlaps
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,value),bloom(u,ts)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u),bloom(u,ts)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,value),bloom(u,ts,value)');
+ERROR:  composite bloom indexes are not supported
+\set ON_ERROR_STOP 1
+-- invalid composite bloom filter cases:
+\set ON_ERROR_STOP 0
+-- nine column composite bloom is not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,"value",d,b,x,age,gender,city)');
+ERROR:  composite bloom indexes are not supported
+-- duplicate column
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,u)');
+ERROR:  composite bloom indexes are not supported
+-- duplicate blooms in different orders
+-- 2 cols
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts),bloom(ts,u)');
+ERROR:  composite bloom indexes are not supported
+-- 3 cols
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,x),bloom(u,x,ts)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(ts,x,u),bloom(ts,u,x)');
+ERROR:  composite bloom indexes are not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(x,ts,u),bloom(x,u,ts)');
+ERROR:  composite bloom indexes are not supported
 \set ON_ERROR_STOP 1
 -- empty sparse index
 alter table test_settings set (timescaledb.compress,

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -482,7 +482,7 @@ ROLLBACK;
 -- invalid syntax
 BEGIN;
 CREATE TABLE t31(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time', tsdb.orderby='value', tsdb.index='bloom(value),bloom(count(device))');
-ERROR:  sparse index bloom's first option must reference a valid column.
+ERROR:  sparse index column reference must reference a valid column name
 ROLLBACK;
 BEGIN;
 CREATE TABLE t32(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time', tsdb.orderby='value', tsdb.index='value,bloom(count(device))');
@@ -495,7 +495,7 @@ ERROR:  duplicate column name "value"
 ROLLBACK;
 BEGIN;
 CREATE TABLE t34(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time', tsdb.orderby='value', tsdb.index='bloom(value),bloom(value)');
-ERROR:  duplicate column name "value"
+ERROR:  duplicate sparse index configuration ('value')
 ROLLBACK;
 -- invalid column
 BEGIN;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_FILES
     compress_batch_size.sql
     compress_bitmap_scan.sql
     compress_bloom_hash.sql
+    compress_compbloom_config.sql
     compress_sparse_config.sql
     compress_default.sql
     compress_dml_copy.sql

--- a/tsl/test/sql/compress_compbloom_config.sql
+++ b/tsl/test/sql/compress_compbloom_config.sql
@@ -1,0 +1,101 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-------------------------------------------------------------------
+-- Config tests
+-------------------------------------------------------------------
+
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+CREATE VIEW compressedcols AS select relname,attname,c.oid as reloid,attnum from pg_attribute a, pg_class c where c.oid=a.attrelid and relname like '%compress_hyper_%chunk' order by c.oid asc, a.attnum asc;
+
+CREATE TABLE t(a int, b int, c int, d int, e int, f int, g int, h int, i int);
+SELECT create_hypertable('t', 'a');
+
+
+-- Should succeed (8 columns max)
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h")');
+\set ON_ERROR_STOP 1
+
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
+where relid = 't'::regclass and index is not null order by 1,2;
+
+-- Should fail (9 columns)
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h","i")');
+\set ON_ERROR_STOP 1
+
+-- The ordering of bloom columns in the composite bloom index should be determined by the order of the columns in the CREATE TABLE statement
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f","e","d","c","b")');
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
+where relid = 't'::regclass and index is not null order by 1,2;
+
+-- Creating two composite bloom indexes with the same columns in different orders should fail
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f"),bloom("f","g","h")');
+\set ON_ERROR_STOP 1
+
+-- Creating a composite bloom index with the same columns should fail
+\set ON_ERROR_STOP 0
+ALTER TABLE t SET (timescaledb.compress_index = 'bloom("a","b","a")');
+ALTER TABLE t SET (timescaledb.compress_index = 'bloom("g","g")');
+\set ON_ERROR_STOP 1
+
+DROP TABLE t CASCADE;
+
+-- Creating a composite bloom index based on a primary key, and create the same manually again
+CREATE TABLE u(a int, b int, c int, d int, PRIMARY KEY (a, b, c));
+SELECT create_hypertable('u', 'a');
+ALTER TABLE u SET (timescaledb.compress, timescaledb.compress_orderby = 'b');
+select index from settings where relid = 'u'::regclass and index is not null order by 1;
+INSERT INTO u VALUES (1, 2, 3, 4), (5, 6, 7, 8);
+
+select count(compress_chunk(x)) from show_chunks('u') x;
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+
+-- Check the auto generated compressed columns
+select relname,attname from compressedcols order by 1,2;
+
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE u SET (timescaledb.compress_index = 'bloom("a","b","c")');
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+
+-- Also in a different order
+-- TODO: remove later, once composite blooms fully rolled out
+\set ON_ERROR_STOP 0
+ALTER TABLE u SET (timescaledb.compress_index = 'bloom("c","b","a")');
+\set ON_ERROR_STOP 1
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+
+DROP TABLE u CASCADE;
+
+-------------------------------------------------------------------
+-- Long column names tests
+-------------------------------------------------------------------
+
+CREATE TABLE v(a_01234567890123456789 int, b_01234567890123456789 int, c_01234567890123456789 int, d_01234567890123456789 int, e_01234567890123456789 int, f_01234567890123456789 int, g_01234567890123456789 int, h_01234567890123456789 int, i_01234567890123456789 int, primary key (a_01234567890123456789, b_01234567890123456789, c_01234567890123456789, d_01234567890123456789, e_01234567890123456789));
+SELECT create_hypertable('v', 'a_01234567890123456789');
+
+ALTER TABLE v SET (timescaledb.compress, timescaledb.compress_orderby = 'b_01234567890123456789');
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+
+INSERT INTO v VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9);
+select count(compress_chunk(x)) from show_chunks('v') x;
+
+-- Check the auto generated composite bloom index configuration and column names
+select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
+select relname,attname from compressedcols order by 1,2;
+
+-- Make sure the duplicate column detection works for long column names
+\set ON_ERROR_STOP 0
+ALTER TABLE v SET (timescaledb.compress_index = 'bloom("a_01234567890123456789","b_01234567890123456789","c_01234567890123456789","a_01234567890123456789")');
+\set ON_ERROR_STOP 1
+
+DROP TABLE v CASCADE;

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -3,11 +3,18 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+
 CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
 
 -- Test configurable sparse indexes settings
 
-create table test_settings(x int, value text, u uuid, ts timestamp);
+create table test_settings(
+  x int, value text, u uuid, ts timestamp, d real, b bigint, age int, gender text, city text,
+  long1_01234567890123456789 text, long2_01234567890123456789 text, long3_01234567890123456789 text);
 select create_hypertable('test_settings', 'x');
 
 -- defaults
@@ -81,19 +88,6 @@ alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), minmax("u")');
 
--- multiple columns
-alter table test_settings set (timescaledb.compress,
-    timescaledb.compress_orderby = 'x',
-    timescaledb.compress_index = 'bloom("u,ts")');
-
-alter table test_settings set (timescaledb.compress,
-    timescaledb.compress_orderby = 'x',
-    timescaledb.compress_index = 'bloom(u,ts)');
-
-alter table test_settings set (timescaledb.compress,
-    timescaledb.compress_orderby = 'x',
-    timescaledb.compress_index = 'bloom(u,abc)');
-
 -- duplicate column
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
@@ -117,6 +111,96 @@ alter table test_settings set (timescaledb.compress,
     timescaledb.compress_index = 'bloom("u")');
 
 reset timescaledb.enable_sparse_index_bloom;
+\set ON_ERROR_STOP 1
+
+-- valid composite bloom filter cases:
+-- two columns
+-- TODO : remove after composite blooms rolled out
+\set ON_ERROR_STOP 0
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u","ts")');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u",ts)');
+
+-- three columns
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,value)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u","ts","value")');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u",ts,"value")');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(long1_01234567890123456789,long2_01234567890123456789,long3_01234567890123456789)');
+
+-- more than 3 columns
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,value,d)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,value,d,b)');
+
+-- partial overlaps
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,value),bloom(u,ts)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u),bloom(u,ts)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,value),bloom(u,ts,value)');
+\set ON_ERROR_STOP 1
+
+-- invalid composite bloom filter cases:
+\set ON_ERROR_STOP 0
+
+-- nine column composite bloom is not supported
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,"value",d,b,x,age,gender,city)');
+
+-- duplicate column
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,u)');
+
+-- duplicate blooms in different orders
+-- 2 cols
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts),bloom(ts,u)');
+
+-- 3 cols
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(u,ts,x),bloom(u,x,ts)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(ts,x,u),bloom(ts,u,x)');
+
+alter table test_settings set (timescaledb.compress,
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom(x,ts,u),bloom(x,u,ts)');
+
 \set ON_ERROR_STOP 1
 
 -- empty sparse index


### PR DESCRIPTION
This is the first slice of changes aiming at rolling out the composite bloom changes. This set contains:

- utility functions to work with lists of Bitmapset
- parsing sparse index configuration from jsonb
- complete code to parse the composite bloom configuration
- functionality to rename or drop columns from the composie bloom config
- support for renaming or dropping columns that are part of a single column or composite bloom filter
- NOTE: the manual or automatic creation of composite bloom indexes are explicitly disabled in this PR, but tests are included so once they are merged the tests will show the difference

Disable-check: force-changelog-file