### PR TITLE
Fix bugs on handling offset for Caggs

### DIFF
--- a/.unreleased/pr_9308
+++ b/.unreleased/pr_9308
@@ -1,0 +1,1 @@
+Fixes: #9308 Fix continuous aggregate offset/origin not applied in watermark and refresh window calculations

--- a/src/time_bucket.h
+++ b/src/time_bucket.h
@@ -15,6 +15,7 @@ extern TSDLLEXPORT Datum ts_int32_bucket(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_int64_bucket(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_date_bucket(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_timestamp_bucket(PG_FUNCTION_ARGS);
+extern TSDLLEXPORT Datum ts_timestamp_offset_bucket(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_timestamptz_bucket(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_timestamptz_timezone_bucket(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT int64 ts_time_bucket_by_type(int64 interval, int64 timestamp, Oid type);

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1300,9 +1300,9 @@ ts_continuous_agg_bucket_on_interval(Oid bucket_function)
 }
 
 /*
- * Calls the desired time bucket function depending on the arguments. If the experimental flag is
- * set on ContinuousAggBucketFunction, one of time_bucket_ng() versions is used. This is a common
- * procedure used by ts_compute_* below.
+ * Calls the desired time bucket function depending on the arguments
+ * (i.e., whether it has timezone and offset/origin).
+ * This is a common procedure used by ts_compute_* below.
  */
 static Datum
 generic_time_bucket(const ContinuousAggBucketFunction *bf, Datum timestamp)
@@ -1310,25 +1310,40 @@ generic_time_bucket(const ContinuousAggBucketFunction *bf, Datum timestamp)
 	FuncInfo *func_info = ts_func_cache_get_bucketing_func(bf->bucket_function);
 	Ensure(func_info != NULL, "unable to get bucket function for Oid %d", bf->bucket_function);
 
+	bool has_offset = (bf->bucket_time_offset != NULL);
+
 	if (bf->bucket_time_timezone != NULL)
 	{
+		/*
+		 * Use LOCAL_FCINFO to call ts_timestamptz_timezone_bucket with all
+		 * 5 arguments, including origin and offset.
+		 */
+		LOCAL_FCINFO(fcinfo, 5);
+		InitFunctionCallInfoData(*fcinfo, NULL, 5, InvalidOid, NULL, NULL);
+		fcinfo->args[0] =
+			(NullableDatum){ .value = IntervalPGetDatum(bf->bucket_time_width), .isnull = false };
+		fcinfo->args[1] = (NullableDatum){ .value = timestamp, .isnull = false };
+		fcinfo->args[2] = (NullableDatum){ .value = CStringGetTextDatum(bf->bucket_time_timezone),
+										   .isnull = false };
 		if (TIMESTAMP_NOT_FINITE(bf->bucket_time_origin))
-		{
-			/* using default origin */
-			return DirectFunctionCall3(ts_timestamptz_timezone_bucket,
-									   IntervalPGetDatum(bf->bucket_time_width),
-									   timestamp,
-									   CStringGetTextDatum(bf->bucket_time_timezone));
-		}
+			fcinfo->args[3] = (NullableDatum){ .value = (Datum) 0, .isnull = true };
 		else
-		{
-			/* custom origin specified */
-			return DirectFunctionCall4(ts_timestamptz_timezone_bucket,
-									   IntervalPGetDatum(bf->bucket_time_width),
-									   timestamp,
-									   CStringGetTextDatum(bf->bucket_time_timezone),
-									   TimestampTzGetDatum(bf->bucket_time_origin));
-		}
+			fcinfo->args[3] = (NullableDatum){ .value = TimestampTzGetDatum(bf->bucket_time_origin),
+											   .isnull = false };
+		if (has_offset)
+			fcinfo->args[4] = (NullableDatum){ .value = IntervalPGetDatum(bf->bucket_time_offset),
+											   .isnull = false };
+		else
+			fcinfo->args[4] = (NullableDatum){ .value = (Datum) 0, .isnull = true };
+		return ts_timestamptz_timezone_bucket(fcinfo);
+	}
+
+	if (has_offset)
+	{
+		return DirectFunctionCall3(ts_timestamp_offset_bucket,
+								   IntervalPGetDatum(bf->bucket_time_width),
+								   timestamp,
+								   IntervalPGetDatum(bf->bucket_time_offset));
 	}
 
 	if (TIMESTAMP_NOT_FINITE(bf->bucket_time_origin))

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -86,6 +86,10 @@ typedef struct ContinuousAggBucketFunction
 	 * If not specified, stores infinity.
 	 */
 	TimestampTz bucket_time_origin;
+	/*
+	 * Bucket offset. Note that we don't support
+	 * both offset and origin at the same time
+	 */
 	Interval *bucket_time_offset;
 	char *bucket_time_timezone;
 

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -643,6 +643,10 @@ invalidation_expand_to_bucket_boundaries(Invalidation *inv, Oid time_type_oid,
 	int64 bucket_width = ts_continuous_agg_fixed_bucket_width(bucket_function);
 	Assert(bucket_width > 0);
 
+	NullableDatum offset = INIT_NULL_DATUM;
+	NullableDatum origin = INIT_NULL_DATUM;
+	fill_bucket_offset_origin(bucket_function, time_type_oid, &offset, &origin);
+
 	/* Compute the start of the "first" bucket for the type. The min value
 	 * must be at the start of the "first" bucket or somewhere in the
 	 * bucket. If the min value falls on the exact start of the bucket we are
@@ -677,8 +681,11 @@ invalidation_expand_to_bucket_boundaries(Invalidation *inv, Oid time_type_oid,
 		/* Above the max bucket, so treat as invalid to +infinity. */
 		inv->lowest_modified_value = INVAL_POS_INFINITY;
 	else
-		inv->lowest_modified_value =
-			ts_time_bucket_by_type(bucket_width, inv->lowest_modified_value, time_type_oid);
+		inv->lowest_modified_value = ts_time_bucket_by_type_extended(bucket_width,
+																	 inv->lowest_modified_value,
+																	 time_type_oid,
+																	 offset,
+																	 origin);
 
 	if (inv->greatest_modified_value < min_bucket_start)
 		/* Below the min bucket, so treat as invalid to -infinity. */
@@ -688,8 +695,11 @@ invalidation_expand_to_bucket_boundaries(Invalidation *inv, Oid time_type_oid,
 		inv->greatest_modified_value = INVAL_POS_INFINITY;
 	else
 	{
-		inv->greatest_modified_value =
-			ts_time_bucket_by_type(bucket_width, inv->greatest_modified_value, time_type_oid);
+		inv->greatest_modified_value = ts_time_bucket_by_type_extended(bucket_width,
+																	   inv->greatest_modified_value,
+																	   time_type_oid,
+																	   offset,
+																	   origin);
 		inv->greatest_modified_value =
 			ts_time_saturating_add(inv->greatest_modified_value, bucket_width - 1, time_type_oid);
 	}

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -23,9 +23,11 @@
 #include <time_utils.h>
 
 #include "continuous_aggs/materialize.h"
+#include "continuous_aggs/refresh.h"
 #include "debug_point.h"
 #include "invalidation_threshold.h"
 #include "ts_catalog/continuous_agg.h"
+#include <utils.h>
 
 /*
  * Invalidation threshold.
@@ -327,7 +329,17 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 
 			int64 bucket_width = ts_continuous_agg_fixed_bucket_width(cagg->bucket_function);
 			Assert(bucket_width > 0);
-			int64 bucket_start = ts_time_bucket_by_type(bucket_width, maxval, refresh_window->type);
+			NullableDatum offset = INIT_NULL_DATUM;
+			NullableDatum origin = INIT_NULL_DATUM;
+			fill_bucket_offset_origin(cagg->bucket_function,
+									  refresh_window->type,
+									  &offset,
+									  &origin);
+			int64 bucket_start = ts_time_bucket_by_type_extended(bucket_width,
+																 maxval,
+																 refresh_window->type,
+																 offset,
+																 origin);
 			/* Add one bucket to get to the end of the last bucket */
 			return ts_time_saturating_add(bucket_start, bucket_width, refresh_window->type);
 		}

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -79,10 +79,6 @@ static bool process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 												   const InternalTimeRange *refresh_window,
 												   const ContinuousAggRefreshContext context,
 												   bool bucketing_refresh_window, bool force);
-static void fill_bucket_offset_origin(const ContinuousAgg *cagg,
-									  const InternalTimeRange *const refresh_window,
-									  NullableDatum *offset, NullableDatum *origin);
-
 static Hypertable *
 cagg_get_hypertable_or_fail(int32 hypertable_id)
 {
@@ -158,10 +154,17 @@ compute_inscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 	Assert(cagg != NULL);
 	Assert(cagg->bucket_function != NULL);
 
-	NullableDatum NULL_DATUM = INIT_NULL_DATUM;
 	InternalTimeRange result = *refresh_window;
 	InternalTimeRange largest_bucketed_window =
 		get_largest_bucketed_window(refresh_window->type, bucket_width);
+
+	/* Get offset and origin for bucket function */
+	NullableDatum offset = INIT_NULL_DATUM;
+	NullableDatum origin = INIT_NULL_DATUM;
+	fill_bucket_offset_origin(cagg->bucket_function, refresh_window->type, &offset, &origin);
+
+	/* Defined offset and origin in one function is not supported */
+	Assert(offset.isnull == true || origin.isnull == true);
 
 	if (refresh_window->start <= largest_bucketed_window.start)
 	{
@@ -179,8 +182,8 @@ compute_inscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 		result.start = ts_time_bucket_by_type_extended(bucket_width,
 													   included_bucket,
 													   refresh_window->type,
-													   NULL_DATUM,
-													   NULL_DATUM);
+													   offset,
+													   origin);
 	}
 
 	if (refresh_window->end >= largest_bucketed_window.end)
@@ -194,8 +197,8 @@ compute_inscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 		result.end = ts_time_bucket_by_type_extended(bucket_width,
 													 refresh_window->end,
 													 refresh_window->type,
-													 NULL_DATUM,
-													 NULL_DATUM);
+													 offset,
+													 origin);
 	}
 	return result;
 }
@@ -225,47 +228,47 @@ int_bucket_offset_to_datum(Oid type, const ContinuousAggBucketFunction *bucket_f
 /*
  * Get a NullableDatum for offset and origin based on the CAgg information
  */
-static void
-fill_bucket_offset_origin(const ContinuousAgg *cagg, const InternalTimeRange *const refresh_window,
+void
+fill_bucket_offset_origin(const ContinuousAggBucketFunction *bucket_function, Oid type,
 						  NullableDatum *offset, NullableDatum *origin)
 {
-	Assert(cagg != NULL);
+	Assert(bucket_function != NULL);
 	Assert(offset != NULL);
 	Assert(origin != NULL);
 	Assert(offset->isnull);
 	Assert(origin->isnull);
 
-	if (cagg->bucket_function->bucket_time_based)
+	if (bucket_function->bucket_time_based)
 	{
-		if (cagg->bucket_function->bucket_time_offset != NULL)
+		if (bucket_function->bucket_time_offset != NULL)
 		{
 			offset->isnull = false;
-			offset->value = IntervalPGetDatum(cagg->bucket_function->bucket_time_offset);
+			offset->value = IntervalPGetDatum(bucket_function->bucket_time_offset);
 		}
 
-		if (TIMESTAMP_NOT_FINITE(cagg->bucket_function->bucket_time_origin) == false)
+		if (TIMESTAMP_NOT_FINITE(bucket_function->bucket_time_origin) == false)
 		{
 			origin->isnull = false;
-			if (refresh_window->type == DATEOID)
+			if (type == DATEOID)
 			{
 				/* Date was converted into a timestamp in process_additional_timebucket_parameter(),
 				 * build a Date again */
-				origin->value = DirectFunctionCall1(timestamp_date,
-													TimestampGetDatum(
-														cagg->bucket_function->bucket_time_origin));
+				origin->value =
+					DirectFunctionCall1(timestamp_date,
+										TimestampGetDatum(bucket_function->bucket_time_origin));
 			}
 			else
 			{
-				origin->value = TimestampGetDatum(cagg->bucket_function->bucket_time_origin);
+				origin->value = TimestampGetDatum(bucket_function->bucket_time_origin);
 			}
 		}
 	}
 	else
 	{
-		if (cagg->bucket_function->bucket_integer_offset != 0)
+		if (bucket_function->bucket_integer_offset != 0)
 		{
 			offset->isnull = false;
-			offset->value = int_bucket_offset_to_datum(refresh_window->type, cagg->bucket_function);
+			offset->value = int_bucket_offset_to_datum(type, bucket_function);
 		}
 	}
 }
@@ -325,7 +328,7 @@ compute_circumscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 	/* Get offset and origin for bucket function */
 	NullableDatum offset = INIT_NULL_DATUM;
 	NullableDatum origin = INIT_NULL_DATUM;
-	fill_bucket_offset_origin(cagg, refresh_window, &offset, &origin);
+	fill_bucket_offset_origin(cagg->bucket_function, refresh_window->type, &offset, &origin);
 
 	/* Defined offset and origin in one function is not supported */
 	Assert(offset.isnull == true || origin.isnull == true);

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -10,6 +10,7 @@
 
 #include "invalidation.h"
 #include "materialize.h"
+#include "ts_catalog/continuous_agg.h"
 
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void
@@ -25,3 +26,6 @@ InternalTimeRange
 compute_circumscribed_bucketed_refresh_window(const ContinuousAgg *cagg,
 											  const InternalTimeRange *const refresh_window,
 											  const ContinuousAggBucketFunction *bucket_function);
+
+extern void fill_bucket_offset_origin(const ContinuousAggBucketFunction *bucket_function, Oid type,
+									  NullableDatum *offset, NullableDatum *origin);

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1394,8 +1394,19 @@ SELECT
 FROM test_data
 GROUP BY bucket
 WITH NO DATA;
+--create continuous aggregate with fixed bucket with offset
+CREATE MATERIALIZED VIEW test_cagg_1d_offset
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day'::interval, time, "offset" => INTERVAL '18 hours') AS bucket,
+    count(*) as count
+FROM test_data
+GROUP BY bucket
+WITH NO DATA;
+SET timezone = 'UTC';
 --Do the first refresh and check materialization invalidation log
 call refresh_continuous_aggregate ('test_cagg','2023-12-29 15:00:00', '2026-01-28 15:00:00');
+call refresh_continuous_aggregate ('test_cagg_1d_offset','2023-12-29 18:00:00', '2024-01-01 18:00:00');
 SELECT materialization_id,
        _timescaledb_functions.to_timestamp(lowest_modified_value) as low,
        _timescaledb_functions.to_timestamp(greatest_modified_value) as high
@@ -1409,7 +1420,29 @@ ORDER BY low;
                  29 | -infinity              | 2023-12-31 23:59:59.999999+00
                  29 | 2026-01-01 00:00:00+00 | infinity
 
+SELECT
+    CASE WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+        THEN '-infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS low,
+    CASE WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+        THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS high
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'test_cagg_1d_offset'
+)
+ORDER BY lowest_modified_value, greatest_modified_value;
+          low           |             high              
+------------------------+-------------------------------
+ -infinity              | 2023-12-29 17:59:59.999999+00
+ 2024-01-01 18:00:00+00 | infinity
+
 --now do the same refresh again, it should say the cagg is already up to date
+CALL refresh_continuous_aggregate ('test_cagg','2023-12-29 15:00:00', '2026-01-28 15:00:00');
+NOTICE:  continuous aggregate "test_cagg" is already up-to-date
 CALL refresh_continuous_aggregate ('test_cagg','2023-12-29 15:00:00', '2026-01-28 15:00:00');
 NOTICE:  continuous aggregate "test_cagg" is already up-to-date
 --Insert data to test that invalidation is moved correctly from hypertable invalidation log
@@ -1435,7 +1468,63 @@ ORDER BY low;
                  29 | 2024-03-01 00:00:00+00 | 2024-12-31 23:59:59.999999+00
                  29 | 2026-01-01 00:00:00+00 | infinity
 
+--should see the invalidation ranges with offset (i.e,boundary at the 18hour)
+SELECT
+    CASE WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+        THEN '-infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS low,
+    CASE WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+        THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS high
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'test_cagg_1d_offset'
+)
+ORDER BY lowest_modified_value, greatest_modified_value;
+          low           |             high              
+------------------------+-------------------------------
+ -infinity              | 2023-12-29 17:59:59.999999+00
+ 2023-12-31 18:00:00+00 | 2024-01-11 17:59:59.999999+00
+ 2024-01-01 18:00:00+00 | infinity
+ 2024-01-20 18:00:00+00 | 2024-02-10 17:59:59.999999+00
+ 2024-02-19 18:00:00+00 | 2024-03-11 17:59:59.999999+00
+ 2024-03-20 18:00:00+00 | 2024-04-10 17:59:59.999999+00
+ 2024-04-19 18:00:00+00 | 2024-05-10 17:59:59.999999+00
+ 2024-05-19 18:00:00+00 | 2024-06-09 17:59:59.999999+00
+ 2024-06-18 18:00:00+00 | 2024-07-09 17:59:59.999999+00
+ 2024-07-18 18:00:00+00 | 2024-08-08 17:59:59.999999+00
+ 2024-08-17 18:00:00+00 | 2024-09-07 17:59:59.999999+00
+ 2024-09-16 18:00:00+00 | 2024-10-07 17:59:59.999999+00
+ 2024-10-16 18:00:00+00 | 2024-11-06 17:59:59.999999+00
+ 2024-11-15 18:00:00+00 | 2024-12-06 17:59:59.999999+00
+ 2024-12-15 18:00:00+00 | 2024-12-26 17:59:59.999999+00
+
+--test that offset was accounted for in invalidation threshold when refresh the offset cagg to NULL
+SELECT  _timescaledb_functions.to_timestamp(watermark) as invalidation_threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id IN (
+  SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'test_cagg_1d_offset');
+ invalidation_threshold 
+------------------------
+ 2026-01-01 00:00:00+00
+
+INSERT INTO test_data values ('2026-01-05 00:00:00', 1);
+CALL refresh_continuous_aggregate ('test_cagg_1d_offset','2023-12-29 15:00:00', NULL);
+--should be at the 18th hour
+SELECT  _timescaledb_functions.to_timestamp(watermark) as invalidation_threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id IN (
+  SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'test_cagg_1d_offset');
+ invalidation_threshold 
+------------------------
+ 2026-01-05 18:00:00+00
+
 --clean up
 DROP TABLE test_data CASCADE;
+NOTICE:  drop cascades to 4 other objects
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
+RESET timezone;

--- a/tsl/test/expected/cagg_query-15.out
+++ b/tsl/test/expected/cagg_query-15.out
@@ -1446,13 +1446,11 @@ psql:include/cagg_query_common.sql:683: LOG:  deleted 0 row(s) from materializat
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1652,7 +1650,7 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
@@ -1661,10 +1659,13 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
@@ -1672,10 +1673,13 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
@@ -1859,11 +1863,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1880,13 +1884,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2109,9 +2113,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication

--- a/tsl/test/expected/cagg_query-16.out
+++ b/tsl/test/expected/cagg_query-16.out
@@ -1440,13 +1440,11 @@ psql:include/cagg_query_common.sql:683: LOG:  deleted 0 row(s) from materializat
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1646,7 +1644,7 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
@@ -1655,10 +1653,13 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
@@ -1666,10 +1667,13 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
@@ -1853,11 +1857,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1874,13 +1878,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2103,9 +2107,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication

--- a/tsl/test/expected/cagg_query-17.out
+++ b/tsl/test/expected/cagg_query-17.out
@@ -1440,13 +1440,11 @@ psql:include/cagg_query_common.sql:683: LOG:  deleted 0 row(s) from materializat
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1646,7 +1644,7 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
@@ -1655,10 +1653,13 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
@@ -1666,10 +1667,13 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
@@ -1853,11 +1857,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1874,13 +1878,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2103,9 +2107,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication

--- a/tsl/test/expected/cagg_query-18.out
+++ b/tsl/test/expected/cagg_query-18.out
@@ -1440,13 +1440,11 @@ psql:include/cagg_query_common.sql:683: LOG:  deleted 0 row(s) from materializat
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1646,7 +1644,7 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
@@ -1655,10 +1653,13 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
@@ -1666,10 +1667,13 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
@@ -1853,11 +1857,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1874,13 +1878,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2103,9 +2107,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication

--- a/tsl/test/expected/cagg_query_using_merge-15.out
+++ b/tsl/test/expected/cagg_query_using_merge-15.out
@@ -1447,13 +1447,11 @@ psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1653,26 +1651,30 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
 psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
@@ -1854,11 +1856,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1875,13 +1877,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2104,9 +2106,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
 psql:include/cagg_query_common.sql:824: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"

--- a/tsl/test/expected/cagg_query_using_merge-16.out
+++ b/tsl/test/expected/cagg_query_using_merge-16.out
@@ -1441,13 +1441,11 @@ psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1647,26 +1645,30 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
 psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
@@ -1848,11 +1850,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1869,13 +1871,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2098,9 +2100,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
 psql:include/cagg_query_common.sql:824: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"

--- a/tsl/test/expected/cagg_query_using_merge-17.out
+++ b/tsl/test/expected/cagg_query_using_merge-17.out
@@ -1441,13 +1441,11 @@ psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1647,26 +1645,30 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
 psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
@@ -1848,11 +1850,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1869,13 +1871,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2098,9 +2100,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
 psql:include/cagg_query_common.sql:824: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"

--- a/tsl/test/expected/cagg_query_using_merge-18.out
+++ b/tsl/test/expected/cagg_query_using_merge-18.out
@@ -1441,13 +1441,11 @@ psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:684: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:684: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:684: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:685: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577995200000000
 psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:685: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:685: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
@@ -1647,26 +1645,30 @@ INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
 psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL);
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
+psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Fri Dec 31 20:30:00 1999 PST, Sun Jan 02 00:30:00 2000 PST ]
+psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
+psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Fri Dec 31 21:00:00 1999 PST, Sun Jan 02 01:00:00 2000 PST ]
+psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
 psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
 psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
