### PR TITLE
Fix DELETE/UPDATE with WHERE EXISTS on hypertables

### DIFF
--- a/.unreleased/pr_9294
+++ b/.unreleased/pr_9294
@@ -1,0 +1,2 @@
+Fixes: #9294 Fix DELETE/UPDATE with WHERE EXISTS on hypertables
+Thanks: @desertmark for reporting an issue with DELETE/UPDATE and subqueries

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -275,3 +275,25 @@ EXPLAIN (verbose, analyze, buffers off, costs off, timing off, summary off) EXEC
 EXECUTE delete_ht;
 DEALLOCATE delete_ht;
 RESET plan_cache_mode;
+-- github issue #6790
+-- test DELETE with WHERE EXISTS on hypertable
+CREATE TABLE i6790(time timestamptz NOT NULL, device int, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+-- DELETE with simple EXISTS - creates gating Result node wrapping ChunkAppend
+DELETE FROM i6790 WHERE EXISTS (SELECT 1);
+-- all rows should be gone
+SELECT count(*) FROM i6790;
+ count 
+-------
+     0
+
+-- repopulate for next test
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+-- DELETE with correlated EXISTS
+DELETE FROM i6790 WHERE EXISTS (SELECT 1 FROM i6790 g WHERE g.device = i6790.device);
+SELECT count(*) FROM i6790;
+ count 
+-------
+     0
+

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -191,3 +191,22 @@ ERROR:  new row for relation "_hyper_2_4_chunk" violates check constraint "const
 UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
 ERROR:  new row for relation "_hyper_2_4_chunk" violates check constraint "constraint_4"
 \set ON_ERROR_STOP 1
+-- github issue #6790
+-- test UPDATE with WHERE EXISTS on hypertable
+CREATE TABLE i6790_update(time timestamptz NOT NULL, device int, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i6790_update SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+-- UPDATE with simple EXISTS - creates gating Result node(s) wrapping ChunkAppend
+UPDATE i6790_update SET value = 0.2 WHERE EXISTS (SELECT 1);
+SELECT count(*) FROM i6790_update WHERE value = 0.2;
+ count 
+-------
+     5
+
+-- UPDATE with correlated EXISTS
+UPDATE i6790_update SET value = 0.3 WHERE EXISTS (SELECT 1 FROM i6790_update g WHERE g.device = i6790_update.device);
+SELECT count(*) FROM i6790_update WHERE value = 0.3;
+ count 
+-------
+     5
+

--- a/test/sql/delete.sql
+++ b/test/sql/delete.sql
@@ -95,3 +95,20 @@ DEALLOCATE delete_ht;
 
 RESET plan_cache_mode;
 
+-- github issue #6790
+-- test DELETE with WHERE EXISTS on hypertable
+CREATE TABLE i6790(time timestamptz NOT NULL, device int, value float) WITH (tsdb.hypertable);
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+
+-- DELETE with simple EXISTS - creates gating Result node wrapping ChunkAppend
+DELETE FROM i6790 WHERE EXISTS (SELECT 1);
+-- all rows should be gone
+SELECT count(*) FROM i6790;
+
+-- repopulate for next test
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+
+-- DELETE with correlated EXISTS
+DELETE FROM i6790 WHERE EXISTS (SELECT 1 FROM i6790 g WHERE g.device = i6790.device);
+SELECT count(*) FROM i6790;
+


### PR DESCRIPTION
DELETE and UPDATE queries with WHERE EXISTS clauses on hypertables
failed with "variable not found in subplan target list" because
ChunkAppend replaced ROWID_VAR entries in its own targetlist, but
wrapping Result nodes (created by create_gating_plan for pseudoconstant
quals) still had the original ROWID_VAR entries. When set_plan_references
processed these Result nodes, the mismatch caused the error.

Fix by replacing ROWID_VAR in all Result node targetlists between
ModifyTable and ChunkAppend, and extending the fix to all DML operations
(DELETE, UPDATE, MERGE) instead of just UPDATE.

Fixes #5475
Fixes #6790
