### PR TITLE
Composite bloom filter pushdown for SELECT queries

### DIFF
--- a/.unreleased/pr_9372
+++ b/.unreleased/pr_9372
@@ -1,0 +1,1 @@
+Implements: #9372 Push down composite bloom filter checks to SELECT execution.

--- a/tsl/src/nodes/columnar_scan/qual_pushdown.c
+++ b/tsl/src/nodes/columnar_scan/qual_pushdown.c
@@ -14,6 +14,7 @@
 #include <utils/typcache.h>
 
 #include "columnar_scan.h"
+#include "compression/batch_metadata_builder.h"
 #include "compression/create.h"
 #include "compression/sparse_index_bloom1.h"
 #include "custom_type_cache.h"
@@ -51,6 +52,31 @@ copy_context(const QualPushdownContext *source)
 
 static Node *qual_pushdown_mutator(Node *node, QualPushdownContext *context);
 
+/*
+ * Result of validating an OpExpr as a potential bloom filter candidate.
+ * Does NOT make decisions about which operand to use.
+ */
+typedef struct HashableEqualityInfo
+{
+	Var *left_var;		 /* NULL if left is not a Var on chunk_rel */
+	Var *right_var;		 /* NULL if right is not a Var on chunk_rel */
+	Expr *left_expr;	 /* Original left operand (after unwrapping RelabelType) */
+	Expr *right_expr;	 /* Original right operand (after unwrapping RelabelType) */
+	Oid opno;			 /* Original operator OID */
+	bool left_hashable;	 /* Is operator in left_var's hash opfamily? */
+	bool right_hashable; /* Is operator in right_var's hash opfamily? */
+	bool valid;			 /* Is this a valid hashable equality? */
+} HashableEqualityInfo;
+
+static HashableEqualityInfo validate_hashable_equality(OpExpr *opexpr,
+													   QualPushdownContext *context);
+static Var *extract_var_for_bloom1(OpExpr *opexpr, QualPushdownContext *context, Expr **value_out,
+								   Oid *op_oid_out);
+
+static Var *extract_var_for_composite_bloom(OpExpr *opexpr, QualPushdownContext *context,
+											Expr **value_out, Oid *op_oid_out);
+static void pushdown_composite_blooms(PlannerInfo *root, QualPushdownContext *context);
+
 void
 pushdown_quals(PlannerInfo *root, CompressionSettings *settings, RelOptInfo *chunk_rel,
 			   RelOptInfo *compressed_rel, bool chunk_partial)
@@ -64,6 +90,17 @@ pushdown_quals(PlannerInfo *root, CompressionSettings *settings, RelOptInfo *chu
 		.compressed_rte = planner_rt_fetch(compressed_rel->relid, root),
 		.settings = settings,
 	};
+
+	/*
+	 * Collect composite bloom candidates first.
+	 * This looks at ALL equality predicates together to find composite bloom matches
+	 * and push down the composite bloom filters.
+	 */
+	if (ts_guc_enable_sparse_index_bloom && settings != NULL && settings->fd.index != NULL &&
+		ts_guc_enable_composite_bloom_indexes)
+	{
+		pushdown_composite_blooms(root, &base_context);
+	}
 
 	foreach (lc, chunk_rel->baserestrictinfo)
 	{
@@ -390,6 +427,188 @@ expr_fetch_bloom1_metadata(QualPushdownContext *context, Expr *expr, AttrNumber 
 	}
 }
 
