### PR TITLE
enable ondemand realtime caggs

### DIFF
--- a/.unreleased/pr_9320
+++ b/.unreleased/pr_9320
@@ -1,0 +1,2 @@
+Implements: #9320 Enable on-demand real-time continuous aggregates settings
+Setting: Control session CAgg behaviour with `realtime_cagg_settings`: (`cagg_view` (default), `materialized_only`, `realtime`, `realtime_with_backfills`).

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -259,6 +259,12 @@ ts_tsl_loaded(PG_FUNCTION_ARGS)
 }
 
 static void
+modify_realtime_caggs_ondemand_tsl_default_fn_community(RangeTblEntry *rte, ContinuousAgg *cagg)
+{
+	/* No op in community licensed code */
+}
+
+static void
 preprocess_query_tsl_default_fn_community(Query *parse, int *cursor_opts)
 {
 	/* No op in community licensed code */
@@ -388,6 +394,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.recompress_chunk_segmentwise = error_no_default_fn_pg_community,
 	.get_compressed_chunk_index_for_recompression = error_no_default_fn_pg_community,
 
+	.modify_realtime_caggs_ondemand_tsl = modify_realtime_caggs_ondemand_tsl_default_fn_community,
 	.preprocess_query_tsl = preprocess_query_tsl_default_fn_community,
 	.merge_chunks = error_no_default_fn_pg_community,
 	.split_chunk = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -178,6 +178,7 @@ typedef struct CrossModuleFunctions
 	PGFunction recompress_chunk_segmentwise;
 	PGFunction get_compressed_chunk_index_for_recompression;
 
+	void (*modify_realtime_caggs_ondemand_tsl)(RangeTblEntry *rte, ContinuousAgg *cagg);
 	void (*preprocess_query_tsl)(Query *parse, int *cursor_opts);
 	PGFunction merge_chunks;
 	PGFunction split_chunk;

--- a/src/guc.c
+++ b/src/guc.c
@@ -65,6 +65,14 @@ static const struct config_enum_entry compress_truncate_behaviour_options[] = {
 	{ NULL, 0, false }
 };
 
+static const struct config_enum_entry realtime_ondemand_cagg_options[] = {
+	{ "cagg_view", CAGG_VIEW, false },
+	{ "materialized_only", MATERIALIZED_ONLY, false },
+	{ "realtime", REALTIME, false },
+	{ "realtime_with_backfills", REALTIME_WITH_BACKFILLS, false },
+	{ NULL, 0, false }
+};
+
 bool ts_guc_enable_direct_compress_copy = false;
 bool ts_guc_enable_direct_compress_copy_sort_batches = true;
 bool ts_guc_enable_direct_compress_copy_client_sorted = false;
@@ -122,6 +130,7 @@ TSDLLEXPORT bool ts_guc_enable_uuid_compression = true;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = TARGET_COMPRESSED_BATCH_SIZE;
 TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
+TSDLLEXPORT RealtimeCaggSettings ts_guc_realtime_cagg_settings = CAGG_VIEW;
 bool ts_guc_enable_event_triggers = false;
 bool ts_guc_enable_chunk_auto_publication = false;
 bool ts_guc_debug_skip_scan_info = false;
@@ -995,6 +1004,25 @@ _guc_init(void)
 							 NULL,
 							 NULL);
 
