### PR TITLE
Composite bloom filter support for UPSERT queries

### DIFF
--- a/.unreleased/pr_9374
+++ b/.unreleased/pr_9374
@@ -1,0 +1,1 @@
+Implements: #9374 Use bloom filters to eliminate decompression of unrelated compressed batches during UPSERTs.

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -288,6 +288,10 @@ modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *
 		state->batches_filtered += counters->batches_filtered;
 		state->batches_decompressed += counters->batches_decompressed;
 		state->tuples_decompressed += counters->tuples_decompressed;
+		state->batches_checked_by_bloom += counters->batches_checked_by_bloom;
+		state->batches_pruned_by_bloom += counters->batches_pruned_by_bloom;
+		state->batches_without_bloom += counters->batches_without_bloom;
+		state->batches_bloom_false_positives += counters->batches_bloom_false_positives;
 	}
 	if (state->batches_filtered > 0)
 		ExplainPropertyInteger("Batches filtered", NULL, state->batches_filtered, es);
@@ -297,6 +301,20 @@ modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *
 		ExplainPropertyInteger("Tuples decompressed", NULL, state->tuples_decompressed, es);
 	if (state->batches_deleted > 0)
 		ExplainPropertyInteger("Batches deleted", NULL, state->batches_deleted, es);
+	if (state->batches_checked_by_bloom > 0)
+		ExplainPropertyInteger("Batches checked by bloom",
+							   NULL,
+							   state->batches_checked_by_bloom,
+							   es);
+	if (state->batches_pruned_by_bloom > 0)
+		ExplainPropertyInteger("Batches pruned by bloom", NULL, state->batches_pruned_by_bloom, es);
+	if (state->batches_without_bloom > 0)
+		ExplainPropertyInteger("Batches without bloom", NULL, state->batches_without_bloom, es);
+	if (state->batches_bloom_false_positives > 0)
+		ExplainPropertyInteger("Batches bloom false positives",
+							   NULL,
+							   state->batches_bloom_false_positives,
+							   es);
 	if (ts_guc_enable_direct_compress_insert && state->mt->operation == CMD_INSERT)
 		ExplainPropertyBool("Direct Compress", state->columnstore_insert, es);
 }

--- a/src/nodes/modify_hypertable.h
+++ b/src/nodes/modify_hypertable.h
@@ -50,6 +50,12 @@ typedef struct ModifyHypertableState
 	int64 batches_deleted;
 	int64 tuples_deleted;
 
