### PR TITLE
Second set of changes to support composite bloom filters

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -67,6 +67,7 @@ jobs:
           columnar_scan_cost
           compress_bloom_sparse_compat
           compress_bloom_sparse_debug
+          compress_composite_bloom_debug
           compress_qualpushdown_saop
           compress_sort_transform
           compression_allocation

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -86,6 +86,7 @@ jobs:
         chunk_adaptive
         compress_bloom_sparse_compat
         compress_bloom_sparse_debug
+        compress_composite_bloom_debug
         compress_qualpushdown_saop
         compress_sort_transform
         compression_algos

--- a/src/guc.c
+++ b/src/guc.c
@@ -107,7 +107,7 @@ TSDLLEXPORT bool ts_guc_enable_compression_indexscan = false;
 TSDLLEXPORT bool ts_guc_enable_bulk_decompression = true;
 TSDLLEXPORT bool ts_guc_auto_sparse_indexes = true;
 TSDLLEXPORT bool ts_guc_enable_sparse_index_bloom = true;
-
+TSDLLEXPORT bool ts_guc_enable_composite_bloom_indexes = true;
 TSDLLEXPORT bool ts_guc_read_legacy_bloom1_v1 = false;
 
 bool ts_guc_enable_chunk_skipping = false;
@@ -1160,6 +1160,18 @@ _guc_init(void)
 							 "This sparse index speeds up the equality queries on compressed "
 							 "columns, and can be disabled when not desired.",
 							 &ts_guc_enable_sparse_index_bloom,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_composite_bloom_indexes"),
+							 "Enable creation of the bloom1 composite index on compressed chunks",
+							 "This composite index speeds up the equality queries on compressed "
+							 "columns, and can be disabled when not desired.",
+							 &ts_guc_enable_composite_bloom_indexes,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -108,6 +108,7 @@ extern TSDLLEXPORT bool ts_guc_enable_compression_indexscan;
 extern TSDLLEXPORT bool ts_guc_enable_bulk_decompression;
 extern TSDLLEXPORT bool ts_guc_auto_sparse_indexes;
 extern TSDLLEXPORT bool ts_guc_enable_sparse_index_bloom;
+extern TSDLLEXPORT bool ts_guc_enable_composite_bloom_indexes;
 extern TSDLLEXPORT bool ts_guc_read_legacy_bloom1_v1;
 extern TSDLLEXPORT bool ts_guc_enable_columnarscan;
 extern TSDLLEXPORT bool ts_guc_enable_columnarindexscan;

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -494,17 +494,11 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 		if (num_columns > 1 && config.type == _SparseIndexTypeEnumBloom)
 		{
 			/* This will be enabled once all composite bloom index functionality is rolled out */
-#if 0
 			if (!ts_guc_enable_composite_bloom_indexes)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("composite bloom indexes are disabled"),
 						 errhint("Set timescaledb.enable_composite_bloom_indexes = true")));
-#else
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("composite bloom indexes are not supported")));
-#endif
 
 			if (num_columns > MAX_BLOOM_FILTER_COLUMNS)
 				ereport(ERROR,

--- a/tsl/src/compression/batch_metadata_builder.h
+++ b/tsl/src/compression/batch_metadata_builder.h
@@ -5,20 +5,52 @@
  */
 #pragma once
 
+#include <postgres.h>
+#include "funcapi.h" /* for PGFunction, FmgrInfo */
+
 typedef struct RowCompressor RowCompressor;
+
+enum BatchMetadataBuilderType
+{
+	METADATA_BUILDER_MINMAX,
+	METADATA_BUILDER_BLOOM1,
+};
 
 typedef struct BatchMetadataBuilder
 {
-	void (*update_val)(void *builder, Datum val);
-	void (*update_null)(void *builder);
-
+	void (*update_row)(void *builder, TupleTableSlot *slot);
 	void (*insert_to_compressed_row)(void *builder, RowCompressor *compressor);
-
 	void (*reset)(void *builder, RowCompressor *compressor);
+	enum BatchMetadataBuilderType builder_type;
 } BatchMetadataBuilder;
 
 BatchMetadataBuilder *batch_metadata_builder_minmax_create(Oid type, Oid collation,
-														   int min_attr_offset,
+														   AttrNumber attnum, int min_attr_offset,
 														   int max_attr_offset);
 
-BatchMetadataBuilder *batch_metadata_builder_bloom1_create(Oid type, int bloom_attr_offset);
+BatchMetadataBuilder *batch_metadata_builder_bloom1_create(int num_columns, const Oid *type_oids,
+														   const AttrNumber *attnums,
+														   int bloom_attr_offset);
+
+/* Hasher interface common to bloom filters, used to compute the hash without updating the bloom
+ * filter */
+typedef struct Bloom1Hasher
+{
+	uint64 (*hash_values)(void *hasher, const NullableDatum *values);
+	int num_columns;
+} Bloom1Hasher;
+
+Bloom1Hasher *bloom1_hasher_create(const Oid *type_oids, int num_columns);
+
+/* Shared utilities between metadata builders */
+int batch_metadata_builder_bloom1_varlena_size(void);
+uint64 batch_metadata_builder_bloom1_calculate_hash(PGFunction hash_function, FmgrInfo *finfo,
+													Datum needle);
+void batch_metadata_builder_bloom1_update_bloom_filter_with_hash(void *varlena_ptr, uint64 hash);
+void batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(void *bloom_varlena,
+																		 int16 bloom_attr_offset,
+																		 RowCompressor *compressor);
+
+/* Returns true if the hash is maybe present in a bloom filter, if the bloom filter data is
+ * NULL, it returns true, because we cannot be sure if the hash is present or not. */
+extern bool bloom1_contains_hash(Datum bloom_datum, uint64 hash);

--- a/tsl/src/compression/batch_metadata_builder_bloom1.c
+++ b/tsl/src/compression/batch_metadata_builder_bloom1.c
@@ -18,6 +18,7 @@
 
 #include "arrow_c_data_interface.h"
 #include "batch_metadata_builder.h"
+#include "city_combine.h"
 #include "compression.h"
 #include "guc.h"
 
@@ -44,18 +45,31 @@
  */
 #define BLOOM1_BLOCK_BITS 256
 
+/* The NULL marker is used to preserve NULLs in the composite hash. The value is coming from Golden
+ * ratio constant so it is unlikely to degrade the collision resistance of the bloom filter.
+ * The purpose of the NULL marker is two fold: 1) to distinguish NULLs from actual values so
+ * we don't get the same hash for ('foo',NULL) and (NULL, 'foo') and 2) with having a specific
+ * marker, we can support IS NULL predicates on columns in addition to equality.
+ * */
+#define NULL_MARKER 0x9E3779B97F4A7C15ULL
+typedef struct Bloom1HasherInternal
+{
+	Bloom1Hasher functions;
+	PGFunction hash_functions[MAX_BLOOM_FILTER_COLUMNS];
+	FmgrInfo *hash_function_finfos[MAX_BLOOM_FILTER_COLUMNS];
+} Bloom1HasherInternal;
+
 typedef struct Bloom1MetadataBuilder
 {
 	BatchMetadataBuilder functions;
-
 	int16 bloom_attr_offset;
-
 	int allocated_varlena_bytes;
 	struct varlena *bloom_varlena;
-
-	PGFunction hash_function;
-	FmgrInfo *hash_function_finfo;
+	AttrNumber input_columns[MAX_BLOOM_FILTER_COLUMNS];
+	Bloom1HasherInternal hasher;
 } Bloom1MetadataBuilder;
+
+static void bloom1_hasher_init(Bloom1HasherInternal *hasher, const Oid *type_oids, int num_columns);
 
 /*
  * Low-bias invertible hash function from this article:
@@ -193,18 +207,10 @@ bloom1_get_hash_function(Oid type, FmgrInfo **finfo)
 }
 
 static void
-bloom1_update_null(void *builder_)
-{
-	/*
-	 * A null value cannot match an equality condition that we're optimizing
-	 * with bloom filters, so we don't need to consider them here.
-	 */
-}
-
-static void
 bloom1_reset(void *builder_, RowCompressor *compressor)
 {
 	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
+	Assert(builder->functions.builder_type == METADATA_BUILDER_BLOOM1);
 
 	struct varlena *bloom = builder->bloom_varlena;
 	memset(bloom, 0, builder->allocated_varlena_bytes);
@@ -226,11 +232,12 @@ bloom1_num_bits(const struct varlena *bloom)
 	return 8 * VARSIZE_ANY_EXHDR(bloom);
 }
 
-static void
-bloom1_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+void
+batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(void *bloom_varlena,
+																	int16 bloom_attr_offset,
+																	RowCompressor *compressor)
 {
-	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
-	struct varlena *bloom = builder->bloom_varlena;
+	struct varlena *bloom = (struct varlena *) bloom_varlena;
 	char *restrict words_buf = bloom1_words_buf(bloom);
 
 	const int orig_num_bits = bloom1_num_bits(bloom);
@@ -250,8 +257,8 @@ bloom1_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
 		 * but technically possible, and the following calculations will
 		 * segfault in this case.
 		 */
-		compressor->compressed_is_null[builder->bloom_attr_offset] = true;
-		compressor->compressed_values[builder->bloom_attr_offset] = PointerGetDatum(NULL);
+		compressor->compressed_is_null[bloom_attr_offset] = true;
+		compressor->compressed_values[bloom_attr_offset] = PointerGetDatum(NULL);
 		return;
 	}
 
@@ -313,15 +320,25 @@ bloom1_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
 	Assert(bloom1_num_bits(bloom) % (sizeof(*words_buf) * 8) == 0);
 	Assert(bloom1_num_bits(bloom) % 64 == 0);
 
-	compressor->compressed_is_null[builder->bloom_attr_offset] = false;
-	compressor->compressed_values[builder->bloom_attr_offset] = PointerGetDatum(bloom);
+	compressor->compressed_is_null[bloom_attr_offset] = false;
+	compressor->compressed_values[bloom_attr_offset] = PointerGetDatum(bloom);
+}
+
+static void
+bloom1_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+{
+	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
+	batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(builder->bloom_varlena,
+																		builder->bloom_attr_offset,
+																		compressor);
 }
 
 /*
  * Call a hash function that uses a postgres "extended hash" signature.
  */
-static inline uint64
-calculate_hash(PGFunction hash_function, FmgrInfo *finfo, Datum needle)
+uint64
+batch_metadata_builder_bloom1_calculate_hash(PGFunction hash_function, FmgrInfo *finfo,
+											 Datum needle)
 {
 	LOCAL_FCINFO(hashfcinfo, 2);
 	*hashfcinfo = (FunctionCallInfoBaseData){ 0 };
@@ -369,13 +386,14 @@ bloom1_get_one_offset(uint64 value_hash, uint32 index)
 	return low + (index * high + index * index) % BLOOM1_BLOCK_BITS;
 }
 
-static void
-bloom1_update_val(void *builder_, Datum needle)
+void
+batch_metadata_builder_bloom1_update_bloom_filter_with_hash(void *varlena_ptr, uint64 hash)
 {
-	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
+	Assert(varlena_ptr != NULL);
+	struct varlena *bloom_varlena = (struct varlena *) varlena_ptr;
 
-	char *restrict words_buf = bloom1_words_buf(builder->bloom_varlena);
-	const uint32 num_bits = bloom1_num_bits(builder->bloom_varlena);
+	char *restrict words_buf = bloom1_words_buf(bloom_varlena);
+	const uint32 num_bits = bloom1_num_bits(bloom_varlena);
 
 	/*
 	 * These calculations are a little inconvenient, but I had to switch to
@@ -390,16 +408,68 @@ bloom1_update_val(void *builder_, Datum needle)
 	const uint32 word_mask = num_word_bits - 1;
 	Assert((word_mask >> num_word_bits) == 0);
 
-	const uint64 datum_hash_1 =
-		calculate_hash(builder->hash_function, builder->hash_function_finfo, needle);
 	const uint32 absolute_mask = num_bits - 1;
 	for (int i = 0; i < BLOOM1_HASHES; i++)
 	{
-		const uint32 absolute_bit_index = bloom1_get_one_offset(datum_hash_1, i) & absolute_mask;
+		const uint32 absolute_bit_index = bloom1_get_one_offset(hash, i) & absolute_mask;
 		const uint32 word_index = absolute_bit_index >> log2_word_bits;
 		const uint32 word_bit_index = absolute_bit_index & word_mask;
 		words_buf[word_index] |= 1ULL << word_bit_index;
 	}
+}
+
+static uint64
+bloom1_hash_values(void *hasher_, const NullableDatum *values)
+{
+	Bloom1HasherInternal *hasher = (Bloom1HasherInternal *) hasher_;
+	int num_columns = hasher->functions.num_columns;
+
+	uint64 accumulated = 0;
+
+	if (values[0].isnull)
+		accumulated = NULL_MARKER;
+	else
+		accumulated = batch_metadata_builder_bloom1_calculate_hash(hasher->hash_functions[0],
+																   hasher->hash_function_finfos[0],
+																   values[0].value);
+
+	for (int i = 1; i < num_columns; i++)
+	{
+		if (values[i].isnull)
+		{
+			accumulated = city_hash_combine(accumulated, NULL_MARKER);
+		}
+		else
+		{
+			uint64 h = batch_metadata_builder_bloom1_calculate_hash(hasher->hash_functions[i],
+																	hasher->hash_function_finfos[i],
+																	values[i].value);
+			accumulated = city_hash_combine(accumulated, h);
+		}
+	}
+
+	return accumulated;
+}
+
+static void
+bloom1_update_row(void *builder_, TupleTableSlot *slot)
+{
+	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
+	Bloom1Hasher *hasher = &builder->hasher.functions;
+	int num_columns = hasher->num_columns;
+	NullableDatum values[MAX_BLOOM_FILTER_COLUMNS];
+
+	for (int i = 0; i < num_columns; i++)
+	{
+		values[i].value = slot_getattr(slot, builder->input_columns[i], &values[i].isnull);
+	}
+
+	/* For single-column blooms, skip NULLs to match old bloom1_update_null (no-op) behavior. */
+	if (num_columns == 1 && values[0].isnull)
+		return;
+
+	uint64 hash = hasher->hash_values(hasher, values);
+	batch_metadata_builder_bloom1_update_bloom_filter_with_hash(builder->bloom_varlena, hash);
 }
 
 /*
@@ -407,9 +477,6 @@ bloom1_update_val(void *builder_, Datum needle)
  */
 typedef struct Bloom1ContainsContext
 {
-	PGFunction hash_function_pointer;
-	FmgrInfo *hash_function_finfo;
-
 	Oid element_type;
 	int16 element_typlen;
 	bool element_typbyval;
@@ -417,6 +484,8 @@ typedef struct Bloom1ContainsContext
 
 	/* This is per-row, here for convenience. */
 	struct varlena *current_row_bloom;
+
+	Bloom1HasherInternal bloom_hasher;
 } Bloom1ContainsContext;
 
 static Bloom1ContainsContext *
