### PR TITLE
Fix two coverity issues

### DIFF
--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -862,6 +862,9 @@ ts_convert_to_sparse_index_settings(Jsonb *jsonb)
 						   "INIT",
 						   JsonbTypeName(&jsonb_value));
 
+					Ensure(list_length(parsed_settings->objects) > 0,
+						   "Jsonb value has a key, but no object has been started, in state INIT");
+
 					SparseIndexSettingsObject *current_object = llast(parsed_settings->objects);
 					Assert(current_object != NULL);
 					tmp_context = MemoryContextSwitchTo(parsed_settings->context);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1862,6 +1862,10 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 
 	CompressionSettings *settings = ts_compression_settings_get(ht->main_table_relid);
+	Ensure(settings != NULL,
+		   "compression settings not found for hypertable \"%s\"",
+		   get_rel_name(ht->main_table_relid));
+
 	Jsonb *jb = settings->fd.index;
 
 	/* check if the column is a segmentby or orderby column */


### PR DESCRIPTION
Both issues are error cases, but we should not crash in either of one:

- when we receive a completely bogus JSON struct where we can have a Key without ever encountering an object start. I'm not sure if this can ever pass previous validations, but better to be safe

- when a hypertable doesn't have a compression settings, which is more likely to happen, so I added an extra check

Disable-check: force-changelog-file