+	/* bloom stats */
+	int64 batches_checked_by_bloom;
+	int64 batches_pruned_by_bloom;
+	int64 batches_without_bloom;
+	int64 batches_bloom_false_positives;
+
 	/*
 	 * When EXPLAIN VERBOSE is used, we temporarily nullify the targetlist of the
 	 * lefttree of the ModifyTable to avoid printing out the full targetlist since

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -450,6 +450,10 @@ struct decompress_batches_stats
 	int64 batches_deleted;
 	int64 batches_filtered;
 	int64 batches_decompressed;
+	int64 batches_checked_by_bloom;
+	int64 batches_pruned_by_bloom;
+	int64 batches_without_bloom;
+	int64 batches_bloom_false_positives;
 	int64 tuples_decompressed;
 	int64 tuples_deleted;
 };

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -25,6 +25,7 @@
 #include <compression/compression.h>
 #include <compression/compression_dml.h>
 #include <compression/create.h>
+#include <compression/sparse_index_bloom1.h>
 #include <compression/wal_utils.h>
 #include <continuous_aggs/insert.h>
 #include <expression_utils.h>
@@ -53,12 +54,11 @@ typedef BatchQualSummary(BatchMatcher)(RowDecompressor *decompressor, ScanKeyDat
 									   int num_scankeys, tuple_filtering_constraints *constraints,
 									   bool check_full_match, bool *skip_current_tuple);
 
-static struct decompress_batches_stats decompress_batches_scan(
-	Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
-	ScanKeyData *index_scankeys, int num_index_scankeys, ScanKeyData *heap_scankeys,
-	int num_heap_scankeys, ScanKeyData *mem_scankeys, int num_mem_scankeys,
-	tuple_filtering_constraints *constraints, bool *skip_current_tuple, bool delete_only,
-	Bitmapset *null_columns, List *is_nulls, InvalidationContext *invalidation_ctx);
+static struct decompress_batches_stats
+decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
+						bool *skip_current_tuple, bool delete_only, List *is_nulls,
+						InvalidationContext *invalidation_ctx, CachedDecompressionState *cdst,
+						TupleTableSlot *insert_slot);
 
 static BatchQualSummary batch_matches(RowDecompressor *decompressor, ScanKeyData *scankeys,
 									  int num_scankeys, tuple_filtering_constraints *constraints,
@@ -86,8 +86,9 @@ static bool can_delete_without_decompression(ModifyHypertableState *ht_state,
 static bool can_vectorize_constraint_checks(tuple_filtering_constraints *constraints,
 											CompressionSettings *settings, Relation chunk_rel,
 											Oid ht_relid, ScanKeyWithAttnos *mem_scankeys);
-static ScanKeyData *get_updated_scankeys(const ScanKeyWithAttnos *scankeys, TupleTableSlot *slot,
-										 int null_flags);
+static void update_scankeys(ScanKeyWithAttnos *scankeys, TupleTableSlot *slot, int null_flags);
+static void init_upsert_bloom_state(ChunkInsertState *cis);
+static Bitmapset *get_arbiter_index_attnums(ChunkInsertState *cis);
 
 static AttrNumber
 TupleDescGetAttrNumber(TupleDesc desc, const char *name)
@@ -99,6 +100,150 @@ TupleDescGetAttrNumber(TupleDesc desc, const char *name)
 	}
 
 	return InvalidAttrNumber;
+}
+
+typedef struct MatchedBloom
+{
+	char *column_name;
+	Bitmapset *attnums;
+	AttrNumber compressed_attnum;
+	int num_cols;
+} MatchedBloom;
+
+/*
+ * Get arbiter index column attnums from the arbiter index list.
+ */
+static Bitmapset *
+get_arbiter_index_attnums(ChunkInsertState *cis)
+{
+	Assert(cis != NULL);
+	Assert(cis->result_relation_info != NULL);
+	List *arbiterIndexes = cis->result_relation_info->ri_onConflictArbiterIndexes;
+	if (arbiterIndexes == NIL)
+		return NULL;
+
+	Oid arbiter_oid = linitial_oid(arbiterIndexes);
+	Relation index_rel = index_open(arbiter_oid, AccessShareLock);
+
+	Bitmapset *attnums = NULL;
+	for (int i = 0; i < index_rel->rd_index->indnkeyatts; i++)
+	{
+		AttrNumber attno = index_rel->rd_index->indkey.values[i];
+		if (!AttributeNumberIsValid(attno))
+		{
+			/* Expression index - can't use bloom optimization */
+			index_close(index_rel, AccessShareLock);
+			return NULL;
+		}
+		attnums = bms_add_member(attnums, attno);
+	}
+
+	index_close(index_rel, AccessShareLock);
+	return attnums;
+}
+
+/*
+ * Per-chunk initialization of UPSERT bloom state. Called once per chunk in
+ * init_decompress_state_for_insert(), inside the has_primary_or_unique_index block. The result is
+ * cached in CachedDecompressionState via ChunkInsertState in subspace_store.
+ *
+ * It assumes cdst->compression_settings is already looked up for the chunk.
+ *
+ * Discovers which bloom columns match arbiter index columns, that is, being a subset of the
+ * conflict columns. Builds the mapping from bloom columns to INSERT tuple attnums, and resolves
+ * bloom column names to compressed chunk attnums. The chosen bloom filter is stored in the
+ * CachedDecompressionState struct.
+ */
+static void
+init_upsert_bloom_state(ChunkInsertState *cis)
+{
+	Bitmapset *conflict_attnums = get_arbiter_index_attnums(cis);
+	CachedDecompressionState *cdst = cis->cached_decompression_state;
+	Assert(cdst != NULL);
+	if (cdst == NULL || conflict_attnums == NULL)
+		return;
+
+	CompressionSettings *settings = cdst->compression_settings;
+	Assert(settings != NULL);
+	if (settings == NULL || settings->fd.index == NULL)
+		return;
+
+	Oid compressed_relid = settings->fd.compress_relid;
+
+	SparseIndexSettings *parsed = ts_convert_to_sparse_index_settings(settings->fd.index);
+	Assert(parsed != NULL);
+	if (parsed == NULL)
+		return;
+
+	/* Map the bloom column names to hypertable attnums, because the bloom columns
+	 * will be built based on the insert tuple attnums which are the hypertable attnums. */
+	TsBmsList per_column_attnos =
+		ts_resolve_columns_to_attnos_from_parsed_settings(parsed, cis->hypertable_relid);
+
+	Assert(list_length(per_column_attnos) == list_length(parsed->objects));
+	Assert(list_length(per_column_attnos) > 0);
+	MatchedBloom best_match = { .num_cols = 0 };
+
+	/** Parallel iteration over objects and their resolved attnums. */
+	ListCell *obj_cell;
+	ListCell *attno_cell;
+	forboth (obj_cell, parsed->objects, attno_cell, per_column_attnos)
+	{
+		SparseIndexSettingsObject *obj = lfirst(obj_cell);
+		Bitmapset *bloom_attnos = lfirst(attno_cell);
+
+		/* Check if bloom type */
+		List *type_values = ts_get_values_by_key_from_parsed_object(obj, "type");
+		if (type_values == NIL || strcmp((char *) linitial(type_values), "bloom") != 0)
+			continue;
+
+		/* Check if bloom columns are a subset of the conflict columns */
+		if (!bms_is_subset(bloom_attnos, conflict_attnums))
+			continue;
+
+		int num_cols = bms_num_members(bloom_attnos);
+
+		/* Only keep the best match (most columns) */
+		if (num_cols <= best_match.num_cols)
+			continue;
+
+		/* Get column name for this bloom */
+		List *column_names = ts_get_column_names_from_parsed_object(obj);
+		char *col_name =
+			compressed_column_metadata_name_list_v2(bloom1_column_prefix, column_names);
+
+		/* Verify bloom column exists in the compressed chunk */
+		AttrNumber compressed_attnum = get_attnum(compressed_relid, col_name);
+		Assert(AttributeNumberIsValid(compressed_attnum));
+		if (!AttributeNumberIsValid(compressed_attnum))
+			continue;
+
+		/* New best match */
+		best_match.column_name = col_name;
+		best_match.attnums = bms_copy(bloom_attnos);
+		best_match.compressed_attnum = compressed_attnum;
+		best_match.num_cols = num_cols;
+	}
+
+	/* Create builder for the best match, having the largest number of columns */
+	if (best_match.num_cols > 0)
+	{
+		Oid type_oids[MAX_BLOOM_FILTER_COLUMNS];
+		cdst->bloom_column_name = best_match.column_name;
+		cdst->bloom_insert_attnums = best_match.attnums;
+		cdst->upsert_bloom_attnum = best_match.compressed_attnum;
+
+		int col_idx = 0;
+		int attnum = -1;
+		while ((attnum = bms_next_member(best_match.attnums, attnum)) >= 0)
+			type_oids[col_idx++] = get_atttype(cis->hypertable_relid, attnum);
+
+		if (ts_guc_enable_sparse_index_bloom)
+			cdst->bloom_hasher = bloom1_hasher_create(type_oids, best_match.num_cols);
+	}
+
+	ts_bmslist_free(per_column_attnos);
+	ts_free_sparse_index_settings(parsed);
 }
 
 void
