### PR TITLE
Fix DELETE/UPDATE with WHERE EXISTS on hypertables

### DIFF
--- a/.unreleased/pr_9294
+++ b/.unreleased/pr_9294
@@ -1,0 +1,2 @@
+Fixes: #9294 Fix DELETE/UPDATE with WHERE EXISTS on hypertables
+Thanks: @desertmark for reporting an issue with DELETE/UPDATE and subqueries

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -217,6 +217,18 @@ modify_hypertable_rescan(CustomScanState *node)
 	ExecReScan(linitial(node->custom_ps));
 }
 
+/*
+ * Check if the plan is a ChunkAppend, possibly wrapped in one or more
+ * Result nodes (for projection and/or pseudoconstant gating quals like EXISTS).
+ */
+static bool
+is_chunk_append_or_projection(Plan *plan)
+{
+	while (IsA(plan, Result) && plan->lefttree != NULL)
+		plan = plan->lefttree;
+	return ts_is_chunk_append_plan(plan);
+}
+
 static void
 modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *es)
 {
@@ -475,10 +487,28 @@ modify_hypertable_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *be
 		cscan->scan.plan.targetlist =
 			ts_replace_rowid_vars(root, cscan->scan.plan.targetlist, mt->nominalRelation);
 
-		if (mt->operation == CMD_UPDATE && ts_is_chunk_append_plan(mt->plan.lefttree))
+		/*
+		 * When the ModifyTable's lefttree contains a ChunkAppend (possibly
+		 * wrapped in one or more Result nodes for projection and/or
+		 * pseudoconstant gating quals like EXISTS), ChunkAppend will have
+		 * already replaced ROWID_VAR entries in its own targetlist to avoid
+		 * assertions in set_customscan_references. However, the wrapping
+		 * Result nodes' targetlists still contain the original ROWID_VAR
+		 * entries. When set_plan_references later calls set_upper_references
+		 * on these Result nodes, it tries to resolve the ROWID_VAR entries
+		 * against the child's (already replaced) targetlist so we have to
+		 * replace ROWID_VAR entries in all Result nodes' targetlists between
+		 * ModifyTable and ChunkAppend.
+		 */
+		if (is_chunk_append_or_projection(mt->plan.lefttree))
 		{
-			mt->plan.lefttree->targetlist =
-				ts_replace_rowid_vars(root, mt->plan.lefttree->targetlist, mt->nominalRelation);
+			Plan *plan = mt->plan.lefttree;
+			while (IsA(plan, Result) && plan->lefttree != NULL)
+			{
+				plan->targetlist =
+					ts_replace_rowid_vars(root, plan->targetlist, mt->nominalRelation);
+				plan = plan->lefttree;
+			}
 		}
 	}
 	cscan->custom_scan_tlist = cscan->scan.plan.targetlist;

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -275,3 +275,25 @@ EXPLAIN (verbose, analyze, buffers off, costs off, timing off, summary off) EXEC
 EXECUTE delete_ht;
 DEALLOCATE delete_ht;
 RESET plan_cache_mode;
+-- github issue #6790
+-- test DELETE with WHERE EXISTS on hypertable
+CREATE TABLE i6790(time timestamptz NOT NULL, device int, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+-- DELETE with simple EXISTS - creates gating Result node wrapping ChunkAppend
+DELETE FROM i6790 WHERE EXISTS (SELECT 1);
+-- all rows should be gone
+SELECT count(*) FROM i6790;
+ count 
+-------
+     0
+
+-- repopulate for next test
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+-- DELETE with correlated EXISTS
+DELETE FROM i6790 WHERE EXISTS (SELECT 1 FROM i6790 g WHERE g.device = i6790.device);
+SELECT count(*) FROM i6790;
+ count 
+-------
+     0
+

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -191,3 +191,22 @@ ERROR:  new row for relation "_hyper_2_4_chunk" violates check constraint "const
 UPDATE ONLY :CHUNK SET time = time + INTERVAL '1 month' RETURNING *;
 ERROR:  new row for relation "_hyper_2_4_chunk" violates check constraint "constraint_4"
 \set ON_ERROR_STOP 1
+-- github issue #6790
+-- test UPDATE with WHERE EXISTS on hypertable
+CREATE TABLE i6790_update(time timestamptz NOT NULL, device int, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO i6790_update SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+-- UPDATE with simple EXISTS - creates gating Result node(s) wrapping ChunkAppend
+UPDATE i6790_update SET value = 0.2 WHERE EXISTS (SELECT 1);
+SELECT count(*) FROM i6790_update WHERE value = 0.2;
+ count 
+-------
+     5
+
+-- UPDATE with correlated EXISTS
+UPDATE i6790_update SET value = 0.3 WHERE EXISTS (SELECT 1 FROM i6790_update g WHERE g.device = i6790_update.device);
+SELECT count(*) FROM i6790_update WHERE value = 0.3;
+ count 
+-------
+     5
+

--- a/test/sql/delete.sql
+++ b/test/sql/delete.sql
@@ -95,3 +95,20 @@ DEALLOCATE delete_ht;
 
 RESET plan_cache_mode;
 
+-- github issue #6790
+-- test DELETE with WHERE EXISTS on hypertable
+CREATE TABLE i6790(time timestamptz NOT NULL, device int, value float) WITH (tsdb.hypertable);
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+
+-- DELETE with simple EXISTS - creates gating Result node wrapping ChunkAppend
+DELETE FROM i6790 WHERE EXISTS (SELECT 1);
+-- all rows should be gone
+SELECT count(*) FROM i6790;
+
+-- repopulate for next test
+INSERT INTO i6790 SELECT t, 1, 0.1 FROM generate_series('2026-01-01'::timestamptz, '2026-01-03'::timestamptz, interval '12 hours') t;
+
+-- DELETE with correlated EXISTS
+DELETE FROM i6790 WHERE EXISTS (SELECT 1 FROM i6790 g WHERE g.device = i6790.device);
+SELECT count(*) FROM i6790;
+


### PR DESCRIPTION
DELETE and UPDATE queries with WHERE EXISTS clauses on hypertables
failed with "variable not found in subplan target list" because
ChunkAppend replaced ROWID_VAR entries in its own targetlist, but
wrapping Result nodes (created by create_gating_plan for pseudoconstant
quals) still had the original ROWID_VAR entries. When set_plan_references
processed these Result nodes, the mismatch caused the error.

Fix by replacing ROWID_VAR in all Result node targetlists between
ModifyTable and ChunkAppend, and extending the fix to all DML operations
(DELETE, UPDATE, MERGE) instead of just UPDATE.

Fixes #5475
Fixes #6790
