### PR TITLE
Defer segmentby default for direct compress

### DIFF
--- a/.unreleased/pr_9355
+++ b/.unreleased/pr_9355
@@ -1,0 +1,1 @@
+Implements: #9355 Defer segmentby default for direct compress

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -125,6 +125,7 @@ typedef struct ChunkInsertState
 	bool chunk_partial;
 	bool columnstore_insert;
 	bool needs_partial;
+	bool created_compressed_chunk;
 
 	/* To speedup repeated calls of `decompress_batches_for_insert` */
 	CachedDecompressionState *cached_decompression_state;

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -87,6 +87,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 	{
 		bool chunk_created = false;
 		bool needs_partial = false;
+		bool created_compressed_chunk = false;
 		const LOCKMODE lockmode = RowExclusiveLock;
 
 		/*
@@ -194,9 +195,12 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 				Hypertable *compressed_ht =
 					ts_hypertable_get_by_id(ctr->hypertable->fd.compressed_hypertable_id);
 				Chunk *compressed_chunk =
-					ts_cm_functions->compression_chunk_create(compressed_ht, chunk);
+					ts_cm_functions->compression_chunk_create(compressed_ht,
+															  chunk,
+															  true); /* skip_segmentby_default */
 				ts_chunk_set_compressed_chunk(chunk, compressed_chunk->fd.id);
 				chunk->fd.compressed_chunk_id = compressed_chunk->fd.id;
+				created_compressed_chunk = true;
 
 				/* mark chunk as partial unless completely new chunk */
 				if (!chunk_created)
@@ -206,6 +210,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 
 		cis = ts_chunk_insert_state_create(chunk->table_id, ctr);
 		cis->needs_partial = needs_partial;
+		cis->created_compressed_chunk = created_compressed_chunk;
 		ts_subspace_store_add(ctr->subspace,
 							  chunk->cube,
 							  cis,

--- a/src/copy.c
+++ b/src/copy.c
@@ -277,7 +277,8 @@ TSCopyMultiInsertBufferInit(TSCopyMultiInsertInfo *miinfo, ChunkInsertState *cis
 				ts_cm_functions->compressor_init(cis->rel,
 												 &buffer->bulk_writer,
 												 sort,
-												 ts_guc_direct_compress_copy_tuple_sort_limit);
+												 ts_guc_direct_compress_copy_tuple_sort_limit,
+												 cis->created_compressed_chunk);
 
 			if (miinfo->has_continuous_aggregate)
 			{

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -135,13 +135,14 @@ typedef struct CrossModuleFunctions
 
 	void (*columnstore_setup)(Hypertable *ht, WithClauseResult *with_clause_options);
 	RowCompressor *(*compressor_init)(Relation in_rel, BulkWriter **bulk_writer, bool sort,
-									  int tuple_sort_limit);
+									  int tuple_sort_limit, bool created_compressed_chunk);
 	void (*compressor_set_invalidation)(RowCompressor *compressor, Hypertable *ht, Oid chunk_relid);
 	void (*compressor_add_slot)(RowCompressor *compressor, BulkWriter *bulk_writer,
 								TupleTableSlot *slot);
 	void (*compressor_flush)(RowCompressor *compressor, BulkWriter *bulk_writer);
 	void (*compressor_free)(RowCompressor *compressor, BulkWriter *bulk_writer);
-	Chunk *(*compression_chunk_create)(Hypertable *ht, Chunk *src_chunk);
+	Chunk *(*compression_chunk_create)(Hypertable *ht, Chunk *src_chunk,
+									   bool skip_segmentby_default);
 
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2479,8 +2479,14 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 
 				if (!ht_state->compressor)
 				{
-					bool sort = ts_guc_enable_direct_compress_insert_sort_batches && !ts_guc_enable_direct_compress_insert_client_sorted;
-					ht_state->compressor = ts_cm_functions->compressor_init(ctr->cis->rel, &ht_state->bulk_writer, sort, ts_guc_direct_compress_insert_tuple_sort_limit);
+					bool sort = ts_guc_enable_direct_compress_insert_sort_batches &&
+							   !ts_guc_enable_direct_compress_insert_client_sorted;
+					ht_state->compressor =
+						ts_cm_functions->compressor_init(ctr->cis->rel,
+														 &ht_state->bulk_writer,
+														 sort,
+														 ts_guc_direct_compress_insert_tuple_sort_limit,
+														 ctr->cis->created_compressed_chunk);
 					ht_state->compressor_relid = RelationGetRelid(ctr->cis->rel);
 
 					if (ht_state->has_continuous_aggregate)

--- a/tsl/src/chunk_split.c
+++ b/tsl/src/chunk_split.c
@@ -1123,7 +1123,7 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 	if (compress_settings != NULL)
 	{
 		Hypertable *ht_compressed = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
-		new_compressed_chunk = create_compress_chunk(ht_compressed, new_chunk, InvalidOid);
+		new_compressed_chunk = create_compress_chunk(ht_compressed, new_chunk, InvalidOid, false);
 		ts_trigger_create_all_on_chunk(new_compressed_chunk);
 		ts_chunk_set_compressed_chunk(new_chunk, new_compressed_chunk->fd.id);
 	}

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -441,7 +441,8 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 		 */
 		EventTriggerAlterTableStart(create_dummy_query());
 		/* create compressed chunk and a new table */
-		compress_ht_chunk = create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, InvalidOid);
+		compress_ht_chunk =
+			create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, InvalidOid, false);
 		/* Associate compressed chunk with main chunk. */
 		ts_chunk_set_compressed_chunk(cxt.srcht_chunk, compress_ht_chunk->fd.id);
 		new_compressed_chunk = true;
@@ -774,7 +775,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 	 */
 	EventTriggerAlterTableStart(create_dummy_query());
 	/* Create compressed chunk using existing table */
-	compress_ht_chunk = create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, chunk_table);
+	compress_ht_chunk = create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, chunk_table, false);
 	EventTriggerAlterTableEnd();
 
 	/* Insert empty stats to compression_chunk_size */