@@ -117,7 +262,7 @@ init_decompress_state_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 
 	MemoryContext old_context = MemoryContextSwitchTo(cis->mctx);
 	cdst = palloc0(sizeof(CachedDecompressionState));
-
+	cis->cached_decompression_state = cdst;
 	cdst->has_primary_or_unique_index = ts_indexing_relation_has_primary_or_unique_index(cis->rel);
 
 	if (cdst->has_primary_or_unique_index)
@@ -168,6 +313,11 @@ init_decompress_state_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 												&index_columns,
 												&cdst->index_scankeys.num_scankeys,
 												&cdst->index_scankeys.attnos);
+
+			if (cis->onConflictAction != ONCONFLICT_NONE)
+			{
+				init_upsert_bloom_state(cis);
+			}
 		}
 
 		if (index_rel)
@@ -199,37 +349,33 @@ init_decompress_state_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 		cdst->columns_with_null_check = columns_with_null_check;
 		table_close(in_rel, NoLock);
 	}
-	cis->cached_decompression_state = cdst;
 
 	MemoryContextSwitchTo(old_context);
 }
 
-static ScanKeyData *
-get_updated_scankeys(const ScanKeyWithAttnos *scankeys, TupleTableSlot *slot, int null_flags)
+static void
+update_scankeys(ScanKeyWithAttnos *scankeys, TupleTableSlot *slot, int null_flags)
 {
 	if (scankeys->num_scankeys == 0)
 	{
-		return NULL;
+		return;
 	}
 
-	ScanKeyData *updated_scankeys = palloc0(sizeof(ScanKeyData) * scankeys->num_scankeys);
 	for (int i = 0; i < scankeys->num_scankeys; i++)
 	{
-		updated_scankeys[i] = scankeys->scankeys[i];
 		bool isnull = false;
 		Datum value = slot_getattr(slot, scankeys->attnos[i], &isnull);
 		if (isnull)
 		{
-			updated_scankeys[i].sk_flags = null_flags;
-			updated_scankeys[i].sk_argument = UnassignedDatum;
+			scankeys->scankeys[i].sk_flags = null_flags;
+			scankeys->scankeys[i].sk_argument = UnassignedDatum;
 		}
 		else
 		{
-			updated_scankeys[i].sk_flags = 0;
-			updated_scankeys[i].sk_argument = value;
+			scankeys->scankeys[i].sk_flags = 0;
+			scankeys->scankeys[i].sk_argument = value;
 		}
 	}
-	return updated_scankeys;
 }
 
 void
@@ -274,7 +420,7 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 
 	/* the scan keys used for in memory tests of the decompressed tuples */
 	bool skip_current_tuple = false;
-	struct decompress_batches_stats stats;
+	struct decompress_batches_stats stats = { 0 };
 
 	Relation index_rel = NULL;
 	if (OidIsValid(cdst->index_relid))
