### PR TITLE
Fix/9360 persist crash next start

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -802,9 +802,17 @@ ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job, int32 consecutive_f
 		if (!ts_flags_are_set_32(jobstat->fd.flags, LAST_CRASH_REPORTED))
 		{
 			ts_bgw_job_stat_mark_crash_reported(job, JOB_FAILURE_IN_EXECUTION);
+			jobstat->fd.flags = ts_set_flags_32(jobstat->fd.flags, LAST_CRASH_REPORTED);
 		}
 
-		return calculate_next_start_on_crash(jobstat->fd.consecutive_crashes, job);
+		if (!bgw_job_stat_next_start_was_set(&jobstat->fd))
+		{
+			TimestampTz next_start =
+				calculate_next_start_on_crash(jobstat->fd.consecutive_crashes, job);
+
+			ts_bgw_job_stat_update_next_start(jobstat->fd.id, next_start, false);
+			jobstat->fd.next_start = next_start;
+		}
 	}
 
 	return jobstat->fd.next_start;

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -871,9 +871,9 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(500);
 
 SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_successes, total_failures, total_crashes, consecutive_crashes
 FROM _timescaledb_internal.bgw_job_stat;
- job_id | last_finish | next_start | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
---------+-------------+------------+------------------+------------+-----------------+----------------+---------------+---------------------
-   1005 | -infinity   | -infinity  | f                |          1 |               0 |              0 |             1 |                   1
+ job_id | last_finish |          next_start          | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
+--------+-------------+------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
+   1005 | -infinity   | Fri Dec 31 16:05:00 1999 PST | f                |          1 |               0 |              0 |             1 |                   1
 
 --But after the 5 min period the job is again run
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(400000);
@@ -883,9 +883,9 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(400000);
 
 SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_successes, total_failures, total_crashes, consecutive_crashes
 FROM _timescaledb_internal.bgw_job_stat;
- job_id |          last_finish           |           next_start           | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
---------+--------------------------------+--------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
-   1005 | Fri Dec 31 16:05:00.5 1999 PST | Fri Dec 31 16:05:05.5 1999 PST | t                |          2 |               1 |              0 |             1 |                   0
+ job_id |         last_finish          |          next_start          | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
+--------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
+   1005 | Fri Dec 31 16:05:00 1999 PST | Fri Dec 31 16:05:05 1999 PST | t                |          2 |               1 |              0 |             1 |                   0
 
 SELECT * FROM sorted_bgw_log;
  msg_no | application_name |                         msg                         
@@ -1535,4 +1535,3 @@ SELECT _timescaledb_functions.stop_background_workers();
  stop_background_workers 
 -------------------------
  t
-

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -868,9 +868,9 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(500);
 
 SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_successes, total_failures, total_crashes, consecutive_crashes
 FROM _timescaledb_internal.bgw_job_stat;
- job_id | last_finish | next_start | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
---------+-------------+------------+------------------+------------+-----------------+----------------+---------------+---------------------
-   1005 | -infinity   | -infinity  | f                |          1 |               0 |              0 |             1 |                   1
+ job_id | last_finish |          next_start          | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
+--------+-------------+------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
+   1005 | -infinity   | Fri Dec 31 16:05:00 1999 PST | f                |          1 |               0 |              0 |             1 |                   1
 
 --But after the 5 min period the job is again run
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(400000);
@@ -880,9 +880,9 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(400000);
 
 SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_successes, total_failures, total_crashes, consecutive_crashes
 FROM _timescaledb_internal.bgw_job_stat;
- job_id |          last_finish           |          next_start          | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
---------+--------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
-   1005 | Fri Dec 31 16:05:00.5 1999 PST | Fri Dec 31 16:05:05 1999 PST | t                |          2 |               1 |              0 |             1 |                   0
+ job_id |         last_finish          |          next_start          | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
+--------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
+   1005 | Fri Dec 31 16:05:00 1999 PST | Fri Dec 31 16:05:05 1999 PST | t                |          2 |               1 |              0 |             1 |                   0
 
 SELECT * FROM sorted_bgw_log;
  msg_no | application_name |                         msg                         
@@ -1706,4 +1706,3 @@ SELECT alter_job(:jobid_fixed_2, fixed_schedule => false);
                                                                 alter_job                                                                 
 ------------------------------------------------------------------------------------------------------------------------------------------
  (1035,"@ 30 secs","@ 0",-1,"@ 5 mins",t,,"Sat Jan 01 00:01:03 2000 PST",,f,"Sat Jan 01 00:00:23 2000 PST",,"User-Defined Action [1035]")
-


### PR DESCRIPTION
Fix background job crash recovery so `next_start` is persisted when a crashed
job has `next_start = -infinity`. In failover/restart scenarios, crash backoff was previously computed only in memory, which could cause the delay window to be recalculated from "now" after scheduler restarts and keep sliding forward.

For jobs in crash state (`consecutive_crashes > 0`) with unset `next_start`,
`ts_bgw_job_stat_next_start` returned a computed backoff timestamp but did not
store it in `_timescaledb_internal.bgw_job_stat`.
As a result, after scheduler restart/failover, the same row could be treated as
unset again and delayed repeatedly.