@@ -1848,11 +1850,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -1869,13 +1871,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577995200000000 |     9223372036854775807
+                 33 |      1577998800000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577995200000000 |     9223372036854775807
+                 34 |      1577998800000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
-                 35 |      1577995200000000 |     9223372036854775807
+                 35 |      1577998800000000 |     9223372036854775807
                  36 |      1609459200000000 |     9223372036854775807
 
 ---
@@ -2098,9 +2100,9 @@ SELECT * FROM cagg_int_offset;
 -- Check that the refresh is properly aligned
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
-psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 135 ]
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
+psql:include/cagg_query_common.sql:824: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
 psql:include/cagg_query_common.sql:824: DEBUG:  building index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_67_chunk" serially
 psql:include/cagg_query_common.sql:824: DEBUG:  index "_hyper_38_67_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
 psql:include/cagg_query_common.sql:824: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -1594,3 +1594,374 @@ ERROR:  invalid materialized hypertable ID: -1
 SELECT COALESCE(_timescaledb_functions.cagg_watermark_materialized(-1),12);
 ERROR:  invalid materialized hypertable ID: -1
 \set ON_ERROR_STOP 1
+-- Issue #3805 and related: Offset not handled correctly in calculating watermark
+-- and refresh windows
+CREATE TABLE metric_data(
+      to_ts       TIMESTAMPTZ NOT NULL,
+      id          INTEGER     NOT NULL,
+      duration_ms BIGINT      NOT NULL
+  );
+SELECT create_hypertable('metric_data', 'to_ts');
+     create_hypertable     
+---------------------------
+ (16,public,metric_data,t)
+
+--timezone (variable) cagg with offset
+CREATE MATERIALIZED VIEW metric_cagg_24h
+WITH (timescaledb.continuous) AS
+SELECT
+time_bucket(INTERVAL '1 day', to_ts, timezone => 'Europe/Stockholm', "offset" => INTERVAL '18 hours') AS to_ts_24h,
+id,
+SUM(duration_ms) AS duration_ms
+FROM metric_data
+GROUP BY to_ts_24h, id
+WITH NO DATA;
+--no timezone, fix-bucket cagg, with offset
+CREATE MATERIALIZED VIEW metric_cagg_24h_no_tz
+WITH (timescaledb.continuous) AS
+SELECT
+time_bucket(INTERVAL '1 day', to_ts, "offset" => INTERVAL '18 hours') AS to_ts_24h,
+id,
+SUM(duration_ms) AS duration_ms
+FROM metric_data
+GROUP BY to_ts_24h, id
+WITH NO DATA;
+SET timezone = 'UTC';
+INSERT INTO metric_data VALUES
+    ('2026-01-23 18:00+00', 1, 1000),
+    ('2026-01-24 10:00+00', 1, 2000);
+--invalidation and watermark before refresh
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h'
+);
+          watermark_ts           
+---------------------------------
+ Mon Nov 24 00:00:00 4714 UTC BC
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_no_tz'
+);
+          watermark_ts           
+---------------------------------
+ Mon Nov 24 00:00:00 4714 UTC BC
+
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) AS lowest_ts,
+        _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest_ts
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h'
+);
+ lowest_ts | greatest_ts 
+-----------+-------------
+ -infinity | infinity
+
+SELECT
+    CASE WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+        THEN '-infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS lowest_ts,
+    CASE WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+        THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS greatest_ts
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_no_tz'
+);
+ lowest_ts | greatest_ts 
+-----------+-------------
+ -infinity | infinity
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h'
+);
+ watermark_ts 
+--------------
+ -infinity
+
+CALL refresh_continuous_aggregate('metric_cagg_24h', '2026-01-20 15:00:00+00', '2026-01-26 15:00:00+00');
+CALL refresh_continuous_aggregate('metric_cagg_24h_no_tz', '2026-01-20 15:00:00+00', '2026-01-26 15:00:00+00');
+SELECT * FROM metric_data;
+            to_ts             | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 18:00:00 2026 UTC |  1 |        1000
+ Sat Jan 24 10:00:00 2026 UTC |  1 |        2000
+
+SELECT * FROM metric_cagg_24h;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 17:00:00 2026 UTC |  1 |        3000
+
+SELECT * from metric_cagg_24h_no_tz;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 18:00:00 2026 UTC |  1 |        3000
+
+ALTER MATERIALIZED VIEW metric_cagg_24h SET (timescaledb.materialized_only = false);
+ALTER MATERIALIZED VIEW metric_cagg_24h_no_tz SET (timescaledb.materialized_only = false);
+--result should not contain duplicates on the grouping column (bucket and id)
+SELECT * FROM metric_cagg_24h;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 17:00:00 2026 UTC |  1 |        3000
+
+--fix-bucket cagg has correct watermark before and after the fix, should be no duplicates
+SELECT * FROM metric_cagg_24h_no_tz;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 18:00:00 2026 UTC |  1 |        3000
+
+--invalidation log, threshold, and watermark should align
+--at the bucket boundary (i.e, 17th hour UTC (which is 18th hour in Stockholm) of each day)
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h'
+);
+         watermark_ts         
+------------------------------
+ Sat Jan 24 17:00:00 2026 UTC
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_no_tz'
+);
+         watermark_ts         
+------------------------------
+ Sat Jan 24 18:00:00 2026 UTC
+
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) AS lowest_ts,
+        _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest_ts
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h'
+);
+          lowest_ts           |             greatest_ts             
+------------------------------+-------------------------------------
+ -infinity                    | Tue Jan 20 16:59:59.999999 2026 UTC
+ Sun Jan 25 17:00:00 2026 UTC | infinity
+
+SELECT
+    CASE WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+        THEN '-infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS lowest_ts,
+    CASE WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+        THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS greatest_ts
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_no_tz'
+);
+          lowest_ts           |             greatest_ts             
+------------------------------+-------------------------------------
+ -infinity                    | Tue Jan 20 17:59:59.999999 2026 UTC
+ Sun Jan 25 18:00:00 2026 UTC | infinity
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h'
+);
+         watermark_ts         
+------------------------------
+ Sun Jan 25 18:00:00 2026 UTC
+
+-- Test origin parameter (same bucket boundaries as offset tests)
+-- origin at 17:00 UTC = 18:00 Stockholm, so buckets align at the same boundary
+--timezone (variable) cagg with origin
+CREATE MATERIALIZED VIEW metric_cagg_24h_origin_tz
+WITH (timescaledb.continuous) AS
+SELECT
+time_bucket(INTERVAL '1 day', to_ts, timezone => 'Europe/Stockholm', origin => '2026-01-01 17:00:00+00') AS to_ts_24h,
+id,
+SUM(duration_ms) AS duration_ms
+FROM metric_data
+GROUP BY to_ts_24h, id
+WITH NO DATA;
+--no timezone, fix-bucket cagg, with origin
+CREATE MATERIALIZED VIEW metric_cagg_24h_origin_no_tz
+WITH (timescaledb.continuous) AS
+SELECT
+time_bucket(INTERVAL '1 day', to_ts, origin => '2026-01-01 18:00:00+00') AS to_ts_24h,
+id,
+SUM(duration_ms) AS duration_ms
+FROM metric_data
+GROUP BY to_ts_24h, id
+WITH NO DATA;
+CALL refresh_continuous_aggregate('metric_cagg_24h_origin_tz', '2026-01-20 15:00:00+00', '2026-01-26 15:00:00+00');
+CALL refresh_continuous_aggregate('metric_cagg_24h_origin_no_tz', '2026-01-20 15:00:00+00', '2026-01-26 15:00:00+00');
+SELECT * FROM metric_cagg_24h_origin_tz;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 17:00:00 2026 UTC |  1 |        3000
+
+SELECT * FROM metric_cagg_24h_origin_no_tz;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 18:00:00 2026 UTC |  1 |        3000
+
+ALTER MATERIALIZED VIEW metric_cagg_24h_origin_tz SET (timescaledb.materialized_only = false);
+ALTER MATERIALIZED VIEW metric_cagg_24h_origin_no_tz SET (timescaledb.materialized_only = false);
+--result should not contain duplicates on the grouping column (bucket and id)
+SELECT * FROM metric_cagg_24h_origin_tz;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 17:00:00 2026 UTC |  1 |        3000
+
+SELECT * FROM metric_cagg_24h_origin_no_tz;
+          to_ts_24h           | id | duration_ms 
+------------------------------+----+-------------
+ Fri Jan 23 18:00:00 2026 UTC |  1 |        3000
+
+--watermark should align at the bucket boundary
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_origin_tz'
+);
+         watermark_ts         
+------------------------------
+ Sat Jan 24 17:00:00 2026 UTC
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_origin_no_tz'
+);
+         watermark_ts         
+------------------------------
+ Sat Jan 24 18:00:00 2026 UTC
+
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) AS lowest_ts,
+        _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest_ts
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_origin_tz'
+);
+          lowest_ts           |             greatest_ts             
+------------------------------+-------------------------------------
+ -infinity                    | Tue Jan 20 16:59:59.999999 2026 UTC
+ Sun Jan 25 17:00:00 2026 UTC | infinity
+
+SELECT _timescaledb_functions.to_timestamp(lowest_modified_value) AS lowest_ts,
+        _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest_ts
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_origin_no_tz'
+);
+          lowest_ts           |             greatest_ts             
+------------------------------+-------------------------------------
+ -infinity                    | Tue Jan 20 17:59:59.999999 2026 UTC
+ Sun Jan 25 18:00:00 2026 UTC | infinity
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_24h_origin_tz'
+);
+         watermark_ts         
+------------------------------
+ Sun Jan 25 18:00:00 2026 UTC
+
+-- Test variable-width bucket (monthly) without timezone, with offset
+-- Monthly bucket with 18h offset: boundaries at 18:00 UTC on the 1st of each month
+-- Data at 2026-02-01 10:00 falls in Jan bucket [2026-01-01 18:00, 2026-02-01 18:00)
+-- This would cause duplicates if watermark doesn't account for offset
+INSERT INTO metric_data VALUES ('2026-02-01 10:00+00', 1, 500);
+CREATE MATERIALIZED VIEW metric_cagg_monthly_offset
+WITH (timescaledb.continuous) AS
+SELECT
+time_bucket(INTERVAL '1 month', to_ts, "offset" => INTERVAL '18 hours') AS to_ts_month,
+id,
+SUM(duration_ms) AS duration_ms
+FROM metric_data
+GROUP BY to_ts_month, id
+WITH NO DATA;
+CREATE MATERIALIZED VIEW metric_cagg_monthly_origin
+WITH (timescaledb.continuous) AS
+SELECT
+time_bucket(INTERVAL '1 month', to_ts, origin => '2026-01-01 18:00:00+00') AS to_ts_month,
+id,
+SUM(duration_ms) AS duration_ms
+FROM metric_data
+GROUP BY to_ts_month, id
+WITH NO DATA;
+CALL refresh_continuous_aggregate('metric_cagg_monthly_offset', '2025-12-01', '2026-02-05');
+CALL refresh_continuous_aggregate('metric_cagg_monthly_origin', '2025-12-01', '2026-02-05');
+SELECT * FROM metric_cagg_monthly_offset;
+         to_ts_month          | id | duration_ms 
+------------------------------+----+-------------
+ Thu Jan 01 18:00:00 2026 UTC |  1 |        3500
+
+SELECT * FROM metric_cagg_monthly_origin;
+         to_ts_month          | id | duration_ms 
+------------------------------+----+-------------
+ Thu Jan 01 00:00:00 2026 UTC |  1 |        3000
+
+ALTER MATERIALIZED VIEW metric_cagg_monthly_offset SET (timescaledb.materialized_only = false);
+ALTER MATERIALIZED VIEW metric_cagg_monthly_origin SET (timescaledb.materialized_only = false);
+--result should not contain duplicates on the grouping column (bucket and id)
+SELECT * FROM metric_cagg_monthly_offset;
+         to_ts_month          | id | duration_ms 
+------------------------------+----+-------------
+ Thu Jan 01 18:00:00 2026 UTC |  1 |        3500
+
+SELECT * FROM metric_cagg_monthly_origin;
+         to_ts_month          | id | duration_ms 
+------------------------------+----+-------------
+ Thu Jan 01 00:00:00 2026 UTC |  1 |        3000
+ Sun Feb 01 00:00:00 2026 UTC |  1 |         500
+
+--watermark should align at 2026-02-01 18:00:00+00 (the next month bucket boundary)
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_monthly_offset'
+);
+         watermark_ts         
+------------------------------
+ Sun Feb 01 18:00:00 2026 UTC
+
+SELECT _timescaledb_functions.to_timestamp(watermark) AS watermark_ts
+FROM _timescaledb_catalog.continuous_aggs_watermark
+WHERE mat_hypertable_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'metric_cagg_monthly_origin'
+);
+         watermark_ts         
+------------------------------
+ Sun Feb 01 00:00:00 2026 UTC
+
+drop table metric_data cascade;
+NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_17_66_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_18_67_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_19_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_20_69_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_71_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_72_chunk