@@ -282,11 +428,9 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 		index_rel = index_open(cdst->index_relid, AccessShareLock);
 	}
 
-	ScanKeyData *index_scankeys =
-		get_updated_scankeys(&cdst->index_scankeys, slot, SK_ISNULL | SK_SEARCHNULL);
-	ScanKeyData *heap_scankeys =
-		get_updated_scankeys(&cdst->heap_scankeys, slot, SK_ISNULL | SK_SEARCHNULL);
-	ScanKeyData *mem_scankeys = get_updated_scankeys(&cdst->mem_scankeys, slot, SK_ISNULL);
+	update_scankeys(&cdst->index_scankeys, slot, SK_ISNULL | SK_SEARCHNULL);
+	update_scankeys(&cdst->heap_scankeys, slot, SK_ISNULL | SK_SEARCHNULL);
+	update_scankeys(&cdst->mem_scankeys, slot, SK_ISNULL);
 
 	if (ts_guc_debug_compression_path_info)
 	{
@@ -308,19 +452,12 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 									out_rel,
 									index_rel,
 									GetActiveSnapshot(),
-									index_scankeys,
-									cdst->index_scankeys.num_scankeys,
-									heap_scankeys,
-									cdst->heap_scankeys.num_scankeys,
-									mem_scankeys,
-									cdst->mem_scankeys.num_scankeys,
-									cdst->constraints,
 									&skip_current_tuple,
 									false,
-									cdst->columns_with_null_check, /* no null column check for
-														   non-segmentby columns */
 									NIL,
-									NULL /* no CAgg invalidation for inserts */);
+									NULL /* no CAgg invalidation for inserts */,
+									cdst,
+									slot);
 	if (index_rel)
 		index_close(index_rel, AccessShareLock);
 	PopActiveSnapshot();
@@ -334,13 +471,10 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 	cis->counters->batches_filtered += stats.batches_filtered;
 	cis->counters->batches_decompressed += stats.batches_decompressed;
 	cis->counters->tuples_decompressed += stats.tuples_decompressed;
-
-	if (index_scankeys)
-		pfree(index_scankeys);
-	if (heap_scankeys)
-		pfree(heap_scankeys);
-	if (mem_scankeys)
-		pfree(mem_scankeys);
+	cis->counters->batches_checked_by_bloom += stats.batches_checked_by_bloom;
+	cis->counters->batches_pruned_by_bloom += stats.batches_pruned_by_bloom;
+	cis->counters->batches_without_bloom += stats.batches_without_bloom;
+	cis->counters->batches_bloom_false_positives += stats.batches_bloom_false_positives;
 
 	CommandCounterIncrement();
 	table_close(in_rel, NoLock);
@@ -376,7 +510,7 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	int num_scankeys = 0;
 	ScanKeyData *index_scankeys = NULL;
 	int num_index_scankeys = 0;
-	struct decompress_batches_stats stats;
+	struct decompress_batches_stats stats = { 0 };
 	int num_mem_scankeys = 0;
 	ScanKeyData *mem_scankeys = NULL;
 
@@ -443,23 +577,28 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 		index_scankeys =
 			build_index_scankeys(matching_index_rel, index_filters, &num_index_scankeys);
 	}
+
+	CachedDecompressionState temp_cdst = { 0 };
+	temp_cdst.index_scankeys.scankeys = index_scankeys;
+	temp_cdst.index_scankeys.num_scankeys = num_index_scankeys;
+	temp_cdst.heap_scankeys.scankeys = scankeys;
+	temp_cdst.heap_scankeys.num_scankeys = num_scankeys;
+	temp_cdst.mem_scankeys.scankeys = mem_scankeys;
+	temp_cdst.mem_scankeys.num_scankeys = num_mem_scankeys;
+	temp_cdst.constraints = NULL;
+	temp_cdst.columns_with_null_check = null_columns;
+
 	PushActiveSnapshot(GetTransactionSnapshot());
 	stats = decompress_batches_scan(comp_chunk_rel,
 									chunk_rel,
 									matching_index_rel,
 									GetActiveSnapshot(),
-									index_scankeys,
-									num_index_scankeys,
-									scankeys,
-									num_scankeys,
-									mem_scankeys,
-									num_mem_scankeys,
-									NULL,
 									NULL,
 									delete_only,
-									null_columns,
 									is_null,
-									ht_state->has_continuous_aggregate ? &invalidation_ctx : NULL);
+									ht_state->has_continuous_aggregate ? &invalidation_ctx : NULL,
+									&temp_cdst,
+									NULL);
 
 	/* close the selected index */
 	if (matching_index_rel)
