### PR TITLE
Remove advisory locks from bgw jobs and add graceful cancellation

### DIFF
--- a/.unreleased/pr_9312
+++ b/.unreleased/pr_9312
@@ -1,0 +1,2 @@
+Implements: #9312 Remove advisory locks from bgw jobs and add graceful cancellation
+Thanks: @leppaott for reporting a deadlock when deleting jobs

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -18,11 +18,9 @@
 #include <postmaster/bgworker.h>
 #include <storage/ipc.h>
 #include <storage/lock.h>
-#include <storage/proc.h>
-#include <storage/procarray.h>
-#include <storage/sinvaladt.h>
 #include <tcop/tcopprot.h>
 #include <utils/acl.h>
+#include <utils/backend_status.h>
 #include <utils/builtins.h>
 #include <utils/elog.h>
 #include <utils/jsonb.h>
@@ -75,12 +73,6 @@ ts_get_mem_guard_callbacks(void)
 
 	return *mem_guard_callback_ptr;
 }
-
-typedef enum JobLockLifetime
-{
-	SESSION_LOCK = 0,
-	TXN_LOCK,
-} JobLockLifetime;
 
 BackgroundWorkerHandle *
 ts_bgw_job_start(BgwJob *job, Oid user_oid)
@@ -517,121 +509,6 @@ init_scan_by_job_id(ScanIterator *iterator, int32 job_id)
 								   Int32GetDatum(job_id));
 }
 
-/* Lock a job tuple using an advisory lock. Advisory job locks are used to
- * lock the job row while a job is running to prevent a job from being
- * modified while in the middle of a run. This lock should be taken before
- * bgw_job table lock to avoid deadlocks.
- *
- * We use an advisory lock instead of a tuple lock because we want the lock on
- * the job id and not on the tid of the row (in case it is vacuumed or updated
- * in some way). We don't want the job modified while it is running for safety
- * reasons. Finally, we use this lock to be able to send a signal to the PID
- * of the running job. This is used by delete because, a job deletion sends a
- * SIGINT to the running job to cancel it.
- *
- * We acquire a SHARE lock on the job during scheduling and when the job is
- * running so that it cannot be deleted during those times and an EXCLUSIVE
- * lock when deleting.
- *
- * returns whether or not the lock was obtained (false return only possible if
- * block==false)
- */
-
-bool
-ts_lock_job_id(int32 job_id, LOCKMODE mode, bool session_lock, LOCKTAG *tag, bool block)
-{
-	/* Use a special pseudo-random field 4 value to avoid conflicting with user-advisory-locks */
-	TS_SET_LOCKTAG_ADVISORY(*tag, MyDatabaseId, job_id, 0);
-
-	return LockAcquire(tag, mode, session_lock, !block) != LOCKACQUIRE_NOT_AVAIL;
-}
-
-static BgwJob *
-ts_bgw_job_find_with_lock(int32 bgw_job_id, MemoryContext mctx, LOCKMODE tuple_lock_mode,
-						  JobLockLifetime lock_type, bool block, bool *got_lock)
-{
-	/* Take a share lock on the table to prevent concurrent data changes during scan. This lock will
-	 * be released after the scan */
-	ScanIterator iterator = ts_scan_iterator_create_with_catalog_snapshot(BGW_JOB, ShareLock, mctx);
-	List *jobs = NIL;
-	BgwJob *job = NULL;
-	LOCKTAG tag;
-
-	/* take advisory lock before relation lock */
-	*got_lock = ts_lock_job_id(bgw_job_id, tuple_lock_mode, lock_type == SESSION_LOCK, &tag, block);
-	if (!*got_lock)
-	{
-		/* return NULL if lock could not be acquired */
-		Assert(!block);
-		return NULL;
-	}
-
-	init_scan_by_job_id(&iterator, bgw_job_id);
-
-	ts_scanner_foreach(&iterator)
-	{
-		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-		job = bgw_job_from_tupleinfo(ti, sizeof(BgwJob));
-		jobs = lappend(jobs, job);
-	}
-
-	if (list_length(jobs) > 1)
-	{
-		ListCell *cell;
-		foreach (cell, jobs)
-		{
-			BgwJob *job = (BgwJob *) lfirst(cell);
-			ereport(LOG,
-					(errmsg("more than one job with same job_id %d", bgw_job_id),
-					 errdetail("job_id: %d, application_name: %s, procedure: %s.%s, scheduled: %s",
-							   job->fd.id,
-							   NameStr(job->fd.application_name),
-							   quote_identifier(NameStr(job->fd.proc_schema)),
-							   quote_identifier(NameStr(job->fd.proc_name)),
-							   job->fd.scheduled ? "true" : "false")));
-		}
-	}
-
-	/* We don't care about duplicate jobs in release builds and will take the
-	 * last job */
-	Assert(list_length(jobs) <= 1);
-
-	return job;
-}
-
-/* Take a lock on the job for the duration of the txn. This prevents
- *  the job from being deleted.
- *
- *  Returns true if the job is found ( we block till we can acquire a lock
- *                               so we will always lock here)
- *          false if the job is missing.
- */
-bool
-ts_bgw_job_get_share_lock(int32 bgw_job_id, MemoryContext mctx)
-{
-	bool got_lock;
-	/* note the mode here is equivalent to FOR SHARE row locks */
-	BgwJob *job = ts_bgw_job_find_with_lock(bgw_job_id,
-											mctx,
-											RowShareLock,
-											TXN_LOCK,
-											true, /* block */
-											&got_lock);
-	if (job != NULL)
-	{
-		if (!got_lock)
-		{
-			/* since we blocked for a lock , this is an unexpected condition */
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("could not acquire share lock for job=%d", bgw_job_id)));
-		}
-		pfree(job);
-		return true;
-	}
-	return false;
-}
-
 BgwJob *
 ts_bgw_job_find(int32 bgw_job_id, MemoryContext mctx, bool fail_if_not_found)
 {
@@ -654,66 +531,6 @@ ts_bgw_job_find(int32 bgw_job_id, MemoryContext mctx, bool fail_if_not_found)
 		ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("job %d not found", bgw_job_id)));
 
 	return job;