--- a/tsl/test/sql/cagg_invalidation.sql
+++ b/tsl/test/sql/cagg_invalidation.sql
@@ -918,8 +918,21 @@ FROM test_data
 GROUP BY bucket
 WITH NO DATA;
 
+--create continuous aggregate with fixed bucket with offset
+CREATE MATERIALIZED VIEW test_cagg_1d_offset
+WITH (timescaledb.continuous) AS
+SELECT
+    time_bucket('1 day'::interval, time, "offset" => INTERVAL '18 hours') AS bucket,
+    count(*) as count
+FROM test_data
+GROUP BY bucket
+WITH NO DATA;
+
+SET timezone = 'UTC';
+
 --Do the first refresh and check materialization invalidation log
 call refresh_continuous_aggregate ('test_cagg','2023-12-29 15:00:00', '2026-01-28 15:00:00');
+call refresh_continuous_aggregate ('test_cagg_1d_offset','2023-12-29 18:00:00', '2024-01-01 18:00:00');
 
 SELECT materialization_id,
        _timescaledb_functions.to_timestamp(lowest_modified_value) as low,
@@ -930,8 +943,28 @@ WHERE materialization_id IN
        WHERE user_view_name = 'test_cagg')
 ORDER BY low;
 
+
+SELECT
+    CASE WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+        THEN '-infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS low,
+    CASE WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+        THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS high
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'test_cagg_1d_offset'
+)
+ORDER BY lowest_modified_value, greatest_modified_value;
+
+
 --now do the same refresh again, it should say the cagg is already up to date
 CALL refresh_continuous_aggregate ('test_cagg','2023-12-29 15:00:00', '2026-01-28 15:00:00');
