### PR TITLE
Fix plan-time error when using enum in orderby compression setting

### DIFF
--- a/.unreleased/pr_9283
+++ b/.unreleased/pr_9283
@@ -1,0 +1,1 @@
+Fixes: #9283 Fix plan-time error when using enum in orderby compression setting

--- a/src/utils.c
+++ b/src/utils.c
@@ -807,8 +807,8 @@ ts_get_appendrelinfo(PlannerInfo *root, Index rti, bool missing_ok)
  * This function was moved to postgres main in PG13 but was removed
  * again in PG15. So we use our own implementation for PG15+.
  */
-Expr *
-ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
+EquivalenceMember *
+ts_find_em_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
 {
 	EquivalenceMember *em;
 #if PG18_GE
@@ -836,12 +836,19 @@ ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
 			 * taken entirely from this relation, we'll be content to choose
 			 * any one of those.
 			 */
-			return em->em_expr;
+			return em;
 		}
 	}
 
-	/* We didn't find any suitable equivalence class expression */
+	/* We didn't find any suitable equivalence class member */
 	return NULL;
+}
+
+Expr *
+ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
+{
+	EquivalenceMember *em = ts_find_em_for_rel(ec, rel);
+	return em ? em->em_expr : NULL;
 }
 
 bool

--- a/src/utils.h
+++ b/src/utils.h
@@ -138,6 +138,7 @@ extern TSDLLEXPORT AppendRelInfo *ts_get_appendrelinfo(PlannerInfo *root, Index 
 													   bool missing_ok);
 
 extern TSDLLEXPORT Expr *ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel);
+extern TSDLLEXPORT EquivalenceMember *ts_find_em_for_rel(EquivalenceClass *ec, RelOptInfo *rel);
 
 extern TSDLLEXPORT bool ts_has_row_security(Oid relid);
 

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -148,7 +148,8 @@ append_ec_for_seqnum(PlannerInfo *root, const CompressionInfo *info, const SortI
 }
 
 static EquivalenceClass *