+	DefineCustomIntVariable(MAKE_EXTOPTION("cagg_max_individual_materializations"),
+							"Maximum of invalidated ranges evaluated for realtime CAgg",
+							"Maximum of invalidated ranges evaluated for realtime CAgg. "
+							"If there are more invalidated ranges than this value, "
+							"CAgg in REALTIME_WITH_BACKFILLS mode will only evaluate data above "
+							"watermark plus materialized data."
+							"Otherwise Cagg in REALTIME_WITH_BACKFILLS mode will evaluate data in "
+							"those ranges"
+							"plus above watermark plus materialized data.",
+							&ts_guc_cagg_max_individual_materializations,
+							10,
+							1,
+							PG_INT16_MAX,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
+
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_merge_on_cagg_refresh"),
 							 "Enable MERGE statement on cagg refresh",
 							 "Enable MERGE statement on cagg refresh",
@@ -1352,6 +1380,25 @@ _guc_init(void)
 							 (int *) &ts_guc_compress_truncate_behaviour,
 							 COMPRESS_TRUNCATE_ONLY,
 							 compress_truncate_behaviour_options,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomEnumVariable(MAKE_EXTOPTION("realtime_cagg_settings"),
+							 "Define behaviour of combining live data with materialized CAgg data",
+							 "Defines how live data will be combined with materialized CAgg data. "
+							 "'cagg_view' will provide data according to CAgg "
+							 "'materialized_only' setting."
+							 "'materialized_only' will provide only materialized CAgg data. "
+							 "'realtime' will add new live data to materialized CAgg data, "
+							 "backfills are ignored. "
+							 "'realtime_with_backfills' will add live new and backfilled data to "
+							 "materialized CAgg data.",
+							 (int *) &ts_guc_realtime_cagg_settings,
+							 CAGG_VIEW,
+							 realtime_ondemand_cagg_options,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -98,6 +98,15 @@ typedef enum CompressTruncateBehaviour
 } CompressTruncateBehaviour;
 extern TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour;
 
+typedef enum RealtimeCaggSettings
+{
+	CAGG_VIEW,
+	MATERIALIZED_ONLY,
+	REALTIME,
+	REALTIME_WITH_BACKFILLS,
+} RealtimeCaggSettings;
+extern TSDLLEXPORT RealtimeCaggSettings ts_guc_realtime_cagg_settings;
+
 #ifdef USE_TELEMETRY
 typedef enum TelemetryLevel
 {

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -417,6 +417,15 @@ preprocess_query(Node *node, PreprocessQueryContext *context)
 			switch (rte->rtekind)
 			{
 				case RTE_SUBQUERY:
+					/* Apply on-demand realtime settings to Caggs in the query */
+					if (ts_guc_enable_optimizations && ts_guc_realtime_cagg_settings != CAGG_VIEW &&
+						rte->relkind == RELKIND_VIEW && rte->relid)
+					{
+						ContinuousAgg *cagg = ts_continuous_agg_find_by_relid(rte->relid);
+						if (cagg)
+							ts_cm_functions->modify_realtime_caggs_ondemand_tsl(rte, cagg);
+					}
+
 					if (ts_guc_enable_optimizations && ts_guc_enable_cagg_reorder_groupby &&
 						query->commandType == CMD_SELECT)
 					{

--- a/tsl/src/continuous_aggs/common.c
+++ b/tsl/src/continuous_aggs/common.c
@@ -6,6 +6,7 @@
 
 #include "common.h"
 
+#include <rewrite/rewriteDefine.h>
 #include <utils/acl.h>
 #include <utils/date.h>
 #include <utils/timestamp.h>
@@ -13,6 +14,7 @@
 
 #include "extension.h"
 #include "guc.h"
+#include "ts_catalog/continuous_aggs_watermark.h"
 
 static Const *check_time_bucket_argument(Node *arg, char *position, bool process_checks,
 										 StringInfo msg, bool for_rewrites);
@@ -26,11 +28,11 @@ static void caggtimebucket_validate(ContinuousAggTimeBucketInfo *tbinfo, List *g
 									List *targetList, List *rtable, bool is_cagg_create);
 static Datum get_bucket_width_datum(ContinuousAggTimeBucketInfo bucket_info);
 static int64 get_bucket_width(ContinuousAggTimeBucketInfo bucket_info);
-static FuncExpr *build_conversion_call(Oid type, FuncExpr *boundary);
+static FuncExpr *build_conversion_call(Oid type, Node *boundary);
 static FuncExpr *build_boundary_call(int32 ht_id, Oid type);
 static Const *cagg_boundary_make_lower_bound(Oid type);
 static Node *build_union_query_quals(int32 ht_id, Oid partcoltype, Oid opno, int varno,
-									 AttrNumber attno);
+									 AttrNumber attno, RealTimeDataContext *rtd_context);
 static RangeTblEntry *makeRangeTblEntry(Query *subquery, const char *aliasname);
 
 #define INTERNAL_TO_DATE_FUNCTION "to_date"
@@ -1391,7 +1393,7 @@ cagg_get_boundary_converter_funcoid(Oid typoid)
 }
 
 static FuncExpr *
-build_conversion_call(Oid type, FuncExpr *boundary)
+build_conversion_call(Oid type, Node *boundary)
 {
 	/*
 	 * If the partitioning column type is not integer we need to convert
@@ -1414,7 +1416,7 @@ build_conversion_call(Oid type, FuncExpr *boundary)
 		}
 		case INT8OID:
 			/* Nothing to do for int8. */
-			return boundary;
+			return (FuncExpr *) boundary;
 		case DATEOID:
 		case TIMESTAMPOID:
 		case TIMESTAMPTZOID:
@@ -1510,7 +1512,7 @@ build_boundary_call(int32 ht_id, Oid type)
 							InvalidOid,
 							COERCE_EXPLICIT_CALL);
 
-	return build_conversion_call(type, boundary);
+	return build_conversion_call(type, (Node *) boundary);
 }
 
 /*
@@ -1542,23 +1544,152 @@ cagg_boundary_make_lower_bound(Oid type)
 }
 
 static Node *
-build_union_query_quals(int32 ht_id, Oid partcoltype, Oid opno, int varno, AttrNumber attno)
+build_boundary_const(int64 value, Oid partcoltype)
+{
+	Const *const_boundary = makeConst(INT8OID,
+									  -1,
+									  InvalidOid,
+									  sizeof(int64),
+									  Int64GetDatum(value),
+									  false,
+									  FLOAT8PASSBYVAL);
+	FuncExpr *boundary_cast = build_conversion_call(partcoltype, (Node *) const_boundary);
+	return (Node *) boundary_cast;
+}
+
+static Node *
+build_union_query_quals(int32 ht_id, Oid partcoltype, Oid opno, int varno, AttrNumber attno,
+						RealTimeDataContext *rtd_context)
 {
 	Var *var = makeVar(varno, attno, partcoltype, -1, InvalidOid, InvalidOid);
-	FuncExpr *boundary = build_boundary_call(ht_id, partcoltype);
+	if (!rtd_context)
+	{
+		FuncExpr *boundary = build_boundary_call(ht_id, partcoltype);
 
-	CoalesceExpr *coalesce = makeNode(CoalesceExpr);
-	coalesce->coalescetype = partcoltype;
-	coalesce->coalescecollid = InvalidOid;
-	coalesce->args = list_make2(boundary, cagg_boundary_make_lower_bound(partcoltype));
+		CoalesceExpr *coalesce = makeNode(CoalesceExpr);
+		coalesce->coalescetype = partcoltype;
+		coalesce->coalescecollid = InvalidOid;
+		coalesce->args = list_make2(boundary, cagg_boundary_make_lower_bound(partcoltype));
 
-	return (Node *) make_opclause(opno,
-								  BOOLOID,
-								  false,
-								  (Expr *) var,
-								  (Expr *) coalesce,
-								  InvalidOid,
-								  InvalidOid);
+		return (Node *) make_opclause(opno,
+									  BOOLOID,
+									  false,
+									  (Expr *) var,
+									  (Expr *) coalesce,
+									  InvalidOid,
+									  InvalidOid);
+	}
+	else
+	{
+		/* OR of invalidated ranges plus above watermark */
+		Node *boundary_quals;
+		List *ranges = NULL;
+
+		/* (var <(or >=) watermark) */
+		Node *watermark_qual =
+			(Node *) make_opclause(opno,
+								   BOOLOID,
+								   false,
+								   (Expr *) var,
+								   (Expr *) build_boundary_const(rtd_context->watermark,
+																 partcoltype),
+								   InvalidOid,
+								   InvalidOid);
+
+		/* need to add boundary conditions for invalidated ranges */
+		int32 numbounds = rtd_context->invalidated_ranges.num_bounds;
+		if (ts_guc_realtime_cagg_settings == REALTIME_WITH_BACKFILLS && numbounds)
+		{
+			/* Exclude invalidated ranges i.e. for N ranges
+			 * (var < l1) OR (var >= h1 AND var < l2) ... OR (var >= h_N AND var < watermark) */
+			if (rtd_context->for_materialized_query)
+			{
+				for (int i = 0; i < numbounds; i++)
+				{
+					int64 low_value = rtd_context->invalidated_ranges.low_bounds[i];
+					Node *low_qual =
+						(Node *) make_opclause(opno,
+											   BOOLOID,
+											   false,
+											   (Expr *) var,
+											   (Expr *) build_boundary_const(low_value,
+																			 partcoltype),
+											   InvalidOid,
+											   InvalidOid);
+					if (i > 0)
+					{
+						int64 high_value = rtd_context->invalidated_ranges.high_bounds[i - 1];
+						Node *high_qual =
+							(Node *) make_opclause(get_negator(opno),
+												   BOOLOID,
+												   false,
+												   (Expr *) var,
+												   (Expr *) build_boundary_const(high_value,
+																				 partcoltype),
+												   InvalidOid,
+												   InvalidOid);
+						/* (var >= h1 AND var < l2) ... */
+						Node *range_bound = make_and_qual(high_qual, low_qual);
+						ranges = lappend(ranges, range_bound);
+					}
+					/* (var < l1) */
+					else
+						ranges = lappend(ranges, low_qual);
+				}
+				/* (var >= h_N AND var < watermark) */
+				int64 last_high_value = rtd_context->invalidated_ranges.high_bounds[numbounds - 1];
+				Node *last_high_qual =
+					(Node *) make_opclause(get_negator(opno),
+										   BOOLOID,
+										   false,
+										   (Expr *) var,
+										   (Expr *) build_boundary_const(last_high_value,
+																		 partcoltype),
+										   InvalidOid,
+										   InvalidOid);
+				Node *last_range = make_and_qual(last_high_qual, watermark_qual);
+				ranges = lappend(ranges, last_range);
+			}
+			/* Include data in invalidated ranges + above watermark i.e. for N ranges
+			 * (var >= l1 AND var < h1) OR (var >= l2 AND var < h2) ... OR (var >= l_n AND var <
+			 * h_N) OR (var >= watermark) */
+			else
+			{
+				for (int i = 0; i < numbounds; i++)
+				{
+					int64 low_value = rtd_context->invalidated_ranges.low_bounds[i];
+					Node *low_qual =
+						(Node *) make_opclause(opno,
+											   BOOLOID,
+											   false,
+											   (Expr *) var,
+											   (Expr *) build_boundary_const(low_value,
+																			 partcoltype),
+											   InvalidOid,
+											   InvalidOid);
+					int64 high_value = rtd_context->invalidated_ranges.high_bounds[i];
+					Node *high_qual =
+						(Node *) make_opclause(get_negator(opno),
+											   BOOLOID,
+											   false,
+											   (Expr *) var,
+											   (Expr *) build_boundary_const(high_value,
+																			 partcoltype),
+											   InvalidOid,
+											   InvalidOid);
+					Node *range_bound = make_and_qual(low_qual, high_qual);
+					ranges = lappend(ranges, range_bound);
+				}
+				ranges = lappend(ranges, watermark_qual);
+			}
+			boundary_quals = (Node *) make_orclause(ranges);
+		}
+		/* no backfills */
+		else
+			boundary_quals = watermark_qual;
+
+		return boundary_quals;
+	}
 }
 
 static RangeTblEntry *
