### PR TITLE
Add icu-dev in ABI Tests

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -82,6 +82,9 @@ jobs:
           # and if it's not present, it means the unversioned package is 1.1, so
           # we install it.
           apk add openssl1.1-compat-dev || apk add openssl-dev
+          # Postgres is compiled with ICU, so the pg_locale.h depends on the ICU
+          # headers and we have to install them
+          apk add icu-dev
           git config --global --add safe.directory /mnt
           cd /mnt
           BUILD_DIR=build_abi BUILD_FORCE_REMOVE=true ./bootstrap


### PR DESCRIPTION
Postgres is built with ICU there, and in this case the Postgres header pg_locale.h includes the ICU headers which have to be present.

Fixes this CI failure: https://github.com/timescale/timescaledb/actions/runs/22322973655/job/64585878734#step:3:572