@@ -437,21 +506,35 @@ bloom1_contains_context_prepare(FunctionCallInfo fcinfo, bool use_element_type)
 				   "cannot determine array element type for bloom1_contains_any");
 		}
 
-		context->hash_function_pointer =
-			bloom1_get_hash_function(context->element_type, &context->hash_function_finfo);
+		Oid type_oids[MAX_BLOOM_FILTER_COLUMNS];
+		int num_columns;
 
-		/*
-		 * Technically this function is callable by user with arbitrary argument
-		 * that might not have an extended hash function, so report this error
-		 * gracefully.
-		 */
-		if (context->hash_function_pointer == NULL)
+		if (context->element_type == RECORDOID)
 		{
-			ereport(ERROR,
-					(errcode(ERRCODE_DATA_EXCEPTION),
-					 errmsg("the argument type %s lacks an extended hash function",
-							format_type_be(context->element_type))));
+			HeapTupleHeader tuple = DatumGetHeapTupleHeader(PG_GETARG_DATUM(1));
+			Oid tupType = HeapTupleHeaderGetTypeId(tuple);
+			int32 tupTypmod = HeapTupleHeaderGetTypMod(tuple);
+			TupleDesc tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+
+			num_columns = tupdesc->natts;
+			if (num_columns > MAX_BLOOM_FILTER_COLUMNS)
+				ereport(ERROR,
+						(errcode(ERRCODE_DATA_EXCEPTION),
+						 errmsg("composite bloom filter supports at most %d columns, got %d",
+								MAX_BLOOM_FILTER_COLUMNS,
+								num_columns)));
+
+			for (int i = 0; i < num_columns; i++)
+				type_oids[i] = TupleDescAttr(tupdesc, i)->atttypid;
+			ReleaseTupleDesc(tupdesc);
 		}
+		else
+		{
+			type_oids[0] = context->element_type;
+			num_columns = 1;
+		}
+
+		bloom1_hasher_init(&context->bloom_hasher, type_oids, num_columns);
 
 		get_typlenbyvalalign(context->element_type,
 							 &context->element_typlen,
@@ -471,6 +554,39 @@ bloom1_contains_context_prepare(FunctionCallInfo fcinfo, bool use_element_type)
 	}
 
 	return context;
+}
+
+static inline bool
+bloom1_contains_hash_internal(const char *words_buf, uint32 num_bits, uint64 hash)
+{
+	Assert(words_buf != NULL);
+
+	/* Must be a power of two. */
+	CheckCompressedData(num_bits == (1ULL << pg_leftmost_one_pos32(num_bits)));
+
+	/* Must be >= 64 bits. */
+	CheckCompressedData(num_bits >= 64);
+
+	const uint32 num_word_bits = sizeof(*words_buf) * 8;
+	Assert(num_bits % num_word_bits == 0);
+	const uint32 log2_word_bits = pg_leftmost_one_pos32(num_word_bits);
+	Assert(num_word_bits == (1ULL << log2_word_bits));
+
+	const uint32 word_mask = num_word_bits - 1;
+	Assert((word_mask >> num_word_bits) == 0);
+
+	const uint32 absolute_mask = num_bits - 1;
+	for (int i = 0; i < BLOOM1_HASHES; i++)
+	{
+		const uint32 absolute_bit_index = bloom1_get_one_offset(hash, i) & absolute_mask;
+		const uint32 word_index = absolute_bit_index >> log2_word_bits;
+		const uint32 word_bit_index = absolute_bit_index & word_mask;
+		if ((words_buf[word_index] & (1ULL << word_bit_index)) == 0)
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 /*
@@ -503,41 +619,24 @@ bloom1_contains(PG_FUNCTION_ARGS)
 		PG_RETURN_BOOL(false);
 	}
 
-	/*
-	 * Compute the bloom filter parameters.
-	 */
-	const char *words_buf = bloom1_words_buf(bloom);
-	const uint32 num_bits = bloom1_num_bits(bloom);
+	uint64 hash = 0;
+	NullableDatum values[MAX_BLOOM_FILTER_COLUMNS];
+	memset(values, 0, sizeof(values));
 
-	/* Must be a power of two. */
-	CheckCompressedData(num_bits == (1ULL << pg_leftmost_one_pos32(num_bits)));
-
-	/* Must be >= 64 bits. */
-	CheckCompressedData(num_bits >= 64);
-
-	const uint32 num_word_bits = sizeof(*words_buf) * 8;
-	Assert(num_bits % num_word_bits == 0);
-	const uint32 log2_word_bits = pg_leftmost_one_pos32(num_word_bits);
-	Assert(num_word_bits == (1ULL << log2_word_bits));
-
-	const uint32 word_mask = num_word_bits - 1;
-	Assert((word_mask >> num_word_bits) == 0);
-
-	Datum needle = PG_GETARG_DATUM(1);
-	const uint64 datum_hash_1 =
-		calculate_hash(context->hash_function_pointer, context->hash_function_finfo, needle);
-	const uint32 absolute_mask = num_bits - 1;
-	for (int i = 0; i < BLOOM1_HASHES; i++)
+	if (context->bloom_hasher.functions.num_columns > 1)
 	{
-		const uint32 absolute_bit_index = bloom1_get_one_offset(datum_hash_1, i) & absolute_mask;
-		const uint32 word_index = absolute_bit_index >> log2_word_bits;
-		const uint32 word_bit_index = absolute_bit_index & word_mask;
-		if ((words_buf[word_index] & (1ULL << word_bit_index)) == 0)
-		{
-			PG_RETURN_BOOL(false);
-		}
+		HeapTupleHeader tuple = DatumGetHeapTupleHeader(PG_GETARG_DATUM(1));
+		for (int i = 0; i < context->bloom_hasher.functions.num_columns; i++)
+			values[i].value = GetAttributeByNum(tuple, i + 1, &values[i].isnull);
 	}
-	PG_RETURN_BOOL(true);
+	else
+	{
+		values[0].value = PG_GETARG_DATUM(1);
+		values[0].isnull = false;
+	}
+
+	hash = bloom1_hash_values(&context->bloom_hasher, values);
+	PG_RETURN_BOOL(bloom1_contains_hash(PointerGetDatum(bloom), hash));
 }
 
 #define ST_SORT sort_hashes
@@ -607,8 +706,8 @@ bloom1_contains_any(PG_FUNCTION_ARGS)
 	uint64 *item_base_hashes = palloc(sizeof(uint64) * num_items);
 #endif
 
-	FmgrInfo *finfo = context->hash_function_finfo;
-	PGFunction hash_fn = context->hash_function_pointer;
+	FmgrInfo *finfo = context->bloom_hasher.hash_function_finfos[0];
+	PGFunction hash_fn = context->bloom_hasher.hash_functions[0];
 
 	int valid = 0;
 	for (int i = 0; i < num_items; i++)
@@ -621,7 +720,8 @@ bloom1_contains_any(PG_FUNCTION_ARGS)
 			continue;
 		}
 
-		item_base_hashes[valid++] = calculate_hash(hash_fn, finfo, items[i]);
+		item_base_hashes[valid++] =
+			batch_metadata_builder_bloom1_calculate_hash(hash_fn, finfo, items[i]);
 	}
 
 	if (valid == 0)
@@ -701,8 +801,8 @@ bloom1_varlena_alloc_size(uint32 num_bits)
 	return VARHDRSZ + num_bits / 8;
 }
 
-BatchMetadataBuilder *
-batch_metadata_builder_bloom1_create(Oid type_oid, int bloom_attr_offset)
+int
+batch_metadata_builder_bloom1_varlena_size(void)
 {
 	/*
 	 * Better make the bloom filter size a power of two, because we compress the
@@ -719,29 +819,65 @@ batch_metadata_builder_bloom1_create(Oid type_oid, int bloom_attr_offset)
 	Assert(lowest_power < 32);
 
 	const int desired_bits = 1ULL << lowest_power;
-	const int varlena_bytes = bloom1_varlena_alloc_size(desired_bits);
+	return bloom1_varlena_alloc_size(desired_bits);
+}
+
+static void
+bloom1_hasher_init(Bloom1HasherInternal *hasher, const Oid *type_oids, int num_columns)
+{
+	*hasher = (Bloom1HasherInternal){
+		.functions =
+			(Bloom1Hasher){
+				.hash_values = bloom1_hash_values,
+				.num_columns = num_columns,
+			},
+	};
+
+	for (int i = 0; i < num_columns; i++)
+	{
+		hasher->hash_functions[i] =
+			bloom1_get_hash_function(type_oids[i], &hasher->hash_function_finfos[i]);
+		if (hasher->hash_functions[i] == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("the argument type %s lacks an extended hash function",
+							format_type_be(type_oids[i]))));
+	}
+}
+
+Bloom1Hasher *
+bloom1_hasher_create(const Oid *type_oids, int num_columns)
+{
+	Bloom1HasherInternal *hasher = palloc(sizeof(*hasher));
+	bloom1_hasher_init(hasher, type_oids, num_columns);
+	return &hasher->functions;
+}
+
+BatchMetadataBuilder *
+batch_metadata_builder_bloom1_create(int num_columns, const Oid *type_oids,
+									 const AttrNumber *attnums, int bloom_attr_offset)
+{
+	Assert(num_columns >= 1 && num_columns <= MAX_BLOOM_FILTER_COLUMNS);
+
+	const int varlena_bytes = batch_metadata_builder_bloom1_varlena_size();
 
 	Bloom1MetadataBuilder *builder = palloc(sizeof(*builder));
 	*builder = (Bloom1MetadataBuilder){
 		.functions =
 			(BatchMetadataBuilder){
-				.update_val = bloom1_update_val,
-				.update_null = bloom1_update_null,
+				.update_row = bloom1_update_row,
 				.insert_to_compressed_row = bloom1_insert_to_compressed_row,
 				.reset = bloom1_reset,
+				.builder_type = METADATA_BUILDER_BLOOM1,
 			},
 		.bloom_attr_offset = bloom_attr_offset,
 		.allocated_varlena_bytes = varlena_bytes,
 	};
 
-	builder->hash_function = bloom1_get_hash_function(type_oid, &builder->hash_function_finfo);
-	if (builder->hash_function == NULL)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("the argument type %s lacks an extended hash function",
-						format_type_be(type_oid))));
-	}
+	memcpy(builder->input_columns, attnums, num_columns * sizeof(AttrNumber));
+
+	/* Initialize the embedded hasher */
+	bloom1_hasher_init(&builder->hasher, type_oids, num_columns);
 
 	/*
 	 * Initialize the bloom filter.
@@ -862,9 +998,64 @@ ts_bloom1_debug_hash(PG_FUNCTION_ARGS)
 
 	Assert(!PG_ARGISNULL(0));
 	Datum needle = PG_GETARG_DATUM(0);
-	PG_RETURN_UINT64(calculate_hash(fn, finfo, needle));
+	PG_RETURN_UINT64(batch_metadata_builder_bloom1_calculate_hash(fn, finfo, needle));
+}
+
+TS_FUNCTION_INFO_V1(ts_bloom1_composite_debug_hash);
+
+Datum
+ts_bloom1_composite_debug_hash(PG_FUNCTION_ARGS)
+{
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	HeapTupleHeader tuple = DatumGetHeapTupleHeader(PG_GETARG_DATUM(0));
+	Oid tupType = HeapTupleHeaderGetTypeId(tuple);
+	int32 tupTypmod = HeapTupleHeaderGetTypMod(tuple);
+	TupleDesc tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+
+	int num_fields = tupdesc->natts;
+	if (num_fields < 2 || num_fields > MAX_BLOOM_FILTER_COLUMNS)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("composite bloom requires 2-%d fields, got %d",
+						MAX_BLOOM_FILTER_COLUMNS,
+						num_fields)));
+
+	Oid type_oids[MAX_BLOOM_FILTER_COLUMNS];
+	for (int i = 0; i < num_fields; i++)
+		type_oids[i] = TupleDescAttr(tupdesc, i)->atttypid;
+	ReleaseTupleDesc(tupdesc);
+
+	Bloom1Hasher *hasher = bloom1_hasher_create(type_oids, num_fields);
+
+	NullableDatum values[MAX_BLOOM_FILTER_COLUMNS];
+	for (int i = 0; i < num_fields; i++)
+		values[i].value = GetAttributeByNum(tuple, i + 1, &values[i].isnull);
+
+	uint64 hash = hasher->hash_values(hasher, values);
+	PG_RETURN_INT64((int64) hash);
 }
 
 #endif // #ifndef NDEBUG
 
 char const *bloom1_column_prefix = NULL;
+
+/* this function will be reused in a later PR when we push down pre-calculated
+ * hash value checks from the planner */
+bool
+bloom1_contains_hash(Datum bloom_datum, uint64 hash)
+{
+	struct varlena *bloom = DatumGetByteaPP(bloom_datum);
+	if (bloom == NULL)
+		return true; /* No bloom = might match */
+
+	const char *words_buf = VARDATA_ANY(bloom);
+	const uint32 num_bits = 8 * VARSIZE_ANY_EXHDR(bloom);
+
+	/* Validate bloom structure */
+	CheckCompressedData(num_bits == (1ULL << pg_leftmost_one_pos32(num_bits)));
+	CheckCompressedData(num_bits >= 64);
+
+	return bloom1_contains_hash_internal(words_buf, num_bits, hash);
+}

--- a/tsl/src/compression/batch_metadata_builder_minmax.h
+++ b/tsl/src/compression/batch_metadata_builder_minmax.h
@@ -17,6 +17,7 @@ typedef struct BatchMetadataBuilderMinMax
 	BatchMetadataBuilder functions;
 
 	Oid type_oid;
+	AttrNumber attnum;
 	bool empty;
 	bool has_null;
 

--- a/tsl/src/compression/city_combine.h
+++ b/tsl/src/compression/city_combine.h
@@ -1,0 +1,51 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/* The code below is taken from the CityHash project: https://github.com/google/cityhash
+ * specifically from here: https://github.com/google/cityhash/blob/master/src/city.h#L101
+ */
+
+/*
+ * Copyright (c) 2011 Google, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * CityHash, by Geoff Pike and Jyrki Alakuijala
+ *
+ * http://code.google.com/p/cityhash/
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+static inline uint64_t
+city_hash_combine(uint64_t accumulated_hash, uint64_t new_hash)
+{
+	const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+	uint64_t a = (accumulated_hash ^ new_hash) * kMul;
+	a ^= (a >> 47);
+	uint64_t b = (new_hash ^ a) * kMul;
+	b ^= (b >> 47);
+	b *= kMul;
+	return b;
+}

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -213,11 +213,6 @@ typedef struct PerColumn
 {
 	/* the compressor to use for regular columns, NULL for segmenters */
 	Compressor *compressor;
-	/*
-	 * Information on the metadata we'll store for this column (currently only min/max).
-	 * Only used for order-by columns right now, will be {-1, NULL} for others.
-	 */
-	BatchMetadataBuilder *metadata_builder;
 
 	/* segment info; only used if compressor is NULL */
 	SegmentInfo *segment_info;
@@ -278,6 +273,8 @@ typedef struct RowCompressor
 	Tuplesortstate *sort_state;
 	int64 tuples_to_sort;	/* number of tuples to sort with tuplesort */
 	int64 tuple_sort_limit; /* number of tuples to flush the compressor on */
+
+	List *metadata_builders; /* List of BatchMetadataBuilder */
 } RowCompressor;
 
 /*

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -97,6 +97,10 @@ static void compression_settings_set_manually_for_create(Hypertable *ht,
 static void compression_settings_set_manually_for_alter(Hypertable *ht,
 														CompressionSettings *settings,
 														WithClauseResult *with_clause_options);
+static void create_default_composite_bloom(IndexInfo *index_info, Hypertable *ht,
+										   CompressionSettings *settings,
+										   JsonbParseState *parse_state,
+										   TsBmsList *sparse_index_columns, bool *has_object);
 
 static char *
 compression_column_segment_metadata_name(const char *type, int16 column_index)
@@ -1561,6 +1565,111 @@ can_set_default_sparse_index(CompressionSettings *settings)
 												 [_SparseIndexSourceEnumConfig]);
 }
 
+static void
+create_default_composite_bloom(IndexInfo *index_info, Hypertable *ht, CompressionSettings *settings,
+							   JsonbParseState *parse_state, TsBmsList *sparse_index_columns,
+							   bool *has_object)
+{
+	int num_cols = index_info->ii_NumIndexKeyAttrs;
+
+	/* Allocate bloom config for the number of columns in the index */
+	BloomFilterConfig bloom_config;
+	bloom_config.base.type = _SparseIndexTypeEnumBloom;
+	bloom_config.base.source = _SparseIndexSourceEnumDefault;
+	bloom_config.columns = palloc0(num_cols * sizeof(SparseIndexColumn));
+
+	/* Extract columns, filtering out segmentby columns.
+	 * Note: orderby columns are not filtered out here because they can
+	 * be in composite bloom filters.
+	 */
+	int valid_columns = 0;
+
+	/*
+	 * The index must be enabled by the GUC.
+	 */
+	if (!ts_guc_enable_sparse_index_bloom)
+	{
+		return;
+	}
+
+	/* Bitmapset of column attnums */
+	Bitmapset *attnums_bitmap = NULL;
+
+	/* Check the total width of the hashable columns */
+	int total_width = 0;
+
+	for (int i = 0; i < num_cols; i++)
+	{
+		AttrNumber attno = index_info->ii_IndexAttrNumbers[i];
+
+		/* Skip expression indexes */
+		if (attno == InvalidAttrNumber)
+			continue;
+
+		char *attname = get_attname(ht->main_table_relid, attno, false);
+
+		/* Skip segmentby columns but continue processing other columns */
+		if (ts_array_is_member(settings->fd.segmentby, attname))
+			continue;
+
+		Oid atttypid = get_atttype(ht->main_table_relid, attno);
+
+		/* Check if hashable */
+		FmgrInfo *finfo = NULL;
+		if (bloom1_get_hash_function(atttypid, &finfo) == NULL)
+			continue;
+
+		TypeCacheEntry *type = lookup_type_cache(atttypid, TYPECACHE_HASH_EXTENDED_PROC);
+		total_width += (type->typlen > 0 ? type->typlen : 4);
+
+		/* Equality queries are unlikely for floating-point types, so we skip them. */
+		if (atttypid == FLOAT4OID || atttypid == FLOAT8OID)
+			continue;
+
+		/* Add to bloom config */
+		bloom_config.columns[valid_columns].attnum = attno;
+		bloom_config.columns[valid_columns].name = attname;
+		bloom_config.columns[valid_columns].type = atttypid;
+		valid_columns++;
+
+		attnums_bitmap = bms_add_member(attnums_bitmap, attno);
+	}
+
+	/* Need at least 2 valid columns for composite bloom and the total width must be at least 4
+	 * bytes. */
+	if (valid_columns < 2 || total_width < 4)
+	{
+		pfree(bloom_config.columns);
+		bms_free(attnums_bitmap);
+		return;
+	}
+
+	/* Check if this exact bloom already exists */
+	if (ts_bmslist_contains_set(*sparse_index_columns, attnums_bitmap))
+	{
+		pfree(bloom_config.columns);
+		bms_free(attnums_bitmap);
+		return;
+	}
+
+	bloom_config.num_columns = valid_columns;
+
+	/* Column names must be in attnum order for metadata column naming */
+	qsort(bloom_config.columns,
+		  bloom_config.num_columns,
+		  sizeof(SparseIndexColumn),
+		  ts_qsort_attrnumber_cmp);
+
+	/* Add the bloom's column set to the list */
+	*sparse_index_columns = ts_bmslist_add_set(*sparse_index_columns, attnums_bitmap);
+
+	/* Convert to JSONB and add to array */
+	ts_convert_sparse_index_config_to_jsonb(parse_state, &bloom_config.base);
+	*has_object = true;
+
+	pfree(bloom_config.columns);
+}
+
 static Jsonb *
 compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings *settings)
 {
@@ -1608,7 +1717,19 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 			continue;
 		}
 
