### PR TITLE
Handle generated columns in ExecCheckPlanOutput

### DIFF
--- a/.unreleased/pr_9327
+++ b/.unreleased/pr_9327
@@ -1,0 +1,1 @@
+Fixes: #9327 Fix handling of generated columns with NOT NULL domain type

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -516,3 +516,30 @@ SELECT * FROM data_records;
 
 \set QUIET on
 ROLLBACK;
+-- Test INSERT into hypertable with a generated column whose type is a
+-- domain with a NOT NULL constraint
+CREATE DOMAIN nn_int AS int CHECK (VALUE IS NOT NULL);
+CREATE TABLE generated_col_ht(
+    time timestamptz NOT NULL,
+    val int NOT NULL,
+    doubled nn_int GENERATED ALWAYS AS (val * 2) STORED
+);
+SELECT create_hypertable('generated_col_ht', 'time');
+       create_hypertable        
+--------------------------------
+ (14,public,generated_col_ht,t)
+
+INSERT INTO generated_col_ht(time, val) VALUES ('2024-01-01', 5);
+INSERT INTO generated_col_ht(time, val) VALUES ('2024-01-02', 10) RETURNING *;
+             time             | val | doubled 
+------------------------------+-----+---------
+ Tue Jan 02 00:00:00 2024 CST |  10 |      20
+
+SELECT * FROM generated_col_ht ORDER BY time;
+             time             | val | doubled 
+------------------------------+-----+---------
+ Mon Jan 01 00:00:00 2024 CST |   5 |      10
+ Tue Jan 02 00:00:00 2024 CST |  10 |      20
+
+DROP TABLE generated_col_ht;
+DROP DOMAIN nn_int;

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -201,3 +201,22 @@ SELECT * FROM data_records;
 
 \set QUIET on
 ROLLBACK;
+
+-- Test INSERT into hypertable with a generated column whose type is a
+-- domain with a NOT NULL constraint
+CREATE DOMAIN nn_int AS int CHECK (VALUE IS NOT NULL);
+
+CREATE TABLE generated_col_ht(
+    time timestamptz NOT NULL,
+    val int NOT NULL,
+    doubled nn_int GENERATED ALWAYS AS (val * 2) STORED
+);
+SELECT create_hypertable('generated_col_ht', 'time');
+
+INSERT INTO generated_col_ht(time, val) VALUES ('2024-01-01', 5);
+INSERT INTO generated_col_ht(time, val) VALUES ('2024-01-02', 10) RETURNING *;
+
+SELECT * FROM generated_col_ht ORDER BY time;
+
+DROP TABLE generated_col_ht;
+DROP DOMAIN nn_int;


### PR DESCRIPTION
On PG18 the planner emits a base-type NULL placeholder for generated
columns instead of coercing to the column's domain type. Our version of
ExecCheckPlanOutput only recognized dropped columns as a special case
and would reject the type mismatch, breaking INSERT into hypertables
with generated columns whose type is a NOT NULL domain.

This commit syncs our version with the upstream version.