@@ -1605,7 +1736,7 @@ makeRangeTblEntry(Query *query, const char *aliasname)
  */
 Query *
 build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *q1, Query *q2,
-				  int materialize_htid)
+				  int materialize_htid, RealTimeDataContext *rtd_context)
 {
 	ListCell *lc1, *lc2;
 	List *col_types = NIL;
@@ -1640,18 +1771,29 @@ build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *
 	TypeCacheEntry *tce_q2 = lookup_type_cache(q2_partcoltype, TYPECACHE_LT_OPR);
 
 	varno = list_length(q1->rtable);
+	if (rtd_context)
+		rtd_context->for_materialized_query = true;
 	q1->jointree->quals = build_union_query_quals(materialize_htid,
 												  q1_partcoltype,
 												  tce_q1->lt_opr,
 												  varno,
-												  matpartcolno);
+												  matpartcolno,
+												  rtd_context);
 	/*
 	 * If there is join in CAgg definition then adjust varno
 	 * to get time column from the hypertable in the join.
 	 */
+	bool ht_only = (list_length(q2->rtable) == 1);
 	varno = list_length(q2->rtable);
-
-	if (list_length(q2->rtable) > 1)
+#if PG18_GE
+	if (rtd_context)
+	{
+		/* hypertable RTE + group RTE */
+		ht_only = (list_length(q2->rtable) == 2);
+		varno = list_length(q2->rtable) - 1;
+	}
+#endif
+	if (!ht_only)
 	{
 		int nvarno = 1;
 		foreach (lc2, q2->rtable)
@@ -1670,11 +1812,14 @@ build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *
 		}
 	}
 
+	if (rtd_context)
+		rtd_context->for_materialized_query = false;
 	q2_quals = build_union_query_quals(materialize_htid,
 									   q2_partcoltype,
 									   get_negator(tce_q2->lt_opr),
 									   varno,
-									   tbinfo->htpartcolno);
+									   tbinfo->htpartcolno,
+									   rtd_context);
 
 	q2->jointree->quals = make_and_qual(q2->jointree->quals, q2_quals);
 
@@ -1908,4 +2053,114 @@ cagg_find_groupingcols(ContinuousAgg *agg, Hypertable *mat_ht)
 			retlist = lappend(retlist, get_attname(mat_relid, cagg_tle->resno, false));
 	}
 	return retlist;
+}
+
+/*
+ * Modify Cagg view at query time to use on-demand realtime settings
+ */
+void
+tsl_modify_realtime_caggs_ondemand(RangeTblEntry *rte, ContinuousAgg *cagg)
+{
+	Assert(rte->subquery != NULL);
+
+	/* Check if we need to provide realtime Caggs on-demand rather than via Cagg "materialized_only"
+	 * setting */
+	switch (ts_guc_realtime_cagg_settings)
+	{
+		case CAGG_VIEW:
+			/* don't want on-demand setting: nothing to do */
+			return;
+		case MATERIALIZED_ONLY:
+			/* on-demand setting matches current Cagg setting, nothing to do */
+			if (cagg->data.materialized_only)
+			{
+				return;
+			}
+			/* return materialized-only part of the query */
+			else
+			{
+				Assert(rte->subquery->setOperations);
+				rte->subquery = destroy_union_query(rte->subquery);
+			}
+			break;
+		case REALTIME:
+		case REALTIME_WITH_BACKFILLS:
+			/* on-demand setting matches current Cagg setting, nothing to do */
+			if (!cagg->data.materialized_only && ts_guc_realtime_cagg_settings == REALTIME)
+			{
+				return;
+			}
+			/* UNION ALL of materialized data + relevant live data.
+			 * Uses live watermark and invalidated ranges boundary values. */
+			else
+			{
+				Query *cagg_query = ts_continuous_agg_get_query(cagg);
+				/* We added a new subquery (Cagg view query) with uninitialized objects to the input
+				 * query, need to set it up and fire view rules if Cagg refers to views  */
+				AcquireRewriteLocks(cagg_query, true, false);
+				List *rewritten = QueryRewrite(cagg_query);
+				Assert(list_length(rewritten) == 1);
+				Query *cagg_view_query = linitial_node(Query, rewritten);
+
+				Query *materialized_query =
+					(cagg->data.materialized_only ? rte->subquery :
+													destroy_union_query(rte->subquery));
+
+				Cache *hcache = ts_hypertable_cache_pin();
+				Hypertable *ht =
+					ts_hypertable_cache_get_entry_by_id(hcache, cagg->data.raw_hypertable_id);
+				Hypertable *mat_ht =
+					ts_hypertable_cache_get_entry_by_id(hcache, cagg->data.mat_hypertable_id);
+				const Dimension *ht_part_dimension = hyperspace_get_open_dimension(ht->space, 0);
+				const Dimension *mat_part_dimension =
+					hyperspace_get_open_dimension(mat_ht->space, 0);
+
+				ContinuousAggTimeBucketInfo bucket_info = { 0 };
+				caggtimebucketinfo_init(&bucket_info,
+										ht->fd.id,
+										ht->main_table_relid,
+										ht_part_dimension->column_attno,
+										ht_part_dimension->fd.column_type,
+										ht_part_dimension->fd.interval_length,
+										INVALID_HYPERTABLE_ID);
+				ts_cache_release(&hcache);
+
+				RealTimeDataContext rtd_context = { 0 };
+				rtd_context.watermark = ts_cagg_watermark_get(cagg->data.mat_hypertable_id);
+
+				/* No materialized data in Cagg: return real-time data only */
+				if (rtd_context.watermark == ts_time_get_min(cagg->partition_type))
+				{
+					rte->subquery = cagg_view_query;
+				}
+				else
+				{
+					if (ts_guc_realtime_cagg_settings == REALTIME_WITH_BACKFILLS)
+					{
+						rtd_context.invalidated_ranges = invalidation_get_cagg_invalidations(
+							cagg,
+							rtd_context.watermark,
+							ts_guc_cagg_max_individual_materializations);
+						if (!rtd_context.invalidated_ranges.is_valid)
+							ereport(NOTICE,
+									(errmsg("Too many invalidated ranges: not including live "
+											"backfilled "
+											"data")));
+					}
+
+					/* This method will build UNION ALL with quals made according to on-demand
+					 * settings: compare to watermark and for REALTIME_WITH_BACKFILLS also compare
+					 * to invalidated ranges */
+					rte->subquery = build_union_query(&bucket_info,
+													  mat_part_dimension->column_attno,
+													  materialized_query,
+													  cagg_view_query,
+													  mat_ht->fd.id,
+													  &rtd_context);
+				}
+			}
+			break;
+		default:
+			ereport(ERROR, (errmsg("Unknown on-demand realtime CAgg settings")));
+	}
 }

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -90,6 +90,21 @@ typedef struct ContinuousAggRefreshContext
 	int32 number_of_batches;
 } ContinuousAggRefreshContext;
 