-		for (int i = 0; i < index_info->ii_NumIndexKeyAttrs; i++)
+		int num_cols = index_info->ii_NumIndexKeyAttrs;
+		if (ts_guc_enable_sparse_index_bloom && num_cols >= 2 &&
+			num_cols <= MAX_BLOOM_FILTER_COLUMNS)
+		{
+			create_default_composite_bloom(index_info,
+										   ht,
+										   settings,
+										   parse_state,
+										   &sparse_index_columns,
+										   &has_object);
+		}
+
+		for (int i = 0; i < num_cols; i++)
 		{
 			char *attname;
 			Oid atttypid;

--- a/tsl/test/expected/compress_compbloom_basics.out
+++ b/tsl/test/expected/compress_compbloom_basics.out
@@ -1,0 +1,472 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+CREATE VIEW metacols AS select relname,attname,count(*) from pg_attribute a, pg_class c where c.oid=a.attrelid and attname like '%_ts_meta%' and relname like '%chunk' GROUP BY 1,2 ORDER BY relname::text COLLATE "C", attname::text COLLATE "C";
+CREATE VIEW compressedcols AS select relname,attname,c.oid as reloid,attnum from pg_attribute a, pg_class c where c.oid=a.attrelid and relname like '%compress_hyper_%' order by c.oid asc, a.attnum asc;
+create table sparse(
+    ts int,
+    o bigint,
+    value float,
+    boo bigint,
+    big1 bigint,
+    big2 bigint,
+    sby bigint,
+    small1 smallint,
+    small2 int2,
+    num numeric,
+    nowts timestamptz,
+    hello bytea);
+select create_hypertable('sparse', 'ts', create_default_indexes=>false);
+  create_hypertable  
+---------------------
+ (1,public,sparse,t)
+
+insert into sparse select x, x, x, x, x, x, x, x%4, x%4, x::numeric, now()::timestamptz, md5(x::text)::bytea from generate_series(1, 10000) x;
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(big2),bloom(value),bloom(value,big1,big2),bloom(o,big2),bloom(big1,big2),bloom(boo,big1),bloom(small1,small2),bloom(num,nowts),bloom(num,hello)');
+select count(compress_chunk(x)) from show_chunks('sparse') x;
+ count 
+-------
+     1
+
+vacuum analyze sparse;
+-- smoke tests
+select min(big1), max(big2) from sparse where value < 100 and value > 10;
+ min | max 
+-----+-----
+  11 |  99
+
+select relname,attname from metacols order by 1,2;
+         relname          |              attname               
+--------------------------+------------------------------------
+ compress_hyper_2_2_chunk | _ts_meta_count
+ compress_hyper_2_2_chunk | _ts_meta_max_1
+ compress_hyper_2_2_chunk | _ts_meta_max_2
+ compress_hyper_2_2_chunk | _ts_meta_min_1
+ compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_big1_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_o_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_value
+ compress_hyper_2_2_chunk | regress-test-bloom_value_big1_big2
+
+select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
+                                                                                                                                                                                                                                                                                                                                                                                            index                                                                                                                                                                                                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"type": "bloom", "column": "big1", "source": "config"}, {"type": "bloom", "column": "big2", "source": "config"}, {"type": "bloom", "column": "value", "source": "config"}, {"type": "bloom", "column": ["value", "big1", "big2"], "source": "config"}, {"type": "bloom", "column": ["o", "big2"], "source": "config"}, {"type": "bloom", "column": ["big1", "big2"], "source": "config"}, {"type": "bloom", "column": ["boo", "big1"], "source": "config"}, {"type": "bloom", "column": ["small1", "small2"], "source": "config"}, {"type": "bloom", "column": ["num", "nowts"], "source": "config"}, {"type": "bloom", "column": ["num", "hello"], "source": "config"}, {"type": "minmax", "column": "o", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+select distinct(attname) from compressedcols where relname = 'sparse' order by 1 asc;
+ attname 
+---------
+
+-- show plan
+explain (buffers off, costs off) select * from sparse where value = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: (value = '1'::double precision)
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_value, '1'::double precision)
+
+explain (buffers off, costs off) select * from sparse where o = 1 and big2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((o = 1) AND (big2 = 1))
+   ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
+         Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1)
+
+explain (buffers off, costs off) select * from sparse where num = 1 and hello = md5('1')::bytea;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((num = '1'::numeric) AND (hello = '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off) select * from sparse where small1 = 1 and small2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((small1 = 1) AND (small2 = 1))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off) select * from sparse where num = 1 and nowts = now()::timestamptz;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on sparse
+   Chunks excluded during startup: 0
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         Filter: (num = '1'::numeric)
+         Vectorized Filter: (nowts = now())
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off) select * from sparse where o in (1,2) and big2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((o = ANY ('{1,2}'::bigint[])) AND (big2 = 1))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1)
+
+explain (buffers off, costs off) select * from sparse where o = 1 and big2 in (1,2);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((big2 = ANY ('{1,2}'::bigint[])) AND (o = 1))
+   ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
+         Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
+         Filter: _timescaledb_functions.bloom1_contains_any(regress-test-bloom_big2, '{1,2}'::bigint[])
+
+explain (buffers off, costs off) select * from sparse where o in (1,2) and big2 in (1,2);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((o = ANY ('{1,2}'::bigint[])) AND (big2 = ANY ('{1,2}'::bigint[])))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains_any(regress-test-bloom_big2, '{1,2}'::bigint[])
+
+-- segmentby = bloom
+explain (buffers off, costs off) select * from sparse where big1 = sby and value = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (big1 = sby)
+   Vectorized Filter: (value = '1'::double precision)
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_big1, sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_value, '1'::double precision))
+
+explain (buffers off, costs off) select * from sparse where o = sby and big2 = sby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((o = sby) AND (sby = big2))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
+
+explain (buffers off, costs off) select * from sparse where o = 1 and big2 = sby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (big2 = sby)
+   Vectorized Filter: (o = 1)
+   ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
+         Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby)
+
+explain (buffers off, costs off) select * from sparse where o = sby and big2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (o = sby)
+   Vectorized Filter: (big2 = 1)
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
+
+-- create a sister table where the same composite blooms should be auto created
+create table sparse_sister as select * from sparse where ts < -1;
+select create_hypertable('sparse_sister', 'ts', create_default_indexes=>false);
+     create_hypertable      
+----------------------------
+ (3,public,sparse_sister,t)
+
+alter table sparse_sister set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby');
+insert into sparse_sister select * from sparse;
+create index on sparse_sister(value,big1,big2);
+create index on sparse_sister(o,big2);
+create index on sparse_sister(big1,big2);
+create index on sparse_sister(boo,big1);
+create index on sparse_sister(small1,small2);
+create index on sparse_sister(num,nowts);
+create index on sparse_sister(num,hello);
+select count(compress_chunk(x)) from show_chunks('sparse_sister') x;
+ count 
+-------
+     1
+
+vacuum analyze sparse_sister;
+-- smoke tests
+select min(big1), max(big2) from sparse_sister where value < 100 and value > 10;
+ min | max 
+-----+-----
+  11 |  99
+
+select relname,attname from metacols order by 1,2;
+         relname          |              attname               
+--------------------------+------------------------------------
+ compress_hyper_2_2_chunk | _ts_meta_count
+ compress_hyper_2_2_chunk | _ts_meta_max_1
+ compress_hyper_2_2_chunk | _ts_meta_max_2
+ compress_hyper_2_2_chunk | _ts_meta_min_1
+ compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_big1_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_o_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_value
+ compress_hyper_2_2_chunk | regress-test-bloom_value_big1_big2
+ compress_hyper_4_4_chunk | _ts_meta_count
+ compress_hyper_4_4_chunk | _ts_meta_max_1
+ compress_hyper_4_4_chunk | _ts_meta_max_2
+ compress_hyper_4_4_chunk | _ts_meta_min_1
+ compress_hyper_4_4_chunk | _ts_meta_min_2
+ compress_hyper_4_4_chunk | regress-test-bloom_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_big1_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_boo
+ compress_hyper_4_4_chunk | regress-test-bloom_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_num_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_num_nowts
+ compress_hyper_4_4_chunk | regress-test-bloom_o_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_small1_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_nowts
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_num
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_small1
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_value
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_nowts
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_num
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_small1
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_value
+
+select index from settings where relid = (select oid from pg_class where relname = 'sparse_sister') and index is not null group by 1 order by 1;
+ index 
+-------
+
+select distinct(attname) from compressedcols where relname = 'sparse_sister' order by 1 asc;
+ attname 
+---------
+
+-- show plan
+explain (buffers off, costs off) select * from sparse_sister where value = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Vectorized Filter: (value = '1'::double precision)
+   ->  Seq Scan on compress_hyper_4_4_chunk
+         Filter: ((_ts_meta_v2_min_value <= '1'::double precision) AND (_ts_meta_v2_max_value >= '1'::double precision))
+
+explain (buffers off, costs off) select * from sparse_sister where o = 1 and big2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Vectorized Filter: ((o = 1) AND (big2 = 1))
+   ->  Index Scan using compress_hyper_4_4_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_4_4_chunk
+         Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1)
+
+explain (buffers off, costs off) select * from sparse_sister where num = 1 and hello = md5('1')::bytea;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Filter: ((num = '1'::numeric) AND (hello = '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
+   ->  Seq Scan on compress_hyper_4_4_chunk
+         Filter: ((_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_hello, '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
+
+explain (buffers off, costs off) select * from sparse_sister where small1 = 1 and small2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Vectorized Filter: ((small1 = 1) AND (small2 = 1))
+   ->  Seq Scan on compress_hyper_4_4_chunk
+         Filter: ((_ts_meta_v2_min_small1 <= 1) AND (_ts_meta_v2_max_small1 >= 1) AND (_ts_meta_v2_min_small2 <= 1) AND (_ts_meta_v2_max_small2 >= 1))
+
+explain (buffers off, costs off) select * from sparse_sister where num = 1 and nowts = now()::timestamptz;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on sparse_sister
+   Chunks excluded during startup: 0
+   ->  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+         Filter: (num = '1'::numeric)
+         Vectorized Filter: (nowts = now())
+         ->  Seq Scan on compress_hyper_4_4_chunk
+               Filter: ((_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND (_ts_meta_v2_min_nowts <= now()) AND (_ts_meta_v2_max_nowts >= now()))
+
+-- segmentby = bloom
+explain (buffers off, costs off) select * from sparse_sister where big1 = sby and value = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Filter: (big1 = sby)
+   Vectorized Filter: (value = '1'::double precision)
+   ->  Seq Scan on compress_hyper_4_4_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_big1, sby) AND (_ts_meta_v2_min_value <= '1'::double precision) AND (_ts_meta_v2_max_value >= '1'::double precision))
+
+explain (buffers off, costs off) select * from sparse_sister where o = sby and big2 = sby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Filter: ((o = sby) AND (sby = big2))
+   ->  Seq Scan on compress_hyper_4_4_chunk
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
+
+explain (buffers off, costs off) select * from sparse_sister where o = 1 and big2 = sby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Filter: (big2 = sby)
+   Vectorized Filter: (o = 1)
+   ->  Index Scan using compress_hyper_4_4_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_4_4_chunk
+         Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby)
+
+explain (buffers off, costs off) select * from sparse_sister where o = sby and big2 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_3_3_chunk
+   Filter: (o = sby)
+   Vectorized Filter: (big2 = 1)
+   ->  Seq Scan on compress_hyper_4_4_chunk
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
+
+-- renaming a column that participates in a composite bloom filter
+alter table sparse rename big2 to xxl;
+select relname,attname from metacols order by 1,2;
+         relname          |              attname              
+--------------------------+-----------------------------------
+ compress_hyper_2_2_chunk | _ts_meta_count
+ compress_hyper_2_2_chunk | _ts_meta_max_1
+ compress_hyper_2_2_chunk | _ts_meta_max_2
+ compress_hyper_2_2_chunk | _ts_meta_min_1
+ compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_big1_xxl
+ compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_o_xxl
+ compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_value
+ compress_hyper_2_2_chunk | regress-test-bloom_value_big1_xxl
+ compress_hyper_2_2_chunk | regress-test-bloom_xxl
+ compress_hyper_4_4_chunk | _ts_meta_count
+ compress_hyper_4_4_chunk | _ts_meta_max_1
+ compress_hyper_4_4_chunk | _ts_meta_max_2
+ compress_hyper_4_4_chunk | _ts_meta_min_1
+ compress_hyper_4_4_chunk | _ts_meta_min_2
+ compress_hyper_4_4_chunk | regress-test-bloom_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_big1_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_boo
+ compress_hyper_4_4_chunk | regress-test-bloom_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_num_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_num_nowts
+ compress_hyper_4_4_chunk | regress-test-bloom_o_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_small1_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_nowts
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_num
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_small1
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_value
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_nowts
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_num
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_small1
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_value
+
+select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
+                                                                                                                                                                                                                                                                                                                                                                                          index                                                                                                                                                                                                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"type": "bloom", "column": "big1", "source": "config"}, {"type": "bloom", "column": "xxl", "source": "config"}, {"type": "bloom", "column": "value", "source": "config"}, {"type": "bloom", "column": ["value", "big1", "xxl"], "source": "config"}, {"type": "bloom", "column": ["o", "xxl"], "source": "config"}, {"type": "bloom", "column": ["big1", "xxl"], "source": "config"}, {"type": "bloom", "column": ["boo", "big1"], "source": "config"}, {"type": "bloom", "column": ["small1", "small2"], "source": "config"}, {"type": "bloom", "column": ["num", "nowts"], "source": "config"}, {"type": "bloom", "column": ["num", "hello"], "source": "config"}, {"type": "minmax", "column": "o", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+select distinct(attname) from compressedcols where relname = 'sparse' order by 1 asc;
+ attname 
+---------
+
+-- dropping a column that participates in a composite bloom filter
+alter table sparse drop column xxl;
+select relname,attname from metacols order by 1,2;
+         relname          |             attname              
+--------------------------+----------------------------------
+ compress_hyper_2_2_chunk | _ts_meta_count
+ compress_hyper_2_2_chunk | _ts_meta_max_1
+ compress_hyper_2_2_chunk | _ts_meta_max_2
+ compress_hyper_2_2_chunk | _ts_meta_min_1
+ compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_value
+ compress_hyper_4_4_chunk | _ts_meta_count
+ compress_hyper_4_4_chunk | _ts_meta_max_1
+ compress_hyper_4_4_chunk | _ts_meta_max_2
+ compress_hyper_4_4_chunk | _ts_meta_min_1
+ compress_hyper_4_4_chunk | _ts_meta_min_2
+ compress_hyper_4_4_chunk | regress-test-bloom_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_big1_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_boo
+ compress_hyper_4_4_chunk | regress-test-bloom_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_num_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_num_nowts
+ compress_hyper_4_4_chunk | regress-test-bloom_o_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_small1_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_nowts
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_num
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_small1
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_max_value
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_nowts
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_num
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_small1
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_small2
+ compress_hyper_4_4_chunk | _ts_meta_v2_min_value
+
+select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
+                                                                                                                                                                                                                                                        index                                                                                                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"type": "bloom", "column": "big1", "source": "config"}, {"type": "bloom", "column": "value", "source": "config"}, {"type": "bloom", "column": ["boo", "big1"], "source": "config"}, {"type": "bloom", "column": ["small1", "small2"], "source": "config"}, {"type": "bloom", "column": ["num", "nowts"], "source": "config"}, {"type": "bloom", "column": ["num", "hello"], "source": "config"}, {"type": "minmax", "column": "o", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+select distinct(attname) from compressedcols where relname = 'sparse' order by 1 asc;
+ attname 
+---------
+
+-- droppping an orderby column should fail
+\set ON_ERROR_STOP 0
+alter table sparse drop column o;
+ERROR:  cannot drop orderby or segmentby column from a hypertable with columnstore enabled
+-- a segmentby column cannot be part of composite key
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(sby,value)');
+ERROR:  the segmentby column "sby" can not have sparse indexes
+-- a segmentby column cannot be part of single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(sby)');
+ERROR:  the segmentby column "sby" can not have sparse indexes
+-- an orderby column cannot be part of a single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o)');
+ERROR:  the orderby column "o" cannot have a bloom sparse index 
+-- an orderby column cannot be part of a single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(boo,o),bloom(o)');
+ERROR:  the orderby column "o" cannot have a bloom sparse index 
+-- an orderby column cannot be part of a single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o),bloom(o,boo)');
+ERROR:  the orderby column "o" cannot have a bloom sparse index 
+\set ON_ERROR_STOP 1
+-- an orderby column _can_ be part of a composite bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o,boo)');
+DROP TABLE IF EXISTS sparse CASCADE;
+DROP TABLE IF EXISTS sparse_sister CASCADE;

