### PR TITLE
Change compression job status when chunks could be compressed

### DIFF
--- a/.unreleased/pr_9363
+++ b/.unreleased/pr_9363
@@ -1,0 +1,1 @@
+Fixes: #9363 Change compression job status when chunks could be compressed

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -149,7 +149,6 @@ BEGIN
           RAISE WARNING 'reindexing index "%.%" for chunk "%" to columnstore failed when columnstore policy is executed', idx_rec.schemaname, idx_rec.indexname, chunk_rec.oid::regclass::text
               USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
                     ERRCODE = _sqlstate;
-          chunks_failure := chunks_failure + 1;
         END;
         COMMIT;
       END LOOP;
@@ -169,10 +168,15 @@ BEGIN
   END LOOP;
 
   IF chunks_failure > 0 THEN
-    RAISE EXCEPTION 'columnstore policy failure'
-      USING
-        DETAIL = format('Failed to convert %L chunks to columnstore. Successfully converted %L chunks.', chunks_failure, numchunks_compressed),
-        ERRCODE = 'data_exception';
+    IF numchunks_compressed > 0 THEN
+      RAISE WARNING 'columnstore policy completed with some failures'
+        USING DETAIL = format('Failed to convert %L chunks to columnstore. Successfully converted %L chunks.', chunks_failure, numchunks_compressed);
+    ELSE
+      RAISE EXCEPTION 'columnstore policy failure'
+        USING
+          DETAIL = format('Failed to convert %L chunks to columnstore. Successfully converted %L chunks.', chunks_failure, numchunks_compressed),
+          ERRCODE = 'data_exception';
+    END IF;
   END IF;
 END;
 $$ LANGUAGE PLPGSQL;

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -921,7 +921,6 @@ SELECT count(*) > 1
 -- is dynamic and it will be printed in those messages.
 SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
-ERROR:  columnstore policy failure
 SET client_min_messages TO NOTICE;
 -- check compression status is not changed for the chunk whose status was manually updated
 SELECT status FROM _timescaledb_catalog.chunk where table_name = :'new_uncompressed_chunk_name';

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -801,7 +801,7 @@ WITH chunks AS (
   FROM _timescaledb_catalog.chunk c
   INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
   WHERE h.table_name = 'test_compression_policy_errors'
-  ORDER BY c.id LIMIT 20
+  ORDER BY c.id
 )
 UPDATE _timescaledb_catalog.chunk
 SET status = 3
@@ -809,7 +809,7 @@ FROM chunks
 WHERE chunk.id = chunks.id
   AND chunk.status = 0;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
--- After the mess 20 = status 3 and 11 = status 0
+-- After the mess 30 = status 3
 SELECT c.status, count(*)
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
@@ -818,18 +818,17 @@ GROUP BY c.status
 ORDER BY 2 DESC;
  status | count 
 --------+-------
-      3 |    20
-      0 |    11
+      3 |    31
 
 \set ON_ERROR_STOP 0
 SET client_min_messages TO ERROR;
 \set VERBOSITY default
 -- This should fail with
--- 20 chunks failed to compress and 11 chunks compressed successfully
+-- 31 chunks failed to compress
 CALL run_job(:compressjob_id);
 ERROR:  columnstore policy failure
-DETAIL:  Failed to convert '20' chunks to columnstore. Successfully converted '11' chunks.
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 117 at RAISE
+DETAIL:  Failed to convert '31' chunks to columnstore. Successfully converted '0' chunks.
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 120 at RAISE
 SQL statement "CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time)"
 PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 62 at CALL
 \set VERBOSITY terse
@@ -843,8 +842,7 @@ GROUP BY c.status
 ORDER BY 2 DESC;
  status | count 
 --------+-------
-      3 |    20
-      1 |    11
+      3 |    31
 
 -- Teardown test
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -374,7 +374,7 @@ WITH chunks AS (
   FROM _timescaledb_catalog.chunk c
   INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
   WHERE h.table_name = 'test_compression_policy_errors'
-  ORDER BY c.id LIMIT 20
+  ORDER BY c.id
 )
 UPDATE _timescaledb_catalog.chunk
 SET status = 3
@@ -384,7 +384,7 @@ WHERE chunk.id = chunks.id
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
--- After the mess 20 = status 3 and 11 = status 0
+-- After the mess 30 = status 3
 SELECT c.status, count(*)
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h on (h.id = c.hypertable_id)
@@ -396,7 +396,7 @@ ORDER BY 2 DESC;
 SET client_min_messages TO ERROR;
 \set VERBOSITY default
 -- This should fail with
--- 20 chunks failed to compress and 11 chunks compressed successfully
+-- 31 chunks failed to compress
 CALL run_job(:compressjob_id);
 \set VERBOSITY terse
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
Previously when even 1 chunk failed with an error the job status
would be failure even though most chunks could have been processed
successfully. This commit change the status to success and the
message to a warning when at least 1 chunk was compressed.
