### PR TITLE
Change materialization hypertable indexes

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -63,6 +63,7 @@
 #include <utils/syscache.h>
 #include <utils/typcache.h>
 
+#include "compat/compat.h"
 #include "common.h"
 #include "config.h"
 #include "create.h"
@@ -296,17 +297,23 @@ cagg_create_hypertable(int32 hypertable_id, Oid mat_tbloid, const char *matpartc
 }
 
 /*
- * Add additional indexes to materialization table for the columns derived from
- * the group-by column list of the partial select query.
+ * Add additional indexes to materialization hypertable for the columns derived from
+ * the group-by column list of the cagg's select query.
+ *
  * If partial select query has:
- * GROUP BY timebucket_expr, <grpcol1, grpcol2, grpcol3 ...>
- * index on mattable is <grpcol1, timebucketcol>, <grpcol2, timebucketcol> ... and so on.
- * i.e. #indexes =(  #grp-cols - 1)
+ * 	 GROUP BY timebucket_expr, <grpcol1, grpcol2, grpcol3 ...>
+ *
+ * Index on mattable will be:
+ *   <grpcol1, grpcol2, grpcol3, timebucket_expr DESC>
  */
 static void
 mattablecolumninfo_add_mattable_index(MaterializationHypertableColumnInfo *matcolinfo,
 									  Hypertable *ht)
 {
+	NameData indxname;
+	ObjectAddress indxaddr;
+	HeapTuple indxtuple;
+	List *indxelements = NIL;
 	IndexStmt stmt = {
 		.type = T_IndexStmt,
 		.accessMethod = DEFAULT_INDEX_TYPE,
@@ -318,39 +325,56 @@ mattablecolumninfo_add_mattable_index(MaterializationHypertableColumnInfo *matco
 						   .name = matcolinfo->matpartcolname,
 						   .ordering = SORTBY_DESC };
 	ListCell *le = NULL;
+	StringInfoData buf;
+	initStringInfo(&buf);
+	char *sep = "";
+
+	if (list_length(matcolinfo->mat_groupcolname_list) == 0)
+		return;
+
 	foreach (le, matcolinfo->mat_groupcolname_list)
 	{
-		NameData indxname;
-		ObjectAddress indxaddr;
-		HeapTuple indxtuple;
 		char *grpcolname = (char *) lfirst(le);
-		IndexElem grpelem = { .type = T_IndexElem, .name = grpcolname };
-		stmt.indexParams = list_make2(&grpelem, &timeelem);
-		indxaddr = DefineIndexCompat(ht->main_table_relid,
-									 &stmt,
-									 InvalidOid, /* indexRelationId */
-									 InvalidOid, /* parentIndexId */
-									 InvalidOid, /* parentConstraintId */
-									 -1,		 /* total_parts */
-									 false,		 /* is_alter_table */
-									 false,		 /* check_rights */
-									 false,		 /* check_not_in_use */
-									 false,		 /* skip_build */
-									 false);	 /* quiet */
-		indxtuple = SearchSysCache1(RELOID, ObjectIdGetDatum(indxaddr.objectId));
+		IndexElem *grpelem = makeNode(IndexElem);
+		grpelem->name = pstrdup(grpcolname);
 
-		if (!HeapTupleIsValid(indxtuple))
-			elog(ERROR, "cache lookup failed for index relid %u", indxaddr.objectId);
-		indxname = ((Form_pg_class) GETSTRUCT(indxtuple))->relname;
-		elog(DEBUG1,
-			 "adding index %s ON %s.%s USING BTREE(%s, %s)",
-			 NameStr(indxname),
-			 NameStr(ht->fd.schema_name),
-			 NameStr(ht->fd.table_name),
-			 grpcolname,
-			 matcolinfo->matpartcolname);
-		ReleaseSysCache(indxtuple);
+		indxelements = lappend(indxelements, grpelem);
+
+		appendStringInfoString(&buf, grpelem->name);
+		appendStringInfoString(&buf, sep);
+		sep = ", ";
 	}
+
+	indxelements = lappend(indxelements, &timeelem);
+	stmt.indexParams = indxelements;
+
+	indxaddr = DefineIndexCompat(ht->main_table_relid,
+								 &stmt,
+								 InvalidOid, /* indexRelationId */
+								 InvalidOid, /* parentIndexId */
+								 InvalidOid, /* parentConstraintId */
+								 -1,		 /* total_parts */
+								 false,		 /* is_alter_table */
+								 false,		 /* check_rights */
+								 false,		 /* check_not_in_use */
+								 false,		 /* skip_build */
+								 false);	 /* quiet */
+
+	indxtuple = SearchSysCache1(RELOID, ObjectIdGetDatum(indxaddr.objectId));
+
+	if (!HeapTupleIsValid(indxtuple))
+		elog(ERROR, "cache lookup failed for index relid %u", indxaddr.objectId);
+
+	indxname = ((Form_pg_class) GETSTRUCT(indxtuple))->relname;
+
+	elog(DEBUG1,
+		 "adding index %s ON %s.%s USING BTREE(%s)",
+		 NameStr(indxname),
+		 NameStr(ht->fd.schema_name),
+		 NameStr(ht->fd.table_name),
+		 buf.data);
+
+	ReleaseSysCache(indxtuple);
 }
 
 /*


### PR DESCRIPTION
Nowadays for the Continuous Aggregate materialization hypertable we add additional indexes. Those additional indexes are one for each group-by column plus time bucket expression and it can lead to unsusable indexes.

This PR change the current logic to add just one additional composite index including all group-by columns plus the time bucket expression.