+typedef struct InvalidatedRanges
+{
+	int32 num_bounds;
+	int64 *low_bounds;
+	int64 *high_bounds;
+	bool is_valid;
+} InvalidatedRanges;
+
+typedef struct RealTimeDataContext
+{
+	bool for_materialized_query;
+	int64 watermark;
+	InvalidatedRanges invalidated_ranges;
+} RealTimeDataContext;
+
 #define IS_TIME_BUCKET_INFO_TIME_BASED(bucket_function)                                            \
 	(bucket_function->bucket_width_type == INTERVALOID)
 
@@ -114,7 +129,10 @@ extern ContinuousAggTimeBucketInfo cagg_validate_query(const Query *query, const
 extern Query *destroy_union_query(Query *q);
 extern void RemoveRangeTableEntries(Query *query);
 extern Query *build_union_query(ContinuousAggTimeBucketInfo *tbinfo, int matpartcolno, Query *q1,
-								Query *q2, int materialize_htid);
+								Query *q2, int materialize_htid, RealTimeDataContext *rtd_context);
+extern InvalidatedRanges invalidation_get_cagg_invalidations(const ContinuousAgg *cagg,
+															 int64 watermark,
+															 long max_materializations);
 extern bool function_allowed_in_cagg_definition(Oid funcid);
 extern Oid get_watermark_function_oid(void);
 extern Oid cagg_get_boundary_converter_funcoid(Oid typoid);
@@ -173,3 +191,4 @@ extern bool caggtimebucket_validate_common(ContinuousAggBucketFunction *bf, List
 										   List *targetList, List *rtable, int ht_partcolno,
 										   StringInfo msg, bool is_cagg_create,
 										   const bool for_rewrites);
+void tsl_modify_realtime_caggs_ondemand(RangeTblEntry *rte, ContinuousAgg *cagg);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -664,13 +664,13 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 													mattblinfo.matcollist,
 													&mataddress,
 													mat_rel->relname);
-
 	if (!materialized_only)
 		final_selquery = build_union_query(bucket_info,
 										   mattblinfo.matpartcolno,
 										   final_selquery,
 										   panquery,
-										   materialize_hypertable_id);
+										   materialize_hypertable_id,
+										   NULL);
 
 	/* Copy view acl to materialization hypertable. */
 	ObjectAddress view_address = create_view_for_query(final_selquery, stmt->view);
@@ -941,7 +941,8 @@ cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 											  mat_part_dimension->column_attno,
 											  user_query,
 											  direct_query,
-											  mat_ht->fd.id);
+											  mat_ht->fd.id,
+											  NULL);
 	}
 
 	SWITCH_TO_TS_USER(NameStr(agg->data.user_view_schema), uid, saved_uid, sec_ctx);

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1255,33 +1255,6 @@ invalidation_hypertable_has_invalidations(int32 hyper_id)
 }
 
 bool
-invalidation_cagg_has_pending_mat_ranges(ContinuousAgg *cagg)
-{
-	bool found = false;
-	int32 cagg_hyper_id = cagg->data.mat_hypertable_id;
-
-	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
-													AccessShareLock,
-													CurrentMemoryContext);
-	iterator.ctx.index = catalog_get_index(ts_catalog_get(),
-										   CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
-										   CONTINUOUS_AGGS_MATERIALIZATION_RANGES_IDX);
-	ts_scan_iterator_scan_key_init(&iterator,
-								   Anum_continuous_aggs_materialization_ranges_materialization_id,
-								   BTEqualStrategyNumber,
-								   F_INT4EQ,
-								   Int32GetDatum(cagg_hyper_id));
-	iterator.ctx.limit = 1; /* we only need to know if there is at least one */
-
-	ts_scan_iterator_start_scan(&iterator);
-	if (ts_scan_iterator_next(&iterator))
-		found = true;
-	ts_scan_iterator_close(&iterator);
-
-	return found;
-}
-
-bool
 invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
 {
 	bool found = false;
@@ -1315,4 +1288,177 @@ invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
 	ts_scan_iterator_close(&iterator);
 
 	return found;
+}
+
+static long
+save_cagg_invalidation_into_store(const ContinuousAggInvalidationState *state,
+								  const Invalidation *invalidation)
+{
+	if (!IsValidInvalidation(invalidation))
+		return tuplestore_tuple_count(state->invalidations);
+
+	InternalTimeRange refresh_window = {
+		.type = state->cagg->partition_type,
+		.start = invalidation->lowest_modified_value,
+		/* Invalidations are inclusive at the end, while refresh windows aren't, so add one to the
+		   end of the invalidated region */
+		.end = ts_time_saturating_add(invalidation->greatest_modified_value,
+									  1,
+									  state->cagg->partition_type),
+	};
+
+	InternalTimeRange bucketed_refresh_window =
+		compute_circumscribed_bucketed_refresh_window(state->cagg,
+													  &refresh_window,
+													  state->cagg->bucket_function);
+
+	int32 cagg_hyper_id = state->cagg->data.mat_hypertable_id;
+	TupleDesc tupdesc = RelationGetDescr(state->cagg_log_rel);
+	HeapTuple tup = create_invalidation_tup(tupdesc,
+											cagg_hyper_id,
+											bucketed_refresh_window.start,
+											bucketed_refresh_window.end);
+	tuplestore_puttuple(state->invalidations, tup);
+	heap_freetuple(tup);
+
+	return tuplestore_tuple_count(state->invalidations);
+}
+
+static void
+get_hyper_and_cagg_invalidations(const ContinuousAggInvalidationState *state, int64 watermark,
+								 long max_materializations)
+{
+	Invalidation mergedentry;
+	invalidation_entry_reset(&mergedentry);
+
+	int32 hyper_id = state->cagg->data.raw_hypertable_id;
+	int32 cagg_hyper_id = state->cagg->data.mat_hypertable_id;
+	const ContinuousAggBucketFunction *bucket_function = state->cagg->bucket_function;
+	long count = 0;
+
+	/* Process all invalidations for the hypertable */
+	ScanIterator hyper_iterator;
+	hypertable_invalidation_scan_init(&hyper_iterator, hyper_id, AccessShareLock);
+	hyper_iterator.ctx.snapshot = RegisterSnapshot(GetTransactionSnapshot());
+	Assert(hyper_iterator.ctx.snapshot != NULL);
+
+	ts_scanner_foreach(&hyper_iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&hyper_iterator);
+		Invalidation logentry;
+
+		invalidation_entry_set_from_hyper_invalidation(&logentry,
+													   ti,
+													   cagg_hyper_id,
+													   state->cagg->partition_type,
+													   bucket_function);
+		if (!IsValidInvalidation(&mergedentry))
+			mergedentry = logentry;
+		else if (!invalidation_entry_try_merge(&mergedentry, &logentry))
+		{
+			count = save_cagg_invalidation_into_store(state, &mergedentry);
+			mergedentry = logentry;
+		}
+
+		if (count > max_materializations)
+			break;
+	}
+	UnregisterSnapshot(hyper_iterator.ctx.snapshot);
+	ts_scan_iterator_close(&hyper_iterator);
+
+	if (count > max_materializations)
+		return;
+
+	/* Process all invalidations for the continuous aggregate */
+	ScanIterator iterator;
+	cagg_invalidations_scan_by_hypertable_init(&iterator, cagg_hyper_id, AccessShareLock);
+	iterator.ctx.snapshot = RegisterSnapshot(GetTransactionSnapshot());
+	Assert(iterator.ctx.snapshot != NULL);
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		Invalidation logentry;
+		invalidation_entry_set_from_cagg_invalidation(&logentry,
+													  ti,
+													  state->cagg->partition_type,
+													  state->cagg->bucket_function);
+
+		/* Entries which cannot be invalidations */
+		if (logentry.greatest_modified_value == INVAL_NEG_INFINITY ||
+			logentry.lowest_modified_value >= watermark)
+			continue;
+
+		if (!IsValidInvalidation(&mergedentry))
+			mergedentry = logentry;
+		else if (!invalidation_entry_try_merge(&mergedentry, &logentry))
+		{
+			count = save_cagg_invalidation_into_store(state, &mergedentry);
+			mergedentry = logentry;
+		}
+
+		if (count > max_materializations)
+			break;
+	}
+	UnregisterSnapshot(iterator.ctx.snapshot);
+	ts_scan_iterator_close(&iterator);
+
+	if (count > max_materializations)
+		return;
+
+	/* Handle the last (merged) remainder */
+	save_cagg_invalidation_into_store(state, &mergedentry);
+}
+
+InvalidatedRanges
+invalidation_get_cagg_invalidations(const ContinuousAgg *cagg, int64 watermark,
+									long max_materializations)
+{
+	ContinuousAggInvalidationState state;
+	long count;
+	InvalidatedRanges invalidated_ranges = { 0 };
+
+	cagg_invalidation_state_init(&state, cagg);
+	state.invalidations = tuplestore_begin_heap(false, false, work_mem);
+
+	get_hyper_and_cagg_invalidations(&state, watermark, max_materializations);
+
+	count = tuplestore_tuple_count(state.invalidations);
+	if (count == 0 || count > max_materializations)
+	{
+		if (count == 0)
+			invalidated_ranges.is_valid = true;
+	}
+	else
+	{
+		invalidated_ranges.is_valid = true;
+		invalidated_ranges.num_bounds = count;
+		invalidated_ranges.low_bounds = palloc(sizeof(int64) * count);
+		invalidated_ranges.high_bounds = palloc(sizeof(int64) * count);
+
+		TupleDesc tupdesc = CreateTupleDescCopy(RelationGetDescr(state.cagg_log_rel));
+		TupleTableSlot *slot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
+		int i = 0;
+		while (tuplestore_gettupleslot(state.invalidations,
+									   true /* forward */,
+									   false /* copy */,
+									   slot))
+		{
+			bool isnull;
+			Datum start = slot_getattr(
+				slot,
+				Anum_continuous_aggs_materialization_invalidation_log_lowest_modified_value,
+				&isnull);
+			Datum end = slot_getattr(
+				slot,
+				Anum_continuous_aggs_materialization_invalidation_log_greatest_modified_value,
+				&isnull);
+			invalidated_ranges.low_bounds[i] = DatumGetInt64(start);
+			invalidated_ranges.high_bounds[i] = DatumGetInt64(end);
+			i++;
+		}
+	}
+	tuplestore_end(state.invalidations);
+	cagg_invalidation_state_cleanup(&state);
+	return invalidated_ranges;
 }

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -58,4 +58,3 @@ extern HeapTuple create_invalidation_tup(const TupleDesc tupdesc, int32 cagg_hyp
 										 int64 end);
 extern bool invalidation_hypertable_has_invalidations(int32 hyper_id);
 extern bool invalidation_cagg_has_invalidations(ContinuousAgg *cagg);
