### PR TITLE
Fix segfault in continuous aggregate creation on PG18

### DIFF
--- a/.unreleased/pr_9303
+++ b/.unreleased/pr_9303
@@ -1,0 +1,1 @@
+Fixes: #9303 Fix segfault in continuous aggregate creation on PG18

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -2181,3 +2181,14 @@ SELECT view_name from timescaledb_information.continuous_aggregates WHERE hypert
 -------------------
  cagg_hypertab_ddl
 
+-- TEST continuous aggregate with functionally dependent columns
+-- name column depends on id which is in GROUP BY so name doesnt have to be
+CREATE table sensor(id int PRIMARY KEY, name text);
+CREATE TABLE sensordata(time timestamptz,id int, value float) WITH	(timescaledb.hypertable);
+NOTICE:  using column "time" as partitioning column
+CREATE MATERIALIZED VIEW cagg_sensordata WITH (tsdb.continuous) AS
+SELECT s.id, s.name,time_bucket('15 minutes', sd.time) as bucket, avg(sd.value) FROM sensordata sd JOIN sensor s USING(id) GROUP BY s.id, bucket WITH NO DATA;
+SELECT * FROM cagg_sensordata;
+ id | name | bucket | avg 
+----+------+--------+-----
+

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -2181,3 +2181,14 @@ SELECT view_name from timescaledb_information.continuous_aggregates WHERE hypert
 -------------------
  cagg_hypertab_ddl
 
+-- TEST continuous aggregate with functionally dependent columns
+-- name column depends on id which is in GROUP BY so name doesnt have to be
+CREATE table sensor(id int PRIMARY KEY, name text);
+CREATE TABLE sensordata(time timestamptz,id int, value float) WITH	(timescaledb.hypertable);
+NOTICE:  using column "time" as partitioning column
+CREATE MATERIALIZED VIEW cagg_sensordata WITH (tsdb.continuous) AS
+SELECT s.id, s.name,time_bucket('15 minutes', sd.time) as bucket, avg(sd.value) FROM sensordata sd JOIN sensor s USING(id) GROUP BY s.id, bucket WITH NO DATA;
+SELECT * FROM cagg_sensordata;
+ id | name | bucket | avg 
+----+------+--------+-----
+

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -2181,3 +2181,14 @@ SELECT view_name from timescaledb_information.continuous_aggregates WHERE hypert
 -------------------
  cagg_hypertab_ddl
 
+-- TEST continuous aggregate with functionally dependent columns
+-- name column depends on id which is in GROUP BY so name doesnt have to be
+CREATE table sensor(id int PRIMARY KEY, name text);
+CREATE TABLE sensordata(time timestamptz,id int, value float) WITH	(timescaledb.hypertable);
+NOTICE:  using column "time" as partitioning column
+CREATE MATERIALIZED VIEW cagg_sensordata WITH (tsdb.continuous) AS
+SELECT s.id, s.name,time_bucket('15 minutes', sd.time) as bucket, avg(sd.value) FROM sensordata sd JOIN sensor s USING(id) GROUP BY s.id, bucket WITH NO DATA;
+SELECT * FROM cagg_sensordata;
+ id | name | bucket | avg 
+----+------+--------+-----
+

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -2181,3 +2181,14 @@ SELECT view_name from timescaledb_information.continuous_aggregates WHERE hypert
 -------------------
  cagg_hypertab_ddl
 
+-- TEST continuous aggregate with functionally dependent columns
+-- name column depends on id which is in GROUP BY so name doesnt have to be
+CREATE table sensor(id int PRIMARY KEY, name text);
+CREATE TABLE sensordata(time timestamptz,id int, value float) WITH	(timescaledb.hypertable);
+NOTICE:  using column "time" as partitioning column
+CREATE MATERIALIZED VIEW cagg_sensordata WITH (tsdb.continuous) AS
+SELECT s.id, s.name,time_bucket('15 minutes', sd.time) as bucket, avg(sd.value) FROM sensordata sd JOIN sensor s USING(id) GROUP BY s.id, bucket WITH NO DATA;
+SELECT * FROM cagg_sensordata;
+ id | name | bucket | avg 
+----+------+--------+-----
+

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -1490,3 +1490,12 @@ SELECT ddl_function();
 SELECT view_name from timescaledb_information.continuous_aggregates WHERE hypertable_name='hypertab_ddl';
 SELECT ddl_function();
 SELECT view_name from timescaledb_information.continuous_aggregates WHERE hypertable_name='hypertab_ddl';
+
+-- TEST continuous aggregate with functionally dependent columns
+-- name column depends on id which is in GROUP BY so name doesnt have to be
+CREATE table sensor(id int PRIMARY KEY, name text);
+CREATE TABLE sensordata(time timestamptz,id int, value float) WITH	(timescaledb.hypertable);
+CREATE MATERIALIZED VIEW cagg_sensordata WITH (tsdb.continuous) AS
+SELECT s.id, s.name,time_bucket('15 minutes', sd.time) as bucket, avg(sd.value) FROM sensordata sd JOIN sensor s USING(id) GROUP BY s.id, bucket WITH NO DATA;
+
+SELECT * FROM cagg_sensordata;


### PR DESCRIPTION
When a continuous aggregate query had functionally dependant
columns that were not part of the GROUP BY clause the create
statement would segfault.