@@ -1004,10 +1005,11 @@ get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 }
 
 Chunk *
-tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk)
+tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk,
+							 bool skip_segmentby_default)
 {
 	/* Create a new compressed chunk */
-	return create_compress_chunk(compressed_ht, src_chunk, InvalidOid);
+	return create_compress_chunk(compressed_ht, src_chunk, InvalidOid, skip_segmentby_default);
 }
 
 Datum

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -16,7 +16,8 @@ extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_rebuild_columnstore(PG_FUNCTION_ARGS);
 extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress);
-extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk);
+extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk,
+										   bool skip_segmentby_default);
 
 extern Datum tsl_get_compressed_chunk_index_for_recompression(
 	PG_FUNCTION_ARGS); // arg is oid of uncompressed chunk

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -984,6 +984,11 @@ tsl_compressor_flush(RowCompressor *compressor, BulkWriter *bulk_writer)
 		{
 			tuplesort_performsort(compressor->sort_state);
 
+			if (compressor->needs_analyze_segmentby)
+			{
+				/* TODO: analyze segmentby and reinit compressor */
+				compressor->needs_analyze_segmentby = false;
+			}
 			TupleTableSlot *slot = MakeTupleTableSlot(compressor->in_desc, &TTSOpsMinimalTuple);
 
 			while (tuplesort_gettupleslot(compressor->sort_state,
@@ -1004,8 +1009,14 @@ tsl_compressor_flush(RowCompressor *compressor, BulkWriter *bulk_writer)
 	else
 	{
 		if (compressor->rows_compressed_into_current_value > 0)
+		{
+			Ensure(!compressor->needs_analyze_segmentby,
+				   "trying to analyze segmentby with no sort state");
 			row_compressor_flush(compressor, bulk_writer, false);
+		}
 	}
+
+	Assert(!compressor->needs_analyze_segmentby);
 }
 
 void
@@ -1028,7 +1039,8 @@ tsl_compressor_free(RowCompressor *compressor, BulkWriter *bulk_writer)
  * Tuplesortstate and sort them before flushing to the output relation.
  */
 RowCompressor *
-tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort, int sort_limit)
+tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort, int sort_limit,
+					bool created_compressed_chunk)
 {
 	RowCompressor *compressor = palloc0(sizeof(RowCompressor));
 	CompressionSettings *settings = ts_compression_settings_get(in_rel->rd_id);
@@ -1038,6 +1050,13 @@ tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort, int so
 
 	if (sort)
 	{
+		/*
+		 * Schedule segmentby analysis on the first flush if no segmentby is
+		 * configured. When the client is responsible for ordering
+		 * (sort=false), we skip analysis entirely.
+		 */
+		compressor->needs_analyze_segmentby =
+			(settings->fd.segmentby == NULL) && created_compressed_chunk;
 		compressor->sort_state = compression_create_tuplesort_state(settings, in_rel);
 		compressor->tuple_sort_limit = sort_limit;
 	}

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -274,6 +274,8 @@ typedef struct RowCompressor
 	int64 tuples_to_sort;	/* number of tuples to sort with tuplesort */
 	int64 tuple_sort_limit; /* number of tuples to flush the compressor on */
 
+	bool needs_analyze_segmentby;
+
 	List *metadata_builders; /* List of BatchMetadataBuilder */
 } RowCompressor;
 