-extern bool invalidation_cagg_has_pending_mat_ranges(ContinuousAgg *cagg);

--- a/tsl/src/continuous_aggs/rewrite_with_caggs.c
+++ b/tsl/src/continuous_aggs/rewrite_with_caggs.c
@@ -277,7 +277,6 @@ match_query_to_cagg(CaggRewriteContext *cagg_rewrite_ctx, Query *query, bool do_
 	/* Diagnostics on matching steps  */
 	StringInfo not_realtime = NULL;
 	StringInfo invalidated = NULL;
-	StringInfo pending_ranges = NULL;
 	StringInfo nonmatching_buckets = NULL;
 	StringInfo nonmatching_joins = NULL;
 	StringInfo nonmatching_groupby = NULL;
@@ -307,14 +306,6 @@ match_query_to_cagg(CaggRewriteContext *cagg_rewrite_ctx, Query *query, bool do_
 		if (invalidation_cagg_has_invalidations(cagg))
 		{
 			add_optional_debug_info(cagg, &invalidated, "Invalidated caggs:");
-			continue;
-		}
-		/* TEMP: only consider Caggs with no pending materialization ranges */
-		if (invalidation_cagg_has_pending_mat_ranges(cagg))
-		{
-			add_optional_debug_info(cagg,
-									&pending_ranges,
-									"Caggs with pending materialization ranges:");
 			continue;
 		}
 
@@ -613,11 +604,6 @@ match_query_to_cagg(CaggRewriteContext *cagg_rewrite_ctx, Query *query, bool do_
 			{
 				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", invalidated->data);
 				pfree(invalidated);
-			}
-			if (pending_ranges)
-			{
-				appendStringInfo(&(cagg_rewrite_ctx->msg), "%s\n", pending_ranges->data);
-				pfree(pending_ranges);
 			}
 			if (nonmatching_buckets)
 			{

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -193,6 +193,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.recompress_chunk_segmentwise = tsl_recompress_chunk_segmentwise,
 	.get_compressed_chunk_index_for_recompression =
 		tsl_get_compressed_chunk_index_for_recompression,
+	.modify_realtime_caggs_ondemand_tsl = tsl_modify_realtime_caggs_ondemand,
 	.preprocess_query_tsl = tsl_preprocess_query,
 	.merge_chunks = chunk_merge_chunks,
 	.split_chunk = chunk_split_chunk,

--- a/tsl/test/expected/cagg_rewrites.out
+++ b/tsl/test/expected/cagg_rewrites.out
@@ -1219,48 +1219,6 @@ Buckets do not match: "public.cagg1_tz" "public.cagg1_origin" "public.cagg2" "pu
  Fri Jun 25 17:00:00 2021 PDT | 32.0000000000000000 |         3
  Sat Jun 26 17:00:00 2021 PDT | 31.0000000000000000 |         3
 
--- Caggs with pending materialization ranges are not eligible.
--- Insert new row into hypertable, remove (cagg2) watermark and then refresh it.
--- It will create pending materialization range on (cagg2) as refresh will error out.
-SET timescaledb.cagg_rewrites_debug_info = 0;
-INSERT INTO conditions (day, city, temperature, device_id) VALUES
-  ('2021-06-16', 'Berlin', 23, 2);
-SELECT ca.mat_hypertable_id AS "CAGG2_ID", watermark AS "CAGG2_WATERMARK"
-FROM _timescaledb_catalog.continuous_agg ca INNER JOIN _timescaledb_catalog.continuous_aggs_watermark wm
-ON (ca.mat_hypertable_id = wm.mat_hypertable_id) WHERE user_view_name = 'cagg2';
- CAGG2_ID | CAGG2_WATERMARK  
-----------+------------------
-        8 | 1624924800000000
-
-\gset
--- This will create pending materialization range
-\c :TEST_DBNAME :ROLE_SUPERUSER
-DELETE FROM _timescaledb_catalog.continuous_aggs_watermark WHERE mat_hypertable_id = :CAGG2_ID;
-\set ON_ERROR_STOP 0
-CALL refresh_continuous_aggregate('cagg2', NULL, NULL);
-psql:include/cagg_rewrites_materialize.sql:59: ERROR:  watermark not defined for continuous aggregate: 8
-\set ON_ERROR_STOP 1
--- Restore deleted watermark so that we can query (cagg2) again
-INSERT INTO _timescaledb_catalog.continuous_aggs_watermark values(:CAGG2_ID, :CAGG2_WATERMARK);
-SET timescaledb.cagg_rewrites_debug_info = 1;
-SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
-   count(device_id)
-FROM conditions
-GROUP BY bucket
-ORDER BY 1, 2
-LIMIT 3;
-psql:include/cagg_rewrites_materialize.sql:71: INFO:  Query cannot be rewritten with CAggs: none of continuous aggregates defined on "public.conditions" are matching the query:
-Caggs with pending materialization ranges: "public.cagg2"
-Buckets do not match: "public.cagg1" "public.cagg1_tz" "public.cagg1_origin" "public.cagg3" "public.cagg_join" "public.cagg_more_conds" "public.cagg_view" "public.cagg_lateral"
-
-            bucket            | count 
-------------------------------+-------
- Sat Jun 12 17:00:00 2021 PDT |     1
- Mon Jun 14 17:00:00 2021 PDT |     4
- Wed Jun 16 17:00:00 2021 PDT |     4
-
--- cleanup materialization ranges
-TRUNCATE TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges;
 RESET timescaledb.cagg_rewrites_debug_info;
 RESET timescaledb.enable_cagg_rewrites;
 DROP MATERIALIZED VIEW cagg_on_cagg1 CASCADE;

--- a/tsl/test/expected/cagg_union_ondemand.out
+++ b/tsl/test/expected/cagg_union_ondemand.out
@@ -1,0 +1,620 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET datestyle TO 'ISO, YMD';
+SET timezone TO 'UTC';
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+CREATE TABLE metrics(time timestamptz NOT NULL, device_id int, value float);
+SELECT table_name FROM create_hypertable('metrics', 'time', chunk_time_interval => INTERVAL '7 days');
+ table_name 
+------------
+ metrics
+
+INSERT INTO metrics(time, value, device_id) VALUES
+  ('2021-06-14', 26,1),
+  ('2021-06-15', 22,2),
+  ('2021-06-15', 21,1),
+  ('2021-06-16', 24,3),
+  ('2021-06-20', 24,4),
+  ('2021-06-18', 27,4),
+  ('2021-06-19', 28,4),
+  ('2021-06-25', 30,1),
+  ('2021-06-21', 31,1),
+  ('2021-06-22', 34,1),
+  ('2021-06-22', 34,2),
+  ('2021-06-24', 34,2),
+  ('2021-06-25', 32,3),
+  ('2021-06-26', 32,3),
+  ('2021-06-15', 23,1),
+  ('2021-06-17', 24,2),
+  ('2021-06-17', 21,3),
+  ('2021-06-27', 31,3);
+-- For stable plans
+SET enable_indexscan = 0;
+SET enable_bitmapscan = 0;
+:PREFIX SELECT * from metrics;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_1_1_chunk
+   ->  Seq Scan on _hyper_1_2_chunk
+   ->  Seq Scan on _hyper_1_3_chunk
+
+-- check default view for new continuous aggregate
+CREATE MATERIALIZED VIEW metrics_realtime
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+  SELECT time_bucket('1d',time) as bucket, avg(value) as av FROM metrics GROUP BY 1 WITH NO DATA;
+CREATE MATERIALIZED VIEW metrics_realtime_h
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+  SELECT time_bucket('2d', bucket), avg(av) FROM metrics_realtime GROUP BY 1 WITH NO DATA;
+CREATE MATERIALIZED VIEW metrics_matonly
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time) as bucket, avg(value) as av FROM metrics GROUP BY 1 WITH NO DATA;
+-- Check settings for "realtime_cagg_settings"
+-- Caggs with no materialized data
+RESET timescaledb.realtime_cagg_settings;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+               ->  Seq Scan on _hyper_1_2_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+               ->  Seq Scan on _hyper_1_3_chunk
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 2 days'::interval, (time_bucket('@ 1 day'::interval, metrics."time")))
+   ->  Result
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (time_bucket('@ 1 day'::interval, "time") >= '4714-11-24 00:00:00+00 BC'::timestamp with time zone)
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+                           ->  Seq Scan on _hyper_1_2_chunk
+                                 Filter: (time_bucket('@ 1 day'::interval, "time") >= '4714-11-24 00:00:00+00 BC'::timestamp with time zone)
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                           ->  Seq Scan on _hyper_1_3_chunk
+                                 Filter: (time_bucket('@ 1 day'::interval, "time") >= '4714-11-24 00:00:00+00 BC'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Result
+   One-Time Filter: false
+
+SET timescaledb.realtime_cagg_settings = materialized_only;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Result
+   One-Time Filter: false
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Result
+   One-Time Filter: false
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Result
+   One-Time Filter: false
+
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+               ->  Seq Scan on _hyper_1_2_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+               ->  Seq Scan on _hyper_1_3_chunk
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 2 days'::interval, (time_bucket('@ 1 day'::interval, metrics."time")))
+   ->  Result
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (time_bucket('@ 1 day'::interval, "time") >= '4714-11-24 00:00:00+00 BC'::timestamp with time zone)
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+                           ->  Seq Scan on _hyper_1_2_chunk
+                                 Filter: (time_bucket('@ 1 day'::interval, "time") >= '4714-11-24 00:00:00+00 BC'::timestamp with time zone)
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                           ->  Seq Scan on _hyper_1_3_chunk
+                                 Filter: (time_bucket('@ 1 day'::interval, "time") >= '4714-11-24 00:00:00+00 BC'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+               ->  Seq Scan on _hyper_1_2_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+               ->  Seq Scan on _hyper_1_3_chunk
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+               ->  Seq Scan on _hyper_1_2_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+               ->  Seq Scan on _hyper_1_3_chunk
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 2 days'::interval, metrics_realtime.bucket)
+   ->  Subquery Scan on metrics_realtime
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+                           ->  Seq Scan on _hyper_1_1_chunk
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+                           ->  Seq Scan on _hyper_1_2_chunk
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                           ->  Seq Scan on _hyper_1_3_chunk
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+               ->  Seq Scan on _hyper_1_2_chunk
+         ->  Partial HashAggregate
+               Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+               ->  Seq Scan on _hyper_1_3_chunk
+
+-- Caggs with entire data materialized
+CALL refresh_continuous_aggregate('metrics_realtime', NULL, NULL);
+CALL refresh_continuous_aggregate('metrics_realtime_h', NULL, NULL);
+CALL refresh_continuous_aggregate('metrics_matonly', NULL, NULL);
+RESET timescaledb.realtime_cagg_settings;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")))
+         ->  Result
+               ->  HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                     ->  Result
+                           ->  Seq Scan on _hyper_1_3_chunk
+                                 Filter: (("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_4_6_chunk
+
+SET timescaledb.realtime_cagg_settings = materialized_only;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_2_4_chunk
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_3_5_chunk
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_4_6_chunk
+
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")))
+         ->  Result
+               ->  HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                     ->  Result
+                           ->  Seq Scan on _hyper_1_3_chunk
+                                 Filter: (("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_4_6_chunk
+         Filter: (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone)
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, (time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")))
+         ->  Result
+               ->  HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                     ->  Result
+                           ->  Seq Scan on _hyper_1_3_chunk
+                                 Filter: (("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_4_6_chunk
+         Filter: (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone)
+
+-- Add new data above watermark
+INSERT INTO metrics(time, value, device_id) VALUES
+  ('2021-06-30', 23,1),
+  ('2021-06-30', 25,2),
+  ('2021-07-01', 30,1);
+-- Refresh "metrics_realtime", leave "metrics_realtime_h" unrefreshed
+CALL refresh_continuous_aggregate('metrics_realtime', NULL, NULL);
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_7_chunk
+                     Filter: ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, _hyper_2_4_chunk.bucket)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_2_4_chunk
+                           Filter: ((bucket < '2021-07-02 00:00:00+00'::timestamp with time zone) AND (bucket >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+                     ->  HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                           ->  Result
+                                 ->  Seq Scan on _hyper_1_7_chunk
+                                       Filter: (("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_7_chunk
+                     Filter: ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, _hyper_2_4_chunk.bucket)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_2_4_chunk
+                           Filter: ((bucket < '2021-07-02 00:00:00+00'::timestamp with time zone) AND (bucket >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+                     ->  HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                           ->  Result
+                                 ->  Seq Scan on _hyper_1_7_chunk
+                                       Filter: (("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+-- Backfill some data
+INSERT INTO metrics(time, value, device_id) VALUES
+  ('2021-06-15', 22,1),
+  ('2021-06-15', 23,2),
+  ('2021-06-20', 25,3),
+  ('2021-06-20', 30,4);
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_7_chunk
+                     Filter: ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, _hyper_2_4_chunk.bucket)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_2_4_chunk
+                           Filter: ((bucket < '2021-07-02 00:00:00+00'::timestamp with time zone) AND (bucket >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+                     ->  HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                           ->  Result
+                                 ->  Seq Scan on _hyper_1_7_chunk
+                                       Filter: (("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_4_6_chunk
+         Filter: (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                     ->  Seq Scan on _hyper_1_3_chunk
+                           Filter: ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone)
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                     ->  Seq Scan on _hyper_1_7_chunk
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: ((bucket < '2021-06-15 00:00:00+00'::timestamp with time zone) OR ((bucket >= '2021-06-16 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-06-20 00:00:00+00'::timestamp with time zone)) OR ((bucket >= '2021-06-21 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+                     ->  Seq Scan on _hyper_1_1_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+                     ->  Seq Scan on _hyper_1_2_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                     ->  Seq Scan on _hyper_1_7_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, _hyper_2_4_chunk.bucket)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_2_4_chunk
+                           Filter: ((bucket >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND ((bucket < '2021-06-15 00:00:00+00'::timestamp with time zone) OR ((bucket >= '2021-06-16 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-06-20 00:00:00+00'::timestamp with time zone)) OR ((bucket >= '2021-06-21 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone))))
+                     ->  HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                           ->  Result
+                                 ->  Seq Scan on _hyper_1_7_chunk
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_4_6_chunk
+         Filter: ((bucket < '2021-06-15 00:00:00+00'::timestamp with time zone) OR ((bucket >= '2021-06-16 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-06-20 00:00:00+00'::timestamp with time zone)) OR ((bucket >= '2021-06-21 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-06-28 00:00:00+00'::timestamp with time zone)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+                     ->  Seq Scan on _hyper_1_1_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+                     ->  Seq Scan on _hyper_1_2_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_3_chunk."time")
+                     ->  Seq Scan on _hyper_1_3_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                     ->  Seq Scan on _hyper_1_7_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-06-28 00:00:00+00'::timestamp with time zone))
+
+-- Push invalidated ranges into cagg tables
+CALL refresh_continuous_aggregate('metrics_matonly', NULL, NULL);
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: ((bucket < '2021-06-15 00:00:00+00'::timestamp with time zone) OR ((bucket >= '2021-06-16 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-06-20 00:00:00+00'::timestamp with time zone)) OR ((bucket >= '2021-06-21 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, metrics."time"))
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time")
+                     ->  Seq Scan on _hyper_1_1_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_2_chunk."time")
+                     ->  Seq Scan on _hyper_1_2_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                     ->  Seq Scan on _hyper_1_7_chunk
+                           Filter: ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_realtime_h;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, _hyper_2_4_chunk.bucket)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_2_4_chunk
+                           Filter: ((bucket >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND ((bucket < '2021-06-15 00:00:00+00'::timestamp with time zone) OR ((bucket >= '2021-06-16 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-06-20 00:00:00+00'::timestamp with time zone)) OR ((bucket >= '2021-06-21 00:00:00+00'::timestamp with time zone) AND (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone))))
+                     ->  HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                           ->  Result
+                                 ->  Seq Scan on _hyper_1_7_chunk
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND ((("time" >= '2021-06-15 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-16 00:00:00+00'::timestamp with time zone)) OR (("time" >= '2021-06-20 00:00:00+00'::timestamp with time zone) AND ("time" < '2021-06-21 00:00:00+00'::timestamp with time zone)) OR ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_4_6_chunk
+         Filter: (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_7_chunk
+                     Filter: ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)
+
+-- Allow only 1 invalidated range to be included: should revert to "realtime" mode from "realtime_with_backfills"
+SET timescaledb.cagg_max_individual_materializations = 1;
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+NOTICE:  Too many invalidated ranges: not including live backfilled data
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_2_4_chunk
+         Filter: (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_7_chunk
+                     Filter: ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)
+
+:PREFIX SELECT * from metrics_realtime_h;
+NOTICE:  Too many invalidated ranges: not including live backfilled data
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_3_5_chunk
+         Filter: (time_bucket < '2021-06-29 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 2 days'::interval, _hyper_2_4_chunk.bucket)
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_2_4_chunk
+                           Filter: ((bucket < '2021-07-02 00:00:00+00'::timestamp with time zone) AND (bucket >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+                     ->  HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+                           ->  Result
+                                 ->  Seq Scan on _hyper_1_7_chunk
+                                       Filter: (("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone) AND ("time" >= '2021-06-29 00:00:00+00'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") >= '2021-06-29 00:00:00+00'::timestamp with time zone))
+
+:PREFIX SELECT * from metrics_matonly;
+--- QUERY PLAN ---
+ Append
+   ->  Seq Scan on _hyper_4_6_chunk
+         Filter: (bucket < '2021-07-02 00:00:00+00'::timestamp with time zone)
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 day'::interval, _hyper_1_7_chunk."time")
+         ->  Result
+               ->  Seq Scan on _hyper_1_7_chunk
+                     Filter: ("time" >= '2021-07-02 00:00:00+00'::timestamp with time zone)
+
+RESET timescaledb.realtime_cagg_settings;
+DROP MATERIALIZED VIEW metrics_realtime_h cascade;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_5_chunk
+DROP MATERIALIZED VIEW metrics_realtime cascade;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_4_chunk
+DROP MATERIALIZED VIEW metrics_matonly cascade;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_6_chunk
+DROP TABLE metrics cascade;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -201,7 +201,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
-  list(APPEND TEST_FILES cagg_planning.sql cagg_rewrites.sql skip_scan_dagg.sql)
+  list(APPEND TEST_FILES cagg_planning.sql cagg_rewrites.sql skip_scan_dagg.sql
+       cagg_union_ondemand.sql)
   list(APPEND TEST_TEMPLATES plan_skip_scan_dagg.sql.in)
 endif()
 

--- a/tsl/test/sql/cagg_union_ondemand.sql
+++ b/tsl/test/sql/cagg_union_ondemand.sql
@@ -1,0 +1,158 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+SET datestyle TO 'ISO, YMD';
+SET timezone TO 'UTC';
+
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+
+CREATE TABLE metrics(time timestamptz NOT NULL, device_id int, value float);
+SELECT table_name FROM create_hypertable('metrics', 'time', chunk_time_interval => INTERVAL '7 days');
+
+INSERT INTO metrics(time, value, device_id) VALUES
+  ('2021-06-14', 26,1),
+  ('2021-06-15', 22,2),
+  ('2021-06-15', 21,1),
+  ('2021-06-16', 24,3),
+  ('2021-06-20', 24,4),
+  ('2021-06-18', 27,4),
+  ('2021-06-19', 28,4),
+  ('2021-06-25', 30,1),
+  ('2021-06-21', 31,1),
+  ('2021-06-22', 34,1),
+  ('2021-06-22', 34,2),
+  ('2021-06-24', 34,2),
+  ('2021-06-25', 32,3),
+  ('2021-06-26', 32,3),
+  ('2021-06-15', 23,1),
+  ('2021-06-17', 24,2),
+  ('2021-06-17', 21,3),
+  ('2021-06-27', 31,3);
+
+-- For stable plans
+SET enable_indexscan = 0;
+SET enable_bitmapscan = 0;
+
+:PREFIX SELECT * from metrics;
+
+-- check default view for new continuous aggregate
+CREATE MATERIALIZED VIEW metrics_realtime
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+  SELECT time_bucket('1d',time) as bucket, avg(value) as av FROM metrics GROUP BY 1 WITH NO DATA;
+
+CREATE MATERIALIZED VIEW metrics_realtime_h
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+  SELECT time_bucket('2d', bucket), avg(av) FROM metrics_realtime GROUP BY 1 WITH NO DATA;
+
+CREATE MATERIALIZED VIEW metrics_matonly
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time) as bucket, avg(value) as av FROM metrics GROUP BY 1 WITH NO DATA;
+
+-- Check settings for "realtime_cagg_settings"
+
+-- Caggs with no materialized data
+RESET timescaledb.realtime_cagg_settings;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = materialized_only;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+-- Caggs with entire data materialized
+CALL refresh_continuous_aggregate('metrics_realtime', NULL, NULL);
+CALL refresh_continuous_aggregate('metrics_realtime_h', NULL, NULL);
+CALL refresh_continuous_aggregate('metrics_matonly', NULL, NULL);
+
+RESET timescaledb.realtime_cagg_settings;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = materialized_only;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+-- Add new data above watermark
+INSERT INTO metrics(time, value, device_id) VALUES
+  ('2021-06-30', 23,1),
+  ('2021-06-30', 25,2),
+  ('2021-07-01', 30,1);
+
+-- Refresh "metrics_realtime", leave "metrics_realtime_h" unrefreshed
+CALL refresh_continuous_aggregate('metrics_realtime', NULL, NULL);
+
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+
+-- Backfill some data
+INSERT INTO metrics(time, value, device_id) VALUES
+  ('2021-06-15', 22,1),
+  ('2021-06-15', 23,2),
+  ('2021-06-20', 25,3),
+  ('2021-06-20', 30,4);
+
+SET timescaledb.realtime_cagg_settings = realtime;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+-- Push invalidated ranges into cagg tables
+CALL refresh_continuous_aggregate('metrics_matonly', NULL, NULL);
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+-- Allow only 1 invalidated range to be included: should revert to "realtime" mode from "realtime_with_backfills"
+SET timescaledb.cagg_max_individual_materializations = 1;
+
+SET timescaledb.realtime_cagg_settings = realtime_with_backfills;
+:PREFIX SELECT * from metrics_realtime;
+:PREFIX SELECT * from metrics_realtime_h;
+:PREFIX SELECT * from metrics_matonly;
+
+RESET timescaledb.realtime_cagg_settings;
+DROP MATERIALIZED VIEW metrics_realtime_h cascade;
+DROP MATERIALIZED VIEW metrics_realtime cascade;
+DROP MATERIALIZED VIEW metrics_matonly cascade;
+
+DROP TABLE metrics cascade;

--- a/tsl/test/sql/include/cagg_rewrites_materialize.sql
+++ b/tsl/test/sql/include/cagg_rewrites_materialize.sql
@@ -39,36 +39,3 @@ SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
 FROM conditions
 GROUP BY device_id, bucket
 ORDER BY 1, 2, 3;
-
--- Caggs with pending materialization ranges are not eligible.
--- Insert new row into hypertable, remove (cagg2) watermark and then refresh it.
--- It will create pending materialization range on (cagg2) as refresh will error out.
-SET timescaledb.cagg_rewrites_debug_info = 0;
-INSERT INTO conditions (day, city, temperature, device_id) VALUES
-  ('2021-06-16', 'Berlin', 23, 2);
-
-SELECT ca.mat_hypertable_id AS "CAGG2_ID", watermark AS "CAGG2_WATERMARK"
-FROM _timescaledb_catalog.continuous_agg ca INNER JOIN _timescaledb_catalog.continuous_aggs_watermark wm
-ON (ca.mat_hypertable_id = wm.mat_hypertable_id) WHERE user_view_name = 'cagg2';
-\gset
-
--- This will create pending materialization range
-\c :TEST_DBNAME :ROLE_SUPERUSER
-DELETE FROM _timescaledb_catalog.continuous_aggs_watermark WHERE mat_hypertable_id = :CAGG2_ID;
-\set ON_ERROR_STOP 0
-CALL refresh_continuous_aggregate('cagg2', NULL, NULL);
-\set ON_ERROR_STOP 1
-
--- Restore deleted watermark so that we can query (cagg2) again
-INSERT INTO _timescaledb_catalog.continuous_aggs_watermark values(:CAGG2_ID, :CAGG2_WATERMARK);
-
-SET timescaledb.cagg_rewrites_debug_info = 1;
-SELECT time_bucket(INTERVAL '2 day', day) AS bucket,
-   count(device_id)
-FROM conditions
-GROUP BY bucket
-ORDER BY 1, 2
-LIMIT 3;
-
--- cleanup materialization ranges
-TRUNCATE TABLE _timescaledb_catalog.continuous_aggs_materialization_ranges;


### PR DESCRIPTION
Implement on-demand realtime Caggs to address timescale/eng-database#810.

Added new GUC `ts_guc_realtime_cagg_settings` to toggle realtime Cagg mode:

- **CAGG_VIEW**: use DDL Cagg view `materialized_only` settings, this is the default.
- **MATERIALIZED_ONLY**: provide only materialized portion of Cagg on-demand.
- **REALTIME**: provide `materialized_only = false` Cagg data on-demand, i.e. materialized data + data above watermark.
- **REALTIME_WITH_BACKFILLS**:  provide materialized data + data above watermark + backfilled data in invalidated ranges up to `ts_guc_cagg_max_individual_materializations` ranges. If there are too many invalidated ranges output NOTICE and fall back to **REALTIME** (? unless we want something else?)

FOR **REALTIME_WITH_BACKFILLS** mode we collect `(low, high)` bounds for invalidated ranges for a given Cagg and then `OR` them together with the watermark qual and add it to realtime UNION ALL quals.

TODO:
- [ ] Add unit tests.
- [ ] Address prepared statements with preplanned qual boundaries (probably should use custom plans with realtime Caggs?) 

