### PR TITLE
Add unit tests for `dimension_vector`

### DIFF
--- a/test/expected/c_unit_tests.out
+++ b/test/expected/c_unit_tests.out
@@ -16,6 +16,8 @@ CREATE OR REPLACE FUNCTION test.jsonb_utils() RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_jsonb_utils' LANGUAGE C;
 CREATE OR REPLACE FUNCTION test.compression_settings() RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_compression_settings' LANGUAGE C;
+CREATE OR REPLACE FUNCTION test.dimension_vector() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_dimension_vector' LANGUAGE C;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT test.time_to_internal_conversion();
  time_to_internal_conversion 
@@ -50,5 +52,10 @@ SELECT test.jsonb_utils();
 SELECT test.compression_settings();
  compression_settings 
 ----------------------
+ 
+
+SELECT test.dimension_vector();
+ dimension_vector 
+------------------
  
 

--- a/test/sql/c_unit_tests.sql
+++ b/test/sql/c_unit_tests.sql
@@ -24,6 +24,9 @@ AS :MODULE_PATHNAME, 'ts_test_jsonb_utils' LANGUAGE C;
 CREATE OR REPLACE FUNCTION test.compression_settings() RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_compression_settings' LANGUAGE C;
 
+CREATE OR REPLACE FUNCTION test.dimension_vector() RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_test_dimension_vector' LANGUAGE C;
+
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 SELECT test.time_to_internal_conversion();
@@ -33,4 +36,4 @@ SELECT test.time_utils();
 SELECT test.bmslist_utils();
 SELECT test.jsonb_utils();
 SELECT test.compression_settings();
-
+SELECT test.dimension_vector();

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     symbol_conflict.c
     test_compression_settings.c
     test_bmslist_utils.c
+    test_dimension_vector.c
     test_jsonb_utils.c
     test_scanner.c
     test_time_to_internal.c

--- a/test/src/test_dimension_vector.c
+++ b/test/src/test_dimension_vector.c
@@ -4,16 +4,13 @@
  * LICENSE-APACHE for a copy of the license.
  */
 
-#include <string.h>
 #include <postgres.h>
-#include "dimension.h"
-#include "dimension_slice.h"
-#include <c.h>
 #include <fmgr.h>
 
-#include "dimension_vector.h"
 #include "export.h"
 #include "test_utils.h"
+#include "dimension_slice.h"
+#include "dimension_vector.h"
 
 TS_FUNCTION_INFO_V1(ts_test_dimension_vector);
 

--- a/test/src/test_dimension_vector.c
+++ b/test/src/test_dimension_vector.c
@@ -7,10 +7,10 @@
 #include <postgres.h>
 #include <fmgr.h>
 
-#include "export.h"
-#include "test_utils.h"
 #include "dimension_slice.h"
 #include "dimension_vector.h"
+#include "export.h"
+#include "test_utils.h"
 
 TS_FUNCTION_INFO_V1(ts_test_dimension_vector);
 