@@ -531,24 +670,36 @@ static bool
 decompress_batch_scan_getnext_slot(DecompressBatchScanDesc scan, ScanDirection direction,
 								   struct TupleTableSlot *slot)
 {
-	if (scan->index_scan)
+	if (scan == NULL)
+	{
+		return false;
+	}
+	else if (scan->index_scan)
 	{
 		return index_getnext_slot(scan->index_scan, direction, slot);
 	}
-	else
+	else if (scan->scan)
 	{
 		return table_scan_getnextslot(scan->scan, direction, slot);
+	}
+	else
+	{
+		return false;
 	}
 }
 
 static void
 decompress_batch_endscan(DecompressBatchScanDesc scan)
 {
-	if (scan->index_scan)
+	if (scan == NULL)
+	{
+		return;
+	}
+	else if (scan->index_scan)
 	{
 		index_endscan(scan->index_scan);
 	}
-	else
+	else if (scan->scan)
 	{
 		table_endscan(scan->scan);
 	}
@@ -568,12 +719,9 @@ decompress_batch_endscan(DecompressBatchScanDesc scan)
  */
 static struct decompress_batches_stats
 decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
-						ScanKeyData *index_scankeys, int num_index_scankeys,
-						ScanKeyData *heap_scankeys, int num_heap_scankeys,
-						ScanKeyData *mem_scankeys, int num_mem_scankeys,
-						tuple_filtering_constraints *constraints, bool *skip_current_tuple,
-						bool delete_only, Bitmapset *null_columns, List *is_nulls,
-						InvalidationContext *invalidation_ctx)
+						bool *skip_current_tuple, bool delete_only, List *is_nulls,
+						InvalidationContext *invalidation_ctx, CachedDecompressionState *cdst,
+						TupleTableSlot *insert_slot)
 {
 	HeapTuple compressed_tuple;
 	BulkWriter writer;
@@ -584,6 +732,15 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 	int num_filtered_rows = 0;
 	TM_Result result;
 	DecompressBatchScanDesc scan = NULL;
+	ScanKeyData *index_scankeys = cdst->index_scankeys.scankeys;
+	int num_index_scankeys = cdst->index_scankeys.num_scankeys;
+	ScanKeyData *heap_scankeys = cdst->heap_scankeys.scankeys;
+	int num_heap_scankeys = cdst->heap_scankeys.num_scankeys;
+	ScanKeyData *mem_scankeys = cdst->mem_scankeys.scankeys;
+	int num_mem_scankeys = cdst->mem_scankeys.num_scankeys;
+	tuple_filtering_constraints *constraints = cdst->constraints;
+	Bitmapset *null_columns = cdst->columns_with_null_check;
+
 	BatchMatcher *batch_matcher =
 		constraints && constraints->vectorized_filtering ? batch_matches_vectorized : batch_matches;
 	AttrNumber meta_count_attno = InvalidAttrNumber;
@@ -684,6 +841,46 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 						  decompressor.compressed_datums,
 						  decompressor.compressed_is_nulls);
 
+		/* To track false positives */
+		bool bloom_passed = false;
+
+		/* Bloom pre-filtering for UPSERT conflict detection */
+		if (insert_slot != NULL && cdst->bloom_hasher != NULL)
+		{
+			Datum bloom_datum =
+				decompressor.compressed_datums[AttrNumberGetAttrOffset(cdst->upsert_bloom_attnum)];
+			bool bloom_isnull =
+				decompressor
+					.compressed_is_nulls[AttrNumberGetAttrOffset(cdst->upsert_bloom_attnum)];
+
+			if (!bloom_isnull)
+			{
+				NullableDatum values[MAX_BLOOM_FILTER_COLUMNS];
+				int col_idx = 0;
+				int attnum = -1;
+				while ((attnum = bms_next_member(cdst->bloom_insert_attnums, attnum)) >= 0)
+				{
+					values[col_idx].value =
+						slot_getattr(insert_slot, attnum, &values[col_idx].isnull);
+					col_idx++;
+				}
+				uint64 hash = cdst->bloom_hasher->hash_values(cdst->bloom_hasher, values);
+
+				stats.batches_checked_by_bloom++;
+				if (!bloom1_contains_hash(bloom_datum, hash))
+				{
+					row_decompressor_reset(&decompressor);
+					stats.batches_pruned_by_bloom++;
+					continue;
+				}
+				bloom_passed = true;
+			}
+			else
+			{
+				stats.batches_without_bloom++;
+			}
+		}
+
 		/* If there are no in-memory quals, all rows pass */
 		BatchQualSummary summary = AllRowsPass;
 		if (num_mem_scankeys)