--- a/tsl/test/expected/compress_compbloom_config.out
+++ b/tsl/test/expected/compress_compbloom_config.out
@@ -13,43 +13,37 @@ SELECT create_hypertable('t', 'a');
  (1,public,t,t)
 
 -- Should succeed (8 columns max)
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h")');
-ERROR:  composite bloom indexes are not supported
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
 where relid = 't'::regclass and index is not null order by 1,2;
- relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
--------+----------------+-----------+---------+--------------+--------------------+-------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                    index                                                                                                    
+-------+----------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ t     |                |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a", "b", "c", "d", "e", "f", "g", "h"], "source": "config"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
 
 -- Should fail (9 columns)
 \set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h","i")');
-ERROR:  composite bloom indexes are not supported
+ERROR:  bloom index has too many columns: 9 > max 8
 \set ON_ERROR_STOP 1
 -- The ordering of bloom columns in the composite bloom index should be determined by the order of the columns in the CREATE TABLE statement
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f","e","d","c","b")');
-ERROR:  composite bloom indexes are not supported
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
 where relid = 't'::regclass and index is not null order by 1,2;
- relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
--------+----------------+-----------+---------+--------------+--------------------+-------
+ relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                 index                                                                                                  
+-------+----------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ t     |                |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["b", "c", "d", "e", "f", "g", "h"], "source": "config"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
 
 -- Creating two composite bloom indexes with the same columns in different orders should fail
 \set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f"),bloom("f","g","h")');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate sparse index configuration ('f','g','h')
 \set ON_ERROR_STOP 1
 -- Creating a composite bloom index with the same columns should fail
 \set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress_index = 'bloom("a","b","a")');
-ERROR:  cannot set sparse index option without orderby option
+ERROR:  duplicate column name ('a') in composite bloom index configuration: ('a','b','a')
 ALTER TABLE t SET (timescaledb.compress_index = 'bloom("g","g")');
-ERROR:  cannot set sparse index option without orderby option
+ERROR:  duplicate column name ('g') in composite bloom index configuration: ('g','g')
 \set ON_ERROR_STOP 1
 DROP TABLE t CASCADE;
 -- Creating a composite bloom index based on a primary key, and create the same manually again
@@ -57,7 +51,7 @@ CREATE TABLE u(a int, b int, c int, d int, PRIMARY KEY (a, b, c));
 SELECT create_hypertable('u', 'a');
  create_hypertable 
 -------------------
- (2,public,u,t)
+ (3,public,u,t)
 
 ALTER TABLE u SET (timescaledb.compress, timescaledb.compress_orderby = 'b');
 select index from settings where relid = 'u'::regclass and index is not null order by 1;
@@ -71,51 +65,46 @@ select count(compress_chunk(x)) from show_chunks('u') x;
      1
 
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
-                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                  index                                                                                  
-----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- _timescaledb_internal._hyper_2_1_chunk | _timescaledb_internal.compress_hyper_3_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                   index                                                                                                                    
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal.compress_hyper_4_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a", "b", "c"], "source": "default"}, {"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
 
 -- Check the auto generated compressed columns
 select relname,attname from compressedcols order by 1,2;