+/*
+ * Validate an OpExpr as a hashable equality predicate.
+ *
+ * Does NOT:
+ * - Decide which operand is "column" vs "value"
+ * - Check bloom metadata
+ * - Check collation (Caller's responsibility - depends on which Var is chosen)
+ * - Commute the operator
+ *
+ * DOES validate:
+ * - OpExpr structure
+ * - Var identification on chunk_rel
+ * - Hash operator validity for each Var
+ *
+ * Returns info about both operands with validation flags.
+ * Caller decides which Var to use and validates collation.
+ */
+static HashableEqualityInfo
+validate_hashable_equality(OpExpr *opexpr, QualPushdownContext *context)
+{
+	Assert(opexpr != NULL);
+	Assert(context != NULL);
+
+	HashableEqualityInfo info = { 0 };
+	info.valid = false;
+	info.left_hashable = false;
+	info.right_hashable = false;
+
+	if (list_length(opexpr->args) != 2)
+		return info;
+
+	Expr *left = linitial(opexpr->args);
+	Expr *right = lsecond(opexpr->args);
+
+	/* Unwrap RelabelType */
+	if (IsA(left, RelabelType))
+		left = ((RelabelType *) left)->arg;
+	if (IsA(right, RelabelType))
+		right = ((RelabelType *) right)->arg;
+
+	info.left_expr = left;
+	info.right_expr = right;
+	info.opno = opexpr->opno;
+
+	/* Must have valid operator OID */
+	if (!OidIsValid(info.opno))
+		return info;
+
+	/* Identify Vars on our relation and validate hash operator for each */
+	if (IsA(left, Var))
+	{
+		Var *left_var = (Var *) left;
+		if ((Index) left_var->varno == context->chunk_rel->relid && left_var->varattno > 0)
+		{
+			info.left_var = left_var;
+
+			/* Check if operator is hashable equality for this type */
+			TypeCacheEntry *tce = lookup_type_cache(left_var->vartype, TYPECACHE_HASH_OPFAMILY);
+			if (OidIsValid(tce->hash_opf))
+			{
+				int strategy = get_op_opfamily_strategy(info.opno, tce->hash_opf);
+				if (strategy == HTEqualStrategyNumber)
+					info.left_hashable = true;
+			}
+		}
+	}
+
+	if (IsA(right, Var))
+	{
+		Var *right_var = (Var *) right;
+		if ((Index) right_var->varno == context->chunk_rel->relid && right_var->varattno > 0)
+		{
+			info.right_var = right_var;
+
+			/* Check if operator is hashable equality for this type */
+			TypeCacheEntry *tce = lookup_type_cache(right_var->vartype, TYPECACHE_HASH_OPFAMILY);
+			if (OidIsValid(tce->hash_opf))
+			{
+				int strategy = get_op_opfamily_strategy(info.opno, tce->hash_opf);
+				if (strategy == HTEqualStrategyNumber)
+					info.right_hashable = true;
+			}
+		}
+	}
+
+	/* Must have at least one Var on our relation */
+	if (info.left_var == NULL && info.right_var == NULL)
+		return info;
+
+	/* Must have at least one Var that passes hashable equality check */
+	if (!info.left_hashable && !info.right_hashable)
+		return info;
+
+	info.valid = true;
+	return info;
+}
+
+/*
+ * Extract Var for single-column bloom filter pushdown.
+ * Uses bloom metadata presence to decide which operand to use.
+ *
+ * This handles cases like:
+ * - bloom_col = 5              (left has bloom)
+ * - 5 = bloom_col              (right has bloom, commute)
+ * - bloom_col = segmentby_col  (left has bloom, caller validates segmentby)
+ * - segmentby_col = bloom_col  (right has bloom, commute, caller validates)
+ * - bloom_col1 = bloom_col2    (left has bloom, caller validates bloom_col2: FAILS)
+ *
+ * Returns the Var that has single-column bloom metadata, along with
+ * the value expression and (possibly commuted) operator.
+ */
+static Var *
+extract_var_for_bloom1(OpExpr *opexpr, QualPushdownContext *context, Expr **value_out,
+					   Oid *op_oid_out)
+{
+	Assert(value_out != NULL);
+	Assert(op_oid_out != NULL);
+	Assert(opexpr != NULL);
+	Assert(context != NULL);
+
+	*value_out = NULL;
+	*op_oid_out = InvalidOid;
+
+	/* Validate the expression */
+	HashableEqualityInfo info = validate_hashable_equality(opexpr, context);
+	if (!info.valid)
+		return NULL;
+
+	/* Try to find a Var with bloom metadata that passes hash operator validation. */
+	Var *chosen_var = NULL;
+	Expr *value_expr_tmp = NULL;
+	Oid op_oid_tmp;
+	AttrNumber bloom1_attno = InvalidAttrNumber;
+
+	if (info.left_var != NULL && info.left_hashable)
+	{
+		expr_fetch_bloom1_metadata(context, (Expr *) info.left_var, &bloom1_attno);
+		if (bloom1_attno != InvalidAttrNumber)
+		{
+			/* Left has bloom metadata and valid hash operator. */
+			chosen_var = info.left_var;
+			value_expr_tmp = info.right_expr;
+			op_oid_tmp = info.opno;
+		}
+	}
+
+	/* If left didn't qualify, try right. */
+	if (chosen_var == NULL && info.right_var != NULL && info.right_hashable)
+	{
+		expr_fetch_bloom1_metadata(context, (Expr *) info.right_var, &bloom1_attno);
+		if (bloom1_attno != InvalidAttrNumber)
+		{
+			/* Right has bloom metadata and valid hash operator. Need commutation. */
+			chosen_var = info.right_var;
+			value_expr_tmp = info.left_expr;
+			op_oid_tmp = get_commutator(info.opno);
+		}
+	}
+
+	if (chosen_var == NULL)
+	{
+		/* No Var with both bloom metadata and valid hash operator */
+		return NULL;
+	}
+
+	/* Validate collation for the chosen Var */
+	Oid op_collation = opexpr->inputcollid;
+	if (chosen_var->varcollid != op_collation)
+	{
+		/* Collation mismatch - bloom filter hash won't match operator hash */
+		return NULL;
+	}
+
+	/* Cannot use non-deterministic collations */
+	if (OidIsValid(op_collation) && !get_collation_isdeterministic(op_collation))
+		return NULL;
+
+	*value_out = value_expr_tmp;
+	*op_oid_out = op_oid_tmp;
+	return chosen_var;
+}
+
 static void *
 pushdown_op_to_segment_meta_bloom1(QualPushdownContext *context, OpExpr *orig_opexpr)
 {
@@ -398,71 +617,24 @@ pushdown_op_to_segment_meta_bloom1(QualPushdownContext *context, OpExpr *orig_op
 	 */
 	context->needs_recheck = true;
 
-	List *expr_args = orig_opexpr->args;
-	Assert(list_length(expr_args) == 2);
-	Expr *orig_leftop = linitial(expr_args);
-	Expr *orig_rightop = lsecond(expr_args);
+	/*
+	 * Use single-column bloom helper to find Var with bloom metadata.
+	 * Helper returns first Var with bloom metadata.
+	 */
+	Expr *orig_rightop = NULL;
+	Oid op_oid;
+	Var *var = extract_var_for_bloom1(orig_opexpr, context, &orig_rightop, &op_oid);
 
-	if (IsA(orig_leftop, RelabelType))
-		orig_leftop = ((RelabelType *) orig_leftop)->arg;
-	if (IsA(orig_rightop, RelabelType))
-		orig_rightop = ((RelabelType *) orig_rightop)->arg;
+	if (var == NULL)
+	{
+		context->can_pushdown = false;
+		return orig_opexpr;
+	}
 
-	/* Find the side that has var with segment meta set expr to the other side */
-	Oid op_oid = orig_opexpr->opno;
+	/* Get bloom metadata. */
 	AttrNumber bloom1_attno = InvalidAttrNumber;
-	expr_fetch_bloom1_metadata(context, orig_leftop, &bloom1_attno);
-	if (bloom1_attno == InvalidAttrNumber)
-	{
-		/* No metadata for the left operand, try to commute the operator. */
-		op_oid = get_commutator(op_oid);
-		Expr *tmp = orig_leftop;
-		orig_leftop = orig_rightop;
-		orig_rightop = tmp;
-
-		expr_fetch_bloom1_metadata(context, orig_leftop, &bloom1_attno);
-	}
-
-	if (bloom1_attno == InvalidAttrNumber)
-	{
-		/* No metadata for either operand. */
-		context->can_pushdown = false;
-		return orig_opexpr;
-	}
-
-	Var *var_with_segment_meta = castNode(Var, orig_leftop);
-
-	/*
-	 * Play it safe and don't push down if the operator collation doesn't match
-	 * the column collation.
-	 */
-	Oid op_collation = orig_opexpr->inputcollid;
-	if (var_with_segment_meta->varcollid != op_collation)
-	{
-		context->can_pushdown = false;
-		return orig_opexpr;
-	}
-
-	/*
-	 * We cannot use bloom filters for non-deterministic collations.
-	 */
-	if (OidIsValid(op_collation) && !get_collation_isdeterministic(op_collation))
-	{
-		context->can_pushdown = false;
-		return orig_opexpr;
-	}
-
-	/*
-	 * We only support hashable equality operators.
-	 */
-	TypeCacheEntry *tce =
-		lookup_type_cache(var_with_segment_meta->vartype, TYPECACHE_HASH_OPFAMILY);
-	const int strategy = get_op_opfamily_strategy(op_oid, tce->hash_opf);
-	if (strategy != HTEqualStrategyNumber)
-	{
-		context->can_pushdown = false;
-		return orig_opexpr;
-	}
+	expr_fetch_bloom1_metadata(context, (Expr *) var, &bloom1_attno);
+	Assert(bloom1_attno != InvalidAttrNumber);
 
 	/*
 	 * The hash equality operators are supposed to be strict.
@@ -636,6 +808,398 @@ pushdown_saop_bloom1(QualPushdownContext *context, ScalarArrayOpExpr *orig_saop)
 						/* funccollid = */ InvalidOid,
 						/* inputcollid = */ InvalidOid,
 						COERCE_EXPLICIT_CALL);
+}
+
+/*
+ * Extract Var for composite bloom filter pushdown.
+ * Uses segmentby membership as a heuristic for Var-to-Var cases.
+ * Does NOT check bloom metadata (composite bloom is checked later by name matching).
+ *
+ * This handles cases like:
+ * - col = 5                (obvious)
+ * - 5 = col                (commute)
+ * - col = segmentby_col    (prefer non-segmentby col)
+ * - col1 = col2            (prefer non-segmentby, but caller validates value)
+ *
+ * IMPORTANT: For col1 = col2 where both are non-segmentby, returns col1 but
+ * the caller (pushdown_composite_blooms) will reject col2 during value validation.
+ * Composite bloom requires value expressions to be constants, params, or segmentby Vars.
+ *
+ * Returns a Var along with the value expression and (possibly commuted) operator.
+ */
+static Var *
+extract_var_for_composite_bloom(OpExpr *opexpr, QualPushdownContext *context, Expr **value_out,
+								Oid *op_oid_out)
+{
+	Assert(opexpr != NULL);
+	Assert(context != NULL);
+	Assert(value_out != NULL);
+	Assert(op_oid_out != NULL);
+
+	*value_out = NULL;
+	*op_oid_out = InvalidOid;
+
+	/* Validate the expression */
+	HashableEqualityInfo info = validate_hashable_equality(opexpr, context);
+	if (!info.valid)
+		return NULL;
+
+	/* Only one side is a Var. */
+	Var *chosen_var = NULL;
+	Expr *value_expr_tmp = NULL;
+	Oid op_oid_tmp;
+	bool value_is_segmentby = false;
+
+	if (info.left_var != NULL && info.right_var == NULL)
+	{
+		chosen_var = info.left_var;
+		value_expr_tmp = info.right_expr;
+		op_oid_tmp = info.opno;
+	}
+	else if (info.right_var != NULL && info.left_var == NULL)
+	{
+		chosen_var = info.right_var;
+		value_expr_tmp = info.left_expr;
+		op_oid_tmp = get_commutator(info.opno);
+	}
+	else if (info.left_var != NULL && info.right_var != NULL)
+	{
+		/*
+		 * Both are Vars. Prefer non-segmentby Var (segmentby columns cannot
+		 * be in bloom filters), but also require valid hash operator.
+		 */
+		bool left_is_segmentby = false;
+		bool right_is_segmentby = false;
+
+		if (context->settings && context->settings->fd.segmentby)
+		{
+			char *left_attname =
+				get_attname(context->chunk_rte->relid, info.left_var->varattno, false);
+			left_is_segmentby = ts_array_is_member(context->settings->fd.segmentby, left_attname);
+
+			char *right_attname =
+				get_attname(context->chunk_rte->relid, info.right_var->varattno, false);
+			right_is_segmentby = ts_array_is_member(context->settings->fd.segmentby, right_attname);
+		}
+
+		/* Try candidates in preference order: non-segmentby+hashable, then segmentby+hashable */
+		if (!right_is_segmentby && info.right_hashable)
+		{
+			/* Right is non-segmentby and hashable - prefer it */
+			chosen_var = info.right_var;
+			value_expr_tmp = info.left_expr;
+			op_oid_tmp = get_commutator(info.opno);
+			value_is_segmentby = left_is_segmentby;
+		}
+		else if (!left_is_segmentby && info.left_hashable)
+		{
+			/* Left is non-segmentby and hashable - use it */
+			chosen_var = info.left_var;
+			value_expr_tmp = info.right_expr;
+			op_oid_tmp = info.opno;
+			value_is_segmentby = right_is_segmentby;
+		}
+		else if (info.left_hashable)
+		{
+			/* Left is hashable (may be segmentby) - use it as fallback */
+			chosen_var = info.left_var;
+			value_expr_tmp = info.right_expr;
+			op_oid_tmp = info.opno;
+			value_is_segmentby = right_is_segmentby;
+		}
+		else if (info.right_hashable)
+		{
+			/* Right is hashable (may be segmentby) - use it as last resort */
+			chosen_var = info.right_var;
+			value_expr_tmp = info.left_expr;
+			op_oid_tmp = get_commutator(info.opno);
+			value_is_segmentby = left_is_segmentby;
+		}
+		else
+		{
+			/* Neither Var has valid hash operator */
+			return NULL;
+		}
+	}
+
+	/* Validate the chosen Var and value expression */
+	if (chosen_var != NULL)
+	{
+		/* Check collation */
+		Oid op_collation = opexpr->inputcollid;
+		if (chosen_var->varcollid != op_collation)
+		{
+			/* Collation mismatch. */
+			return NULL;
+		}
+
+		/* Cannot use non-deterministic collations */
+		if (OidIsValid(op_collation) && !get_collation_isdeterministic(op_collation))
+			return NULL;
+
+		/*
+		 * Reject non-segmentby Vars in value expression.
+		 * For composite bloom, value expressions must be pushable (const, param, or segmentby Var).
+		 * Non-segmentby Vars need decompression and cannot be used in bloom checks.
+		 *
+		 * Note: value_is_segmentby is only set when both sides are Vars (both-Vars case).
+		 * In that case, value_expr_tmp is always a Var on chunk_rel. If value_is_segmentby
+		 * is false in the both-Vars case, the value Var is non-segmentby and must be rejected.
+		 * In the single-Var case, value_expr_tmp is not a Var on chunk_rel, so this check
+		 * doesn't apply (value_is_segmentby remains false but value_expr_tmp is not a Var).
+		 */
+		if (IsA(value_expr_tmp, Var))
+		{
+			Var *value_var = (Var *) value_expr_tmp;
+			/* Only check segmentby for Vars on our relation */
+			if ((Index) value_var->varno == context->chunk_rel->relid && value_var->varattno > 0 &&
+				!value_is_segmentby)
+			{
+				/* Value is a non-segmentby Var on our relation - cannot be pushed */
+				return NULL;
+			}
+		}
+
+		*value_out = value_expr_tmp;
+		*op_oid_out = op_oid_tmp;
+		return chosen_var;
+	}
+
+	return NULL;
+}
+
+/*
+ * Scan baserestrictinfo for composite bloom opportunities.
+ * For each applicable composite bloom, generate bloom1_contains(bloom, ROW(...)).
+ *
+ * Scans predicates first, then parses settings only if needed.
+ */
+static void
+pushdown_composite_blooms(PlannerInfo *root, QualPushdownContext *context)
+{
+	Assert(root != NULL);
+	Assert(context != NULL);
+
+	/* We need settings to generate composite blooms. */
+	CompressionSettings *settings = context->settings;
+	if (settings == NULL || settings->fd.index == NULL)
+	{
+		return;
+	}
+
+	/* We need at least two baserestrictinfo to have a chance to push down a composite bloom filter.
+	 */
+	if (list_length(context->chunk_rel->baserestrictinfo) < 2)
+	{
+		return;
+	}
+
+	ListCell *lc;
+	Bitmapset *var_attnos = NULL;
+
+	/* Build map: chunk_attno -> value_expr for equality predicates. */
+	/* Note that we may have more than one predicate for the same attribute
+	 * (e.g. col1 = 1 AND col1 = 2) which is a contradiction and we should
+	 * be able to detect and optimize for this, meaning that this predicate
+	 * will always be false. This is a TODO.
+	 *
+	 * For now, we will just use the last one, which will filter out some
+	 * chunks which is better than nothing.
+	 */
+	AttrNumber max_attno = context->chunk_rel->max_attr;
+	Expr **attno_to_value = palloc0((max_attno + 1) * sizeof(Expr *));
+
+	/* Determine vars with equality predicates. */
+	foreach (lc, context->chunk_rel->baserestrictinfo)
+	{
+		RestrictInfo *ri = lfirst_node(RestrictInfo, lc);
+		if (!IsA(ri->clause, OpExpr))
+			continue;
+
+		Expr *value = NULL;
+		Oid op_oid = InvalidOid;
+		Var *var =
+			extract_var_for_composite_bloom(castNode(OpExpr, ri->clause), context, &value, &op_oid);
+		if (var != NULL && value != NULL)
+		{
+			var_attnos = bms_add_member(var_attnos, var->varattno);
+			attno_to_value[var->varattno] = value;
+		}
+	}
+
+	/* Check if not enough vars with equality predicates. */
+	if (bms_num_members(var_attnos) < 2)
+		return;
+
+	/* Parse settings to get per-column compression settings. */
+	SparseIndexSettings *parsed = ts_convert_to_sparse_index_settings(settings->fd.index);
+	if (parsed == NULL)
+	{
+		bms_free(var_attnos);
+		pfree(attno_to_value);
+		return;
+	}
+
+	/* For each sparse index object, resolve the columns to attribute numbers. */
+	TsBmsList per_column_attnos =
+		ts_resolve_columns_to_attnos_from_parsed_settings(parsed, context->chunk_rte->relid);
+
+	/* This bitmap tells which sparse index objects are candidates for composite bloom filters. */
+	Bitmapset *composite_filter_candidates_ids = NULL;
+
+	/* Iterate over the resolved columns and check if they match the vars with equality predicates.
+	 */
+	ListCell *attno_cell = NULL;
+	int sparse_index_obj_id = -1;
+	foreach (attno_cell, per_column_attnos)
+	{
+		sparse_index_obj_id++;
+		Bitmapset *attnos = lfirst(attno_cell);
+		/* Only care about sparse indices with at least 2 columns. */
+		if (bms_num_members(attnos) < 2)
+		{
+			continue;
+		}
+		if (bms_is_subset(attnos, var_attnos))
+		{
+			/* This sparse index object matches the vars with equality predicates. */
+			SparseIndexSettingsObject *obj = list_nth(parsed->objects, sparse_index_obj_id);
+			Assert(obj != NULL);
+			if (obj == NULL)
+			{
+				continue;
+			}
+
+			/* Get the index type from the parsed object. */
+			List *index_type =
+				ts_get_values_by_key_from_parsed_object(obj,
+														ts_sparse_index_common_keys
+															[SparseIndexKeyType] /* "type" */);
+			Assert(index_type != NIL && list_length(index_type) == 1);
+			if (index_type == NIL || list_length(index_type) != 1)
+			{
+				continue;
+			}
+			/* Check that it is a bloom index. */
+			const char *index_type_str = lfirst(list_head(index_type));
+			if (strcmp(index_type_str,
+					   ts_sparse_index_type_names[_SparseIndexTypeEnumBloom] /* "bloom" */) != 0)
+			{
+				continue;
+			}
+			Assert(list_length(ts_get_column_names_from_parsed_object(obj)) >= 2);
+			composite_filter_candidates_ids =
+				bms_add_member(composite_filter_candidates_ids, sparse_index_obj_id);
+		}
+	}
+
+	/* Check if there are composite filter candidates. */
+	if (bms_is_empty(composite_filter_candidates_ids))
+	{
+		pfree(attno_to_value);
+		bms_free(var_attnos);
+		ts_bmslist_free(per_column_attnos);
+		ts_free_sparse_index_settings(parsed);
+		return;
+	}
+
+	/* For each composite filter candidate, build the composite bloom filter. */
+	int candidate_filter_id = -1;
+	while ((candidate_filter_id =
+				bms_next_member(composite_filter_candidates_ids, candidate_filter_id)) >= 0)
+	{
+		SparseIndexSettingsObject *obj = list_nth(parsed->objects, candidate_filter_id);
+		Assert(obj != NULL);
+		/* The column attnos generated from the parsed object is a list indexed by the object id.*/
+		Bitmapset *column_attnos = list_nth(per_column_attnos, candidate_filter_id);
+		Assert(bms_num_members(column_attnos) >= 2);
+
+		/* Iterate over the attnos for the current candidate filter an check if this is a valid
+		 * predicate to push down. This is a safety check and hope that the composite bloom filter
+		 * will also be valid to push down by induction.
+		 */
+		List *pushed_value_exprs = NIL;
+		bool all_valid = true;
+		int col_attno = -1;
+		while ((col_attno = bms_next_member(column_attnos, col_attno)) >= 0)
+		{
+			Expr *value_expr = attno_to_value[col_attno];
+			Assert(value_expr != NULL);
+
+			/* Validate the value expression via qual_pushdown_mutator. */
+			QualPushdownContext tmp_context = copy_context(context);
+			Expr *pushed_value = (Expr *) qual_pushdown_mutator((Node *) value_expr, &tmp_context);
+
+			if (!tmp_context.can_pushdown || tmp_context.needs_recheck)
+			{
+				all_valid = false;
+				break;
+			}
+			pushed_value_exprs = lappend(pushed_value_exprs, pushed_value);
+		}
+		if (!all_valid)
+		{
+			continue;
+		}
+
+		List *column_names = ts_get_column_names_from_parsed_object(obj);
+		Assert(list_length(column_names) >= 2 &&
+			   list_length(column_names) <= MAX_BLOOM_FILTER_COLUMNS);
+
+		/* Check if this chunk has the composite bloom column */
+		char *composite_col_name =
+			compressed_column_metadata_name_list_v2(bloom1_column_prefix, column_names);
+		AttrNumber composite_attno = get_attnum(context->compressed_rte->relid, composite_col_name);
+		pfree(composite_col_name);
+		if (!AttributeNumberIsValid(composite_attno))
+		{
+			continue;
+		}
+
+		/* Build bloom1_contains(composite_bloom, ROW(...)) */
+		Var *bloom_var = makeVar(context->compressed_rel->relid,
+								 composite_attno,
+								 ts_custom_type_cache_get(CUSTOM_TYPE_BLOOM1)->type_oid,
+								 -1,
+								 InvalidOid,
+								 0);
+
+		/* If all pushed-down values are Const, pre-hash at planning time. */
+		FuncExpr *bloom_check = NULL;
+
+		/* Build ROW(val1, val2, ...) expression using pushed-down values */
+		RowExpr *row_expr = makeNode(RowExpr);
+		row_expr->args = pushed_value_exprs;
+		row_expr->row_typeid = RECORDOID;
+		row_expr->row_format = COERCE_IMPLICIT_CAST;
+		row_expr->colnames = NIL;
+		row_expr->location = -1;
+
+		Oid func_oid = LookupFuncName(list_make2(makeString("_timescaledb_functions"),
+												 makeString("bloom1_contains")),
+									  -1,
+									  (void *) -1,
+									  false);
+
+		bloom_check = makeFuncExpr(func_oid,
+								   BOOLOID,
+								   list_make2(bloom_var, row_expr),
+								   InvalidOid,
+								   InvalidOid,
+								   COERCE_EXPLICIT_CALL);
+
+		/* Add to baserestrictinfo. */
+		context->compressed_rel->baserestrictinfo =
+			lappend(context->compressed_rel->baserestrictinfo,
+					make_simple_restrictinfo(root, (Expr *) bloom_check));
+	}
+
+	/* Cleanup */
+	bms_free(var_attnos);
+	bms_free(composite_filter_candidates_ids);
+	ts_free_sparse_index_settings(parsed);
+	ts_bmslist_free(per_column_attnos);
+	pfree(attno_to_value);
 }
 
 static bool

