### PR TITLE
Ignore vector_agg_planning test on windows

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -99,6 +99,7 @@ jobs:
         vector_agg_filter
         vector_agg_groupagg
         vector_agg_grouping
+        vector_agg_planning-*
         vector_agg_text
         vector_agg_uuid
         vectorized_aggregation


### PR DESCRIPTION
Windows does not have vectorized grouping by text or multiple
columns so the plans will look different on windows.
