### PR TITLE
Segmentwise recompress should only clear partial flag

### DIFF
--- a/.unreleased/pr_9339
+++ b/.unreleased/pr_9339
@@ -1,0 +1,1 @@
+Fixes: #9339 Fix segmentwise recompression clearing unordered flag

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1190,9 +1190,13 @@ try_updating_chunk_status(Chunk *uncompressed_chunk, Relation uncompressed_chunk
 
 	if (!has_tuples)
 	{
-		if (ts_chunk_clear_status(uncompressed_chunk,
-								  CHUNK_STATUS_COMPRESSED_UNORDERED |
-									  CHUNK_STATUS_COMPRESSED_PARTIAL))
+		/*
+		 * Only clear PARTIAL. Segmentwise recompression only processes
+		 * segments that have new uncompressed data, so segments without new
+		 * data are left as-is. Any overlapping batches in those segments
+		 * remain as is, so the UNORDERED flag must be preserved.
+		 */
+		if (ts_chunk_clear_status(uncompressed_chunk, CHUNK_STATUS_COMPRESSED_PARTIAL))
 			ereport(DEBUG1,
 					(errmsg("cleared chunk status for recompression: \"%s.%s\"",
 							NameStr(uncompressed_chunk->fd.schema_name),

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1656,8 +1656,10 @@ SELECT compress_chunk(show_chunks('i9314'));
 
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 --- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _hyper_50_103_chunk
-   ->  Index Scan Backward using compress_hyper_51_104_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_51_104_chunk
+ Sort
+   Sort Key: _hyper_50_103_chunk."time"
+   ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+         ->  Seq Scan on compress_hyper_51_104_chunk
 
 SELECT * FROM i9314 ORDER BY time;
              time             | value | doubled 
@@ -1688,8 +1690,10 @@ COPY i9314 FROM STDIN DELIMITER ',' CSV;
 --- QUERY PLAN ---
  Custom Scan (ChunkAppend) on i9314
    Order: i9314."time"
-   ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
-         ->  Index Scan Backward using compress_hyper_51_104_chunk__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_51_104_chunk
+   ->  Sort
+         Sort Key: _hyper_50_103_chunk."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+               ->  Seq Scan on compress_hyper_51_104_chunk
    ->  Sort
          Sort Key: _hyper_50_105_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_50_105_chunk

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -688,3 +688,75 @@ ORDER BY 1;
 
 ROLLBACK;
 RESET timescaledb.enable_exclusive_locking_recompression;
+-- Test: recompress_chunk_segmentwise should not clear the UNORDERED flag
+--
+-- The UNORDERED flag means that some compressed batches do not follow the
+-- configured compress_orderby. Segmentwise recompression only processes
+-- segments that have new uncompressed data. Segments that were UNORDERED
+-- but have no new uncompressed rows are left untouched, so the chunk-level
+-- UNORDERED flag must be preserved after segmentwise recompression.
+CREATE TABLE segwise_unordered(time timestamptz NOT NULL, a int, b int);
+SELECT create_hypertable('segwise_unordered', by_range('time', INTERVAL '1 day'));
+ create_hypertable 
+-------------------
+ (25,t)
+
+ALTER TABLE segwise_unordered SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'a',
+    timescaledb.compress_orderby = 'time'
+);
+SET timescaledb.enable_direct_compress_insert TO ON;
+INSERT INTO segwise_unordered
+SELECT t, a, 0
+FROM generate_series('2025-01-01 00:00:00+00'::timestamptz,
+                     '2025-01-01 00:10:00+00'::timestamptz,
+                     '1 minute'::interval) t
+CROSS JOIN (VALUES (1), (2)) AS seg(a);
+INSERT INTO segwise_unordered
+SELECT t, 2, 0
+FROM generate_series('2025-01-01 00:00:00+00'::timestamptz,
+                     '2025-01-01 00:10:00+00'::timestamptz,
+                     '1 minute'::interval) t;
+RESET timescaledb.enable_direct_compress_insert;
+SELECT show_chunks AS chunk_to_compress FROM show_chunks('segwise_unordered') LIMIT 1 \gset
+-- Chunk should now be COMPRESSED|UNORDERED (status=3)
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
+-- Insert new data for only segment a=1 via normal INSERT so the chunk becomes PARTIAL
+INSERT INTO segwise_unordered VALUES ('2025-01-01 03:00:00+00', 1, 30);
+-- Chunk should now be COMPRESSED|UNORDERED|PARTIAL (status=11)
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
+       chunk_status_text        
+--------------------------------
+ {COMPRESSED,UNORDERED,PARTIAL}
+
+-- Segmentwise recompression processes only segment a=1 (which has new data).
+-- Segment a=2 is never touched, so its unordered batches remain unordered.
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+       recompress_chunk_segmentwise       
+------------------------------------------
+ _timescaledb_internal._hyper_25_27_chunk
+
+-- PARTIAL should be cleared (no more uncompressed rows).
+-- UNORDERED must be preserved (segment a=2 still has unordered compressed data).
+-- Expected status: 3 (COMPRESSED|UNORDERED), NOT 1 (COMPRESSED).
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
+-- Output would be incorrectly ordered if the flag was cleared
+-- We have to see a sort on top of the ColumnarScan node due to UNORDERED flag
+EXPLAIN SELECT a, time FROM segwise_unordered WHERE a = 2 ORDER BY a, time;
+--- QUERY PLAN ---
+ Sort  (cost=284.54..294.54 rows=4000 width=12)
+   Sort Key: _hyper_25_27_chunk."time"
+   ->  Custom Scan (ColumnarScan) on _hyper_25_27_chunk  (cost=1.42..45.22 rows=4000 width=12)
+         ->  Index Scan using compress_hyper_26_28_chunk_a__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_26_28_chunk  (cost=0.15..5.22 rows=4 width=56)
+               Index Cond: (a = 2)
+
+DROP TABLE segwise_unordered;

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -389,3 +389,59 @@ ORDER BY 1;
 ROLLBACK;
 
 RESET timescaledb.enable_exclusive_locking_recompression;
+
+-- Test: recompress_chunk_segmentwise should not clear the UNORDERED flag
+--
+-- The UNORDERED flag means that some compressed batches do not follow the
+-- configured compress_orderby. Segmentwise recompression only processes
+-- segments that have new uncompressed data. Segments that were UNORDERED
+-- but have no new uncompressed rows are left untouched, so the chunk-level
+-- UNORDERED flag must be preserved after segmentwise recompression.
+CREATE TABLE segwise_unordered(time timestamptz NOT NULL, a int, b int);
+SELECT create_hypertable('segwise_unordered', by_range('time', INTERVAL '1 day'));
+ALTER TABLE segwise_unordered SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'a',
+    timescaledb.compress_orderby = 'time'
+);
+
+SET timescaledb.enable_direct_compress_insert TO ON;
+INSERT INTO segwise_unordered
+SELECT t, a, 0
+FROM generate_series('2025-01-01 00:00:00+00'::timestamptz,
+                     '2025-01-01 00:10:00+00'::timestamptz,
+                     '1 minute'::interval) t
+CROSS JOIN (VALUES (1), (2)) AS seg(a);
+INSERT INTO segwise_unordered
+SELECT t, 2, 0
+FROM generate_series('2025-01-01 00:00:00+00'::timestamptz,
+                     '2025-01-01 00:10:00+00'::timestamptz,
+                     '1 minute'::interval) t;
+RESET timescaledb.enable_direct_compress_insert;
+
+SELECT show_chunks AS chunk_to_compress FROM show_chunks('segwise_unordered') LIMIT 1 \gset
+
+-- Chunk should now be COMPRESSED|UNORDERED (status=3)
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
+
+-- Insert new data for only segment a=1 via normal INSERT so the chunk becomes PARTIAL
+INSERT INTO segwise_unordered VALUES ('2025-01-01 03:00:00+00', 1, 30);
+
+-- Chunk should now be COMPRESSED|UNORDERED|PARTIAL (status=11)
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
+
+
+-- Segmentwise recompression processes only segment a=1 (which has new data).
+-- Segment a=2 is never touched, so its unordered batches remain unordered.
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress');
+
+-- PARTIAL should be cleared (no more uncompressed rows).
+-- UNORDERED must be preserved (segment a=2 still has unordered compressed data).
+-- Expected status: 3 (COMPRESSED|UNORDERED), NOT 1 (COMPRESSED).
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
+
+-- Output would be incorrectly ordered if the flag was cleared
+-- We have to see a sort on top of the ColumnarScan node due to UNORDERED flag
+EXPLAIN SELECT a, time FROM segwise_unordered WHERE a = 2 ORDER BY a, time;
+
+DROP TABLE segwise_unordered;


### PR DESCRIPTION
Segmentwise recompression only recompresses the uncompressed portion 
so it should only clear partial flag is possible. Any other flags on the 
chunk (i.e. unordered) should be preserved.