@@ -698,6 +895,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			/* If no rows pass, complete batch gets filtered */
 			if (summary == NoRowsPass)
 			{
+				if (bloom_passed)
+					stats.batches_bloom_false_positives++;
 				row_decompressor_reset(&decompressor);
 				stats.batches_filtered++;
 				continue;

--- a/tsl/test/expected/compress_compbloom_upsert.out
+++ b/tsl/test/expected/compress_compbloom_upsert.out
@@ -1,0 +1,281 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-------------------------------------------------------------------
+-- Upsert tests
+-------------------------------------------------------------------
+-- Explain test
+CREATE TABLE explain_test(ts timestamptz, device_id int, metric text, value float);
+SELECT create_hypertable('explain_test', by_range('ts'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+CREATE UNIQUE INDEX idx_explain ON explain_test(device_id, metric, ts);
+ALTER TABLE explain_test SET (timescaledb.compress, timescaledb.compress_segmentby ='');
+INSERT INTO explain_test
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval, i % 10, 'temp', i
+FROM generate_series(1, 5000) i;
+SELECT count(compress_chunk(c)) FROM show_chunks('explain_test') c;
+ count 
+-------
+     2
+
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_test VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
+ON CONFLICT (device_id, metric, ts) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 2
+   Batches pruned by bloom: 2
+   ->  Insert on explain_test (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_explain
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+ROLLBACK;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_test VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
+ON CONFLICT (device_id, metric, ts)
+DO UPDATE SET value = EXCLUDED.value;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 2
+   Batches pruned by bloom: 2
+   ->  Insert on explain_test (actual rows=0.00 loops=1)
+         Conflict Resolution: UPDATE
+         Conflict Arbiter Indexes: idx_explain
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+DROP TABLE IF EXISTS explain_test CASCADE;
+-------------------------------------------------------------------
+CREATE TABLE upsert_test(ts timestamptz, uid int, event text, seg int);
+SELECT create_hypertable('upsert_test', by_range('ts'));
+ create_hypertable 
+-------------------
+ (3,t)
+
+CREATE UNIQUE INDEX idx_uid_event ON upsert_test (uid, event, ts);
+ALTER TABLE upsert_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg'
+);
+INSERT INTO upsert_test
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval,
+       (i % 100) + 1,
+       CASE WHEN i % 3 = 0 THEN 'login' WHEN i % 3 = 1 THEN 'logout' ELSE 'click' END,
+       i % 5
+FROM generate_series(1, 5000) i;
+SELECT compress_chunk(c) FROM show_chunks('upsert_test') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+ _timescaledb_internal._hyper_3_6_chunk
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_test VALUES ('2024-01-01 00:03:00', 1, 'login', 1)
+ON CONFLICT (uid, event, ts) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   ->  Insert on upsert_test (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_uid_event
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_test VALUES ('2024-01-01 00:03:30', 50, 'login', 1)
+ON CONFLICT (uid, event, ts) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 3
+   Batches pruned by bloom: 3
+   ->  Insert on upsert_test (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_uid_event
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+DROP TABLE upsert_test CASCADE;
+-------------------------------------------------------------------
+CREATE TABLE upsert_temporal(
+    time TIMESTAMPTZ NOT NULL,
+    sensor_id INT,
+    metric TEXT,
+    value FLOAT
+);
+SELECT create_hypertable('upsert_temporal', 'time');
+      create_hypertable       
+------------------------------
+ (5,public,upsert_temporal,t)
+
+CREATE UNIQUE INDEX idx_unique ON upsert_temporal(sensor_id, metric, time);
+ALTER TABLE upsert_temporal SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = ''
+);
+INSERT INTO upsert_temporal
+SELECT t, (EXTRACT(HOUR FROM t)::int % 10) + 1, 'temp', 25.5
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-31'::timestamptz, '1 hour') t;
+-- sensor_id: 1-10, time: whole hours
+SELECT compress_chunk(c) FROM show_chunks('upsert_temporal') c;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_9_chunk
+ _timescaledb_internal._hyper_5_10_chunk
+ _timescaledb_internal._hyper_5_11_chunk
+ _timescaledb_internal._hyper_5_12_chunk
+ _timescaledb_internal._hyper_5_13_chunk
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_temporal VALUES ('2024-01-15 10:00:00', 1, 'temp', 26.0)
+ON CONFLICT (sensor_id, metric, time) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 1
+   ->  Insert on upsert_temporal (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_unique
+         Tuples Inserted: 0
+         Conflicting Tuples: 1
+         ->  Result (actual rows=1.00 loops=1)
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_temporal VALUES ('2024-01-15 10:30:00', 5, 'temp', 26.0)
+ON CONFLICT (sensor_id, metric, time) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 1
+   Batches pruned by bloom: 1
+   ->  Insert on upsert_temporal (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_unique
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+DROP TABLE upsert_temporal CASCADE;
+-------------------------------------------------------------------
+CREATE TABLE upsert_demographics(
+    time TIMESTAMPTZ NOT NULL,
+    user_id INT,
+    age SMALLINT,
+    gender SMALLINT,
+    value INT
+);
+SELECT create_hypertable('upsert_demographics', 'time');
+        create_hypertable         
+----------------------------------
+ (7,public,upsert_demographics,t)
+
+CREATE UNIQUE INDEX idx_demo ON upsert_demographics(user_id, age, gender, time);
+ALTER TABLE upsert_demographics SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = ''
+);
+INSERT INTO upsert_demographics
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval,
+       (i % 100) + 1,      -- user_id: 1-100
+       (18 + (i % 50)),    -- age: 18-67
+       (i % 2) + 1,        -- gender: 1-2
+       i
+FROM generate_series(1, 2000) i;
+SELECT compress_chunk(c) FROM show_chunks('upsert_demographics') c;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_19_chunk
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_demographics VALUES ('2024-01-01 00:01:00', 1, 18, 1, 200)
+ON CONFLICT (user_id, age, gender, time) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 1
+   Batches pruned by bloom: 1
+   ->  Insert on upsert_demographics (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_demo
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_demographics VALUES ('2024-01-01 00:01:30', 50, 30, 1, 200)
+ON CONFLICT (user_id, age, gender, time) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 1
+   Batches pruned by bloom: 1
+   ->  Insert on upsert_demographics (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_demo
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+DROP TABLE upsert_demographics CASCADE;
+-------------------------------------------------------------------
+CREATE TABLE explain_partial(ts timestamptz, device_id int, metric text, value float);
+SELECT create_hypertable('explain_partial', by_range('ts'));
+ create_hypertable 
+-------------------
+ (9,t)
+
+CREATE UNIQUE INDEX idx_partial ON explain_partial(device_id, metric, ts);
+-- Manually configure compression with only partial bloom (device_id, metric)
+-- This is a SUBSET of the conflict columns (device_id, metric, ts)
+ALTER TABLE explain_partial SET (
+    timescaledb.compress,
+    timescaledb.order_by = 'ts',
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_index = 'bloom(device_id, metric)'
+);
+WARNING:  column "device_id" should be used for segmenting or ordering
+WARNING:  column "metric" should be used for segmenting or ordering
+INSERT INTO explain_partial
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval,
+       i % 10, 'temp', i
+FROM generate_series(1, 1000) i;
+SELECT compress_chunk(c) FROM show_chunks('explain_partial') c;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_21_chunk
+
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_partial VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
+ON CONFLICT (device_id, metric, ts) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered: 1
+   Batches checked by bloom: 1
+   Batches bloom false positives: 1
+   ->  Insert on explain_partial (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_partial
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+
+ROLLBACK;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_partial VALUES ('2024-01-01 00:05:00', 5, 'humidity', 100)
+ON CONFLICT (device_id, metric, ts) DO NOTHING;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches checked by bloom: 1
+   Batches pruned by bloom: 1
+   ->  Insert on explain_partial (actual rows=0.00 loops=1)
+         Conflict Resolution: NOTHING
+         Conflict Arbiter Indexes: idx_partial
+         Tuples Inserted: 1
+         Conflicting Tuples: 0
+         ->  Result (actual rows=1.00 loops=1)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_FILES
     compress_compbloom_index_add.sql
     compress_compbloom_index_drop.sql
     compress_compbloom_manual_config.sql
+    compress_compbloom_upsert.sql
     compress_sparse_config.sql
     compress_default.sql
     compress_dml_copy.sql

--- a/tsl/test/sql/compress_compbloom_upsert.sql
+++ b/tsl/test/sql/compress_compbloom_upsert.sql
@@ -1,0 +1,162 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-------------------------------------------------------------------
+-- Upsert tests
+-------------------------------------------------------------------
+
+-- Explain test
+CREATE TABLE explain_test(ts timestamptz, device_id int, metric text, value float);
+SELECT create_hypertable('explain_test', by_range('ts'));
+CREATE UNIQUE INDEX idx_explain ON explain_test(device_id, metric, ts);
+ALTER TABLE explain_test SET (timescaledb.compress, timescaledb.compress_segmentby ='');
+
+INSERT INTO explain_test
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval, i % 10, 'temp', i
+FROM generate_series(1, 5000) i;
+
+SELECT count(compress_chunk(c)) FROM show_chunks('explain_test') c;
+
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_test VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
+ON CONFLICT (device_id, metric, ts) DO NOTHING;
+ROLLBACK;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_test VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
+ON CONFLICT (device_id, metric, ts)
+DO UPDATE SET value = EXCLUDED.value;
+
+DROP TABLE IF EXISTS explain_test CASCADE;
+
+-------------------------------------------------------------------
+CREATE TABLE upsert_test(ts timestamptz, uid int, event text, seg int);
+SELECT create_hypertable('upsert_test', by_range('ts'));
+
+CREATE UNIQUE INDEX idx_uid_event ON upsert_test (uid, event, ts);
+
+ALTER TABLE upsert_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg'
+);
+
+INSERT INTO upsert_test
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval,
+       (i % 100) + 1,
+       CASE WHEN i % 3 = 0 THEN 'login' WHEN i % 3 = 1 THEN 'logout' ELSE 'click' END,
+       i % 5
+FROM generate_series(1, 5000) i;
+
+SELECT compress_chunk(c) FROM show_chunks('upsert_test') c;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_test VALUES ('2024-01-01 00:03:00', 1, 'login', 1)
+ON CONFLICT (uid, event, ts) DO NOTHING;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_test VALUES ('2024-01-01 00:03:30', 50, 'login', 1)
+ON CONFLICT (uid, event, ts) DO NOTHING;
+
+DROP TABLE upsert_test CASCADE;
+
+-------------------------------------------------------------------
+CREATE TABLE upsert_temporal(
+    time TIMESTAMPTZ NOT NULL,
+    sensor_id INT,
+    metric TEXT,
+    value FLOAT
+);
+
+SELECT create_hypertable('upsert_temporal', 'time');
+CREATE UNIQUE INDEX idx_unique ON upsert_temporal(sensor_id, metric, time);
+
+ALTER TABLE upsert_temporal SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = ''
+);
+
+INSERT INTO upsert_temporal
+SELECT t, (EXTRACT(HOUR FROM t)::int % 10) + 1, 'temp', 25.5
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-31'::timestamptz, '1 hour') t;
+-- sensor_id: 1-10, time: whole hours
+
+SELECT compress_chunk(c) FROM show_chunks('upsert_temporal') c;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_temporal VALUES ('2024-01-15 10:00:00', 1, 'temp', 26.0)
+ON CONFLICT (sensor_id, metric, time) DO NOTHING;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_temporal VALUES ('2024-01-15 10:30:00', 5, 'temp', 26.0)
+ON CONFLICT (sensor_id, metric, time) DO NOTHING;
+
+DROP TABLE upsert_temporal CASCADE;
+
+-------------------------------------------------------------------
+CREATE TABLE upsert_demographics(
+    time TIMESTAMPTZ NOT NULL,
+    user_id INT,
+    age SMALLINT,
+    gender SMALLINT,
+    value INT
+);
+
+SELECT create_hypertable('upsert_demographics', 'time');
+CREATE UNIQUE INDEX idx_demo ON upsert_demographics(user_id, age, gender, time);
+
+ALTER TABLE upsert_demographics SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = ''
+);
+
+INSERT INTO upsert_demographics
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval,
+       (i % 100) + 1,      -- user_id: 1-100
+       (18 + (i % 50)),    -- age: 18-67
+       (i % 2) + 1,        -- gender: 1-2
+       i
+FROM generate_series(1, 2000) i;
+
+SELECT compress_chunk(c) FROM show_chunks('upsert_demographics') c;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_demographics VALUES ('2024-01-01 00:01:00', 1, 18, 1, 200)
+ON CONFLICT (user_id, age, gender, time) DO NOTHING;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO upsert_demographics VALUES ('2024-01-01 00:01:30', 50, 30, 1, 200)
+ON CONFLICT (user_id, age, gender, time) DO NOTHING;
+
+DROP TABLE upsert_demographics CASCADE;
+
+-------------------------------------------------------------------
+CREATE TABLE explain_partial(ts timestamptz, device_id int, metric text, value float);
+SELECT create_hypertable('explain_partial', by_range('ts'));
+CREATE UNIQUE INDEX idx_partial ON explain_partial(device_id, metric, ts);
+
+-- Manually configure compression with only partial bloom (device_id, metric)
+-- This is a SUBSET of the conflict columns (device_id, metric, ts)
+ALTER TABLE explain_partial SET (
+    timescaledb.compress,
+    timescaledb.order_by = 'ts',
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_index = 'bloom(device_id, metric)'
+);
+
+INSERT INTO explain_partial
+SELECT '2024-01-01'::timestamptz + (i || ' minutes')::interval,
+       i % 10, 'temp', i
+FROM generate_series(1, 1000) i;
+SELECT compress_chunk(c) FROM show_chunks('explain_partial') c;
+
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_partial VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
+ON CONFLICT (device_id, metric, ts) DO NOTHING;
+ROLLBACK;
+
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO explain_partial VALUES ('2024-01-01 00:05:00', 5, 'humidity', 100)
+ON CONFLICT (device_id, metric, ts) DO NOTHING;


### PR DESCRIPTION
This PR introduces bloom filter support for UPSERT queries, both composite and otherwise. With this we can save decompression of batches when we can tell from the bloom filter that the arbiter values are not in the given batch.

This PR introduces a few new explain statistics as well:

 - Batches checked by bloom
 - Batches pruned by bloom
 - Batches without bloom
 - Batches bloom false positives

I also refactored the 'decompress_batches_scan' function which already had 16 arguments, and I didn't want to add more.

The 'CachedDecompressionState' now holds cached information about what bloom filter to use for the given compressed chunk table, so we don't need to figure this for every batch.

There may be more than one applicable bloom filter for the query, because any subset of the arbiter index columns may be able to reduce the number of batches to decompress. Here I choose the bloom filter with the most columns, assuming that being the most selective.