--- a/tsl/test/expected/compress_compbloom_basics.out
+++ b/tsl/test/expected/compress_compbloom_basics.out
@@ -82,19 +82,21 @@ explain (buffers off, costs off) select * from sparse where o = 1 and big2 = 1;
    Vectorized Filter: ((o = 1) AND (big2 = 1))
    ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1)
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(1, 1)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
 
 explain (buffers off, costs off) select * from sparse where num = 1 and hello = md5('1')::bytea;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Filter: ((num = '1'::numeric) AND (hello = '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
    ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_num_hello, ROW('1'::numeric, '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
 
 explain (buffers off, costs off) select * from sparse where small1 = 1 and small2 = 1;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Vectorized Filter: ((small1 = 1) AND (small2 = 1))
    ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_small1_small2, ROW(1, 1))
 
 explain (buffers off, costs off) select * from sparse where num = 1 and nowts = now()::timestamptz;
 --- QUERY PLAN ---
@@ -104,6 +106,7 @@ explain (buffers off, costs off) select * from sparse where num = 1 and nowts = 
          Filter: (num = '1'::numeric)
          Vectorized Filter: (nowts = now())
          ->  Seq Scan on compress_hyper_2_2_chunk
+               Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_num_nowts, ROW('1'::numeric, now()))
 
 explain (buffers off, costs off) select * from sparse where o in (1,2) and big2 = 1;
 --- QUERY PLAN ---
@@ -141,7 +144,7 @@ explain (buffers off, costs off) select * from sparse where o = sby and big2 = s
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Filter: ((o = sby) AND (sby = big2))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(sby, sby)) AND (_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
 
 explain (buffers off, costs off) select * from sparse where o = 1 and big2 = sby;
 --- QUERY PLAN ---
@@ -150,7 +153,7 @@ explain (buffers off, costs off) select * from sparse where o = 1 and big2 = sby
    Vectorized Filter: (o = 1)
    ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby)
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(1, sby)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
 
 explain (buffers off, costs off) select * from sparse where o = sby and big2 = 1;
 --- QUERY PLAN ---