-         relname          |       attname        
---------------------------+----------------------
- compress_hyper_3_2_chunk | _ts_meta_count
- compress_hyper_3_2_chunk | _ts_meta_max_1
- compress_hyper_3_2_chunk | _ts_meta_max_2
- compress_hyper_3_2_chunk | _ts_meta_min_1
- compress_hyper_3_2_chunk | _ts_meta_min_2
- compress_hyper_3_2_chunk | regress-test-bloom_c
- compress_hyper_3_2_chunk | a
- compress_hyper_3_2_chunk | b
- compress_hyper_3_2_chunk | c
- compress_hyper_3_2_chunk | cmax
- compress_hyper_3_2_chunk | cmin
- compress_hyper_3_2_chunk | ctid
- compress_hyper_3_2_chunk | d
- compress_hyper_3_2_chunk | tableoid
- compress_hyper_3_2_chunk | xmax
- compress_hyper_3_2_chunk | xmin
+         relname          |         attname          
+--------------------------+--------------------------
+ compress_hyper_4_2_chunk | _ts_meta_count
+ compress_hyper_4_2_chunk | _ts_meta_max_1
+ compress_hyper_4_2_chunk | _ts_meta_max_2
+ compress_hyper_4_2_chunk | _ts_meta_min_1
+ compress_hyper_4_2_chunk | _ts_meta_min_2
+ compress_hyper_4_2_chunk | regress-test-bloom_a_b_c
+ compress_hyper_4_2_chunk | regress-test-bloom_c
+ compress_hyper_4_2_chunk | a
+ compress_hyper_4_2_chunk | b
+ compress_hyper_4_2_chunk | c
+ compress_hyper_4_2_chunk | cmax
+ compress_hyper_4_2_chunk | cmin
+ compress_hyper_4_2_chunk | ctid
+ compress_hyper_4_2_chunk | d
+ compress_hyper_4_2_chunk | tableoid
+ compress_hyper_4_2_chunk | xmax
+ compress_hyper_4_2_chunk | xmin
 
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE u SET (timescaledb.compress_index = 'bloom("a","b","c")');
-ERROR:  composite bloom indexes are not supported
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
-                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                  index                                                                                  
-----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- _timescaledb_internal._hyper_2_1_chunk | _timescaledb_internal.compress_hyper_3_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                   index                                                                                                                    
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ u                                      |                                                |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a", "b", "c"], "source": "config"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+ _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal.compress_hyper_4_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a", "b", "c"], "source": "default"}, {"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
 
 -- Also in a different order
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE u SET (timescaledb.compress_index = 'bloom("c","b","a")');
-ERROR:  composite bloom indexes are not supported
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
-                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                  index                                                                                  
-----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- _timescaledb_internal._hyper_2_1_chunk | _timescaledb_internal.compress_hyper_3_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+                 relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                   index                                                                                                                    
+----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ u                                      |                                                |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a", "b", "c"], "source": "config"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
+ _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal.compress_hyper_4_2_chunk |           | {b,a}   | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a", "b", "c"], "source": "default"}, {"type": "bloom", "column": "c", "source": "default"}, {"type": "minmax", "column": "b", "source": "orderby"}, {"type": "minmax", "column": "a", "source": "orderby"}]
 
 DROP TABLE u CASCADE;
 -------------------------------------------------------------------
@@ -125,7 +114,7 @@ CREATE TABLE v(a_01234567890123456789 int, b_01234567890123456789 int, c_0123456
 SELECT create_hypertable('v', 'a_01234567890123456789');
  create_hypertable 
 -------------------
- (4,public,v,t)
+ (5,public,v,t)
 
 ALTER TABLE v SET (timescaledb.compress, timescaledb.compress_orderby = 'b_01234567890123456789');
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
@@ -140,40 +129,41 @@ select count(compress_chunk(x)) from show_chunks('v') x;
 
 -- Check the auto generated composite bloom index configuration and column names
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
-                 relid                  |                 compress_relid                 | segmentby |                     orderby                     | orderby_desc | orderby_nullsfirst |                                                                                                                                                                                             index                                                                                                                                                                                              
-----------------------------------------+------------------------------------------------+-----------+-------------------------------------------------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal.compress_hyper_5_4_chunk |           | {b_01234567890123456789,a_01234567890123456789} | {f,t}        | {f,t}              | [{"type": "bloom", "column": "c_01234567890123456789", "source": "default"}, {"type": "bloom", "column": "d_01234567890123456789", "source": "default"}, {"type": "bloom", "column": "e_01234567890123456789", "source": "default"}, {"type": "minmax", "column": "b_01234567890123456789", "source": "orderby"}, {"type": "minmax", "column": "a_01234567890123456789", "source": "orderby"}]
+                 relid                  |                 compress_relid                 | segmentby |                     orderby                     | orderby_desc | orderby_nullsfirst |                                                                                                                                                                                                                                                                                        index                                                                                                                                                                                                                                                                                         
+----------------------------------------+------------------------------------------------+-----------+-------------------------------------------------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_5_3_chunk | _timescaledb_internal.compress_hyper_6_4_chunk |           | {b_01234567890123456789,a_01234567890123456789} | {f,t}        | {f,t}              | [{"type": "bloom", "column": ["a_01234567890123456789", "b_01234567890123456789", "c_01234567890123456789", "d_01234567890123456789", "e_01234567890123456789"], "source": "default"}, {"type": "bloom", "column": "c_01234567890123456789", "source": "default"}, {"type": "bloom", "column": "d_01234567890123456789", "source": "default"}, {"type": "bloom", "column": "e_01234567890123456789", "source": "default"}, {"type": "minmax", "column": "b_01234567890123456789", "source": "orderby"}, {"type": "minmax", "column": "a_01234567890123456789", "source": "orderby"}]
 
 select relname,attname from compressedcols order by 1,2;
-         relname          |                  attname                  
---------------------------+-------------------------------------------
- compress_hyper_5_4_chunk | _ts_meta_count
- compress_hyper_5_4_chunk | _ts_meta_max_1
- compress_hyper_5_4_chunk | _ts_meta_max_2
- compress_hyper_5_4_chunk | _ts_meta_min_1
- compress_hyper_5_4_chunk | _ts_meta_min_2
- compress_hyper_5_4_chunk | regress-test-bloom_c_01234567890123456789
- compress_hyper_5_4_chunk | regress-test-bloom_d_01234567890123456789
- compress_hyper_5_4_chunk | regress-test-bloom_e_01234567890123456789
- compress_hyper_5_4_chunk | a_01234567890123456789
- compress_hyper_5_4_chunk | b_01234567890123456789
- compress_hyper_5_4_chunk | c_01234567890123456789
- compress_hyper_5_4_chunk | cmax
- compress_hyper_5_4_chunk | cmin
- compress_hyper_5_4_chunk | ctid
- compress_hyper_5_4_chunk | d_01234567890123456789
- compress_hyper_5_4_chunk | e_01234567890123456789
- compress_hyper_5_4_chunk | f_01234567890123456789
- compress_hyper_5_4_chunk | g_01234567890123456789
- compress_hyper_5_4_chunk | h_01234567890123456789
- compress_hyper_5_4_chunk | i_01234567890123456789
- compress_hyper_5_4_chunk | tableoid
- compress_hyper_5_4_chunk | xmax
- compress_hyper_5_4_chunk | xmin
+         relname          |                             attname                             
+--------------------------+-----------------------------------------------------------------
+ compress_hyper_6_4_chunk | _ts_meta_count
+ compress_hyper_6_4_chunk | _ts_meta_max_1
+ compress_hyper_6_4_chunk | _ts_meta_max_2
+ compress_hyper_6_4_chunk | _ts_meta_min_1
+ compress_hyper_6_4_chunk | _ts_meta_min_2
+ compress_hyper_6_4_chunk | regress-test-bloom_c_01234567890123456789
+ compress_hyper_6_4_chunk | regress-test-bloom_d_01234567890123456789
+ compress_hyper_6_4_chunk | regress-test-bloom_ddd4_a_01234567890123456789_b_01234567890123
+ compress_hyper_6_4_chunk | regress-test-bloom_e_01234567890123456789
+ compress_hyper_6_4_chunk | a_01234567890123456789
+ compress_hyper_6_4_chunk | b_01234567890123456789
+ compress_hyper_6_4_chunk | c_01234567890123456789
+ compress_hyper_6_4_chunk | cmax
+ compress_hyper_6_4_chunk | cmin
+ compress_hyper_6_4_chunk | ctid
+ compress_hyper_6_4_chunk | d_01234567890123456789
+ compress_hyper_6_4_chunk | e_01234567890123456789
+ compress_hyper_6_4_chunk | f_01234567890123456789
+ compress_hyper_6_4_chunk | g_01234567890123456789
+ compress_hyper_6_4_chunk | h_01234567890123456789
+ compress_hyper_6_4_chunk | i_01234567890123456789
+ compress_hyper_6_4_chunk | tableoid
+ compress_hyper_6_4_chunk | xmax
+ compress_hyper_6_4_chunk | xmin
 
 -- Make sure the duplicate column detection works for long column names
 \set ON_ERROR_STOP 0
 ALTER TABLE v SET (timescaledb.compress_index = 'bloom("a_01234567890123456789","b_01234567890123456789","c_01234567890123456789","a_01234567890123456789")');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate column name ('a_01234567890123456789') in composite bloom index configuration: ('a_01234567890123456789','b_01234567890123456789','c_01234567890123456789','a_01234567890123456789')
 \set ON_ERROR_STOP 1
 DROP TABLE v CASCADE;

--- a/tsl/test/expected/compress_compbloom_manual_config.out
+++ b/tsl/test/expected/compress_compbloom_manual_config.out
@@ -1,0 +1,247 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+---------------------------------------------------------------------
+-- Manual config change between chunk compressions
+---------------------------------------------------------------------
+CREATE TABLE mixed_avail_manual(ts timestamptz, a int, b int, c int, seg int);
+SELECT create_hypertable('mixed_avail_manual', by_range('ts', interval '1 day'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+-- Initial config: bloom(a,b)
+ALTER TABLE mixed_avail_manual SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b)'
+);
+INSERT INTO mixed_avail_manual
+SELECT ts, (i % 10), (i % 5), (i % 3), 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+-- Compress first chunk with bloom(a,b)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c LIMIT 1;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND b = 2;
+ count 
+-------
+     0
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND c = 2;
+ count 
+-------
+   147
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE b = 1 AND c = 2;
+ count 
+-------
+   294
+
+-- Before config changes
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_manual (actual rows=0.00 loops=1)
+   Order: mixed_avail_manual.ts, mixed_avail_manual.c
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.c
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 1600
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.c
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=0.00 loops=1)
+               Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 2400
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.c
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=0.00 loops=1)
+               Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 900
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND c = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_manual (actual rows=147.00 loops=1)
+   Order: mixed_avail_manual.ts, mixed_avail_manual.b
+   ->  Sort (actual rows=48.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.b
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=48.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (c = 2))
+               Rows Removed by Filter: 1552
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=72.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.b
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=72.00 loops=1)
+               Filter: ((a = 1) AND (c = 2))
+               Rows Removed by Filter: 2328
+   ->  Sort (actual rows=27.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.b
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=27.00 loops=1)
+               Filter: ((a = 1) AND (c = 2))
+               Rows Removed by Filter: 873
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE b = 1 AND c = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_manual (actual rows=294.00 loops=1)
+   Order: mixed_avail_manual.ts, mixed_avail_manual.a
+   ->  Sort (actual rows=96.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.a
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=96.00 loops=1)
+               Vectorized Filter: ((b = 1) AND (c = 2))
+               Rows Removed by Filter: 1504
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=144.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.a
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=144.00 loops=1)
+               Filter: ((b = 1) AND (c = 2))
+               Rows Removed by Filter: 2256
+   ->  Sort (actual rows=54.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.a
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=54.00 loops=1)
+               Filter: ((b = 1) AND (c = 2))
+               Rows Removed by Filter: 846
+
+-- Change config: bloom(a,c)
+ALTER TABLE mixed_avail_manual SET (
+    timescaledb.compress_index = 'bloom(a,c)'
+);
+-- Compress second chunk with bloom(a,c)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c OFFSET 1 LIMIT 1;
+NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+
+-- Change config: bloom(b,c)
+ALTER TABLE mixed_avail_manual SET (
+    timescaledb.compress_index = 'bloom(b,c)'
+);
+-- Compress third chunk with bloom(b,c)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c OFFSET 2;
+NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+NOTICE:  chunk "_hyper_1_2_chunk" is already converted to columnstore
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND b = 2;
+ count 
+-------
+     0
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND c = 2;
+ count 
+-------
+   147
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE b = 1 AND c = 2;
+ count 
+-------
+   294
+
+-- After config changes
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_manual (actual rows=0.00 loops=1)
+   Order: mixed_avail_manual.ts, mixed_avail_manual.c
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.c
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 1600
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.c
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 2400
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.c
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 900
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1.00 loops=1)
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND c = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_manual (actual rows=147.00 loops=1)
+   Order: mixed_avail_manual.ts, mixed_avail_manual.b
+   ->  Sort (actual rows=48.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.b
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=48.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (c = 2))
+               Rows Removed by Filter: 1552
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=72.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.b
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=72.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (c = 2))
+               Rows Removed by Filter: 2328
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=27.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.b
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=27.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (c = 2))
+               Rows Removed by Filter: 873
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1.00 loops=1)
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE b = 1 AND c = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_manual (actual rows=294.00 loops=1)
+   Order: mixed_avail_manual.ts, mixed_avail_manual.a
+   ->  Sort (actual rows=96.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.a
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=96.00 loops=1)
+               Vectorized Filter: ((b = 1) AND (c = 2))
+               Rows Removed by Filter: 1504
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=144.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.a
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=144.00 loops=1)
+               Vectorized Filter: ((b = 1) AND (c = 2))
+               Rows Removed by Filter: 2256
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=54.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.a
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=54.00 loops=1)
+               Vectorized Filter: ((b = 1) AND (c = 2))
+               Rows Removed by Filter: 846
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1.00 loops=1)
+
+DROP TABLE IF EXISTS mixed_avail_manual CASCADE;