-}
-
-static void
-get_job_lock_for_delete(int32 job_id)
-{
-	LOCKTAG tag;
-	bool got_lock;
-
-	/* Try getting an exclusive lock on the tuple in a non-blocking manner. Note this is the
-	 * equivalent of a row-based FOR UPDATE lock */
-	got_lock = ts_lock_job_id(job_id,
-							  AccessExclusiveLock,
-							  /* session_lock */ false,
-							  &tag,
-							  /* block */ false);
-	if (!got_lock)
-	{
-		/* If I couldn't get a lock, try killing the background worker that's running the job.
-		 * This is probably not bulletproof but best-effort is good enough here. */
-		VirtualTransactionId *vxid = GetLockConflicts(&tag, AccessExclusiveLock, NULL);
-		PGPROC *proc;
-
-		if (VirtualTransactionIdIsValid(*vxid))
-		{
-			proc = VirtualTransactionGetProcCompat(vxid);
-			if (proc != NULL
-#if PG18_LT
-				&& proc->isBackgroundWorker
-#else
-				&& !proc->isRegularBackend
-#endif
-			)
-			{
-				/* Simply assuming that this pid corresponds to the background worker
-				 * running the job is not sufficient. The scheduler could also be the
-				 * one holding the lock, when transitioning the state of the job back
-				 * to scheduled state. So we must check we don't kill the scheduler.
-				 * See https://github.com/timescale/timescaledb/issues/5224
-				 */
-				const char *worker_name = GetBackgroundWorkerTypeByPid(proc->pid);
-
-				if (strcmp(worker_name, SCHEDULER_APPNAME) != 0)
-				{
-					elog(NOTICE,
-						 "cancelling the background worker for job %d (pid %d)",
-						 job_id,
-						 proc->pid);
-					DirectFunctionCall1(pg_cancel_backend, Int32GetDatum(proc->pid));
-				}
-			}
-		}
-
-		/* We have to grab this lock before proceeding so grab it in a blocking manner now */
-		got_lock = ts_lock_job_id(job_id,
-								  AccessExclusiveLock,
-								  /* session_lock */ false,
-								  &tag,
-								  /* block */ true);
-	}
-	Ensure(got_lock, "unable to lock job id %d", job_id);
 }
 
 static ScanTupleResult
@@ -745,9 +562,6 @@ bgw_job_delete_scan(ScanKeyData *scankey, int32 job_id)
 	Catalog *catalog = ts_catalog_get();
 	ScannerCtx scanctx;
 