-append_ec_for_metadata_col(PlannerInfo *root, const CompressionInfo *info, Expr *expr, PathKey *pk)
+append_ec_for_metadata_col(PlannerInfo *root, const CompressionInfo *info, Expr *expr, PathKey *pk,
+						   Oid em_datatype)
 {
 	MemoryContext oldcontext = MemoryContextSwitchTo(root->planner_cxt);
 	EquivalenceMember *em = makeNode(EquivalenceMember);
@@ -157,7 +158,7 @@ append_ec_for_metadata_col(PlannerInfo *root, const CompressionInfo *info, Expr 
 	em->em_relids = bms_make_singleton(info->compressed_rel->relid);
 	em->em_is_const = false;
 	em->em_is_child = false;
-	em->em_datatype = exprType((Node *) expr);
+	em->em_datatype = em_datatype;
 	EquivalenceClass *ec = makeNode(EquivalenceClass);
 	ec->ec_opfamilies = pk->pk_eclass->ec_opfamilies;
 	ec->ec_collation = pk->pk_eclass->ec_collation;
@@ -293,10 +294,19 @@ build_compressed_scan_pathkeys(const SortInfo *sort_info, PlannerInfo *root, Lis
 			for (; lc != NULL; lc = lnext(chunk_pathkeys, lc))
 			{
 				pk = lfirst(lc);
-				expr = ts_find_em_expr_for_rel(pk->pk_eclass, info->chunk_rel);
+				EquivalenceMember *chunk_em = ts_find_em_for_rel(pk->pk_eclass, info->chunk_rel);
 
-				Assert(expr);
-				Oid opcintype = exprType((Node *) expr);
+				Assert(chunk_em);
+				expr = chunk_em->em_expr;
+				/*
+				 * Use em_datatype from the original equivalence member as the
+				 * opcintype. For polymorphic types like anyenum,
+				 * canonicalize_ec_expression will not add a RelabelType (it
+				 * replaces polymorphic req_type with the concrete type), so we
+				 * must explicitly pass the correct em_datatype to the metadata
+				 * column EC.
+				 */
+				Oid opcintype = chunk_em->em_datatype;
 				Oid collation = exprCollation((Node *) expr);
 				expr = (Expr *) strip_implicit_coercions((Node *) expr);
 				var = castNode(Var, expr);
@@ -334,7 +344,8 @@ build_compressed_scan_pathkeys(const SortInfo *sort_info, PlannerInfo *root, Lis
 											var->varlevelsup);
 				Expr *min_expr =
 					canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
-				EquivalenceClass *min_ec = append_ec_for_metadata_col(root, info, min_expr, pk);
+				EquivalenceClass *min_ec =
+					append_ec_for_metadata_col(root, info, min_expr, pk, opcintype);
 				PathKey *min =
 					make_canonical_pathkey(root, min_ec, pk->pk_opfamily, strategy, nulls_first);
 				required_compressed_pathkeys = lappend(required_compressed_pathkeys, min);
@@ -349,7 +360,8 @@ build_compressed_scan_pathkeys(const SortInfo *sort_info, PlannerInfo *root, Lis
 									   var->varlevelsup);
 				Expr *max_expr =
 					canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
-				EquivalenceClass *max_ec = append_ec_for_metadata_col(root, info, max_expr, pk);
+				EquivalenceClass *max_ec =
+					append_ec_for_metadata_col(root, info, max_expr, pk, opcintype);
 				PathKey *max =
 					make_canonical_pathkey(root, max_ec, pk->pk_opfamily, strategy, nulls_first);
 

--- a/tsl/test/expected/transparent_decompression_queries-15.out
+++ b/tsl/test/expected/transparent_decompression_queries-15.out
@@ -249,3 +249,23 @@ SELECT max(date) AS date FROM options_data WHERE contract_code='CONTRACT2023-12-
  
 
 RESET random_page_cost;
+-- gh issue 8918
+-- test enum in order by
+CREATE TYPE animal AS ENUM ('raccoon', 'hedgehog', 'tiger');
+CREATE TABLE i8918(time timestamptz, sensor_id int, enum_type animal, value float) WITH (tsdb.hypertable, tsdb.compress_segmentby='sensor_id', tsdb.compress_orderby='enum_type, time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'raccoon', 1);
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'hedgehog', 1);
+SELECT compress_chunk(show_chunks('i8918'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_22_chunk
+
+SET enable_hashagg TO off;
+EXPLAIN (costs off, buffers off, analyze, timing off, summary off) SELECT sensor_id, enum_type, count(*) FROM i8918 GROUP BY sensor_id, enum_type;
+--- QUERY PLAN ---
+ GroupAggregate (actual rows=2.00 loops=1)
+   Group Key: _hyper_9_22_chunk.sensor_id, _hyper_9_22_chunk.enum_type
+   ->  Custom Scan (ColumnarScan) on _hyper_9_22_chunk (actual rows=2.00 loops=1)
+         ->  Index Scan using compress_hyper_10_23_chunk_sensor_id__ts_meta_min_1__ts_met_idx on compress_hyper_10_23_chunk (actual rows=1.00 loops=1)
+

--- a/tsl/test/expected/transparent_decompression_queries-16.out
+++ b/tsl/test/expected/transparent_decompression_queries-16.out
@@ -249,3 +249,23 @@ SELECT max(date) AS date FROM options_data WHERE contract_code='CONTRACT2023-12-
  
 
 RESET random_page_cost;
+-- gh issue 8918
+-- test enum in order by
+CREATE TYPE animal AS ENUM ('raccoon', 'hedgehog', 'tiger');
+CREATE TABLE i8918(time timestamptz, sensor_id int, enum_type animal, value float) WITH (tsdb.hypertable, tsdb.compress_segmentby='sensor_id', tsdb.compress_orderby='enum_type, time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'raccoon', 1);
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'hedgehog', 1);
+SELECT compress_chunk(show_chunks('i8918'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_22_chunk
+
+SET enable_hashagg TO off;
+EXPLAIN (costs off, buffers off, analyze, timing off, summary off) SELECT sensor_id, enum_type, count(*) FROM i8918 GROUP BY sensor_id, enum_type;
+--- QUERY PLAN ---
+ GroupAggregate (actual rows=2.00 loops=1)
+   Group Key: _hyper_9_22_chunk.sensor_id, _hyper_9_22_chunk.enum_type
+   ->  Custom Scan (ColumnarScan) on _hyper_9_22_chunk (actual rows=2.00 loops=1)
+         ->  Index Scan using compress_hyper_10_23_chunk_sensor_id__ts_meta_min_1__ts_met_idx on compress_hyper_10_23_chunk (actual rows=1.00 loops=1)
+

--- a/tsl/test/expected/transparent_decompression_queries-17.out
+++ b/tsl/test/expected/transparent_decompression_queries-17.out
@@ -260,3 +260,23 @@ SELECT max(date) AS date FROM options_data WHERE contract_code='CONTRACT2023-12-
  
 
 RESET random_page_cost;
+-- gh issue 8918
+-- test enum in order by
+CREATE TYPE animal AS ENUM ('raccoon', 'hedgehog', 'tiger');
+CREATE TABLE i8918(time timestamptz, sensor_id int, enum_type animal, value float) WITH (tsdb.hypertable, tsdb.compress_segmentby='sensor_id', tsdb.compress_orderby='enum_type, time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'raccoon', 1);
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'hedgehog', 1);
+SELECT compress_chunk(show_chunks('i8918'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_22_chunk
+
+SET enable_hashagg TO off;
+EXPLAIN (costs off, buffers off, analyze, timing off, summary off) SELECT sensor_id, enum_type, count(*) FROM i8918 GROUP BY sensor_id, enum_type;
+--- QUERY PLAN ---
+ GroupAggregate (actual rows=2.00 loops=1)
+   Group Key: _hyper_9_22_chunk.sensor_id, _hyper_9_22_chunk.enum_type
+   ->  Custom Scan (ColumnarScan) on _hyper_9_22_chunk (actual rows=2.00 loops=1)
+         ->  Index Scan using compress_hyper_10_23_chunk_sensor_id__ts_meta_min_1__ts_met_idx on compress_hyper_10_23_chunk (actual rows=1.00 loops=1)
+

--- a/tsl/test/expected/transparent_decompression_queries-18.out
+++ b/tsl/test/expected/transparent_decompression_queries-18.out
@@ -260,3 +260,23 @@ SELECT max(date) AS date FROM options_data WHERE contract_code='CONTRACT2023-12-
  
 
 RESET random_page_cost;
+-- gh issue 8918
+-- test enum in order by
+CREATE TYPE animal AS ENUM ('raccoon', 'hedgehog', 'tiger');
+CREATE TABLE i8918(time timestamptz, sensor_id int, enum_type animal, value float) WITH (tsdb.hypertable, tsdb.compress_segmentby='sensor_id', tsdb.compress_orderby='enum_type, time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'raccoon', 1);
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'hedgehog', 1);
+SELECT compress_chunk(show_chunks('i8918'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_22_chunk
+
+SET enable_hashagg TO off;
+EXPLAIN (costs off, buffers off, analyze, timing off, summary off) SELECT sensor_id, enum_type, count(*) FROM i8918 GROUP BY sensor_id, enum_type;
+--- QUERY PLAN ---
+ GroupAggregate (actual rows=2.00 loops=1)
+   Group Key: _hyper_9_22_chunk.sensor_id, _hyper_9_22_chunk.enum_type
+   ->  Custom Scan (ColumnarScan) on _hyper_9_22_chunk (actual rows=2.00 loops=1)
+         ->  Index Scan using compress_hyper_10_23_chunk_sensor_id__ts_meta_min_1__ts_met_idx on compress_hyper_10_23_chunk (actual rows=1.00 loops=1)
+

--- a/tsl/test/sql/transparent_decompression_queries.sql.in
+++ b/tsl/test/sql/transparent_decompression_queries.sql.in
@@ -146,3 +146,14 @@ VACUUM ANALYZE options_data;
 SELECT max(date) AS date FROM options_data WHERE contract_code='CONTRACT2023-12-03 04:00:00+01';
 
 RESET random_page_cost;
+
+-- gh issue 8918
+-- test enum in order by
+CREATE TYPE animal AS ENUM ('raccoon', 'hedgehog', 'tiger');
+CREATE TABLE i8918(time timestamptz, sensor_id int, enum_type animal, value float) WITH (tsdb.hypertable, tsdb.compress_segmentby='sensor_id', tsdb.compress_orderby='enum_type, time');
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'raccoon', 1);
+INSERT INTO i8918 VALUES ('2020-01-01'::timestamptz, 1, 'hedgehog', 1);
+SELECT compress_chunk(show_chunks('i8918'));
+SET enable_hashagg TO off;
+EXPLAIN (costs off, buffers off, analyze, timing off, summary off) SELECT sensor_id, enum_type, count(*) FROM i8918 GROUP BY sensor_id, enum_type;
+


### PR DESCRIPTION
When building compressed scan pathkeys for orderby columns, the code
used exprType() to determine the opcintype for metadata column
EquivalenceMembers. For enum types, this returns the specific enum OID,
but the enum_ops btree opfamily registers operators for the polymorphic
anyenum type. Additionally, PG18's canonicalize_ec_expression() detects
polymorphic types and replaces them with the concrete type, so it cannot
coerce to anyenum.

Fix by using em_datatype from the original pathkey's EquivalenceMember
(which PostgreSQL's planner correctly sets to anyenum) and passing it
explicitly to append_ec_for_metadata_col() instead of deriving it from
the expression type.

Fixes #8918