--- a/tsl/test/expected/compress_composite_bloom_debug.out
+++ b/tsl/test/expected/compress_composite_bloom_debug.out
@@ -1,0 +1,509 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-----------------------------------------------------------
+-- Debug Function Setup
+-----------------------------------------------------------
+CREATE OR REPLACE FUNCTION ts_bloom1_composite_debug_hash(
+    composite_value anyelement
+) RETURNS int8
+AS :TSL_MODULE_PATHNAME, 'ts_bloom1_composite_debug_hash'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+-----------------------------------------------------------
+-- Hash Signature Stability Tests
+-----------------------------------------------------------
+-- Binary compatibility tests
+-- INT4 + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4)) AS hash_1_2;
+       hash_1_2       
+----------------------
+ -8269931708899725482
+
+SELECT ts_bloom1_composite_debug_hash(ROW(2::int4, 1::int4)) AS hash_2_1;
+       hash_2_1       
+----------------------
+ -6811200433784778399
+
+-- Order matters
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 1::int4)) AS hash_1_1;
+      hash_1_1       
+---------------------
+ 4901182463118210331
+
+SELECT ts_bloom1_composite_debug_hash(ROW(100::int4, 200::int4)) AS hash_100_200;
+    hash_100_200     
+---------------------
+ -985178163871232840
+
+-- NULL handling
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, NULL::int4)) AS hash_1_null;
+     hash_1_null      
+----------------------
+ -4087059175533773721
+
+SELECT ts_bloom1_composite_debug_hash(ROW(NULL::int4, 1::int4)) AS hash_null_1;
+     hash_null_1     
+---------------------
+ 3190298981888668881
+
+-- NULL position matters
+SELECT ts_bloom1_composite_debug_hash(ROW(NULL::int4, NULL::int4)) AS hash_null_null;
+    hash_null_null    
+----------------------
+ -6642147184848171498
+
+-- Deterministic
+-- INT4 + TEXT
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 'hello'::text)) AS hash_int_text;
+    hash_int_text    
+---------------------
+ 1882521017801179394
+
+SELECT ts_bloom1_composite_debug_hash(ROW('hello'::text, 1::int4)) AS hash_text_int;
+    hash_text_int    
+---------------------
+ 7678076970108472495
+
+-- Type order matters
+-- TEXT + TEXT
+SELECT ts_bloom1_composite_debug_hash(ROW('hello'::text, 'world'::text)) AS hash_hello_world;
+   hash_hello_world   
+----------------------
+ -3643056055927828098
+
+SELECT ts_bloom1_composite_debug_hash(ROW('world'::text, 'hello'::text)) AS hash_world_hello;
+  hash_world_hello   
+---------------------
+ 2877725537500410663
+
+-- INT8 + INT8
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int8, 2::int8)) AS hash_bigint_1_2;
+   hash_bigint_1_2    
+----------------------
+ -8269931708899725482
+
+-- FLOAT8 + FLOAT8
+SELECT ts_bloom1_composite_debug_hash(ROW(3.14::float8, 2.71::float8)) AS hash_pi_e;
+      hash_pi_e      
+---------------------
+ 1298558980710853543
+
+-- DATE + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW('2025-01-01'::date, 123::int4)) AS hash_date_int;
+    hash_date_int    
+---------------------
+ 1942430286969053094
+
+-- TIMESTAMPTZ + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW('2025-01-01 12:00:00+00'::timestamptz, 456::int4)) AS hash_ts_int;
+     hash_ts_int     
+---------------------
+ 5390614616176477665
+
+-- UUID + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW('c9757a73-7632-462e-bcfa-d5d9659e498f'::uuid, 789::int4)) AS hash_uuid_int;
+    hash_uuid_int    
+---------------------
+ -606148817205698442
+
+-- Triples
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 'test'::text, 3.14::float8)) AS hash_triple_1;
+    hash_triple_1     
+----------------------
+ -6185554987398458301
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 'test'::text, 2.71::float8)) AS hash_triple_2;
+   hash_triple_2    
+--------------------
+ 768561903953156722
+
+-- Triples with NULL
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, NULL::text, 3.14::float8)) AS hash_triple_null_middle;
+ hash_triple_null_middle 
+-------------------------
+    -3234125659019344963
+
+-----------------------------------------------------------
+-- Actual Filtering Tests - Basic Setup
+-----------------------------------------------------------
+-- Create table with known data distribution
+CREATE TABLE composite_filter_test(
+    ts timestamptz NOT NULL,
+    device_id int,
+    sensor_type text,
+    value float,
+    segmentby_col int
+);
+SELECT create_hypertable('composite_filter_test', by_range('ts'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+ALTER TABLE composite_filter_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'segmentby_col',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(device_id,sensor_type)'
+);
+-- Insert data with DISTINCT patterns per segment
+-- Segment 1: device_id=1, sensor_type='temp' ONLY
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       1, 'temp', random() * 100, 1
+FROM generate_series(1, 1000) i;
+-- Segment 2: device_id=2, sensor_type='humidity' ONLY
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       2, 'humidity', random() * 100, 2
+FROM generate_series(1, 1000) i;
+-- Segment 3: device_id=3, sensor_type='pressure' ONLY
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       3, 'pressure', random() * 100, 3
+FROM generate_series(1, 1000) i;
+-- Segment 4: Mixed data (multiple combinations)
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       (i % 3) + 1,
+       CASE (i % 3) WHEN 0 THEN 'temp' WHEN 1 THEN 'humidity' ELSE 'pressure' END,
+       random() * 100,
+       4
+FROM generate_series(1, 900) i;
+SELECT compress_chunk(c) FROM show_chunks('composite_filter_test') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+VACUUM ANALYZE composite_filter_test;
+-- Create uncompressed reference for false negative testing
+CREATE TABLE composite_filter_ref AS SELECT * FROM composite_filter_test;
+-----------------------------------------------------------
+-- Verify Composite Bloom Column Exists
+-----------------------------------------------------------
+SELECT cc.schema_name || '.' || cc.table_name AS chunk
+FROM _timescaledb_catalog.chunk uc, timescaledb_information.chunks tc, _timescaledb_catalog.chunk cc
+WHERE uc.table_name = tc.chunk_name
+  AND cc.id = uc.compressed_chunk_id
+  AND tc.hypertable_name = 'composite_filter_test'
+  AND tc.is_compressed
+ORDER BY cc.table_name
+LIMIT 1
+\gset
+\echo 'Chunk: ' :chunk
+Chunk:  _timescaledb_internal.compress_hyper_2_2_chunk
+SELECT attname AS composite_bloom_col
+FROM pg_attribute
+WHERE attrelid = :'chunk'::regclass
+  AND attname LIKE '%device_id%sensor_type%'
+  LIMIT 1
+\gset
+\echo 'Composite bloom column: ' :composite_bloom_col
+Composite bloom column:  regress-test-bloom_device_id_sensor_type
+-----------------------------------------------------------
+-- Filtering Effectiveness Tests
+-----------------------------------------------------------
+-- Query for data in Segment 1 only
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'temp';
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1300.00 loops=1)
+   Vectorized Filter: ((device_id = 1) AND (sensor_type = 'temp'::text))
+   Rows Removed by Filter: 2600
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+
+-- Expected behavior:
+-- - Filter should show: bloom1_contains(composite_bloom, ROW(1, 'temp'::text))
+-- - Should scan ~1000-1100 rows (segment 1 + maybe some from segment 4 due to false positives)
+-- - Should NOT scan segments 2 and 3 (different device_id/sensor_type)
+-- - Pruning: ~50-60% of segments
+-- Query for data in Segment 2 only
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 2 AND sensor_type = 'humidity';
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1300.00 loops=1)
+   Vectorized Filter: ((device_id = 2) AND (sensor_type = 'humidity'::text))
+   Rows Removed by Filter: 2600
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+
+-- Expected: Similar pruning as Test 5.1
+-- Query for non-existent combination
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 5 AND sensor_type = 'temp';
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+   Vectorized Filter: ((device_id = 5) AND (sensor_type = 'temp'::text))
+   Rows Removed by Filter: 3900
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+
+-- Expected:
+-- - Should scan 0 or very few rows (bloom filter prunes all segments)
+-- - Actual rows returned: 0
+-- Non-existent pairing (device_id=1, sensor_type=humidity)
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'humidity';
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+   Vectorized Filter: ((device_id = 1) AND (sensor_type = 'humidity'::text))
+   Rows Removed by Filter: 3900
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+
+-- Expected:
+-- Segment 4 data: (i%3)+1 paired with sensor via CASE
+-- Pairs: (1,temp), (2,humidity), (3,pressure)
+-- Query (1,humidity) doesn't exist → should return 0 rows
+-----------------------------------------------------------
+-- False Negative Prevention Tests
+-----------------------------------------------------------
+-- Test all expected combinations and verify counts match reference
+WITH test_cases AS (
+    SELECT device_id, sensor_type
+    FROM (VALUES
+        (1, 'temp'),        -- Segment 1: ~1000 rows
+        (2, 'humidity'),    -- Segment 2: ~1000 rows
+        (3, 'pressure'),    -- Segment 3: ~1000 rows
+        (1, 'humidity'),    -- Segment 4: ~300 rows
+        (2, 'pressure'),    -- Segment 4: ~300 rows
+        (3, 'temp'),        -- Segment 4: ~300 rows
+        (4, 'temp'),        -- Non-existent: 0 rows
+        (1, 'pressure'),    -- Segment 4: ~300 rows
+        (2, 'temp')         -- Segment 4: ~300 rows
+    ) AS t(device_id, sensor_type)
+)
+SELECT
+    device_id,
+    sensor_type,
+    (SELECT COUNT(*) FROM composite_filter_test
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) AS compressed_count,
+    (SELECT COUNT(*) FROM composite_filter_ref
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) AS reference_count,
+    (SELECT COUNT(*) FROM composite_filter_test
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) =
+    (SELECT COUNT(*) FROM composite_filter_ref
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) AS match
+FROM test_cases tc
+ORDER BY device_id, sensor_type;
+ device_id | sensor_type | compressed_count | reference_count | match 
+-----------+-------------+------------------+-----------------+-------
+         1 | humidity    |                0 |               0 | t
+         1 | pressure    |                0 |               0 | t
+         1 | temp        |             1300 |            1300 | t
+         2 | humidity    |             1300 |            1300 | t
+         2 | pressure    |                0 |               0 | t
+         2 | temp        |                0 |               0 | t
+         3 | pressure    |             1300 |            1300 | t
+         3 | temp        |                0 |               0 | t
+         4 | temp        |                0 |               0 | t
+
+-- All match values should be TRUE
+-----------------------------------------------------------
+-- NULL Handling Tests
+-----------------------------------------------------------
+CREATE TABLE null_test(
+    ts int,
+    a int,
+    b text,
+    seg int
+);
+SELECT create_hypertable('null_test', 'ts');
+   create_hypertable    
+------------------------
+ (3,public,null_test,t)
+
+ALTER TABLE null_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b)'
+);
+-- Insert various NULL combinations
+INSERT INTO null_test VALUES (1, NULL, NULL, 1);
+INSERT INTO null_test VALUES (2, NULL, 'test', 1);
+INSERT INTO null_test VALUES (3, 1, NULL, 1);
+INSERT INTO null_test VALUES (4, 2, 'test', 1);
+INSERT INTO null_test VALUES (5, NULL, 'test', 1);
+SELECT compress_chunk(c) FROM show_chunks('null_test') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_3_chunk
+
+-- Test NULL queries
+SELECT COUNT(*) FROM null_test WHERE a IS NULL AND b IS NULL;
+ count 
+-------
+     1
+
+SELECT COUNT(*) FROM null_test WHERE a IS NULL AND b = 'test';
+ count 
+-------
+     2
+
+SELECT COUNT(*) FROM null_test WHERE a = 1 AND b IS NULL;
+ count 
+-------
+     1
+
+SELECT COUNT(*) FROM null_test WHERE a = 2 AND b = 'test';
+ count 
+-------
+     1
+
+-- Verify no false negatives
+CREATE TABLE null_test_ref AS SELECT * FROM null_test;
+WITH test_cases AS (
+    SELECT a, b FROM (VALUES
+        (NULL, NULL),
+        (NULL, 'test'),
+        (1, NULL),
+        (2, 'test')
+    ) AS t(a, b)
+)
+SELECT
+    COALESCE(a::text, 'NULL') AS a,
+    COALESCE(b, 'NULL') AS b,
+    (SELECT COUNT(*) FROM null_test WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) AS compressed,
+    (SELECT COUNT(*) FROM null_test_ref WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) AS reference,
+    (SELECT COUNT(*) FROM null_test WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) =
+    (SELECT COUNT(*) FROM null_test_ref WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) AS match
+FROM test_cases tc;
+  a   |  b   | compressed | reference | match 
+------+------+------------+-----------+-------
+ NULL | NULL |          1 |         1 | t
+ NULL | test |          2 |         2 | t
+ 1    | NULL |          1 |         1 | t
+ 2    | test |          1 |         1 | t
+
+-- All match values should be TRUE
+-----------------------------------------------------------
+-- More Type Pairs
+-----------------------------------------------------------
+-- INT2 + INT2 (smallint)
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int2, 2::int2));
+ ts_bloom1_composite_debug_hash 
+--------------------------------
+           -2833411701426218174
+
+-- INT4 + INT8 (mixed integer sizes)
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int8));
+ ts_bloom1_composite_debug_hash 
+--------------------------------
+           -8269931708899725482
+
+-- FLOAT4 + FLOAT8 (mixed float sizes)
+SELECT ts_bloom1_composite_debug_hash(ROW(1.5::float4, 2.5::float8));
+ ts_bloom1_composite_debug_hash 
+--------------------------------
+           -8062175379131696515
+
+-- VARCHAR + TEXT (string types)
+SELECT ts_bloom1_composite_debug_hash(ROW('hello'::varchar, 'world'::text));
+ ts_bloom1_composite_debug_hash 
+--------------------------------
+           -3643056055927828098
+
+-- TIMESTAMP + TIMESTAMPTZ
+SELECT ts_bloom1_composite_debug_hash(ROW('2025-01-01 12:00:00'::timestamp, '2025-01-01 12:00:00+00'::timestamptz));
+ ts_bloom1_composite_debug_hash 
+--------------------------------
+            3614883595137105983
+
+-- BOOL + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW(true::bool, 1::int4));
+ ts_bloom1_composite_debug_hash 
+--------------------------------
+            1292015507012526368
+
+-----------------------------------------------------------
+-- 3 or more fields
+-----------------------------------------------------------
+SELECT ts_bloom1_composite_debug_hash(ROW(42::int4, 'answer'::text, 3.14159::float8)) AS hash_triple;
+     hash_triple      
+----------------------
+ -8542448666174421461
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4, 3::int4, 4::int4)) AS hash_quad;
+      hash_quad       
+----------------------
+ -1407394388838765122
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4, 3::int4, 4::int4, 5::int4)) AS hash_quint;
+     hash_quint      
+---------------------
+ 4133756361080909164
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4, 3::int4, 4::int4, 5::int4, 6::int4, 7::int4, 8::int4)) AS hash_octet;
+     hash_octet      
+---------------------
+ 4290262262381336723
+
+-----------------------------------------------------------
+-- Triple Column Tests
+-----------------------------------------------------------
+CREATE TABLE test_triple(ts int, a int, b text, c float8, seg int);
+SELECT create_hypertable('test_triple', 'ts');
+    create_hypertable     
+--------------------------
+ (5,public,test_triple,t)
+
+ALTER TABLE test_triple SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b,c)'
+);
+INSERT INTO test_triple
+SELECT ts,
+       ts % 5,
+       CASE ts % 3 WHEN 0 THEN 'x' WHEN 1 THEN 'y' ELSE 'z' END,
+       (ts % 4)::float8,
+       ts % 2
+FROM generate_series(1, 1000) ts;
+SELECT compress_chunk(c) FROM show_chunks('test_triple') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_5_chunk
+
+-- Test various triple combinations
+SELECT COUNT(*) FROM test_triple WHERE a = 1 AND b = 'x' AND c = 2.0;
+ count 
+-------
+    17
+
+SELECT COUNT(*) FROM test_triple WHERE a = 2 AND b = 'y' AND c = 1.0;
+ count 
+-------
+    17
+
+CREATE TABLE test_triple_ref AS SELECT * FROM test_triple;
+-- Verify comprehensive
+WITH test_cases AS (
+    SELECT a, b, c FROM (VALUES
+        (1, 'x', 2.0),
+        (2, 'y', 1.0),
+        (0, 'z', 0.0),
+        (4, 'x', 3.0)
+    ) AS t(a, b, c)
+)
+SELECT
+    a, b, c,
+    (SELECT COUNT(*) FROM test_triple WHERE a = tc.a AND b = tc.b AND c = tc.c) AS compressed,
+    (SELECT COUNT(*) FROM test_triple_ref WHERE a = tc.a AND b = tc.b AND c = tc.c) AS reference,
+    (SELECT COUNT(*) FROM test_triple WHERE a = tc.a AND b = tc.b AND c = tc.c) =
+    (SELECT COUNT(*) FROM test_triple_ref WHERE a = tc.a AND b = tc.b AND c = tc.c) AS match
+FROM test_cases tc;
+ a | b |  c  | compressed | reference | match 
+---+---+-----+------------+-----------+-------
+ 1 | x | 2.0 |         17 |        17 | t
+ 2 | y | 1.0 |         17 |        17 | t
+ 0 | z | 0.0 |         17 |        17 | t
+ 4 | x | 3.0 |         17 |        17 | t
+
+-----------------------------------------------------------
+-- Cleanup
+-----------------------------------------------------------
+DROP TABLE IF EXISTS composite_filter_test CASCADE;
+DROP TABLE IF EXISTS composite_filter_ref CASCADE;
+DROP TABLE IF EXISTS null_test CASCADE;
+DROP TABLE IF EXISTS null_test_ref CASCADE;
+DROP TABLE IF EXISTS test_triple CASCADE;
+DROP TABLE IF EXISTS test_triple_ref CASCADE;

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -2,9 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- disable hash pushdown so we don't include the hash values in the plans
--- which makes the test stable. the hash pushdown is tested separately
-set timescaledb.enable_bloom1_hash_pushdown = false;
 CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
 -- Test configurable sparse indexes settings
 create table test_settings(
@@ -130,91 +127,76 @@ reset timescaledb.enable_sparse_index_bloom;
 \set ON_ERROR_STOP 1
 -- valid composite bloom filter cases:
 -- two columns
--- TODO : remove after composite blooms rolled out
-\set ON_ERROR_STOP 0
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts)');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u","ts")');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u",ts)');
-ERROR:  composite bloom indexes are not supported
 -- three columns
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,value)');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u","ts","value")');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u",ts,"value")');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(long1_01234567890123456789,long2_01234567890123456789,long3_01234567890123456789)');
-ERROR:  composite bloom indexes are not supported
 -- more than 3 columns
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,value,d)');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,value,d,b)');
-ERROR:  composite bloom indexes are not supported
 -- partial overlaps
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,value),bloom(u,ts)');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u),bloom(u,ts)');
-ERROR:  composite bloom indexes are not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,value),bloom(u,ts,value)');
-ERROR:  composite bloom indexes are not supported
-\set ON_ERROR_STOP 1
 -- invalid composite bloom filter cases:
 \set ON_ERROR_STOP 0
 -- nine column composite bloom is not supported
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,"value",d,b,x,age,gender,city)');
-ERROR:  composite bloom indexes are not supported
+ERROR:  bloom index has too many columns: 9 > max 8
 -- duplicate column
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,u)');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate column name ('u') in composite bloom index configuration: ('u','ts','u')
 -- duplicate blooms in different orders
 -- 2 cols
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts),bloom(ts,u)');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate sparse index configuration ('ts','u')
 -- 3 cols
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,x),bloom(u,x,ts)');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate sparse index configuration ('u','x','ts')
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(ts,x,u),bloom(ts,u,x)');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate sparse index configuration ('ts','u','x')
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(x,ts,u),bloom(x,u,ts)');
-ERROR:  composite bloom indexes are not supported
+ERROR:  duplicate sparse index configuration ('x','u','ts')
 \set ON_ERROR_STOP 1
 -- empty sparse index
 alter table test_settings set (timescaledb.compress,

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -91,9 +91,9 @@ select count(compress_chunk(x)) from show_chunks('metrics') x;
     27
 
 select * from chunk_settings;
- hypertable | chunks | segmentby |        orderby        |                                                            index                                                            
-------------+--------+-----------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------
- metrics    |     27 |           | device_id,"time" DESC | [{"type": "minmax", "column": "device_id", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ hypertable | chunks | segmentby |        orderby        |                                                                                                index                                                                                                 
+------------+--------+-----------+-----------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ metrics    |     27 |           | device_id,"time" DESC | [{"type": "bloom", "column": ["time", "device_id"], "source": "default"}, {"type": "minmax", "column": "device_id", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
 
 select count(decompress_chunk(x)) from show_chunks('metrics') x;
  count 
@@ -646,9 +646,9 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_table') x;
      1
 
 select * from chunk_settings;
- hypertable | chunks | segmentby |   orderby    |                                                        index                                                         
-------------+--------+-----------+--------------+----------------------------------------------------------------------------------------------------------------------
- test_table |      1 |           | uuid,ts DESC | [{"type": "minmax", "column": "uuid", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+ hypertable | chunks | segmentby |   orderby    |                                                                                         index                                                                                          
+------------+--------+-----------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ test_table |      1 |           | uuid,ts DESC | [{"type": "bloom", "column": ["ts", "uuid"], "source": "default"}, {"type": "minmax", "column": "uuid", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_table;
 -- test that date/time columns (category 'D') are not selected as segmentby
@@ -763,8 +763,8 @@ SELECT count(compress_chunk(x)) FROM show_chunks('test_exclude_datetype') x;
     10
 
 SELECT * FROM timescaledb_information.chunk_compression_settings WHERE hypertable = 'test_exclude_datetype'::regclass ORDER BY chunk LIMIT 1;
-      hypertable       |                   chunk                   | segmentby |      orderby       |                                                           index                                                            
------------------------+-------------------------------------------+-----------+--------------------+----------------------------------------------------------------------------------------------------------------------------
- test_exclude_datetype | _timescaledb_internal._hyper_28_279_chunk | device_id | event_date,ts DESC | [{"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+      hypertable       |                   chunk                   | segmentby |      orderby       |                                                                                               index                                                                                                
+-----------------------+-------------------------------------------+-----------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ test_exclude_datetype | _timescaledb_internal._hyper_28_279_chunk | device_id | event_date,ts DESC | [{"type": "bloom", "column": ["ts", "event_date"], "source": "default"}, {"type": "minmax", "column": "event_date", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
 
 DROP TABLE test_exclude_datetype;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -25,7 +25,9 @@ set(TEST_FILES
     compress_batch_size.sql
     compress_bitmap_scan.sql
     compress_bloom_hash.sql
+    compress_compbloom_basics.sql
     compress_compbloom_config.sql
+    compress_compbloom_manual_config.sql
     compress_sparse_config.sql
     compress_default.sql
     compress_dml_copy.sql
@@ -127,6 +129,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     chunk_utils_compression.sql
     chunk_utils_internal.sql
     compress_bloom_sparse_debug.sql
+    compress_composite_bloom_debug.sql
     compression_algos.sql
     compression_bgw.sql
     compression_bools.sql

--- a/tsl/test/sql/compress_compbloom_basics.sql
+++ b/tsl/test/sql/compress_compbloom_basics.sql
@@ -1,0 +1,155 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+CREATE VIEW metacols AS select relname,attname,count(*) from pg_attribute a, pg_class c where c.oid=a.attrelid and attname like '%_ts_meta%' and relname like '%chunk' GROUP BY 1,2 ORDER BY relname::text COLLATE "C", attname::text COLLATE "C";
+CREATE VIEW compressedcols AS select relname,attname,c.oid as reloid,attnum from pg_attribute a, pg_class c where c.oid=a.attrelid and relname like '%compress_hyper_%' order by c.oid asc, a.attnum asc;
+
+create table sparse(
+    ts int,
+    o bigint,
+    value float,
+    boo bigint,
+    big1 bigint,
+    big2 bigint,
+    sby bigint,
+    small1 smallint,
+    small2 int2,
+    num numeric,
+    nowts timestamptz,
+    hello bytea);
+select create_hypertable('sparse', 'ts', create_default_indexes=>false);
+insert into sparse select x, x, x, x, x, x, x, x%4, x%4, x::numeric, now()::timestamptz, md5(x::text)::bytea from generate_series(1, 10000) x;
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(big2),bloom(value),bloom(value,big1,big2),bloom(o,big2),bloom(big1,big2),bloom(boo,big1),bloom(small1,small2),bloom(num,nowts),bloom(num,hello)');
+
+select count(compress_chunk(x)) from show_chunks('sparse') x;
+vacuum analyze sparse;
+
+-- smoke tests
+select min(big1), max(big2) from sparse where value < 100 and value > 10;
+select relname,attname from metacols order by 1,2;
+select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
+select distinct(attname) from compressedcols where relname = 'sparse' order by 1 asc;
+
+-- show plan
+explain (buffers off, costs off) select * from sparse where value = 1;
+explain (buffers off, costs off) select * from sparse where o = 1 and big2 = 1;
+explain (buffers off, costs off) select * from sparse where num = 1 and hello = md5('1')::bytea;
+explain (buffers off, costs off) select * from sparse where small1 = 1 and small2 = 1;
+explain (buffers off, costs off) select * from sparse where num = 1 and nowts = now()::timestamptz;
+explain (buffers off, costs off) select * from sparse where o in (1,2) and big2 = 1;
+explain (buffers off, costs off) select * from sparse where o = 1 and big2 in (1,2);
+explain (buffers off, costs off) select * from sparse where o in (1,2) and big2 in (1,2);
+
+-- segmentby = bloom
+explain (buffers off, costs off) select * from sparse where big1 = sby and value = 1;
+explain (buffers off, costs off) select * from sparse where o = sby and big2 = sby;
+explain (buffers off, costs off) select * from sparse where o = 1 and big2 = sby;
+explain (buffers off, costs off) select * from sparse where o = sby and big2 = 1;
+
+-- create a sister table where the same composite blooms should be auto created
+create table sparse_sister as select * from sparse where ts < -1;
+select create_hypertable('sparse_sister', 'ts', create_default_indexes=>false);
+alter table sparse_sister set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby');
+insert into sparse_sister select * from sparse;
+
+create index on sparse_sister(value,big1,big2);
+create index on sparse_sister(o,big2);
+create index on sparse_sister(big1,big2);
+create index on sparse_sister(boo,big1);
+create index on sparse_sister(small1,small2);
+create index on sparse_sister(num,nowts);
+create index on sparse_sister(num,hello);
+
+select count(compress_chunk(x)) from show_chunks('sparse_sister') x;
+vacuum analyze sparse_sister;
+
+-- smoke tests
+select min(big1), max(big2) from sparse_sister where value < 100 and value > 10;
+select relname,attname from metacols order by 1,2;
+select index from settings where relid = (select oid from pg_class where relname = 'sparse_sister') and index is not null group by 1 order by 1;
+select distinct(attname) from compressedcols where relname = 'sparse_sister' order by 1 asc;
+
+-- show plan
+explain (buffers off, costs off) select * from sparse_sister where value = 1;
+explain (buffers off, costs off) select * from sparse_sister where o = 1 and big2 = 1;
+explain (buffers off, costs off) select * from sparse_sister where num = 1 and hello = md5('1')::bytea;
+explain (buffers off, costs off) select * from sparse_sister where small1 = 1 and small2 = 1;
+explain (buffers off, costs off) select * from sparse_sister where num = 1 and nowts = now()::timestamptz;
+
+-- segmentby = bloom
+explain (buffers off, costs off) select * from sparse_sister where big1 = sby and value = 1;
+explain (buffers off, costs off) select * from sparse_sister where o = sby and big2 = sby;
+explain (buffers off, costs off) select * from sparse_sister where o = 1 and big2 = sby;
+explain (buffers off, costs off) select * from sparse_sister where o = sby and big2 = 1;
+
+-- renaming a column that participates in a composite bloom filter
+alter table sparse rename big2 to xxl;
+select relname,attname from metacols order by 1,2;
+select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
+select distinct(attname) from compressedcols where relname = 'sparse' order by 1 asc;
+
+-- dropping a column that participates in a composite bloom filter
+alter table sparse drop column xxl;
+select relname,attname from metacols order by 1,2;
+select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
+select distinct(attname) from compressedcols where relname = 'sparse' order by 1 asc;
+
+-- droppping an orderby column should fail
+\set ON_ERROR_STOP 0
+alter table sparse drop column o;
+
+-- a segmentby column cannot be part of composite key
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(sby,value)');
+
+-- a segmentby column cannot be part of single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(sby)');
+
+-- an orderby column cannot be part of a single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o)');
+
+-- an orderby column cannot be part of a single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(boo,o),bloom(o)');
+
+-- an orderby column cannot be part of a single col bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o),bloom(o,boo)');
+
+\set ON_ERROR_STOP 1
+
+-- an orderby column _can_ be part of a composite bloom filter
+alter table sparse set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o,boo)');
+
+DROP TABLE IF EXISTS sparse CASCADE;
+DROP TABLE IF EXISTS sparse_sister CASCADE;

--- a/tsl/test/sql/compress_compbloom_config.sql
+++ b/tsl/test/sql/compress_compbloom_config.sql
@@ -14,10 +14,7 @@ SELECT create_hypertable('t', 'a');
 
 
 -- Should succeed (8 columns max)
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("a","b","c","d","e","f","g","h")');
-\set ON_ERROR_STOP 1
 
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
 where relid = 't'::regclass and index is not null order by 1,2;
@@ -28,10 +25,7 @@ ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', tim
 \set ON_ERROR_STOP 1
 
 -- The ordering of bloom columns in the composite bloom index should be determined by the order of the columns in the CREATE TABLE statement
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f","e","d","c","b")');
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
 where relid = 't'::regclass and index is not null order by 1,2;
 
@@ -61,17 +55,11 @@ select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,in
 -- Check the auto generated compressed columns
 select relname,attname from compressedcols order by 1,2;
 
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE u SET (timescaledb.compress_index = 'bloom("a","b","c")');
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
 
 -- Also in a different order
--- TODO: remove later, once composite blooms fully rolled out
-\set ON_ERROR_STOP 0
 ALTER TABLE u SET (timescaledb.compress_index = 'bloom("c","b","a")');
-\set ON_ERROR_STOP 1
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
 
 DROP TABLE u CASCADE;

--- a/tsl/test/sql/compress_compbloom_manual_config.sql
+++ b/tsl/test/sql/compress_compbloom_manual_config.sql
@@ -1,0 +1,77 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+---------------------------------------------------------------------
+-- Manual config change between chunk compressions
+---------------------------------------------------------------------
+CREATE TABLE mixed_avail_manual(ts timestamptz, a int, b int, c int, seg int);
+SELECT create_hypertable('mixed_avail_manual', by_range('ts', interval '1 day'));
+
+-- Initial config: bloom(a,b)
+ALTER TABLE mixed_avail_manual SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b)'
+);
+
+INSERT INTO mixed_avail_manual
+SELECT ts, (i % 10), (i % 5), (i % 3), 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+
+-- Compress first chunk with bloom(a,b)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c LIMIT 1;
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND b = 2;
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND c = 2;
+SELECT COUNT(*) FROM mixed_avail_manual WHERE b = 1 AND c = 2;
+
+-- Before config changes
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND c = 2
+ORDER BY 1,2,3,4;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE b = 1 AND c = 2
+ORDER BY 1,2,3,4;
+
+-- Change config: bloom(a,c)
+ALTER TABLE mixed_avail_manual SET (
+    timescaledb.compress_index = 'bloom(a,c)'
+);
+
+-- Compress second chunk with bloom(a,c)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c OFFSET 1 LIMIT 1;
+
+-- Change config: bloom(b,c)
+ALTER TABLE mixed_avail_manual SET (
+    timescaledb.compress_index = 'bloom(b,c)'
+);
+
+-- Compress third chunk with bloom(b,c)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c OFFSET 2;
+
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND b = 2;
+SELECT COUNT(*) FROM mixed_avail_manual WHERE a = 1 AND c = 2;
+SELECT COUNT(*) FROM mixed_avail_manual WHERE b = 1 AND c = 2;
+
+-- After config changes
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE a = 1 AND c = 2
+ORDER BY 1,2,3,4;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_manual WHERE b = 1 AND c = 2
+ORDER BY 1,2,3,4;
+
+DROP TABLE IF EXISTS mixed_avail_manual CASCADE;

--- a/tsl/test/sql/compress_composite_bloom_debug.sql
+++ b/tsl/test/sql/compress_composite_bloom_debug.sql
@@ -1,0 +1,369 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-----------------------------------------------------------
+-- Debug Function Setup
+-----------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION ts_bloom1_composite_debug_hash(
+    composite_value anyelement
+) RETURNS int8
+AS :TSL_MODULE_PATHNAME, 'ts_bloom1_composite_debug_hash'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-----------------------------------------------------------
+-- Hash Signature Stability Tests
+-----------------------------------------------------------
+-- Binary compatibility tests
+
+-- INT4 + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4)) AS hash_1_2;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(2::int4, 1::int4)) AS hash_2_1;
+-- Order matters
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 1::int4)) AS hash_1_1;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(100::int4, 200::int4)) AS hash_100_200;
+
+-- NULL handling
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, NULL::int4)) AS hash_1_null;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(NULL::int4, 1::int4)) AS hash_null_1;
+-- NULL position matters
+
+SELECT ts_bloom1_composite_debug_hash(ROW(NULL::int4, NULL::int4)) AS hash_null_null;
+-- Deterministic
+
+-- INT4 + TEXT
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 'hello'::text)) AS hash_int_text;
+
+SELECT ts_bloom1_composite_debug_hash(ROW('hello'::text, 1::int4)) AS hash_text_int;
+-- Type order matters
+
+-- TEXT + TEXT
+SELECT ts_bloom1_composite_debug_hash(ROW('hello'::text, 'world'::text)) AS hash_hello_world;
+
+SELECT ts_bloom1_composite_debug_hash(ROW('world'::text, 'hello'::text)) AS hash_world_hello;
+
+
+-- INT8 + INT8
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int8, 2::int8)) AS hash_bigint_1_2;
+
+-- FLOAT8 + FLOAT8
+SELECT ts_bloom1_composite_debug_hash(ROW(3.14::float8, 2.71::float8)) AS hash_pi_e;
+
+-- DATE + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW('2025-01-01'::date, 123::int4)) AS hash_date_int;
+
+-- TIMESTAMPTZ + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW('2025-01-01 12:00:00+00'::timestamptz, 456::int4)) AS hash_ts_int;
+
+-- UUID + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW('c9757a73-7632-462e-bcfa-d5d9659e498f'::uuid, 789::int4)) AS hash_uuid_int;
+
+-- Triples
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 'test'::text, 3.14::float8)) AS hash_triple_1;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 'test'::text, 2.71::float8)) AS hash_triple_2;
+
+-- Triples with NULL
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, NULL::text, 3.14::float8)) AS hash_triple_null_middle;
+
+-----------------------------------------------------------
+-- Actual Filtering Tests - Basic Setup
+-----------------------------------------------------------
+-- Create table with known data distribution
+CREATE TABLE composite_filter_test(
+    ts timestamptz NOT NULL,
+    device_id int,
+    sensor_type text,
+    value float,
+    segmentby_col int
+);
+
+SELECT create_hypertable('composite_filter_test', by_range('ts'));
+
+ALTER TABLE composite_filter_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'segmentby_col',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(device_id,sensor_type)'
+);
+
+-- Insert data with DISTINCT patterns per segment
+-- Segment 1: device_id=1, sensor_type='temp' ONLY
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       1, 'temp', random() * 100, 1
+FROM generate_series(1, 1000) i;
+
+-- Segment 2: device_id=2, sensor_type='humidity' ONLY
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       2, 'humidity', random() * 100, 2
+FROM generate_series(1, 1000) i;
+
+-- Segment 3: device_id=3, sensor_type='pressure' ONLY
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       3, 'pressure', random() * 100, 3
+FROM generate_series(1, 1000) i;
+
+-- Segment 4: Mixed data (multiple combinations)
+INSERT INTO composite_filter_test
+SELECT '2024-01-01'::timestamptz + i * interval '1 minute',
+       (i % 3) + 1,
+       CASE (i % 3) WHEN 0 THEN 'temp' WHEN 1 THEN 'humidity' ELSE 'pressure' END,
+       random() * 100,
+       4
+FROM generate_series(1, 900) i;
+
+SELECT compress_chunk(c) FROM show_chunks('composite_filter_test') c;
+VACUUM ANALYZE composite_filter_test;
+
+-- Create uncompressed reference for false negative testing
+CREATE TABLE composite_filter_ref AS SELECT * FROM composite_filter_test;
+
+-----------------------------------------------------------
+-- Verify Composite Bloom Column Exists
+-----------------------------------------------------------
+SELECT cc.schema_name || '.' || cc.table_name AS chunk
+FROM _timescaledb_catalog.chunk uc, timescaledb_information.chunks tc, _timescaledb_catalog.chunk cc
+WHERE uc.table_name = tc.chunk_name
+  AND cc.id = uc.compressed_chunk_id
+  AND tc.hypertable_name = 'composite_filter_test'
+  AND tc.is_compressed
+ORDER BY cc.table_name
+LIMIT 1
+\gset
+
+\echo 'Chunk: ' :chunk
+
+SELECT attname AS composite_bloom_col
+FROM pg_attribute
+WHERE attrelid = :'chunk'::regclass
+  AND attname LIKE '%device_id%sensor_type%'
+  LIMIT 1
+\gset
+
+\echo 'Composite bloom column: ' :composite_bloom_col
+
+-----------------------------------------------------------
+-- Filtering Effectiveness Tests
+-----------------------------------------------------------
+
+-- Query for data in Segment 1 only
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'temp';
+
+-- Expected behavior:
+-- - Filter should show: bloom1_contains(composite_bloom, ROW(1, 'temp'::text))
+-- - Should scan ~1000-1100 rows (segment 1 + maybe some from segment 4 due to false positives)
+-- - Should NOT scan segments 2 and 3 (different device_id/sensor_type)
+-- - Pruning: ~50-60% of segments
+
+-- Query for data in Segment 2 only
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 2 AND sensor_type = 'humidity';
+
+-- Expected: Similar pruning as Test 5.1
+
+-- Query for non-existent combination
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 5 AND sensor_type = 'temp';
+
+-- Expected:
+-- - Should scan 0 or very few rows (bloom filter prunes all segments)
+-- - Actual rows returned: 0
+
+-- Non-existent pairing (device_id=1, sensor_type=humidity)
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'humidity';
+
+-- Expected:
+-- Segment 4 data: (i%3)+1 paired with sensor via CASE
+-- Pairs: (1,temp), (2,humidity), (3,pressure)
+-- Query (1,humidity) doesn't exist → should return 0 rows
+
+-----------------------------------------------------------
+-- False Negative Prevention Tests
+-----------------------------------------------------------
+-- Test all expected combinations and verify counts match reference
+
+WITH test_cases AS (
+    SELECT device_id, sensor_type
+    FROM (VALUES
+        (1, 'temp'),        -- Segment 1: ~1000 rows
+        (2, 'humidity'),    -- Segment 2: ~1000 rows
+        (3, 'pressure'),    -- Segment 3: ~1000 rows
+        (1, 'humidity'),    -- Segment 4: ~300 rows
+        (2, 'pressure'),    -- Segment 4: ~300 rows
+        (3, 'temp'),        -- Segment 4: ~300 rows
+        (4, 'temp'),        -- Non-existent: 0 rows
+        (1, 'pressure'),    -- Segment 4: ~300 rows
+        (2, 'temp')         -- Segment 4: ~300 rows
+    ) AS t(device_id, sensor_type)
+)
+SELECT
+    device_id,
+    sensor_type,
+    (SELECT COUNT(*) FROM composite_filter_test
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) AS compressed_count,
+    (SELECT COUNT(*) FROM composite_filter_ref
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) AS reference_count,
+    (SELECT COUNT(*) FROM composite_filter_test
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) =
+    (SELECT COUNT(*) FROM composite_filter_ref
+     WHERE device_id = tc.device_id AND sensor_type = tc.sensor_type) AS match
+FROM test_cases tc
+ORDER BY device_id, sensor_type;
+
+-- All match values should be TRUE
+
+-----------------------------------------------------------
+-- NULL Handling Tests
+-----------------------------------------------------------
+CREATE TABLE null_test(
+    ts int,
+    a int,
+    b text,
+    seg int
+);
+
+SELECT create_hypertable('null_test', 'ts');
+
+ALTER TABLE null_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b)'
+);
+
+-- Insert various NULL combinations
+INSERT INTO null_test VALUES (1, NULL, NULL, 1);
+INSERT INTO null_test VALUES (2, NULL, 'test', 1);
+INSERT INTO null_test VALUES (3, 1, NULL, 1);
+INSERT INTO null_test VALUES (4, 2, 'test', 1);
+INSERT INTO null_test VALUES (5, NULL, 'test', 1);
+
+SELECT compress_chunk(c) FROM show_chunks('null_test') c;
+
+-- Test NULL queries
+SELECT COUNT(*) FROM null_test WHERE a IS NULL AND b IS NULL;
+SELECT COUNT(*) FROM null_test WHERE a IS NULL AND b = 'test';
+SELECT COUNT(*) FROM null_test WHERE a = 1 AND b IS NULL;
+SELECT COUNT(*) FROM null_test WHERE a = 2 AND b = 'test';
+
+-- Verify no false negatives
+CREATE TABLE null_test_ref AS SELECT * FROM null_test;
+
+WITH test_cases AS (
+    SELECT a, b FROM (VALUES
+        (NULL, NULL),
+        (NULL, 'test'),
+        (1, NULL),
+        (2, 'test')
+    ) AS t(a, b)
+)
+SELECT
+    COALESCE(a::text, 'NULL') AS a,
+    COALESCE(b, 'NULL') AS b,
+    (SELECT COUNT(*) FROM null_test WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) AS compressed,
+    (SELECT COUNT(*) FROM null_test_ref WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) AS reference,
+    (SELECT COUNT(*) FROM null_test WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) =
+    (SELECT COUNT(*) FROM null_test_ref WHERE (a IS NOT DISTINCT FROM tc.a) AND (b IS NOT DISTINCT FROM tc.b)) AS match
+FROM test_cases tc;
+
+-- All match values should be TRUE
+
+-----------------------------------------------------------
+-- More Type Pairs
+-----------------------------------------------------------
+-- INT2 + INT2 (smallint)
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int2, 2::int2));
+
+-- INT4 + INT8 (mixed integer sizes)
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int8));
+
+-- FLOAT4 + FLOAT8 (mixed float sizes)
+SELECT ts_bloom1_composite_debug_hash(ROW(1.5::float4, 2.5::float8));
+
+-- VARCHAR + TEXT (string types)
+SELECT ts_bloom1_composite_debug_hash(ROW('hello'::varchar, 'world'::text));
+
+-- TIMESTAMP + TIMESTAMPTZ
+SELECT ts_bloom1_composite_debug_hash(ROW('2025-01-01 12:00:00'::timestamp, '2025-01-01 12:00:00+00'::timestamptz));
+
+-- BOOL + INT4
+SELECT ts_bloom1_composite_debug_hash(ROW(true::bool, 1::int4));
+
+-----------------------------------------------------------
+-- 3 or more fields
+-----------------------------------------------------------
+SELECT ts_bloom1_composite_debug_hash(ROW(42::int4, 'answer'::text, 3.14159::float8)) AS hash_triple;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4, 3::int4, 4::int4)) AS hash_quad;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4, 3::int4, 4::int4, 5::int4)) AS hash_quint;
+
+SELECT ts_bloom1_composite_debug_hash(ROW(1::int4, 2::int4, 3::int4, 4::int4, 5::int4, 6::int4, 7::int4, 8::int4)) AS hash_octet;
+
+-----------------------------------------------------------
+-- Triple Column Tests
+-----------------------------------------------------------
+CREATE TABLE test_triple(ts int, a int, b text, c float8, seg int);
+SELECT create_hypertable('test_triple', 'ts');
+ALTER TABLE test_triple SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b,c)'
+);
+
+INSERT INTO test_triple
+SELECT ts,
+       ts % 5,
+       CASE ts % 3 WHEN 0 THEN 'x' WHEN 1 THEN 'y' ELSE 'z' END,
+       (ts % 4)::float8,
+       ts % 2
+FROM generate_series(1, 1000) ts;
+
+SELECT compress_chunk(c) FROM show_chunks('test_triple') c;
+
+-- Test various triple combinations
+SELECT COUNT(*) FROM test_triple WHERE a = 1 AND b = 'x' AND c = 2.0;
+SELECT COUNT(*) FROM test_triple WHERE a = 2 AND b = 'y' AND c = 1.0;
+
+CREATE TABLE test_triple_ref AS SELECT * FROM test_triple;
+
+-- Verify comprehensive
+WITH test_cases AS (
+    SELECT a, b, c FROM (VALUES
+        (1, 'x', 2.0),
+        (2, 'y', 1.0),
+        (0, 'z', 0.0),
+        (4, 'x', 3.0)
+    ) AS t(a, b, c)
+)
+SELECT
+    a, b, c,
+    (SELECT COUNT(*) FROM test_triple WHERE a = tc.a AND b = tc.b AND c = tc.c) AS compressed,
+    (SELECT COUNT(*) FROM test_triple_ref WHERE a = tc.a AND b = tc.b AND c = tc.c) AS reference,
+    (SELECT COUNT(*) FROM test_triple WHERE a = tc.a AND b = tc.b AND c = tc.c) =
+    (SELECT COUNT(*) FROM test_triple_ref WHERE a = tc.a AND b = tc.b AND c = tc.c) AS match
+FROM test_cases tc;
+
+-----------------------------------------------------------
+-- Cleanup
+-----------------------------------------------------------
+
+DROP TABLE IF EXISTS composite_filter_test CASCADE;
+DROP TABLE IF EXISTS composite_filter_ref CASCADE;
+DROP TABLE IF EXISTS null_test CASCADE;
+DROP TABLE IF EXISTS null_test_ref CASCADE;
+DROP TABLE IF EXISTS test_triple CASCADE;
+DROP TABLE IF EXISTS test_triple_ref CASCADE;

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -4,10 +4,6 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
--- disable hash pushdown so we don't include the hash values in the plans
--- which makes the test stable. the hash pushdown is tested separately
-set timescaledb.enable_bloom1_hash_pushdown = false;
-
 CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
 
 -- Test configurable sparse indexes settings