@@ -158,7 +161,7 @@ explain (buffers off, costs off) select * from sparse where o = sby and big2 = 1
    Filter: (o = sby)
    Vectorized Filter: (big2 = 1)
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(sby, 1)) AND (_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
 
 -- create a sister table where the same composite blooms should be auto created
 create table sparse_sister as select * from sparse where ts < -1;
@@ -257,21 +260,21 @@ explain (buffers off, costs off) select * from sparse_sister where o = 1 and big
    Vectorized Filter: ((o = 1) AND (big2 = 1))
    ->  Index Scan using compress_hyper_4_4_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_4_4_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1)
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(1, 1)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
 
 explain (buffers off, costs off) select * from sparse_sister where num = 1 and hello = md5('1')::bytea;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
    Filter: ((num = '1'::numeric) AND (hello = '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: ((_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_hello, '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_num_hello, ROW('1'::numeric, '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea)) AND (_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_hello, '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
 
 explain (buffers off, costs off) select * from sparse_sister where small1 = 1 and small2 = 1;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
    Vectorized Filter: ((small1 = 1) AND (small2 = 1))
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: ((_ts_meta_v2_min_small1 <= 1) AND (_ts_meta_v2_max_small1 >= 1) AND (_ts_meta_v2_min_small2 <= 1) AND (_ts_meta_v2_max_small2 >= 1))
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_small1_small2, ROW(1, 1)) AND (_ts_meta_v2_min_small1 <= 1) AND (_ts_meta_v2_max_small1 >= 1) AND (_ts_meta_v2_min_small2 <= 1) AND (_ts_meta_v2_max_small2 >= 1))
 
 explain (buffers off, costs off) select * from sparse_sister where num = 1 and nowts = now()::timestamptz;
 --- QUERY PLAN ---
@@ -281,7 +284,7 @@ explain (buffers off, costs off) select * from sparse_sister where num = 1 and n
          Filter: (num = '1'::numeric)
          Vectorized Filter: (nowts = now())
          ->  Seq Scan on compress_hyper_4_4_chunk
-               Filter: ((_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND (_ts_meta_v2_min_nowts <= now()) AND (_ts_meta_v2_max_nowts >= now()))
+               Filter: ((_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_num_nowts, ROW('1'::numeric, now())) AND (_ts_meta_v2_min_nowts <= now()) AND (_ts_meta_v2_max_nowts >= now()))
 
 -- segmentby = bloom
 explain (buffers off, costs off) select * from sparse_sister where big1 = sby and value = 1;
@@ -297,7 +300,7 @@ explain (buffers off, costs off) select * from sparse_sister where o = sby and b
  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
    Filter: ((o = sby) AND (sby = big2))
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(sby, sby)) AND (_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
 
 explain (buffers off, costs off) select * from sparse_sister where o = 1 and big2 = sby;
 --- QUERY PLAN ---
@@ -306,7 +309,7 @@ explain (buffers off, costs off) select * from sparse_sister where o = 1 and big
    Vectorized Filter: (o = 1)
    ->  Index Scan using compress_hyper_4_4_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_4_4_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby)
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(1, sby)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, sby))
 
 explain (buffers off, costs off) select * from sparse_sister where o = sby and big2 = 1;
 --- QUERY PLAN ---