--- a/test/src/test_dimension_vector.c
+++ b/test/src/test_dimension_vector.c
@@ -1,0 +1,272 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <string.h>
+#include <postgres.h>
+#include "dimension.h"
+#include "dimension_slice.h"
+#include <c.h>
+#include <fmgr.h>
+
+#include "dimension_vector.h"
+#include "export.h"
+#include "test_utils.h"
+
+TS_FUNCTION_INFO_V1(ts_test_dimension_vector);
+
+static void
+test_ts_dimension_vec_create(void)
+{
+	DimensionVec *vec;
+
+	vec = ts_dimension_vec_create(0);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 0);
+	TestAssertInt64Eq(vec->num_slices, 0);
+	ts_dimension_vec_free(vec);
+
+	vec = ts_dimension_vec_create(100);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 100);
+	TestAssertInt64Eq(vec->num_slices, 0);
+	ts_dimension_vec_free(vec);
+
+	// Test with overflow capcity (int32)
+	TestEnsureError(ts_dimension_vec_create((PG_INT32_MIN)));
+}
+
+static void
+test_ts_dimension_vec_sort(void)
+{
+	DimensionVec *vec;
+	DimensionSlice *slice_one;
+	DimensionSlice *slice_two;
+	DimensionSlice *slice_three;
+
+	vec = ts_dimension_vec_create(3);
+	slice_one = ts_dimension_slice_create(1, 0, 10);
+	slice_two = ts_dimension_slice_create(1, 10, 20);
+	slice_three = ts_dimension_slice_create(1, 20, 30);
+
+	slice_one->fd.id = 101;
+	slice_two->fd.id = 102;
+	slice_three->fd.id = 103;
+
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_three);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_one);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_two);
+
+	TestAssertTrue(vec->num_slices == 3);
+	TestAssertTrue(vec->slices[0] == slice_three);
+	TestAssertTrue(vec->slices[1] == slice_one);
+	TestAssertTrue(vec->slices[2] == slice_two);
+
+	ts_dimension_vec_sort(&vec);
+
+	TestAssertTrue(vec->slices[0] == slice_one);
+	TestAssertTrue(vec->slices[1] == slice_two);
+	TestAssertTrue(vec->slices[2] == slice_three);
+
+	ts_dimension_vec_free(vec);
+}
+
+static void
+test_ts_dimension_vec_add_slice(void)
+{
+	DimensionVec *vec;
+	DimensionSlice *slice_one;
+	DimensionSlice *slice_two;
+	DimensionSlice *slice_three;
+
+	vec = ts_dimension_vec_create(2);
+	slice_one = ts_dimension_slice_create(1, 0, 10);
+	vec = ts_dimension_vec_add_slice(&vec, slice_one);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 2);
+	TestAssertInt64Eq(vec->num_slices, 1);
+	TestAssertTrue(vec->slices[0] == slice_one);
+
+	slice_two = ts_dimension_slice_create(1, 0, 10);
+	vec = ts_dimension_vec_add_slice(&vec, slice_two);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 2);
+	TestAssertInt64Eq(vec->num_slices, 2);
+	TestAssertTrue(vec->slices[0] == slice_one);
+	TestAssertTrue(vec->slices[1] == slice_two);
+
+	slice_three = ts_dimension_slice_create(1, 0, 10);
+	vec = ts_dimension_vec_add_slice(&vec, slice_three);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 12);
+	TestAssertInt64Eq(vec->num_slices, 3);
+	TestAssertTrue(vec->slices[0] == slice_one);
+	TestAssertTrue(vec->slices[1] == slice_two);
+	TestAssertTrue(vec->slices[2] == slice_three);
+
+	ts_dimension_vec_free(vec);
+}
+
+static void
+test_ts_dimension_vec_add_unique_slice(void)
+{
+	DimensionVec *vec;
+	DimensionSlice *slice;
+
+	vec = ts_dimension_vec_create(2);
+	slice = ts_dimension_slice_create(10, 0, 10);
+
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 2);
+	TestAssertInt64Eq(vec->num_slices, 0);
+
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 2);
+	TestAssertInt64Eq(vec->num_slices, 1);
+	TestAssertTrue(vec->slices[0] == slice);
+
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice);
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 2);
+	TestAssertInt64Eq(vec->num_slices, 1);
+	TestAssertTrue(vec->slices[0] == slice);
+
+	ts_dimension_vec_free(vec);
+}
+
+static void
+test_ts_dimension_vec_remove_slice(void)
+{
+	DimensionVec *vec;
+	DimensionSlice *slice_one;
+	DimensionSlice *slice_two;
+	DimensionSlice *slice_three;
+
+	vec = ts_dimension_vec_create(3);
+	slice_one = ts_dimension_slice_create(1, 0, 10);
+	slice_two = ts_dimension_slice_create(1, 10, 20);
+	slice_three = ts_dimension_slice_create(1, 20, 30);
+	slice_one->fd.id = 101;
+	slice_two->fd.id = 102;
+	slice_three->fd.id = 103;
+
+	TestAssertTrue(vec != NULL);
+	TestAssertInt64Eq(vec->capacity, 3);
+	TestAssertInt64Eq(vec->num_slices, 0);
+
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_one);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_two);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_three);
+
+	TestAssertTrue(vec->num_slices == 3);
+
+	TestAssertTrue(vec->slices[0] == slice_one);
+	TestAssertTrue(vec->slices[1] == slice_two);
+	TestAssertTrue(vec->slices[2] == slice_three);
+
+	ts_dimension_vec_remove_slice(&vec, 0);
+
+	TestAssertTrue(vec->num_slices == 2);
+
+	TestAssertTrue(vec->slices[0] == slice_two);
+	TestAssertTrue(vec->slices[1] == slice_three);
+
+	ts_dimension_vec_remove_slice(&vec, 1);
+
+	TestAssertTrue(vec->num_slices == 1);
+
+	TestAssertTrue(vec->slices[0] == slice_two);
+
+	ts_dimension_vec_remove_slice(&vec, 0);
+
+	TestAssertTrue(vec->num_slices == 0);
+
+	ts_dimension_vec_free(vec);
+}
+
+static void
+test_ts_dimension_vec_find_slice(void)
+{
+	DimensionVec *vec;
+	DimensionSlice *slice_one;
+	DimensionSlice *slice_two;
+	DimensionSlice *slice_three;
+
+	vec = ts_dimension_vec_create(3);
+	slice_one = ts_dimension_slice_create(1, 0, 10);
+	slice_two = ts_dimension_slice_create(1, 20, 30);
+	slice_three = ts_dimension_slice_create(1, 30, 40);
+
+	slice_one->fd.id = 101;
+	slice_two->fd.id = 102;
+	slice_three->fd.id = 103;
+
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_one);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_two);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_three);
+
+	TestAssertTrue(vec->num_slices == 3);
+
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, 5) == slice_one);
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, 25) == slice_two);
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, 35) == slice_three);
+
+	// Inclusive start, exclusive end
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, 0) == slice_one);
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, 10) == NULL);
+
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, -5) == NULL);
+	TestAssertTrue(ts_dimension_vec_find_slice(vec, 45) == NULL);
+
+	ts_dimension_vec_free(vec);
+}
+
+static void
+test_ts_dimension_vec_find_slice_index(void)
+{
+	DimensionVec *vec;
+	DimensionSlice *slice_one;
+	DimensionSlice *slice_two;
+	DimensionSlice *slice_three;
+
+	vec = ts_dimension_vec_create(3);
+	slice_one = ts_dimension_slice_create(1, 0, 10);
+	slice_two = ts_dimension_slice_create(1, 10, 20);
+	slice_three = ts_dimension_slice_create(1, 20, 30);
+
+	slice_one->fd.id = 101;
+	slice_two->fd.id = 102;
+	slice_three->fd.id = 103;
+
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_three);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_one);
+	vec = ts_dimension_vec_add_unique_slice(&vec, slice_two);
+
+	TestAssertTrue(vec->num_slices == 3);
+
+	TestAssertInt64Eq(ts_dimension_vec_find_slice_index(vec, 103), 0);
+	TestAssertInt64Eq(ts_dimension_vec_find_slice_index(vec, 101), 1);
+	TestAssertInt64Eq(ts_dimension_vec_find_slice_index(vec, 102), 2);
+
+	TestAssertInt64Eq(ts_dimension_vec_find_slice_index(vec, 100), -1);
+	TestAssertInt64Eq(ts_dimension_vec_find_slice_index(vec, 104), -1);
+
+	ts_dimension_vec_free(vec);
+}
+
+Datum
+ts_test_dimension_vector(PG_FUNCTION_ARGS)
+{
+	test_ts_dimension_vec_create();
+	test_ts_dimension_vec_sort();
+	test_ts_dimension_vec_add_slice();
+	test_ts_dimension_vec_add_unique_slice();
+	test_ts_dimension_vec_remove_slice();
+	test_ts_dimension_vec_find_slice();
+	test_ts_dimension_vec_find_slice_index();
+
+	PG_RETURN_VOID();
+}


### PR DESCRIPTION
`DimensionVec` is a core data structure heavily tested indirectly by almost every SQL test in the suite (e.g., via subspace_store.c for inserts and hypertable_restrict_info.c for chunk exclusion) but lacks isolated unit tests.

This PR adds `test_dimension_vector.c`  and tries to thoroughly validate all the functions in an isolated manner:
	1. `test_ts_dimension_vec_create()` to create.
	2. `test_ts_dimension_vec_sort()` to verify sorting.
	3. `test_ts_dimension_vec_add_slice()` to add slices.
	4. `test_ts_dimension_vec_add_unique_slice()` to handle deduplication.
	5. `test_ts_dimension_vec_remove_slice()` to remove.
	6. `test_ts_dimension_vec_find_slice()` to verify binary search.
	7. `test_ts_dimension_vec_find_slice_index()` to get index of slice.