@@ -115,8 +111,6 @@ reset timescaledb.enable_sparse_index_bloom;
 
 -- valid composite bloom filter cases:
 -- two columns
--- TODO : remove after composite blooms rolled out
-\set ON_ERROR_STOP 0
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts)');
@@ -167,7 +161,6 @@ alter table test_settings set (timescaledb.compress,
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,value),bloom(u,ts,value)');
-\set ON_ERROR_STOP 1
 
 -- invalid composite bloom filter cases:
 \set ON_ERROR_STOP 0

--- a/tsl/test/src/compression_unit_test.c
+++ b/tsl/test/src/compression_unit_test.c
@@ -1687,16 +1687,27 @@ ts_segment_meta_min_max_append(PG_FUNCTION_ARGS)
 
 	old_context = MemoryContextSwitchTo(agg_context);
 
+	TupleTableSlot *slot = (TupleTableSlot *) fcinfo->flinfo->fn_extra;
 	if (builder == NULL)
 	{
 		Oid type_to_compress = get_fn_expr_argtype(fcinfo->flinfo, 1);
-		builder =
-			batch_metadata_builder_minmax_create(type_to_compress, fcinfo->fncollation, -1, -1);
+		builder = batch_metadata_builder_minmax_create(type_to_compress,
+													   fcinfo->fncollation,
+													   (AttrNumber) 1,
+													   -1,
+													   -1);
+
+		TupleDesc tupdesc = CreateTemplateTupleDesc(1);
+		TupleDescInitEntry(tupdesc, 1, "val", type_to_compress, -1, 0);
+		slot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsVirtual);
+		fcinfo->flinfo->fn_extra = slot;
 	}
-	if (PG_ARGISNULL(1))
-		builder->update_null(builder);
-	else
-		builder->update_val(builder, PG_GETARG_DATUM(1));
+
+	ExecClearTuple(slot);
+	slot->tts_values[0] = PG_GETARG_DATUM(1);
+	slot->tts_isnull[0] = PG_ARGISNULL(1);
+	ExecStoreVirtualTuple(slot);
+	builder->update_row(builder, slot);
 
 	MemoryContextSwitchTo(old_context);
 	PG_RETURN_POINTER(builder);


### PR DESCRIPTION
This set of changes include:

- the batch metdata builders to use a row based interface
- the batch metadata builders are now a list in the RowCompressor and not in PerColumn
- separate hasher interface similar to the batch metadata builder but it doesn't hold/update blooom filter data
- the code to generate composite bloom data
- tests to verify the impact of dropping and renaming columns on composite bloom columns
- GUC to disable comp blooms: enable_composite_bloom_indexes
- a few explain tests to show the current state without the bloom clause push down, so we will see the difference when that will be merged

Disable-check: force-changelog-file