### PR TITLE
Fix time_bucket_gapfill inside LATERAL subqueries

### DIFF
--- a/.unreleased/pr_9293
+++ b/.unreleased/pr_9293
@@ -1,0 +1,2 @@
+Fixes: #9293 Fix time_bucket_gapfill inside LATERAL subqueries
+Thanks: @CaptainCuddleCube for reporting an issue with time_bucket_gapfill and LATERAL subqueries

--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -488,10 +488,11 @@ plan_add_gapfill(PlannerInfo *root, RelOptInfo *group_rel)
 		group_rel->cheapest_startup_path = NULL;
 		group_rel->cheapest_unique_path = NULL;
 
-		/* Parameterized paths pathlist is currently deleted instead of being processed */
-		list_free(group_rel->ppilist);
-		group_rel->ppilist = NULL;
-
+		/*
+		 * cheapest_parameterized_paths will be rebuilt by set_cheapest()
+		 * after this hook returns. We must not delete ppilist as it contains
+		 * ParamPathInfo entries needed for parameterized paths (e.g. LATERAL).
+		 */
 		list_free(group_rel->cheapest_parameterized_paths);
 		group_rel->cheapest_parameterized_paths = NULL;
 

--- a/tsl/test/shared/expected/gapfill_bug.out
+++ b/tsl/test/shared/expected/gapfill_bug.out
@@ -363,3 +363,63 @@ SELECT
  Fri Sep 30 22:00:00 2022 PDT |      |      |        5
 
 drop table hourly cascade;
+-- github issue #4693: test time_bucket_gapfill inside LATERAL subquery
+CREATE TYPE i4693_type AS (time timestamptz, num bigint);
+CREATE TABLE i4693(id integer, reports i4693_type[]);
+INSERT INTO i4693(id, reports) VALUES
+    (1, ARRAY[ROW('2020-09-01 13:22:02+00', 360), ROW('2020-09-01 13:24:02+00', 3600)]::i4693_type[]),
+    (2, ARRAY[ROW('2020-09-01 13:22:02+00', 90), ROW('2020-09-01 13:25:02+00', 900)]::i4693_type[]);
+-- Gapfill inside LATERAL should produce gap-filled rows for each outer row
+SELECT id, rep.* FROM i4693, LATERAL (
+    SELECT time_bucket_gapfill('1 minute', time,
+        start := '2020-09-01 13:22:00+00'::timestamptz,
+        finish := '2020-09-01 13:28:00+00'::timestamptz) AS mins,
+        sum(num)
+    FROM unnest(reports)
+    GROUP BY mins
+) AS rep
+ORDER BY id, mins;
+ id |             mins             | sum  
+----+------------------------------+------
+  1 | Tue Sep 01 06:22:00 2020 PDT |  360
+  1 | Tue Sep 01 06:23:00 2020 PDT |     
+  1 | Tue Sep 01 06:24:00 2020 PDT | 3600
+  1 | Tue Sep 01 06:25:00 2020 PDT |     
+  1 | Tue Sep 01 06:26:00 2020 PDT |     
+  1 | Tue Sep 01 06:27:00 2020 PDT |     
+  2 | Tue Sep 01 06:22:00 2020 PDT |   90
+  2 | Tue Sep 01 06:23:00 2020 PDT |     
+  2 | Tue Sep 01 06:24:00 2020 PDT |     
+  2 | Tue Sep 01 06:25:00 2020 PDT |  900
+  2 | Tue Sep 01 06:26:00 2020 PDT |     
+  2 | Tue Sep 01 06:27:00 2020 PDT |     
+
+-- test with locf and interpolate
+SELECT id, rep.* FROM i4693, LATERAL (
+    SELECT time_bucket_gapfill('1 minute', time,
+        start := '2020-09-01 13:22:00+00'::timestamptz,
+        finish := '2020-09-01 13:28:00+00'::timestamptz) AS mins,
+        locf(sum(num)),
+        interpolate(sum(num)),
+        sum(num)
+    FROM unnest(reports)
+    GROUP BY mins
+) AS rep
+ORDER BY id, mins;
+ id |             mins             | locf | interpolate | sum  
+----+------------------------------+------+-------------+------
+  1 | Tue Sep 01 06:22:00 2020 PDT |  360 |         360 |  360
+  1 | Tue Sep 01 06:23:00 2020 PDT |  360 |        1980 |     
+  1 | Tue Sep 01 06:24:00 2020 PDT | 3600 |        3600 | 3600
+  1 | Tue Sep 01 06:25:00 2020 PDT | 3600 |             |     
+  1 | Tue Sep 01 06:26:00 2020 PDT | 3600 |             |     
+  1 | Tue Sep 01 06:27:00 2020 PDT | 3600 |             |     
+  2 | Tue Sep 01 06:22:00 2020 PDT |   90 |          90 |   90
+  2 | Tue Sep 01 06:23:00 2020 PDT |   90 |         360 |     
+  2 | Tue Sep 01 06:24:00 2020 PDT |   90 |         630 |     
+  2 | Tue Sep 01 06:25:00 2020 PDT |  900 |         900 |  900
+  2 | Tue Sep 01 06:26:00 2020 PDT |  900 |             |     
+  2 | Tue Sep 01 06:27:00 2020 PDT |  900 |             |     
+
+DROP TABLE i4693;
+DROP TYPE i4693_type;


### PR DESCRIPTION
The gapfill CustomScan node did not work correctly when used inside a
LATERAL subquery because gapfill_rescan had two bugs:

1. It did not call UpdateChangedParamSet on its child plan state before
   ExecReScan, so the child plan did not know that LATERAL parameters
   changed and kept returning stale data from the previous outer row.

2. It did not reset internal gapfill state (next_timestamp, next_offset,
   groups_initialized, column states) on rescan, so gap-filling was
   skipped on subsequent scans since next_timestamp was already at
   gapfill_end.

Fixes #4693