-	/* get job lock before relation lock */
-	get_job_lock_for_delete(job_id);
-
 	scanctx = (ScannerCtx){
 		.table = catalog_get_table_id(catalog, BGW_JOB),
 		.index = catalog_get_index(catalog, BGW_JOB, BGW_JOB_PKEY_IDX),
@@ -766,17 +580,45 @@ bgw_job_delete_scan(ScanKeyData *scankey, int32 job_id)
 }
 
 /*
- * This function will try to delete the job identified by `job_id`. If the job is currently running,
- * this function will send a `SIGINT` to the job, and wait for the job to terminate before deleting
- * the job. In the event that it cannot  send the signal (for instance, if the job is not in a
- * transaction, we have no way to send the signal), it will still wait for the job to terminate and
- * release the job lock, or will ERROR due to a lock or deadlock timeout. In this case,  the user
- * has to  manually determine the `pid` of the BGW and send an `SIGINT` or a `SIGKILL`.
+ * Cancel the background worker running the given job, identified by its
+ * application_name. This is best-effort: if the worker is not found or
+ * already exited, we simply do nothing.
+ */
+static void
+cancel_worker_for_job(const char *appname)
+{
+	const int num_backends = pgstat_fetch_stat_numbackends();
+	for (int i = 1; i <= num_backends; i++)
+	{
+		const LocalPgBackendStatus *local_beentry = pgstat_get_local_beentry_by_index_compat(i);
+		const PgBackendStatus *beentry = &local_beentry->backendStatus;
+		if (beentry->st_databaseid == MyDatabaseId && beentry->st_appname[0] != '\0' &&
+			strcmp(beentry->st_appname, appname) == 0)
+		{
+			DirectFunctionCall1(pg_cancel_backend, Int32GetDatum(beentry->st_procpid));
+			break;
+		}
+	}
+}
+
+/*
+ * Delete the job identified by `job_id`. If the job is currently running,
+ * we send SIGINT to the worker for prompt cancellation.
  */
 bool
 ts_bgw_job_delete_by_id(int32 job_id)
 {
 	ScanKeyData scankey[1];
+	NameData appname = { .data = { 0 } };
+	bool result;
+
+	/* Look up the job's application_name before deleting */
+	BgwJob *job = ts_bgw_job_find(job_id, CurrentMemoryContext, false);
+	if (job != NULL)
+	{
+		namestrcpy(&appname, NameStr(job->fd.application_name));
+		pfree(job);
+	}
 
 	ScanKeyInit(&scankey[0],
 				Anum_bgw_job_pkey_idx_id,
@@ -784,7 +626,13 @@ ts_bgw_job_delete_by_id(int32 job_id)
 				F_INT4EQ,
 				Int32GetDatum(job_id));
 
-	return bgw_job_delete_scan(scankey, job_id);
+	result = bgw_job_delete_scan(scankey, job_id);
+
+	/* Send SIGINT to the running worker for prompt cancellation */
+	if (result && NameStr(appname)[0] != '\0')
+		cancel_worker_for_job(NameStr(appname));
+
+	return result;
 }
 
 /* This function only updates the fields modifiable with alter_job. */
@@ -1160,7 +1008,6 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 	BgwParams params;
 	BgwJob *job;
 	JobResult volatile res = JOB_FAILURE_IN_EXECUTION;
-	bool got_lock;
 	instr_time start;
 	instr_time duration;
 