@@ -381,7 +383,7 @@ extern void row_compressor_init(RowCompressor *row_compressor, const Compression
 								const TupleDesc compressed_tupdesc);
 
 extern RowCompressor *tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort,
-										  int tuple_sort_limit);
+										  int tuple_sort_limit, bool created_compressed_chunk);
 extern void tsl_compressor_set_invalidation(RowCompressor *compressor, Hypertable *ht,
 											Oid chunk_relid);
 extern void tsl_compressor_add_slot(RowCompressor *compressor, BulkWriter *bulk_writer,

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -691,7 +691,8 @@ build_columndef_singlecolumn(const char *colname, Oid typid)
  *
  */
 Chunk *
-create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id)
+create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id,
+					  bool skip_segmentby_default)
 {
 	Catalog *catalog = ts_catalog_get();
 	CatalogSecurityContext sec_ctx;
@@ -767,7 +768,11 @@ create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id)
 	}
 
 	Hypertable *ht = ts_hypertable_get_by_id(src_chunk->fd.hypertable_id);
-	compression_settings_set_defaults(ht, settings, ts_alter_table_with_clause_parse(NIL));
+
+	compression_settings_set_defaults(ht,
+									  settings,
+									  ts_alter_table_with_clause_parse(NIL),
+									  skip_segmentby_default);
 
 	if (OidIsValid(table_id))
 		compress_chunk->table_id = table_id;