@@ -314,7 +317,7 @@ explain (buffers off, costs off) select * from sparse_sister where o = sby and b
    Filter: (o = sby)
    Vectorized Filter: (big2 = 1)
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_o_big2, ROW(sby, 1)) AND (_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_big2, 1))
 
 -- renaming a column that participates in a composite bloom filter
 alter table sparse rename big2 to xxl;

--- a/tsl/test/expected/compress_compbloom_index_add.out
+++ b/tsl/test/expected/compress_compbloom_index_add.out
@@ -1,0 +1,106 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+---------------------------------------------------------------------
+-- Index added after partial compression
+---------------------------------------------------------------------
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+CREATE TABLE mixed_avail_add(ts timestamptz, a int, b int, seg int);
+SELECT create_hypertable('mixed_avail_add', by_range('ts', interval '1 day'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+ALTER TABLE mixed_avail_add SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts'
+);
+-- Insert and compress first 2 chunks (no composite bloom)
+INSERT INTO mixed_avail_add
+SELECT ts, (i % 10), (i % 5), 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_add') c LIMIT 2;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+
+-- Before index add
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_add WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_add (actual rows=0.00 loops=1)
+   Order: mixed_avail_add.ts, mixed_avail_add.seg
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 1600
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 2400
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.seg
+         Sort Method: quicksort 
+         ->  Seq Scan on _hyper_1_3_chunk (actual rows=0.00 loops=1)
+               Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 900
+
+-- Create index
+CREATE INDEX idx_ab ON mixed_avail_add (a, b);
+-- Compress last chunk (will have composite bloom from new index)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_add') c OFFSET 2;
+NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+NOTICE:  chunk "_hyper_1_2_chunk" is already converted to columnstore
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- Query should work on all chunks
+SELECT COUNT(*) FROM mixed_avail_add WHERE a = 1 AND b = 2;
+ count 
+-------
+     0
+
+-- After index add
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_add WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_add (actual rows=0.00 loops=1)
+   Order: mixed_avail_add.ts, mixed_avail_add.seg
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 1600
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 2400
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0.00 loops=1)
+                     Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_a, 1) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_b, 2))
+                     Rows Removed by Filter: 1
+
+DROP TABLE IF EXISTS mixed_avail_add CASCADE;

--- a/tsl/test/expected/compress_compbloom_index_drop.out
+++ b/tsl/test/expected/compress_compbloom_index_drop.out
@@ -1,0 +1,111 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+---------------------------------------------------------------------
+-- Some chunks don't have a composite bloom index after index change
+---------------------------------------------------------------------
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+CREATE TABLE mixed_avail_drop(ts timestamptz, a int, b int, seg int);
+SELECT create_hypertable('mixed_avail_drop', by_range('ts', interval '1 day'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+-- Create index
+CREATE INDEX idx_ab ON mixed_avail_drop (a, b);
+ALTER TABLE mixed_avail_drop SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts'
+);
+-- Insert data for 3 days (3 chunks)
+INSERT INTO mixed_avail_drop
+SELECT ts, (i % 10), (i % 5), 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+-- Compress first 2 chunks (will have composite bloom from index)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_drop') c LIMIT 2;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+
+-- Before index drop
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_drop WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_drop (actual rows=0.00 loops=1)
+   Order: mixed_avail_drop.ts, mixed_avail_drop.seg
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
+                     Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_a, 1) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_b, 2))
+                     Rows Removed by Filter: 2
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=0.00 loops=1)
+                     Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_a, 1) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_b, 2))
+                     Rows Removed by Filter: 3
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.seg
+         Sort Method: quicksort 
+         ->  Index Scan using _hyper_1_3_chunk_idx_ab on _hyper_1_3_chunk (actual rows=0.00 loops=1)
+               Index Cond: ((a = 1) AND (b = 2))
+
+-- Drop index
+DROP INDEX idx_ab;
+-- Compress last chunk (no composite bloom, index is gone)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_drop') c OFFSET 2;
+NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+NOTICE:  chunk "_hyper_1_2_chunk" is already converted to columnstore
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- Query should work on all chunks
+SELECT COUNT(*) FROM mixed_avail_drop WHERE a = 1 AND b = 2;
+ count 
+-------
+     0
+
+-- After index drop
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_drop WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on mixed_avail_drop (actual rows=0.00 loops=1)
+   Order: mixed_avail_drop.ts, mixed_avail_drop.seg
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_1_chunk.ts, _hyper_1_1_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
+                     Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_a, 1) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_b, 2))
+                     Rows Removed by Filter: 2
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=0.00 loops=1)
+                     Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_a, 1) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_b, 2))
+                     Rows Removed by Filter: 3
+   ->  Sort (actual rows=0.00 loops=1)
+         Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.seg
+         Sort Method: quicksort 
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=0.00 loops=1)
+               Vectorized Filter: ((a = 1) AND (b = 2))
+               Rows Removed by Filter: 900
+               ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1.00 loops=1)
+
+DROP TABLE IF EXISTS mixed_avail_drop CASCADE;

--- a/tsl/test/expected/compress_compbloom_manual_config.out
+++ b/tsl/test/expected/compress_compbloom_manual_config.out
@@ -54,8 +54,9 @@ ORDER BY 1,2,3,4;
          Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
-               Rows Removed by Filter: 1600
-               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
+                     Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2))
+                     Rows Removed by Filter: 2
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.c
          Sort Method: quicksort 
@@ -171,8 +172,9 @@ ORDER BY 1,2,3,4;
          Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