@@ -1203,14 +1050,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
-	/* Grab a session lock on the job row to prevent concurrent deletes. Lock is released
-	 * when the job process exits */
-	job = ts_bgw_job_find_with_lock(params.job_id,
-									TopMemoryContext,
-									RowShareLock,
-									SESSION_LOCK,
-									/* block */ true,
-									&got_lock);
+	job = ts_bgw_job_find(params.job_id, TopMemoryContext, false);
 	if (job == NULL)
 		/* If the job is not found, we can't proceed */
 		ereport(ERROR,
@@ -1281,16 +1121,9 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 
 		/*
 		 * Note that the mark_start happens in the scheduler right before the
-		 * job is launched. Try to get a lock on the job again. Because the error
-		 * removed the session lock. Don't block and only record if the lock was actually
-		 * obtained.
+		 * job is launched.
 		 */
-		job = ts_bgw_job_find_with_lock(params.job_id,
-										TopMemoryContext,
-										RowShareLock,
-										TXN_LOCK,
-										/* block */ false,
-										&got_lock);
+		job = ts_bgw_job_find(params.job_id, TopMemoryContext, false);
 		if (job != NULL)
 		{
 			namestrcpy(&proc_name, NameStr(job->fd.proc_name));

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -7,7 +7,6 @@
 
 #include <postgres.h>
 #include <postmaster/bgworker.h>
-#include <storage/lock.h>
 
 #include "export.h"
 #include "ts_catalog/catalog.h"
@@ -73,9 +72,6 @@ extern TSDLLEXPORT List *ts_bgw_job_find_by_proc_and_hypertable_id(const char *p
 																   const char *proc_schema,
 																   int32 hypertable_id);
 
-extern bool ts_bgw_job_get_share_lock(int32 bgw_job_id, MemoryContext mctx);
-TSDLLEXPORT bool ts_lock_job_id(int32 job_id, LOCKMODE mode, bool session_lock, LOCKTAG *tag,
-								bool block);
 TSDLLEXPORT BgwJob *ts_bgw_job_find(int job_id, MemoryContext mctx, bool fail_if_not_found);
 
 extern bool ts_bgw_job_has_timeout(BgwJob *job);

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -13,6 +13,7 @@
 #include <utils/resowner.h>
 
 #include "guc.h"
+#include "job.h"
 #include "job_stat.h"
 #include "job_stat_history.h"
 #include "jsonb_utils.h"
@@ -670,6 +671,13 @@ ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result, Jsonb *edata)
 								  &res,
 								  ShareRowExclusiveLock))
 	{
+		if (!ts_bgw_job_find(job->fd.id, CurrentMemoryContext, false))
+		{
+			elog(WARNING,
+				 "skipping job statistics update for job %d, job was deleted during execution",
+				 job->fd.id);
+			return;
+		}
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("unable to find job statistics for job %d", job->fd.id)));

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -236,7 +236,7 @@ worker_state_cleanup(ScheduledBgwJob *sjob)
 	{
 		BgwJobStat *job_stat;
 
-		if (!ts_bgw_job_get_share_lock(sjob->job.fd.id, CurrentMemoryContext))
+		if (!ts_bgw_job_find(sjob->job.fd.id, CurrentMemoryContext, false))
 		{
 			elog(WARNING,
 				 "scheduler detected that job %d was deleted after job quit",
@@ -308,7 +308,7 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 			StartTransactionCommand();
 			PushActiveSnapshot(GetTransactionSnapshot());
 
-			if (!ts_bgw_job_get_share_lock(sjob->job.fd.id, CurrentMemoryContext))
+			if (!ts_bgw_job_find(sjob->job.fd.id, CurrentMemoryContext, false))
 			{
 				elog(WARNING,
 					 "scheduler detected that job %d was deleted when starting job",
@@ -383,7 +383,7 @@ on_failure_to_start_job(ScheduledBgwJob *sjob)
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
 
-	if (!ts_bgw_job_get_share_lock(sjob->job.fd.id, CurrentMemoryContext))
+	if (!ts_bgw_job_find(sjob->job.fd.id, CurrentMemoryContext, false))
 	{
 		elog(WARNING,
 			 "scheduler detected that job %d was deleted while failing to start",
@@ -471,8 +471,36 @@ terminate_and_cleanup_job(ScheduledBgwJob *sjob)
 {
 	if (sjob->handle != NULL)
 	{
-		TerminateBackgroundWorker(sjob->handle);
-		WaitForBackgroundWorkerShutdown(sjob->handle);
+		pid_t pid;
+		BgwHandleStatus status;
+
+		status = GetBackgroundWorkerPid(sjob->handle, &pid);
+		if (status == BGWH_STARTED)
+		{
+			/* Try graceful cancellation first (SIGINT via pg_cancel_backend) */
+			DirectFunctionCall1(pg_cancel_backend, Int32GetDatum(pid));
+
+			/* Poll for up to 3 seconds for the worker to exit */
+			for (int i = 0; i < 30; i++)
+			{
+				pg_usleep(100000); /* 100ms */
+				status = GetBackgroundWorkerPid(sjob->handle, &pid);
+				if (status == BGWH_STOPPED)
+					break;
+			}
+
+			if (status != BGWH_STOPPED)
+			{
+				elog(WARNING, "job %d did not exit after SIGINT, sending SIGTERM", sjob->job.fd.id);
+				TerminateBackgroundWorker(sjob->handle);
+				WaitForBackgroundWorkerShutdown(sjob->handle);
+			}
+		}
+		else if (status != BGWH_STOPPED)
+		{
+			TerminateBackgroundWorker(sjob->handle);
+			WaitForBackgroundWorkerShutdown(sjob->handle);
+		}
 	}
 	sjob->may_need_mark_end = false;
 	worker_state_cleanup(sjob);

--- a/src/utils.h
+++ b/src/utils.h
@@ -77,10 +77,6 @@ contains_volatile_functions_checker(Oid func_id, void *context)
 	return (func_volatile(func_id) == PROVOLATILE_VOLATILE);
 }
 
-/* Use a special pseudo-random field 4 value to avoid conflicting with user-advisory-locks */
-#define TS_SET_LOCKTAG_ADVISORY(tag, id1, id2, id3)                                                \
-	SET_LOCKTAG_ADVISORY((tag), (id1), (id2), (id3), 29749)
-
 /* find the length of a statically sized array */
 #define TS_ARRAY_LEN(array) (sizeof(array) / sizeof(*array))
 

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -364,7 +364,7 @@ test_job_3_long()
 
 	elog(WARNING, "Before sleep job 3");
 
-	DirectFunctionCall1(pg_sleep, Float8GetDatum(0.5L));
+	DirectFunctionCall1(pg_sleep, Float8GetDatum(2.0L));
 
 	elog(WARNING, "After sleep job 3");
 	return true;

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -204,23 +204,9 @@ static BgwJob *
 find_job(int32 job_id, bool null_job_id, bool missing_ok)
 {
 	BgwJob *job;
-	bool got_lock;
-	LOCKTAG tag;
 
 	if (null_job_id && !missing_ok)
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("job ID cannot be NULL")));
-
-	/* The job table manipulation functions in job.c use an advisory lock
-	 * rather than a row lock to prevent the job from being modified while
-	 * running. Since we use this function to find a job for either running
-	 * manually or for altering it, we need to grab that advisory lock here as
-	 * well. */
-	got_lock = ts_lock_job_id(job_id,
-							  RowShareLock,
-							  /* session_lock */ false,
-							  &tag,
-							  /* block */ true);
-	Ensure(got_lock, "could not get lock on job id %d", job_id);
 
 	job = ts_bgw_job_find(job_id, CurrentMemoryContext, !missing_ok);
 

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -245,14 +245,16 @@ wait_event_type  | Timeout
 wait_event       | PgSleep
 
 \x off
--- have to suppress notices here as delete_job will print pid of the running background worker processes
-SET client_min_messages TO WARNING;
 SELECT delete_job(:job_id);
  delete_job 
 ------------
  
 
-RESET client_min_messages;
+SELECT wait_application_pid('User-Defined Action [' || :job_id || ']', false);
+ wait_application_pid 
+----------------------
+                     
+
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
  application_name 
 ------------------

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -237,18 +237,15 @@ wait_event_type  | Timeout
 wait_event       | PgSleep
 
 \x off
--- have to suppress notices here as delete_job will print pid of the running background worker processes
-SET client_min_messages TO WARNING;
 SELECT delete_job(:job_id);
  delete_job 
 ------------
  
 
-RESET client_min_messages;
-SELECT count(*) FROM wait_for_logentry(:job_id);
- count 
--------
-     1
+SELECT wait_application_pid('User-Defined Action [' || :job_id || ']', false);
+ wait_application_pid 
+----------------------
+                     
 
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
  application_name 

--- a/tsl/test/isolation/expected/delete_job_deadlock.out
+++ b/tsl/test/isolation/expected/delete_job_deadlock.out
@@ -1,0 +1,21 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_lock s2_run_job s3_delete_job s1_unlock
+step s1_lock: 
+    BEGIN;
+    LOCK TABLE delete_job_gate IN ACCESS EXCLUSIVE MODE;
+
+step s2_run_job: 
+    CALL run_job(get_delete_test_job_id());
+ <waiting ...>
+step s3_delete_job: 
+    SELECT delete_job(get_delete_test_job_id());
+
+delete_job
+----------
+          
+
+step s1_unlock: 
+    COMMIT;
+
+step s2_run_job: <... completed>

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -24,7 +24,8 @@ list(
   parallel_compression.spec
   osm_range_updates_iso.spec
   concurrent_decompress_update.spec
-  bgw_job_stat_history_retention_isolation.spec)
+  bgw_job_stat_history_retention_isolation.spec
+  delete_job_deadlock.spec)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_TEMPLATES_MODULE ${TEST_TEMPLATES_MODULE_DEBUG})

--- a/tsl/test/isolation/specs/delete_job_deadlock.spec
+++ b/tsl/test/isolation/specs/delete_job_deadlock.spec
@@ -1,0 +1,79 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+###
+# Test that delete_job does not deadlock when a job is concurrently running
+# (issue #6152).
+#
+# Before the fix, both run_job and delete_job used advisory locks on the
+# job ID. When a job was running (holding a SHARE advisory lock via
+# find_job), delete_job would block trying to acquire an EXCLUSIVE
+# advisory lock. Combined with catalog table locks taken during deletion
+# and job status updates, this caused deadlocks between delete_job and
+# running background workers.
+#
+# After the fix, advisory locks are no longer used for job synchronization.
+# delete_job simply deletes the catalog row and sends SIGINT to the worker.
+#
+# Test flow:
+# 1. Session s1 locks a synchronization table
+# 2. Session s2 starts run_job, the job proc blocks reading the locked table
+# 3. Session s3 calls delete_job - should complete without blocking
+# 4. Session s1 releases the table lock
+# 5. Session s2's run_job completes
+#
+# The key assertion is that s3_delete_job does NOT show <waiting ...> in
+# the expected output, proving it completes immediately while the job is
+# still running.
+###
+
+setup {
+    CREATE TABLE delete_job_gate();
+
+    CREATE OR REPLACE FUNCTION test_job_proc_delete(job_id int, config jsonb)
+    RETURNS void LANGUAGE plpgsql AS $$
+    BEGIN
+        -- This will block when another session holds ACCESS EXCLUSIVE on the table
+        PERFORM * FROM delete_job_gate;
+    END;
+    $$;
+
+    SELECT 1 FROM add_job('test_job_proc_delete', '1 hour', initial_start => '2100-01-01'::timestamptz);
+
+    CREATE OR REPLACE FUNCTION get_delete_test_job_id() RETURNS int AS $$
+        SELECT job_id FROM timescaledb_information.jobs WHERE proc_name = 'test_job_proc_delete';
+    $$ LANGUAGE SQL;
+}
+
+teardown {
+    SELECT delete_job(job_id) FROM timescaledb_information.jobs WHERE proc_name = 'test_job_proc_delete';
+    DROP FUNCTION IF EXISTS test_job_proc_delete(int, jsonb);
+    DROP FUNCTION IF EXISTS get_delete_test_job_id();
+    DROP TABLE IF EXISTS delete_job_gate;
+}
+
+session "s1"
+
+step "s1_lock" {
+    BEGIN;
+    LOCK TABLE delete_job_gate IN ACCESS EXCLUSIVE MODE;
+}
+
+step "s1_unlock" {
+    COMMIT;
+}
+
+session "s2"
+
+step "s2_run_job" {
+    CALL run_job(get_delete_test_job_id());
+}
+
+session "s3"
+
+step "s3_delete_job" {
+    SELECT delete_job(get_delete_test_job_id());
+}
+
+permutation "s1_lock" "s2_run_job" "s3_delete_job" "s1_unlock"

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -179,10 +179,8 @@ SELECT datname, usename, application_name, state, query, wait_event_type, wait_e
   FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
 \x off
 
--- have to suppress notices here as delete_job will print pid of the running background worker processes
-SET client_min_messages TO WARNING;
 SELECT delete_job(:job_id);
-RESET client_min_messages;
+SELECT wait_application_pid('User-Defined Action [' || :job_id || ']', false);
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
 
 -- wait for scheduler finish

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -184,11 +184,8 @@ SELECT datname, usename, application_name, state, query, wait_event_type, wait_e
   FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
 \x off
 
--- have to suppress notices here as delete_job will print pid of the running background worker processes
-SET client_min_messages TO WARNING;
 SELECT delete_job(:job_id);
-RESET client_min_messages;
-SELECT count(*) FROM wait_for_logentry(:job_id);
+SELECT wait_application_pid('User-Defined Action [' || :job_id || ']', false);
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
 
 --


### PR DESCRIPTION
Replace advisory lock-based job synchronization with a simpler
signal-based approach. Advisory locks caused deadlocks between
delete_job and running workers.

Fixes: #6152