@@ -1795,7 +1800,8 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 
 void
 compression_settings_set_defaults(Hypertable *ht, CompressionSettings *settings,
-								  WithClauseResult *with_clause_options)
+								  WithClauseResult *with_clause_options,
+								  bool skip_segmentby_default)
 {
 	/* orderby arrays should always be in sync either all NULL or none */
 	Assert(
@@ -1806,7 +1812,8 @@ compression_settings_set_defaults(Hypertable *ht, CompressionSettings *settings,
 	/* get default settings which will be stored at chunk level */
 	if (!(settings->fd.orderby) && with_clause_options[AlterTableFlagOrderBy].is_default)
 	{
-		if (!settings->fd.segmentby && with_clause_options[AlterTableFlagSegmentBy].is_default)
+		if (!skip_segmentby_default && !settings->fd.segmentby &&
+			with_clause_options[AlterTableFlagSegmentBy].is_default)
 		{
 			settings->fd.segmentby = compression_setting_segmentby_get_default(ht);
 		}

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -22,7 +22,8 @@ bool tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_op
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
 void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);
-Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id);
+Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id,
+							 bool skip_segmentby_default);
 
 char *column_segment_min_name(int16 column_index);
 char *column_segment_max_name(int16 column_index);
@@ -38,4 +39,5 @@ int compressed_column_metadata_attno(const CompressionSettings *settings, Oid ch
 void tsl_columnstore_setup(Hypertable *ht, WithClauseResult *with_clause_options);
 
 void compression_settings_set_defaults(Hypertable *ht, CompressionSettings *settings,
-									   WithClauseResult *with_clause_options);
+									   WithClauseResult *with_clause_options,
+									   bool skip_segmentby_default);

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -836,7 +836,8 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 		ts_compression_settings_get(uncompressed_chunk->hypertable_relid);
 	compression_settings_set_defaults(ht,
 									  check_new_settings,
-									  ts_alter_table_with_clause_parse(NIL));
+									  ts_alter_table_with_clause_parse(NIL),
+									  false);
 
 	if (!ts_array_equal(settings->fd.segmentby, check_new_settings->fd.segmentby))
 	{
@@ -869,7 +870,7 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	ts_compression_settings_delete(uncompressed_chunk->table_id);
 	Hypertable *compressed_ht = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
 	Chunk *new_compressed_chunk =
-		create_compress_chunk(compressed_ht, uncompressed_chunk, InvalidOid);
+		create_compress_chunk(compressed_ht, uncompressed_chunk, InvalidOid, false);
 	/* The old compression settings were deleted above to avoid catalog conflicts. */
 	CompressionSettings *new_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
 	Relation new_compressed_chunk_rel = table_open(new_compressed_chunk->table_id, lockmode);

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -674,3 +674,78 @@ RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.enable_direct_compress_insert_client_sorted;
 DROP TABLE compress_src;
 DROP TABLE compress_tgt;
+-- simple test to check default segmentby does not get set for direct compress
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_segmentby_stats (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    value FLOAT
+) WITH (tsdb.hypertable, tsdb.compress);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO test_segmentby_stats
+SELECT t, (i % 5), random()
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-02'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+ANALYZE test_segmentby_stats;
+SELECT compress_chunk(c) FROM show_chunks('test_segmentby_stats') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_12_89_chunk
+
+-- will have devide_id as default segmentby for compressed chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
+ metrics                                  |                                                  |             | {time}  | {f}          | {f}                | 
+ metrics_status                           |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_4_54_chunk  | _timescaledb_internal.compress_hyper_5_55_chunk  |             | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics_chunk                            |                                                  |             |         |              |                    | 
+ test_segmentby_stats                     |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_12_89_chunk | _timescaledb_internal.compress_hyper_13_90_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO test_segmentby_stats
+SELECT t, (i % 5), random()
+FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+ANALYZE test_segmentby_stats;
+-- will have no segment by as default segmentby for direct compressed chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
+ metrics                                  |                                                  |             | {time}  | {f}          | {f}                | 
+ metrics_status                           |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_4_54_chunk  | _timescaledb_internal.compress_hyper_5_55_chunk  |             | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics_chunk                            |                                                  |             |         |              |                    | 
+ test_segmentby_stats                     |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_12_89_chunk | _timescaledb_internal.compress_hyper_13_90_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_12_91_chunk | _timescaledb_internal.compress_hyper_13_92_chunk |             | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+ROLLBACK;
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_segmentby_stats (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    value FLOAT
+) WITH (tsdb.hypertable, tsdb.compress, tsdb.segmentby='device_id');
+NOTICE:  using column "time" as partitioning column
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO test_segmentby_stats
+SELECT t, (i % 5), random()
+FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+ANALYZE test_segmentby_stats;
+-- will have device_id by as configured segmentby for direct compressed chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
+ metrics                                  |                                                  |             | {time}  | {f}          | {f}                | 
+ metrics_status                           |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_4_54_chunk  | _timescaledb_internal.compress_hyper_5_55_chunk  |             | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics_chunk                            |                                                  |             |         |              |                    | 
+ test_segmentby_stats                     |                                                  | {device_id} |         |              |                    | 
+ _timescaledb_internal._hyper_14_93_chunk | _timescaledb_internal.compress_hyper_15_94_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -374,3 +374,51 @@ RESET timescaledb.enable_direct_compress_insert_client_sorted;
 
 DROP TABLE compress_src;
 DROP TABLE compress_tgt;
+
+-- simple test to check default segmentby does not get set for direct compress
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_segmentby_stats (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    value FLOAT
+) WITH (tsdb.hypertable, tsdb.compress);
+
+INSERT INTO test_segmentby_stats
+SELECT t, (i % 5), random()
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-02'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+
+ANALYZE test_segmentby_stats;
+SELECT compress_chunk(c) FROM show_chunks('test_segmentby_stats') c;
+
+-- will have devide_id as default segmentby for compressed chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO test_segmentby_stats
+SELECT t, (i % 5), random()
+FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+ANALYZE test_segmentby_stats;
+-- will have no segment by as default segmentby for direct compressed chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ROLLBACK;
+
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_segmentby_stats (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    value FLOAT
+) WITH (tsdb.hypertable, tsdb.compress, tsdb.segmentby='device_id');
+
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO test_segmentby_stats
+SELECT t, (i % 5), random()
+FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+ANALYZE test_segmentby_stats;
+-- will have device_id by as configured segmentby for direct compressed chunk;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ROLLBACK;


### PR DESCRIPTION
Compressed chunks created via direct compress lack data to select a default segmentby. Skip default
segmentby selection for these chunks and flag the
ChunkInsertState for analysis at a later stage.

First cut into segmentby analysis
Future work https://github.com/timescale/timescaledb/pull/9396

Second cut: https://github.com/timescale/timescaledb/pull/9403