-               Rows Removed by Filter: 1600
-               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=2.00 loops=1)
+               ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
+                     Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_a_b, ROW(1, 2))
+                     Rows Removed by Filter: 2
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.c
          Sort Method: quicksort 
@@ -208,6 +210,7 @@ ORDER BY 1,2,3,4;
                Vectorized Filter: ((a = 1) AND (c = 2))
                Rows Removed by Filter: 2328
                ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
+                     Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_a_c, ROW(1, 2))
    ->  Sort (actual rows=27.00 loops=1)
          Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.b
          Sort Method: quicksort 
@@ -243,5 +246,6 @@ ORDER BY 1,2,3,4;
                Vectorized Filter: ((b = 1) AND (c = 2))
                Rows Removed by Filter: 846
                ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1.00 loops=1)
+                     Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_b_c, ROW(1, 2))
 
 DROP TABLE IF EXISTS mixed_avail_manual CASCADE;

--- a/tsl/test/expected/compress_composite_bloom_debug.out
+++ b/tsl/test/expected/compress_composite_bloom_debug.out
@@ -209,8 +209,10 @@ SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'temp'
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1300.00 loops=1)
    Vectorized Filter: ((device_id = 1) AND (sensor_type = 'temp'::text))
-   Rows Removed by Filter: 2600
-   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+   Rows Removed by Filter: 600
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=2.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_device_id_sensor_type, ROW(1, 'temp'::text))
+         Rows Removed by Filter: 2
 
 -- Expected behavior:
 -- - Filter should show: bloom1_contains(composite_bloom, ROW(1, 'temp'::text))
@@ -223,8 +225,10 @@ SELECT * FROM composite_filter_test WHERE device_id = 2 AND sensor_type = 'humid
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1300.00 loops=1)
    Vectorized Filter: ((device_id = 2) AND (sensor_type = 'humidity'::text))
-   Rows Removed by Filter: 2600
-   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+   Rows Removed by Filter: 600
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=2.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_device_id_sensor_type, ROW(2, 'humidity'::text))
+         Rows Removed by Filter: 2
 
 -- Expected: Similar pruning as Test 5.1
 -- Query for non-existent combination
@@ -233,8 +237,9 @@ SELECT * FROM composite_filter_test WHERE device_id = 5 AND sensor_type = 'temp'
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
    Vectorized Filter: ((device_id = 5) AND (sensor_type = 'temp'::text))
-   Rows Removed by Filter: 3900
-   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_device_id_sensor_type, ROW(5, 'temp'::text))
+         Rows Removed by Filter: 4
 
 -- Expected:
 -- - Should scan 0 or very few rows (bloom filter prunes all segments)
@@ -245,8 +250,9 @@ SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'humid
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
    Vectorized Filter: ((device_id = 1) AND (sensor_type = 'humidity'::text))
-   Rows Removed by Filter: 3900
-   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=4.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_device_id_sensor_type, ROW(1, 'humidity'::text))
+         Rows Removed by Filter: 4
 
 -- Expected:
 -- Segment 4 data: (i%3)+1 paired with sensor via CASE

