### PR TITLE
Propagate ALTER <object> OWNER TO to policy jobs

### DIFF
--- a/.unreleased/pr_9290
+++ b/.unreleased/pr_9290
@@ -1,0 +1,1 @@
+Fixes: #9290 Propagate ALTER <object> OWNER TO to policy jobs

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -1013,6 +1013,13 @@ ERROR:  must be member of role "test_role_1"
 \set ON_ERROR_STOP 1
 -- Superuser can always change owner
 SET ROLE :ROLE_SUPERUSER;
+-- Add a refresh policy before changing owner to verify job owner is propagated
+SELECT add_continuous_aggregate_policy('owner_check', NULL, 1::int8, '1 day'::interval) AS cagg_job_id \gset
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+       owner       
+-------------------
+ default_perm_user
+
 ALTER MATERIALIZED VIEW owner_check OWNER TO :ROLE_1;
 \x on
 SELECT * FROM cagg_info WHERE user_view::text = 'owner_check';
@@ -1028,6 +1035,17 @@ partial_view_owner | test_role_1
 tablespace         | 
 
 \x off
+-- make sure policy job owner is propagated
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+    owner    
+-------------
+ test_role_1
+
+SELECT remove_continuous_aggregate_policy('owner_check');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+
 --
 -- Test drop continuous aggregate cases
 --

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -1013,6 +1013,13 @@ ERROR:  must be able to SET ROLE "test_role_1"
 \set ON_ERROR_STOP 1
 -- Superuser can always change owner
 SET ROLE :ROLE_SUPERUSER;
+-- Add a refresh policy before changing owner to verify job owner is propagated
+SELECT add_continuous_aggregate_policy('owner_check', NULL, 1::int8, '1 day'::interval) AS cagg_job_id \gset
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+       owner       
+-------------------
+ default_perm_user
+
 ALTER MATERIALIZED VIEW owner_check OWNER TO :ROLE_1;
 \x on
 SELECT * FROM cagg_info WHERE user_view::text = 'owner_check';
@@ -1028,6 +1035,17 @@ partial_view_owner | test_role_1
 tablespace         | 
 
 \x off
+-- make sure policy job owner is propagated
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+    owner    
+-------------
+ test_role_1
+
+SELECT remove_continuous_aggregate_policy('owner_check');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+
 --
 -- Test drop continuous aggregate cases
 --

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -1013,6 +1013,13 @@ ERROR:  must be able to SET ROLE "test_role_1"
 \set ON_ERROR_STOP 1
 -- Superuser can always change owner
 SET ROLE :ROLE_SUPERUSER;
+-- Add a refresh policy before changing owner to verify job owner is propagated
+SELECT add_continuous_aggregate_policy('owner_check', NULL, 1::int8, '1 day'::interval) AS cagg_job_id \gset
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+       owner       
+-------------------
+ default_perm_user
+
 ALTER MATERIALIZED VIEW owner_check OWNER TO :ROLE_1;
 \x on
 SELECT * FROM cagg_info WHERE user_view::text = 'owner_check';
@@ -1028,6 +1035,17 @@ partial_view_owner | test_role_1
 tablespace         | 
 
 \x off
+-- make sure policy job owner is propagated
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+    owner    
+-------------
+ test_role_1
+
+SELECT remove_continuous_aggregate_policy('owner_check');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+
 --
 -- Test drop continuous aggregate cases
 --

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -1013,6 +1013,13 @@ ERROR:  must be able to SET ROLE "test_role_1"
 \set ON_ERROR_STOP 1
 -- Superuser can always change owner
 SET ROLE :ROLE_SUPERUSER;
+-- Add a refresh policy before changing owner to verify job owner is propagated
+SELECT add_continuous_aggregate_policy('owner_check', NULL, 1::int8, '1 day'::interval) AS cagg_job_id \gset
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+       owner       
+-------------------
+ default_perm_user
+
 ALTER MATERIALIZED VIEW owner_check OWNER TO :ROLE_1;
 \x on
 SELECT * FROM cagg_info WHERE user_view::text = 'owner_check';
@@ -1028,6 +1035,17 @@ partial_view_owner | test_role_1
 tablespace         | 
 
 \x off
+-- make sure policy job owner is propagated
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+    owner    
+-------------
+ test_role_1
+
+SELECT remove_continuous_aggregate_policy('owner_check');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+
 --
 -- Test drop continuous aggregate cases
 --

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -517,6 +517,7 @@ INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = 
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 \gset
+SELECT add_compression_policy('test1', interval '1 day') AS compression_job_id \gset
 ALTER TABLE test1 OWNER TO :ROLE_DEFAULT_PERM_USER_2;
 --make sure new owner is propagated down
 SELECT a.rolname from pg_class c INNER JOIN pg_authid a ON(c.relowner = a.oid) WHERE c.oid = 'test1'::regclass;
@@ -534,9 +535,20 @@ SELECT a.rolname from pg_class c INNER JOIN pg_authid a ON(c.relowner = a.oid) W
 ---------------------
  default_perm_user_2
 
+--make sure compression policy job owner is propagated
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :compression_job_id;
+        owner        
+---------------------
+ default_perm_user_2
+
 --
 -- turn off compression
 --
+select remove_compression_policy('test1');
+ remove_compression_policy 
+---------------------------
+ t
+
 SELECT count(decompress_chunk(ch)) FROM show_chunks('test1') ch;
  count 
 -------
@@ -546,7 +558,7 @@ VACUUM FULL ANALYZE test1;
 select add_compression_policy('test1', interval '1 day');
  add_compression_policy 
 ------------------------
-                   1002
+                   1003
 
 \set ON_ERROR_STOP 0
 ALTER table test1 set (timescaledb.compress='f');

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -744,11 +744,21 @@ ALTER MATERIALIZED VIEW owner_check OWNER TO :ROLE_1;
 
 -- Superuser can always change owner
 SET ROLE :ROLE_SUPERUSER;
+
+-- Add a refresh policy before changing owner to verify job owner is propagated
+SELECT add_continuous_aggregate_policy('owner_check', NULL, 1::int8, '1 day'::interval) AS cagg_job_id \gset
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+
 ALTER MATERIALIZED VIEW owner_check OWNER TO :ROLE_1;
 
 \x on
 SELECT * FROM cagg_info WHERE user_view::text = 'owner_check';
 \x off
+
+-- make sure policy job owner is propagated
+SELECT owner FROM _timescaledb_config.bgw_job WHERE id = :cagg_job_id;
+
+SELECT remove_continuous_aggregate_policy('owner_check');
 
 --
 -- Test drop continuous aggregate cases


### PR DESCRIPTION
When ALTER TABLE ... OWNER TO is run on a hypertable, the ownership
change is now propagated to background jobs (e.g. compression policies)
associated with that hypertable. Similarly, ALTER MATERIALIZED VIEW ...
OWNER TO on a continuous aggregate propagates to its refresh policy
jobs.

Fixes: #9289
