### PR TITLE
Improve HAVING support in ColumnarIndexScan

### DIFF
--- a/src/expression_utils.c
+++ b/src/expression_utils.c
@@ -254,8 +254,8 @@ ts_plan_tree_walker(Plan *plan, ts_plan_tree_walkerfunc func, void *context)
  * targetlists of aggregation nodes, replacing them with the uncompressed chunk
  * variables.
  */
-List *
-ts_resolve_outer_special_vars(List *agg_tlist, Plan *childplan)
+Node *
+ts_resolve_outer_special_vars(Node *node, Plan *childplan)
 {
-	return castNode(List, resolve_outer_special_vars_mutator((Node *) agg_tlist, childplan));
+	return resolve_outer_special_vars_mutator(node, childplan);
 }

--- a/src/expression_utils.h
+++ b/src/expression_utils.h
@@ -14,7 +14,7 @@ bool TSDLLEXPORT ts_extract_expr_args(Expr *expr, Var **var, Expr **arg_value, O
 									  Oid *opcode);
 
 TSDLLEXPORT List *ts_build_trivial_custom_output_targetlist(List *scan_targetlist);
-TSDLLEXPORT List *ts_resolve_outer_special_vars(List *agg_tlist, Plan *childplan);
+TSDLLEXPORT Node *ts_resolve_outer_special_vars(Node *node, Plan *childplan);
 
 typedef Plan *(*ts_plan_tree_walkerfunc)(Plan *, void *);
 extern TSDLLEXPORT Plan *ts_plan_tree_walker(Plan *plan, ts_plan_tree_walkerfunc func,

--- a/tsl/src/nodes/vector_agg/plan.c
+++ b/tsl/src/nodes/vector_agg/plan.c
@@ -629,7 +629,8 @@ insert_vector_agg(Plan *plan, void *context)
 	 * the subsequent checks are performed on the aggregated targetlist with
 	 * all variables resolved to uncompressed chunk variables.
 	 */
-	List *resolved_targetlist = ts_resolve_outer_special_vars(agg->plan.targetlist, childplan);
+	List *resolved_targetlist =
+		castNode(List, ts_resolve_outer_special_vars((Node *) agg->plan.targetlist, childplan));
 
 	const VectorAggGroupingType grouping_type =
 		get_vectorized_grouping_type(&vqi, agg, resolved_targetlist);

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -216,26 +216,26 @@ SHOW timescaledb.enable_columnarindexscan;
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) > '20'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min("time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -216,26 +216,26 @@ SHOW timescaledb.enable_columnarindexscan;
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) > '20'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min("time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -216,26 +216,26 @@ SHOW timescaledb.enable_columnarindexscan;
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) > '20'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min("time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -216,26 +216,26 @@ SHOW timescaledb.enable_columnarindexscan;
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) > '20'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) > '20'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk.value) < '25'::double precision)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device
-   Filter: (min(_hyper_1_1_chunk."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device
+   Filter: (min("time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 -- tableoid doesnt prevent optimization

--- a/tsl/test/expected/compress_unordered_sort.out
+++ b/tsl/test/expected/compress_unordered_sort.out
@@ -254,9 +254,9 @@ select device, sensor, avg(value+1), max(time) + make_interval(days => length(se
 :PREFIX select device, sensor, count(*) from metrics group by device, sensor having count(*) > length(sensor) order by 1,2;
 --- QUERY PLAN ---
  GroupAggregate
-   Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
-   Filter: (count(*) > length(_hyper_1_1_chunk.sensor))
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Group Key: device, sensor
+   Filter: (COALESCE(sum(compress_hyper_2_2_chunk._ts_meta_count), '0'::bigint) > length(sensor))
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
 
 select device, sensor, count(*) from metrics group by device, sensor having count(*) > length(sensor) order by 1,2;


### PR DESCRIPTION
When a query uses HAVING with an aggregate (e.g., HAVING min(value) > 20)
on a single fully-compressed chunk, PostgreSQL produces an AGGSPLIT_SIMPLE
plan where the HAVING filter lives on the Agg node's plan.qual. Previously
we unconditionally bailed out on non-NIL plan.qual, preventing the
ColumnarIndexScan optimization for these queries. This commit adds
support for HAVING quals in these circumstances.

Disable-check: force-changelog-file
