### PR TITLE
Fix segfault when using OLD/NEW refs in RETURNING clause on PG18

### DIFF
--- a/.unreleased/pr_9321
+++ b/.unreleased/pr_9321
@@ -1,0 +1,2 @@
+Fixes: #9321 Fix segfault when using OLD/NEW refs in RETURNING clause on PG18
+Thanks: @flaviofernandes004 for reporting an issue with RETURNING clause and references to OLD/NEW

--- a/test/expected/insert_returning_old_new.out
+++ b/test/expected/insert_returning_old_new.out
@@ -1,0 +1,67 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test OLD/NEW references in RETURNING clause (PG18+ feature)
+CREATE TABLE ht_returning(
+    time timestamptz NOT NULL,
+    value int NOT NULL,
+    UNIQUE(time)
+) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- Insert initial rows
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-01', 10);
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-02', 20);
+-- Test 1: INSERT ON CONFLICT DO UPDATE with RETURNING OLD.col, NEW.col
+-- This should show the old value (10) and the new value (100)
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-01', 100)
+ON CONFLICT (time) DO UPDATE SET value = EXCLUDED.value
+RETURNING OLD.value AS old_val, NEW.value AS new_val;
+ old_val | new_val 
+---------+---------
+      10 |     100
+
+-- Test 2: INSERT ON CONFLICT DO UPDATE with RETURNING arithmetic on OLD/NEW
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-02', 50)
+ON CONFLICT (time) DO UPDATE SET value = EXCLUDED.value
+RETURNING OLD.value AS old_val, NEW.value AS new_val, NEW.value - OLD.value AS diff;
+ old_val | new_val | diff 
+---------+---------+------
+      20 |      50 |   30
+
+-- Test 3: Plain INSERT with RETURNING NEW.col (OLD should be NULL for fresh inserts)
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-03', 30)
+RETURNING OLD.value AS old_val, NEW.value AS new_val;
+ old_val | new_val 
+---------+---------
+         |      30
+
+-- Test 4: MERGE with both UPDATE and INSERT paths, returning OLD/NEW values and merge_action()
+CREATE TABLE t1(time timestamptz NOT NULL, value int NOT NULL);
+INSERT INTO t1(time, value) VALUES ('2024-01-01', 5);   -- Will trigger UPDATE (existing row)
+INSERT INTO t1(time, value) VALUES ('2024-01-05', 10);   -- Will trigger INSERT (new row)
+MERGE INTO ht_returning AS t
+USING t1 AS s
+ON t.time = s.time
+WHEN MATCHED THEN
+    UPDATE SET
+        value = t.value + s.value
+WHEN NOT MATCHED THEN
+    INSERT (time, value)
+    VALUES (s.time, s.value)
+RETURNING NEW.time, NEW.value, t.value, OLD.value, s.value, merge_action();
+             time             | value | value | value | value | merge_action 
+------------------------------+-------+-------+-------+-------+--------------
+ Mon Jan 01 00:00:00 2024 PST |   105 |   105 |   100 |     5 | UPDATE
+ Fri Jan 05 00:00:00 2024 PST |    10 |    10 |       |    10 | INSERT
+
+-- Verify final state
+SELECT * FROM ht_returning ORDER BY time;
+             time             | value 
+------------------------------+-------
+ Mon Jan 01 00:00:00 2024 PST |   105
+ Tue Jan 02 00:00:00 2024 PST |    50
+ Wed Jan 03 00:00:00 2024 PST |    30
+ Fri Jan 05 00:00:00 2024 PST |    10
+
+-- Cleanup
+DROP TABLE ht_returning;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -128,6 +128,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))
   list(APPEND TEST_FILES tableam_alter_defaults.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "18"))
+  list(APPEND TEST_FILES insert_returning_old_new.sql)
+endif()
+
 # pg_dump_unprivileged.sql was fixed by an upstream change to pg_dump in 15.6,
 # and 16.2
 if(((${PG_VERSION_MAJOR} EQUAL "15") AND (${PG_VERSION_MINOR} GREATER_EQUAL "6")

--- a/test/sql/insert_returning_old_new.sql
+++ b/test/sql/insert_returning_old_new.sql
@@ -1,0 +1,52 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Test OLD/NEW references in RETURNING clause (PG18+ feature)
+
+CREATE TABLE ht_returning(
+    time timestamptz NOT NULL,
+    value int NOT NULL,
+    UNIQUE(time)
+) WITH (tsdb.hypertable);
+
+-- Insert initial rows
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-01', 10);
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-02', 20);
+
+-- Test 1: INSERT ON CONFLICT DO UPDATE with RETURNING OLD.col, NEW.col
+-- This should show the old value (10) and the new value (100)
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-01', 100)
+ON CONFLICT (time) DO UPDATE SET value = EXCLUDED.value
+RETURNING OLD.value AS old_val, NEW.value AS new_val;
+
+-- Test 2: INSERT ON CONFLICT DO UPDATE with RETURNING arithmetic on OLD/NEW
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-02', 50)
+ON CONFLICT (time) DO UPDATE SET value = EXCLUDED.value
+RETURNING OLD.value AS old_val, NEW.value AS new_val, NEW.value - OLD.value AS diff;
+
+-- Test 3: Plain INSERT with RETURNING NEW.col (OLD should be NULL for fresh inserts)
+INSERT INTO ht_returning(time, value) VALUES ('2024-01-03', 30)
+RETURNING OLD.value AS old_val, NEW.value AS new_val;
+
+-- Test 4: MERGE with both UPDATE and INSERT paths, returning OLD/NEW values and merge_action()
+CREATE TABLE t1(time timestamptz NOT NULL, value int NOT NULL);
+INSERT INTO t1(time, value) VALUES ('2024-01-01', 5);   -- Will trigger UPDATE (existing row)
+INSERT INTO t1(time, value) VALUES ('2024-01-05', 10);   -- Will trigger INSERT (new row)
+
+MERGE INTO ht_returning AS t
+USING t1 AS s
+ON t.time = s.time
+WHEN MATCHED THEN
+    UPDATE SET
+        value = t.value + s.value
+WHEN NOT MATCHED THEN
+    INSERT (time, value)
+    VALUES (s.time, s.value)
+RETURNING NEW.time, NEW.value, t.value, OLD.value, s.value, merge_action();
+
+-- Verify final state
+SELECT * FROM ht_returning ORDER BY time;
+
+-- Cleanup
+DROP TABLE ht_returning;


### PR DESCRIPTION
PostgreSQL 18 added OLD/NEW references in RETURNING clauses. The forked
executor in modify_hypertable_exec.c did not set ecxt_oldtuple/
ecxt_newtuple or manage EEO_FLAG_* flags, causing NULL pointer
dereferences when RETURNING references OLD or NEW.

Update ExecProcessReturning to accept cmdType/oldSlot/newSlot on all PG
versions (pre-PG18 derives the legacy tupleSlot from them) and add the
OLD/NEW tuple setup behind a single PG18_GE block.  Add an oldSlot
parameter to ExecUpdate and materialize the returning slot in
ExecOnConflictUpdate before clearing the existing tuple.

Fixes #9319