--- a/tsl/test/expected/compress_qualpushdown_complex.out
+++ b/tsl/test/expected/compress_qualpushdown_complex.out
@@ -1,0 +1,405 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- This file tests combinations of quals that we can or cannot push down.
+--
+-- We have these sparse index/columns that we can use to push down quals
+-- to the compressed chunk scans:
+--
+--  - segmentby columns: hold a specific attribute value so all quals that
+--                      may be used for the hypertable may be pushed down
+--
+--  - minmax indexes: hold the min and max values of the attribute values in
+--                    the chunk, so range and equality quals may be pushed down
+--
+--  - bloom indexes: hold the bloom filter for the attribute values in the chunk,
+--                    so equality quals may be pushed down
+--
+--  - composite bloom indexes: hold the composite bloom filter for multiple
+--                              attribute values in the chunk, so equality quals
+--                             that much all columns in the composite bloom may
+--                             be pushed down
+--
+-- Furthermore, we may be able to push down partial expressions from the full
+-- qual, if the partial expression is not more restrictive that the full qual.
+-- Supporting the partial expressions may happen when one qual cannot satisfy
+-- the above pushdown constraints.
+--
+-- The rules to decide if the partial expression is not more restrictive
+-- than the original are as follows with respect to conjunctions and disjunctions:
+--
+--  - R1: we can omit any qual from a conjunction. i.e given a qual like:
+--     a = 1 AND b = 2 AND c = 3, but we cannot push down b = 2, we can push down
+--     a = 1 AND c = 3.
+--
+--  - R2: we cannot omit any qual from a disjunction. i.e given a qual like:
+--     a = 1 OR b = 2 OR c = 3, but we cannot push down b = 2, we cannot push down
+--     a = 1 OR c = 3.
+--
+--  - R3: we can relax the qual within a disjunction. i.e given a qual like:
+--     (a = 1 AND b = 2) OR (c = 3 AND d = 4), but we cannot push down b = 2, we
+--     can push down (a = 1) OR (c = 3 AND d = 4).
+--
+--  - R4: when we relax the qual within a disjunction, we cannot eliminate all quals
+--    such that the entire disjunction is eliminated. i.e given a qual like:
+--     (a = 1 AND b = 2) OR (c = 3 AND d = 4), but we cannot push down b = 2, and
+--     we cannot push down a = 1, we cannot push down anything.
+--
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+DROP TABLE IF EXISTS complex_pushdown;
+NOTICE:  table "complex_pushdown" does not exist, skipping
+CREATE TABLE complex_pushdown(
+    ts int,
+    segby int,
+    mm1 int,
+    mm2 int,
+    blm1 int,
+    blm2 int,
+    other int
+)
+with (
+    tsdb.hypertable,
+    tsdb.compress,
+    tsdb.partition_column = 'ts',
+    tsdb.segmentby = 'segby',
+    tsdb.orderby = 'ts, mm1, mm2',
+    tsdb.index = 'bloom(blm1), bloom(blm2), bloom(blm2, other)'
+);
+INSERT INTO complex_pushdown
+SELECT x as ts, x % 10 as segby, x as mm1, x as mm2, x as blm1, x as blm2, x as other
+FROM generate_series(1, 10000) x;
+VACUUM ANALYZE complex_pushdown;
+select count(compress_chunk(x)) from show_chunks('complex_pushdown') x;
+ count 
+-------
+     1
+
+-- combine sparse indices
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 AND mm1 = 1 AND blm1 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((mm1 = 1) AND (blm1 = 1))
+   ->  Index Scan using compress_hyper_2_2_chunk_segby__ts_meta_min_1__ts_meta_max__idx on compress_hyper_2_2_chunk
+         Index Cond: ((segby = 1) AND (_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1))
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, 1)
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 OR mm1 = 1 OR blm1 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((segby = 1) OR (mm1 = 1) OR (blm1 = 1))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: ((segby = 1) OR ((_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1)) OR _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, 1))
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+ts < 5 OR ts > 100;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((ts < 5) OR (ts > 100))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: ((_ts_meta_min_1 < 5) OR (_ts_meta_max_1 > 100))
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+ts != 5 OR ts != 100;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((ts <> 5) OR (ts <> 100))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+mm1 != 5 OR blm1 != 100;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((mm1 <> 5) OR (blm1 <> 100))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+((segby = 1 OR mm1 = 1) AND blm1 = 1) OR blm2 = 10;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((((segby = 1) OR (mm1 = 1)) AND (blm1 = 1)) OR (blm2 = 10))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: ((((segby = 1) OR ((_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1))) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, 1)) OR _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, 10))
+
+-- R1: we can omit any qual from a conjunction
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 AND mm1 % 10 = 1 AND blm1 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((mm1 % 10) = 1)
+   Vectorized Filter: (blm1 = 1)
+   ->  Index Scan using compress_hyper_2_2_chunk_segby__ts_meta_min_1__ts_meta_max__idx on compress_hyper_2_2_chunk
+         Index Cond: (segby = 1)
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, 1)
+
+-- R1: composite bloom index and another to omit
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+mm1 % 10 = 1 AND blm2 = 10 AND other = 11 AND blm1 = 12;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((mm1 % 10) = 1)
+   Vectorized Filter: ((blm2 = 10) AND (other = 11) AND (blm1 = 12))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_blm2_other, ROW(10, 11)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, 10) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, 12))
+
+-- R2: we cannot omit any qual from a disjunction, so segby cannot be pushed down
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 OR mm1 % 10 = 1;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((segby = 1) OR ((mm1 % 10) = 1))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- R3: base case combining conjunctions and disjunctions
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 = 1) OR (blm1 = 1 AND blm2 = 10);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND (mm1 = 1)) OR ((blm1 = 1) AND (blm2 = 10)))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (((segby = 1) AND (_ts_meta_min_2 <= 1) AND (_ts_meta_max_2 >= 1)) OR (_timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, 1) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, 10)))
+
+-- R3: base case with composite bloom index
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 = 1) OR (other = 1 AND blm2 = 10);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND (mm1 = 1)) OR ((other = 1) AND (blm2 = 10)))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- R3: we can relax the qual within a disjunction. segby and blm2 should be
+-- pushed down, but blm1 and mm1 should not
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 % 10 = 1) OR (blm1 % 10 = 1 AND blm2 = 10);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND ((mm1 % 10) = 1)) OR (((blm1 % 10) = 1) AND (blm2 = 10)))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- R3: another variation
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND other % 10 = 1) OR (blm1 = 10 AND other % 10 = 2);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND ((other % 10) = 1)) OR ((blm1 = 10) AND ((other % 10) = 2)))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- R4: when we relax the qual within a disjunction, we cannot eliminate all quals
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 % 10 = 1) OR (blm1 % 10 = 1);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND ((mm1 % 10) = 1)) OR ((blm1 % 10) = 1))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- simple composite bloom verification
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = 10 AND other = 11;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((blm2 = 10) AND (other = 11))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_blm2_other, ROW(10, 11)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, 10))
+
+-- another variation for the composite bloom, different order
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+other = 11 AND blm2 = 10;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((other = 11) AND (blm2 = 10))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_blm2_other, ROW(10, 11)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, 10))
+
+-- partial composite bloom cannot be pushed down
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE other = 11;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: (other = 11)
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- composite bloom index split across OR arms
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 = 10) OR (blm2 = 10 AND other = 11);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND (mm1 = 10)) OR ((blm2 = 10) AND (other = 11)))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND blm2 = 10) OR (mm1 = 1 AND other = 11);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((segby = 1) AND (blm2 = 10)) OR ((mm1 = 1) AND (other = 11)))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- composite bloom index used in an equality qual
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(blm2 = 10) = (other = 11);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm2 = 10) = (other = 11))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- between qual
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+mm1 BETWEEN 5 AND 10;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((mm1 >= 5) AND (mm1 <= 10))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: ((_ts_meta_max_2 >= 5) AND (_ts_meta_min_2 <= 10))
+
+-- composite IS NULL qual
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 IS NULL AND other IS NULL;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((blm2 IS NULL) AND (other IS NULL))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 IS NULL AND other = 12;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Vectorized Filter: ((blm2 IS NULL) AND (other = 12))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+-- Few test cases below that involve
+-- segmentby and bloom columns
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = segby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (blm1 = segby)
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, segby)
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and blm1 = other;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm2 = segby) AND (blm1 = other))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, segby)
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3) and blm1 = other;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm2 = segby) AND (blm1 = other))
+   Vectorized Filter: (other = ANY ('{1,2,3}'::integer[]))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, segby)
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (blm2 = segby)
+   Vectorized Filter: (other = ANY ('{1,2,3}'::integer[]))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, segby)
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3) and blm1 = segby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm2 = segby) AND (segby = blm1))
+   Vectorized Filter: (other = ANY ('{1,2,3}'::integer[]))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, segby) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, segby))
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3) or blm1 = segby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (((blm2 = segby) AND (other = ANY ('{1,2,3}'::integer[]))) OR (blm1 = segby))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(blm1 = segby or blm2 = segby) and other in (1,2,3) and blm1 = other;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm1 = other) AND ((blm1 = segby) OR (blm2 = segby)))
+   Vectorized Filter: (other = ANY ('{1,2,3}'::integer[]))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_blm1, segby) OR _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, segby))
+
+-- Edge case to make sure blm1 = blm2 doesn't
+-- blow up
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (blm1 = blm2)
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 AND blm1 = segby;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm1 = blm2) AND (blm2 = segby))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+         Filter: _timescaledb_functions.bloom1_contains(regress-test-bloom_blm2, segby)
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 and other in (1,2,3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (blm1 = blm2)
+   Vectorized Filter: (other = ANY ('{1,2,3}'::integer[]))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 or other in (1,2,3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: ((blm1 = blm2) OR (other = ANY ('{1,2,3}'::integer[])))
+   ->  Seq Scan on compress_hyper_2_2_chunk
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 and segby in (1,2,3);
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+   Filter: (blm1 = blm2)
+   ->  Index Scan using compress_hyper_2_2_chunk_segby__ts_meta_min_1__ts_meta_max__idx on compress_hyper_2_2_chunk
+         Index Cond: (segby = ANY ('{1,2,3}'::integer[]))
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -27,6 +27,8 @@ set(TEST_FILES
     compress_bloom_hash.sql
     compress_compbloom_basics.sql
     compress_compbloom_config.sql
+    compress_compbloom_index_add.sql
+    compress_compbloom_index_drop.sql
     compress_compbloom_manual_config.sql
     compress_sparse_config.sql
     compress_default.sql
@@ -35,6 +37,7 @@ set(TEST_FILES
     compress_float8_corrupt.sql
     compress_unordered_sort.sql
     compress_qualpushdown_saop.sql
+    compress_qualpushdown_complex.sql
     compress_sort_transform.sql
     compressed_collation.sql
     compressed_detoaster.sql

--- a/tsl/test/sql/compress_compbloom_index_add.sql
+++ b/tsl/test/sql/compress_compbloom_index_add.sql
@@ -1,0 +1,49 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+---------------------------------------------------------------------
+-- Index added after partial compression
+---------------------------------------------------------------------
+
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+
+CREATE TABLE mixed_avail_add(ts timestamptz, a int, b int, seg int);
+SELECT create_hypertable('mixed_avail_add', by_range('ts', interval '1 day'));
+
+ALTER TABLE mixed_avail_add SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts'
+);
+
+-- Insert and compress first 2 chunks (no composite bloom)
+INSERT INTO mixed_avail_add
+SELECT ts, (i % 10), (i % 5), 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_add') c LIMIT 2;
+
+-- Before index add
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_add WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+
+-- Create index
+CREATE INDEX idx_ab ON mixed_avail_add (a, b);
+
+-- Compress last chunk (will have composite bloom from new index)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_add') c OFFSET 2;
+
+-- Query should work on all chunks
+SELECT COUNT(*) FROM mixed_avail_add WHERE a = 1 AND b = 2;
+
+-- After index add
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_add WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+
+DROP TABLE IF EXISTS mixed_avail_add CASCADE;

--- a/tsl/test/sql/compress_compbloom_index_drop.sql
+++ b/tsl/test/sql/compress_compbloom_index_drop.sql
@@ -1,0 +1,53 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+---------------------------------------------------------------------
+-- Some chunks don't have a composite bloom index after index change
+---------------------------------------------------------------------
+
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+
+CREATE TABLE mixed_avail_drop(ts timestamptz, a int, b int, seg int);
+SELECT create_hypertable('mixed_avail_drop', by_range('ts', interval '1 day'));
+
+-- Create index
+CREATE INDEX idx_ab ON mixed_avail_drop (a, b);
+
+ALTER TABLE mixed_avail_drop SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts'
+);
+
+-- Insert data for 3 days (3 chunks)
+INSERT INTO mixed_avail_drop
+SELECT ts, (i % 10), (i % 5), 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+
+-- Compress first 2 chunks (will have composite bloom from index)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_drop') c LIMIT 2;
+
+-- Before index drop
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_drop WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+
+-- Drop index
+DROP INDEX idx_ab;
+
+-- Compress last chunk (no composite bloom, index is gone)
+SELECT compress_chunk(c) FROM show_chunks('mixed_avail_drop') c OFFSET 2;
+
+-- Query should work on all chunks
+SELECT COUNT(*) FROM mixed_avail_drop WHERE a = 1 AND b = 2;
+
+-- After index drop
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM mixed_avail_drop WHERE a = 1 AND b = 2
+ORDER BY 1,2,3,4;
+
+DROP TABLE IF EXISTS mixed_avail_drop CASCADE;

--- a/tsl/test/sql/compress_qualpushdown_complex.sql
+++ b/tsl/test/sql/compress_qualpushdown_complex.sql
@@ -1,0 +1,240 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- This file tests combinations of quals that we can or cannot push down.
+--
+-- We have these sparse index/columns that we can use to push down quals
+-- to the compressed chunk scans:
+--
+--  - segmentby columns: hold a specific attribute value so all quals that
+--                      may be used for the hypertable may be pushed down
+--
+--  - minmax indexes: hold the min and max values of the attribute values in
+--                    the chunk, so range and equality quals may be pushed down
+--
+--  - bloom indexes: hold the bloom filter for the attribute values in the chunk,
+--                    so equality quals may be pushed down
+--
+--  - composite bloom indexes: hold the composite bloom filter for multiple
+--                              attribute values in the chunk, so equality quals
+--                             that much all columns in the composite bloom may
+--                             be pushed down
+--
+-- Furthermore, we may be able to push down partial expressions from the full
+-- qual, if the partial expression is not more restrictive that the full qual.
+-- Supporting the partial expressions may happen when one qual cannot satisfy
+-- the above pushdown constraints.
+--
+-- The rules to decide if the partial expression is not more restrictive
+-- than the original are as follows with respect to conjunctions and disjunctions:
+--
+--  - R1: we can omit any qual from a conjunction. i.e given a qual like:
+--     a = 1 AND b = 2 AND c = 3, but we cannot push down b = 2, we can push down
+--     a = 1 AND c = 3.
+--
+--  - R2: we cannot omit any qual from a disjunction. i.e given a qual like:
+--     a = 1 OR b = 2 OR c = 3, but we cannot push down b = 2, we cannot push down
+--     a = 1 OR c = 3.
+--
+--  - R3: we can relax the qual within a disjunction. i.e given a qual like:
+--     (a = 1 AND b = 2) OR (c = 3 AND d = 4), but we cannot push down b = 2, we
+--     can push down (a = 1) OR (c = 3 AND d = 4).
+--
+--  - R4: when we relax the qual within a disjunction, we cannot eliminate all quals
+--    such that the entire disjunction is eliminated. i.e given a qual like:
+--     (a = 1 AND b = 2) OR (c = 3 AND d = 4), but we cannot push down b = 2, and
+--     we cannot push down a = 1, we cannot push down anything.
+--
+
+-- disable hash pushdown so we don't include the hash values in the plans
+-- which makes the test stable. the hash pushdown is tested separately
+set timescaledb.enable_bloom1_hash_pushdown = false;
+
+DROP TABLE IF EXISTS complex_pushdown;
+CREATE TABLE complex_pushdown(
+    ts int,
+    segby int,
+    mm1 int,
+    mm2 int,
+    blm1 int,
+    blm2 int,
+    other int
+)
+with (
+    tsdb.hypertable,
+    tsdb.compress,
+    tsdb.partition_column = 'ts',
+    tsdb.segmentby = 'segby',
+    tsdb.orderby = 'ts, mm1, mm2',
+    tsdb.index = 'bloom(blm1), bloom(blm2), bloom(blm2, other)'
+);
+
+INSERT INTO complex_pushdown
+SELECT x as ts, x % 10 as segby, x as mm1, x as mm2, x as blm1, x as blm2, x as other
+FROM generate_series(1, 10000) x;
+
+VACUUM ANALYZE complex_pushdown;
+
+select count(compress_chunk(x)) from show_chunks('complex_pushdown') x;
+
+-- combine sparse indices
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 AND mm1 = 1 AND blm1 = 1;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 OR mm1 = 1 OR blm1 = 1;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+ts < 5 OR ts > 100;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+ts != 5 OR ts != 100;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+mm1 != 5 OR blm1 != 100;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+((segby = 1 OR mm1 = 1) AND blm1 = 1) OR blm2 = 10;
+
+-- R1: we can omit any qual from a conjunction
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 AND mm1 % 10 = 1 AND blm1 = 1;
+
+-- R1: composite bloom index and another to omit
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+mm1 % 10 = 1 AND blm2 = 10 AND other = 11 AND blm1 = 12;
+
+-- R2: we cannot omit any qual from a disjunction, so segby cannot be pushed down
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+segby = 1 OR mm1 % 10 = 1;
+
+-- R3: base case combining conjunctions and disjunctions
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 = 1) OR (blm1 = 1 AND blm2 = 10);
+
+-- R3: base case with composite bloom index
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 = 1) OR (other = 1 AND blm2 = 10);
+
+-- R3: we can relax the qual within a disjunction. segby and blm2 should be
+-- pushed down, but blm1 and mm1 should not
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 % 10 = 1) OR (blm1 % 10 = 1 AND blm2 = 10);
+
+-- R3: another variation
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND other % 10 = 1) OR (blm1 = 10 AND other % 10 = 2);
+
+-- R4: when we relax the qual within a disjunction, we cannot eliminate all quals
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 % 10 = 1) OR (blm1 % 10 = 1);
+
+-- simple composite bloom verification
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = 10 AND other = 11;
+
+-- another variation for the composite bloom, different order
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+other = 11 AND blm2 = 10;
+
+-- partial composite bloom cannot be pushed down
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE other = 11;
+
+-- composite bloom index split across OR arms
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND mm1 = 10) OR (blm2 = 10 AND other = 11);
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(segby = 1 AND blm2 = 10) OR (mm1 = 1 AND other = 11);
+
+-- composite bloom index used in an equality qual
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(blm2 = 10) = (other = 11);
+
+-- between qual
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+mm1 BETWEEN 5 AND 10;
+
+-- composite IS NULL qual
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 IS NULL AND other IS NULL;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 IS NULL AND other = 12;
+
+-- Few test cases below that involve
+-- segmentby and bloom columns
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = segby;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and blm1 = other;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3) and blm1 = other;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3);
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3) and blm1 = segby;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm2 = segby and other in (1,2,3) or blm1 = segby;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+(blm1 = segby or blm2 = segby) and other in (1,2,3) and blm1 = other;
+
+-- Edge case to make sure blm1 = blm2 doesn't
+-- blow up
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 AND blm1 = segby;
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 and other in (1,2,3);
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 or other in (1,2,3);
+
+explain (buffers off, costs off)
+SELECT * FROM complex_pushdown WHERE
+blm1 = blm2 and segby in (1,2,3);
+


### PR DESCRIPTION
This change allows pushing down composite bloom filter predicates to the compressed table scans when a composite bloom filter exists for the predicates. Example:

```
explain (buffers off, costs off)
select * from sparse where o = 1 and big2 = 1;
    Vectorized Filter: ((o = 1) AND (big2 = 1))
    ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
          Filter: (_timescaledb_functions.bloom1_contains(...bloom_o_big2, ROW(1, 1)))
```

In the above case there is a 'bloom(o,big2)' bloom filter which the query can utilize.

The composite bloom filters can be disabled with the `enable_composite_bloom_indexes` GUC which disables both the creation of new composite bloom data and also its usage in the SELECT queries.