+CALL refresh_continuous_aggregate ('test_cagg','2023-12-29 15:00:00', '2026-01-28 15:00:00');
+
 
 --Insert data to test that invalidation is moved correctly from hypertable invalidation log
 -- to materialization invalidation log
@@ -954,5 +987,39 @@ WHERE materialization_id IN
        WHERE user_view_name = 'test_cagg')
 ORDER BY low;
 
+--should see the invalidation ranges with offset (i.e,boundary at the 18hour)
+SELECT
+    CASE WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+        THEN '-infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS low,
+    CASE WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+        THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS high
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'test_cagg_1d_offset'
+)
+ORDER BY lowest_modified_value, greatest_modified_value;
+
+--test that offset was accounted for in invalidation threshold when refresh the offset cagg to NULL
+
+SELECT  _timescaledb_functions.to_timestamp(watermark) as invalidation_threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id IN (
+  SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'test_cagg_1d_offset');
+
+INSERT INTO test_data values ('2026-01-05 00:00:00', 1);
+CALL refresh_continuous_aggregate ('test_cagg_1d_offset','2023-12-29 15:00:00', NULL);
+
+--should be at the 18th hour
+SELECT  _timescaledb_functions.to_timestamp(watermark) as invalidation_threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id IN (
+  SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'test_cagg_1d_offset');
+
 --clean up
 DROP TABLE test_data CASCADE;
+RESET timezone;

--- a/tsl/test/sql/include/cagg_query_common.sql
+++ b/tsl/test/sql/include/cagg_query_common.sql
@@ -821,7 +821,7 @@ SELECT * FROM cagg_int_offset;
 INSERT INTO table_int VALUES(114, 0);
 
 SET client_min_messages TO DEBUG1;
-CALL refresh_continuous_aggregate('cagg_int_offset', 110, 130);
+CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130);
 RESET client_min_messages;
 
 SELECT * FROM cagg_int_offset;


### PR DESCRIPTION
Fix bugs in handling offset for Caggs
    
    1. Fix generic_time_bucket to account for offset and origin. This fixes
    cases with variable-length caggs when watermarks and refresh windows
    were not aligned with the bucket boundary
    
    2. Fix compute_inscribed_bucketed_refresh_window to account for offset
    and origin. With this fix, the inscribed refresh window is now aligned with
    the cagg bucket with offset, and so is invalidation cutting. This is for
    a cagg with a fixed-length bucket.
