### PR TITLE
Fix join order in 3-way join query in ordered_append_join test

### DIFF
--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -667,11 +667,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -710,6 +711,7 @@ LIMIT 100;
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
@@ -1536,11 +1538,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -1549,36 +1552,37 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
-                     Filter: (device_id = 1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
+                     Filter: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Index Cond: (device_id = 2)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
+                                 Filter: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
-                                       Filter: (device_id = 3)
+                           ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
@@ -2588,11 +2592,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -2608,15 +2613,15 @@ LIMIT 100;
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                            Filter: (device_id = 3)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
@@ -2627,15 +2632,15 @@ LIMIT 100;
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        Filter: (device_id = 2)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
@@ -2644,17 +2649,18 @@ LIMIT 100;
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                                              Filter: (device_id = 1)
-                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                              Filter: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
@@ -3991,11 +3997,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -4004,45 +4011,46 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
+                           Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
+                                       Index Cond: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
+                                             Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 -- Disable plain/sorted aggregation to get a deterministic test output
 SET timescaledb.enable_chunkwise_aggregation = OFF;

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -667,11 +667,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -710,6 +711,7 @@ LIMIT 100;
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
@@ -1536,11 +1538,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -1549,36 +1552,37 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
-                     Filter: (device_id = 1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
+                     Filter: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Index Cond: (device_id = 2)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
+                                 Filter: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
-                                       Filter: (device_id = 3)
+                           ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
@@ -2588,11 +2592,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -2608,15 +2613,15 @@ LIMIT 100;
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                            Filter: (device_id = 3)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
@@ -2627,15 +2632,15 @@ LIMIT 100;
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        Filter: (device_id = 2)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
@@ -2644,17 +2649,18 @@ LIMIT 100;
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                                              Filter: (device_id = 1)
-                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                              Filter: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
@@ -3991,11 +3997,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -4004,45 +4011,46 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
+                           Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
+                                       Index Cond: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
+                                             Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 -- Disable plain/sorted aggregation to get a deterministic test output
 SET timescaledb.enable_chunkwise_aggregation = OFF;

--- a/tsl/test/shared/expected/ordered_append_join-17.out
+++ b/tsl/test/shared/expected/ordered_append_join-17.out
@@ -664,11 +664,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -707,6 +708,7 @@ LIMIT 100;
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
@@ -1524,11 +1526,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -1537,36 +1540,37 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
-                     Filter: (device_id = 1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
+                     Filter: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Index Cond: (device_id = 2)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
+                                 Filter: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
-                                       Filter: (device_id = 3)
+                           ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
@@ -2579,11 +2583,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -2599,15 +2604,15 @@ LIMIT 100;
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                            Filter: (device_id = 3)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
@@ -2618,15 +2623,15 @@ LIMIT 100;
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        Filter: (device_id = 2)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
@@ -2635,17 +2640,18 @@ LIMIT 100;
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                                              Filter: (device_id = 1)
-                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                              Filter: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
@@ -3973,11 +3979,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -3986,45 +3993,46 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
+                           Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
+                                       Index Cond: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
+                                             Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 -- Disable plain/sorted aggregation to get a deterministic test output
 SET timescaledb.enable_chunkwise_aggregation = OFF;

--- a/tsl/test/shared/expected/ordered_append_join-18.out
+++ b/tsl/test/shared/expected/ordered_append_join-18.out
@@ -664,11 +664,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -707,6 +708,7 @@ LIMIT 100;
                                  ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
                                        Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
@@ -1524,11 +1526,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -1537,36 +1540,37 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
-                     Filter: (device_id = 1)
-               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
-                     Filter: (device_id = 1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
+                     Filter: (device_id = 3)
+               ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
+                     Filter: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
-                                 Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
-                                 Index Cond: (device_id = 2)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_2 (never executed)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o1_3 (never executed)
+                                 Filter: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_2 (never executed)
-                                       Filter: (device_id = 3)
-                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_time_idx on _hyper_X_X_chunk o3_3 (never executed)
-                                       Filter: (device_id = 3)
+                           ->  Custom Scan (ChunkAppend) on metrics_space o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 2)
+                                 ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
@@ -2579,11 +2583,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -2599,15 +2604,15 @@ LIMIT 100;
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                            Filter: (device_id = 3)
-                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
+                           ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
-                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
                            Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
@@ -2618,15 +2623,15 @@ LIMIT 100;
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        Filter: (device_id = 2)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
-                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
+                                 ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (never executed)
                                        Index Cond: (device_id = 2)
                      ->  Materialize (actual rows=100.00 loops=1)
                            ->  Custom Scan (ChunkAppend) on metrics_compressed o1 (actual rows=100.00 loops=1)
@@ -2635,17 +2640,18 @@ LIMIT 100;
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
                                              Filter: (device_id = 1)
-                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
+                                             ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                              Filter: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
-                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
+                                       ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (never executed)
                                              Index Cond: (device_id = 1)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
@@ -3973,11 +3979,12 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
@@ -3986,45 +3993,46 @@ LIMIT 100;
 --- QUERY PLAN ---
  Limit (actual rows=100.00 loops=1)
    ->  Merge Join (actual rows=100.00 loops=1)
-         Merge Cond: (o1."time" = o2."time")
-         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
-               Order: o1."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
+         Merge Cond: (o3."time" = o1."time")
+         ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
+               Order: o3."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
+                           Index Cond: (device_id = 3)
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
                      ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                           Index Cond: (device_id = 1)
+                           Index Cond: (device_id = 3)
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Merge Join (actual rows=100.00 loops=1)
-                     Merge Cond: (o2."time" = o3."time")
-                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
-                           Order: o2."time"
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
+                     Merge Cond: (o1."time" = o2."time")
+                     ->  Custom Scan (ChunkAppend) on metrics_space_compressed o1 (actual rows=100.00 loops=1)
+                           Order: o1."time"
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_2 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
-                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
+                                       Index Cond: (device_id = 1)
+                           ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_3 (never executed)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                       Index Cond: (device_id = 2)
+                                       Index Cond: (device_id = 1)
                      ->  Materialize (actual rows=100.00 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o3 (actual rows=100.00 loops=1)
-                                 Order: o3."time"
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics_space_compressed o2 (actual rows=100.00 loops=1)
+                                 Order: o2."time"
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_2 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_2 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
-                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_3 (never executed)
+                                             Index Cond: (device_id = 2)
+                                 ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_3 (never executed)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (never executed)
-                                             Index Cond: (device_id = 3)
+                                             Index Cond: (device_id = 2)
 
+RESET join_collapse_limit;
 RESET enable_seqscan;
 -- Disable plain/sorted aggregation to get a deterministic test output
 SET timescaledb.enable_chunkwise_aggregation = OFF;

--- a/tsl/test/shared/sql/include/ordered_append_join.sql
+++ b/tsl/test/shared/sql/include/ordered_append_join.sql
@@ -291,15 +291,16 @@ LIMIT 100;
 
 -- test JOIN on time column with 3 hypertables
 -- should use 3 ChunkAppend
+SET join_collapse_limit = 1;
 :PREFIX
 SELECT o1.time
-FROM :TEST_TABLE o1
-  INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time
-  INNER JOIN :TEST_TABLE o3 ON o1.time = o3.time
+FROM :TEST_TABLE o3
+  INNER JOIN (:TEST_TABLE o1 INNER JOIN :TEST_TABLE o2 ON o1.time = o2.time)
+  ON o3.time = o1.time
 WHERE o1.device_id = 1
   AND o2.device_id = 2
   AND o3.device_id = 3
 ORDER BY o1.time
 LIMIT 100;
-
+RESET join_collapse_limit;
 RESET enable_seqscan;


### PR DESCRIPTION
Stabilize ordered_append_join test by fixing join order in 3-way join query.

Disable-check: approval-count
