### PR TITLE
Prepare for adding MERGE support to compressed hypertables

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -97,6 +97,7 @@ TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify = true;
 TSDLLEXPORT int ts_guc_cagg_max_individual_materializations = 10;
 bool ts_guc_enable_osm_reads = true;
 TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete = true;
+TSDLLEXPORT bool ts_guc_enable_compressed_merge = false;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering = true;
 TSDLLEXPORT bool ts_guc_enable_dml_bloom_filter = true;
@@ -741,6 +742,20 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+#ifdef TS_DEBUG
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_compressed_merge"),
+							 "Enable MERGE support for compressed hypertables",
+							 "Enable MERGE support for compressed hypertables. This is only "
+							 "available in debug builds and will currently do full decompression",
+							 &ts_guc_enable_compressed_merge,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+#endif
 
 	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_dml_decompression"),
 							 "Enable DML decompression",

--- a/src/guc.h
+++ b/src/guc.h
@@ -37,6 +37,7 @@ extern TSDLLEXPORT bool ts_guc_enable_osm_reads;
 extern TSDLLEXPORT bool ts_guc_enable_cagg_sort_pushdown;
 #endif
 extern TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify;
+extern TSDLLEXPORT bool ts_guc_enable_compressed_merge;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering;
 extern TSDLLEXPORT bool ts_guc_enable_dml_bloom_filter;

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2319,10 +2319,13 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 	context.estate = estate;
 
 	/*
-	 * For UPDATE/DELETE on compressed hypertable, decompress chunks and
-	 * move rows to uncompressed chunks.
+	 * For UPDATE/DELETE/MERGE on compressed hypertable, decompress chunks and
+	 * move rows to uncompressed chunks. For MERGE, decompression is needed
+	 * even for DO NOTHING or INSERT-only actions because the join evaluation
+	 * must see the actual rows to correctly determine matched vs not-matched.
 	 */
-	if ((operation == CMD_DELETE || operation == CMD_UPDATE) && !ht_state->comp_chunks_processed)
+	if ((operation == CMD_DELETE || operation == CMD_UPDATE || operation == CMD_MERGE) &&
+		!ht_state->comp_chunks_processed)
 	{
 		/* Modify snapshot only if something got decompressed */
 		if (ts_cm_functions->decompress_target_segments &&
@@ -2417,7 +2420,7 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 		if (TupIsNull(context.planSlot))
 			break;
 
-		if (operation == CMD_INSERT || operation == CMD_MERGE)
+		if (operation == CMD_INSERT || (operation == CMD_MERGE && (node->mt_merge_subcommands & MERGE_INSERT)))
 		{
 			TupleTableSlot *slot = context.planSlot;
 			if (operation == CMD_MERGE)
@@ -3399,9 +3402,9 @@ ExecMergeNotMatched(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	 * for PG >= 17? See PostgreSQL commit 0294df2f1f84
 	 */
 #if PG17_GE
-	actionStates = ctr->cis->result_relation_info->ri_MergeActions[MERGE_WHEN_NOT_MATCHED_BY_TARGET];
+	actionStates = resultRelInfo->ri_MergeActions[MERGE_WHEN_NOT_MATCHED_BY_TARGET];
 #else
-	actionStates = ctr->cis->result_relation_info->ri_notMatchedMergeAction;
+	actionStates = resultRelInfo->ri_notMatchedMergeAction;
 #endif
 	/*
 	 * Make source tuple available to ExecQual and ExecProject. We don't

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1375,28 +1375,11 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 		case TS_REL_CHUNK_STANDALONE:
 		case TS_REL_CHUNK_CHILD:
 			/* Check for UPDATE/DELETE/MERGE (DML) on compressed chunks */
-			if (IS_UPDL_CMD(root->parse) && dml_involves_hypertable(root, ht, rti))
+			if ((IS_UPDL_CMD(root->parse) || root->parse->commandType == CMD_MERGE) &&
+				dml_involves_hypertable(root, ht, rti))
 			{
 				if (ts_cm_functions->set_rel_pathlist_dml != NULL)
 					ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
-				break;
-			}
-			/*
-			 * For MERGE command if there is an UPDATE or DELETE action, then
-			 * do not allow this to succeed on compressed chunks
-			 */
-			if (root->parse->commandType == CMD_MERGE && dml_involves_hypertable(root, ht, rti))
-			{
-				ListCell *ml;
-				foreach (ml, root->parse->mergeActionList)
-				{
-					MergeAction *action = (MergeAction *) lfirst(ml);
-					if (action->commandType == CMD_UPDATE || action->commandType == CMD_DELETE)
-					{
-						if (ts_cm_functions->set_rel_pathlist_dml != NULL)
-							ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
-					}
-				}
 				break;
 			}
 			TS_FALLTHROUGH;
@@ -1660,21 +1643,29 @@ replace_modify_hypertable_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 				}
 				case CMD_MERGE:
 				{
-					List *firstMergeActionList = linitial(mt->mergeActionLists);
-					ListCell *l;
 					/*
-					 * Iterate over merge action to check if there is an INSERT sql.
-					 * If so, then add ModifyHypertable node.
+					 * Create ModifyHypertable node for MERGE when:
+					 * - INSERT actions need chunk tuple routing
+					 * - Compressed chunks need decompression for correct
+					 *   join evaluation of matched vs not-matched rows
 					 */
-					foreach (l, firstMergeActionList)
+					bool need_modify = (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht));
+					if (!need_modify)
 					{
-						MergeAction *action = (MergeAction *) lfirst(l);
-						if (action->commandType == CMD_INSERT)
+						List *firstMergeActionList = linitial(mt->mergeActionLists);
+						ListCell *l;
+						foreach (l, firstMergeActionList)
 						{
-							path = ts_modify_hypertable_path_create(root, mt, input_rel);
-							break;
+							MergeAction *action = (MergeAction *) lfirst(l);
+							if (action->commandType == CMD_INSERT)
+							{
+								need_modify = true;
+								break;
+							}
 						}
 					}
+					if (need_modify)
+						path = ts_modify_hypertable_path_create(root, mt, input_rel);
 					break;
 				}
 				default:

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -140,14 +140,9 @@ void
 tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rte,
 						 Hypertable *ht)
 {
-	/*
-	 * We do not support MERGE command with UPDATE/DELETE merge actions on
-	 * compressed hypertables, because Custom Scan (ModifyHypertable) node is
-	 * not generated in the plan for MERGE command on compressed hypertables
-	 */
 	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
-		if (root->parse->commandType == CMD_MERGE)
+		if (!ts_guc_enable_compressed_merge && root->parse->commandType == CMD_MERGE)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("The MERGE command with UPDATE/DELETE merge actions is not support on "

--- a/tsl/test/expected/merge_compress.out
+++ b/tsl/test/expected/merge_compress.out
@@ -1,6 +1,8 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Test MERGE on compressed hypertables
+SET timescaledb.enable_compressed_merge TO on;
 CREATE TABLE target (
     time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     value DOUBLE PRECISION NOT NULL,
@@ -31,6 +33,8 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('target') ch;
 -------
      4
 
+-- create a plain PG table with same data for result comparison
+CREATE TABLE target_pg AS SELECT * FROM target;
 CREATE TABLE source (
         time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
         value DOUBLE PRECISION NOT NULL,
@@ -44,52 +48,138 @@ SELECT table_name FROM create_hypertable(
 ------------
  source
 
-SELECT '2022-10-10 10:00:00.0123+05:30' as start_date \gset
+-- Use a small source that won't cause "cannot affect row a second time"
+-- by matching on partition_column (unique per series_id in target)
 INSERT INTO source (time, series_id, value)
-  SELECT t, s,1 from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
-    generate_series(1,2, 1) s;
-\set ON_ERROR_STOP 0
--- Merge UPDATE on compressed hypertables should report error
-MERGE INTO target t
-            USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
-            WHEN MATCHED THEN
-            UPDATE SET series_id = (t.series_id * 0.123);
-ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
--- Merge DELETE on compressed hypertables should report error
-MERGE INTO target t
-            USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
-            WHEN MATCHED THEN
-            DELETE;
-ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
--- Merge UPDATE/INSERT on compressed hypertables should report error
-MERGE INTO target t
-            USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
-            WHEN MATCHED THEN
-            UPDATE SET series_id = (t.series_id * 0.123)
-            WHEN NOT MATCHED THEN
-            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
-ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
--- Merge DELETE/INSERT on compressed hypertables should report error
-MERGE INTO target t
-            USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
-            WHEN MATCHED THEN
-            DELETE
-            WHEN NOT MATCHED THEN
-            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
-ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
-\set ON_ERROR_STOP 1
--- total compressed chunks
+  SELECT t, s, 1 from generate_series('2022-10-10 14:33:44.1234+05:30'::timestamptz,
+    '2022-10-10 14:33:44.1234+05:30'::timestamptz + interval '2 hours', '5m') t
+    cross join generate_series(1, 2, 1) s;
+-- total compressed chunks before any MERGE
 SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
-    hypertable_name = 'target' GROUP BY is_compressed;
+    hypertable_name = 'target' GROUP BY is_compressed ORDER BY is_compressed;
  total compressed_chunks | is_compressed 
 -------------------------+---------------
                        4 | t
 
--- Merge INSERT on compressed hypertables should work
+-- Merge UPDATE on compressed hypertables should work
+MERGE INTO target t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET value = t.value + 1;
+-- Apply same UPDATE on PG table for comparison
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET value = t.value + 1;
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress for next test
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+ count 
+-------
+     4
+
+-- Merge DELETE on compressed hypertables should work
+MERGE INTO target t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE;
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE;
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress for next test
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+ count 
+-------
+     4
+
+-- Merge UPDATE/INSERT on compressed hypertables should work
+MERGE INTO target t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET value = t.value + 1
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET value = t.value + 1
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress for next test
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+ count 
+-------
+     5
+
+-- Merge DELETE/INSERT on compressed hypertables should work
+MERGE INTO target t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- Merge INSERT on compressed hypertables should still work
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+ count 
+-------
+     5
+
+SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
+    hypertable_name = 'target' GROUP BY is_compressed ORDER BY is_compressed;
+ total compressed_chunks | is_compressed 
+-------------------------+---------------
+                       5 | t
+
 MERGE INTO target t
             USING source s
             ON t.partition_column = s.time AND t.value = s.value
@@ -97,11 +187,779 @@ MERGE INTO target t
             INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
 -- you should notice 1 uncompressed chunk
 SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
-    hypertable_name = 'target' GROUP BY is_compressed;
+    hypertable_name = 'target' GROUP BY is_compressed ORDER BY is_compressed;
  total compressed_chunks | is_compressed 
 -------------------------+---------------
-                       1 | f
-                       4 | t
+                       5 | t
 
 DROP TABLE target;
+DROP TABLE target_pg;
 DROP TABLE source;
+-- Test MERGE DELETE on table with filler columns (different attribute numbering)
+CREATE TABLE target2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int);
+SELECT create_hypertable('target2', 'time');
+  create_hypertable   
+----------------------
+ (4,public,target2,t)
+
+ALTER TABLE target2 SET (timescaledb.compress, timescaledb.compress_segmentby='device_id', timescaledb.compress_orderby='time');
+INSERT INTO target2 SELECT 1,2,3, t, d, 0 FROM generate_series('2000-01-01'::timestamptz, '2000-01-02', '1h') t cross join generate_series(1,3) d;
+SELECT compress_chunk(ch) FROM show_chunks('target2') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_4_12_chunk
+
+CREATE TABLE source2(time timestamptz NOT NULL, device_id int);
+INSERT INTO source2 SELECT t, d FROM generate_series('2000-01-01'::timestamptz, '2000-01-01 12:00:00', '1h') t cross join generate_series(1,2) d;
+CREATE TABLE target2_pg AS SELECT * FROM target2;
+SELECT count(*) FROM target2;
+ count 
+-------
+    75
+
+-- MERGE DELETE with filler columns
+MERGE INTO target2 t USING source2 s ON t.time = s.time AND t.device_id = s.device_id WHEN MATCHED THEN DELETE;
+MERGE INTO target2_pg t USING source2 s ON t.time = s.time AND t.device_id = s.device_id WHEN MATCHED THEN DELETE;
+SELECT CASE WHEN EXISTS (TABLE target2 EXCEPT TABLE target2_pg)
+              OR EXISTS (TABLE target2_pg EXCEPT TABLE target2)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+DROP TABLE target2;
+DROP TABLE target2_pg;
+DROP TABLE source2;
+-- ============================================================
+-- Additional correctness tests for MERGE on compressed hypertables
+-- ============================================================
+CREATE TABLE merge_target (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION,
+    label TEXT
+);
+SELECT create_hypertable('merge_target', 'time', chunk_time_interval => interval '1 day');
+     create_hypertable     
+---------------------------
+ (6,public,merge_target,t)
+
+ALTER TABLE merge_target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time'
+);
+INSERT INTO merge_target
+  SELECT t, d, d * 10.0 + extract(hour from t), 'orig'
+  FROM generate_series('2000-01-01'::timestamptz, '2000-01-03 23:00', '1h') t
+  CROSS JOIN generate_series(1, 3) d;
+SELECT count(compress_chunk(ch)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+CREATE TABLE merge_target_pg AS SELECT * FROM merge_target;
+CREATE TABLE merge_source (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION,
+    label TEXT
+);
+-- Source covers only part of the target's time range and some devices
+INSERT INTO merge_source
+  SELECT t, d, d * 100.0, 'new'
+  FROM generate_series('2000-01-01'::timestamptz, '2000-01-02 12:00', '1h') t
+  CROSS JOIN generate_series(2, 4) d;
+-- -----------------------------------------------------------
+-- Test 1: Conditional WHEN MATCHED AND ... UPDATE
+-- Only update rows where temp > 20
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 20 THEN
+    UPDATE SET temp = s.temp, label = 'cond_updated'
+  WHEN MATCHED THEN
+    DO NOTHING;
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 20 THEN
+    UPDATE SET temp = s.temp, label = 'cond_updated'
+  WHEN MATCHED THEN
+    DO NOTHING;
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 2: DO NOTHING for matched, INSERT for not matched
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DO NOTHING
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'inserted');
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DO NOTHING
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'inserted');
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 3: Multiple sequential MERGEs without recompression
+-- (tests that partially compressed chunks work correctly)
+-- -----------------------------------------------------------
+-- First MERGE: update some rows
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = t.temp + 1;
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = t.temp + 1;
+-- Second MERGE without recompression: delete some rows
+MERGE INTO merge_target t
+  USING (SELECT * FROM merge_source WHERE device_id = 2) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DELETE;
+MERGE INTO merge_target_pg t
+  USING (SELECT * FROM merge_source WHERE device_id = 2) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DELETE;
+-- Third MERGE without recompression: update again
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'triple_merge';
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'triple_merge';
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 4: MERGE with subquery as source
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING (SELECT time, device_id, temp * 2 as temp, label
+         FROM merge_source
+         WHERE device_id = 3 AND time < '2000-01-02'::timestamptz) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'sub_insert');
+MERGE INTO merge_target_pg t
+  USING (SELECT time, device_id, temp * 2 as temp, label
+         FROM merge_source
+         WHERE device_id = 3 AND time < '2000-01-02'::timestamptz) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'sub_insert');
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 5: MERGE UPDATE on orderby column (time)
+-- Updating the column used in compress_orderby
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET time = t.time + interval '30 seconds';
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET time = t.time + interval '30 seconds';
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 6: MERGE with all three actions: UPDATE + DELETE + INSERT
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 500 THEN
+    DELETE
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp + t.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'all_three');
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 500 THEN
+    DELETE
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp + t.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'all_three');
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 7: MERGE with source matching across all chunks
+-- (ensures multi-chunk decompression works)
+-- -----------------------------------------------------------
+CREATE TABLE merge_source_large (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION
+);
+INSERT INTO merge_source_large
+  SELECT t, d, -1.0
+  FROM generate_series('2000-01-01'::timestamptz, '2000-01-03 23:00', '3h') t
+  CROSS JOIN generate_series(1, 3) d;
+MERGE INTO merge_target t
+  USING merge_source_large s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp;
+MERGE INTO merge_target_pg t
+  USING merge_source_large s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp;
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 8: MERGE with NULL values in non-key columns
+-- -----------------------------------------------------------
+CREATE TABLE merge_source_nulls (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION,
+    label TEXT
+);
+INSERT INTO merge_source_nulls VALUES
+  ('2000-01-01 00:00'::timestamptz, 1, NULL, NULL),
+  ('2000-01-01 01:00'::timestamptz, 2, NULL, 'has_label'),
+  ('2000-01-01 02:00'::timestamptz, 3, 999.9, NULL);
+MERGE INTO merge_target t
+  USING merge_source_nulls s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp, label = s.label;
+MERGE INTO merge_target_pg t
+  USING merge_source_nulls s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp, label = s.label;
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 9: MERGE on partially compressed table
+-- (some chunks compressed, some not)
+-- -----------------------------------------------------------
+-- decompress one chunk to create mixed state
+SELECT decompress_chunk(ch) FROM show_chunks('merge_target') ch LIMIT 1;
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_6_14_chunk
+
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp * 3
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'partial');
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp * 3
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'partial');
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+ count 
+-------
+     4
+
+-- -----------------------------------------------------------
+-- Test 10: MERGE with empty source (no rows should be affected)
+-- -----------------------------------------------------------
+SELECT count(*) AS before_count FROM merge_target;
+ before_count 
+--------------
+          327
+
+MERGE INTO merge_target t
+  USING (SELECT * FROM merge_source WHERE false) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DELETE
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'empty');
+SELECT count(*) AS after_count FROM merge_target;
+ after_count 
+-------------
+         327
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- -----------------------------------------------------------
+-- Test 11: MERGE with CTE as source
+-- -----------------------------------------------------------
+WITH ranked_source AS (
+  SELECT time, device_id, temp,
+         row_number() OVER (PARTITION BY device_id ORDER BY time) as rn
+  FROM merge_source
+)
+MERGE INTO merge_target t
+  USING (SELECT * FROM ranked_source WHERE rn <= 5) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'cte_updated';
+WITH ranked_source AS (
+  SELECT time, device_id, temp,
+         row_number() OVER (PARTITION BY device_id ORDER BY time) as rn
+  FROM merge_source
+)
+MERGE INTO merge_target_pg t
+  USING (SELECT * FROM ranked_source WHERE rn <= 5) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'cte_updated';
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- cleanup
+DROP TABLE merge_target;
+DROP TABLE merge_target_pg;
+DROP TABLE merge_source;
+DROP TABLE merge_source_large;
+DROP TABLE merge_source_nulls;
+-- Test MERGE segmentby batch filtering optimization
+-- When MERGE source only has a subset of segmentby values, only those
+-- batches should be decompressed instead of all batches.
+CREATE TABLE segopt_target (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+SELECT table_name FROM create_hypertable('segopt_target', 'time', chunk_time_interval => interval '1 day');
+  table_name   
+---------------
+ segopt_target
+
+ALTER TABLE segopt_target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time'
+);
+-- Insert data for devices 1-5
+INSERT INTO segopt_target
+  SELECT t, 1.0, d
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 23:59:00', '1 minute') t
+  CROSS JOIN generate_series(1, 5) d;
+SELECT count(compress_chunk(ch)) FROM show_chunks('segopt_target') ch;
+ count 
+-------
+     2
+
+-- Plain PG copy for correctness verification
+CREATE TABLE segopt_target_pg AS SELECT * FROM segopt_target;
+-- Source with only device_id = 1 (1 out of 5 segmentby values)
+CREATE TABLE segopt_source (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+INSERT INTO segopt_source
+  SELECT t, 2.0, 1
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 12:00:00', '1 minute') t;
+-- Enable debug messages to verify optimization fires
+SET client_min_messages = DEBUG1;
+MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+LOG:  statement: MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+-- Apply same to PG table for correctness check
+MERGE INTO segopt_target_pg t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+SELECT CASE WHEN EXISTS (TABLE segopt_target EXCEPT TABLE segopt_target_pg)
+              OR EXISTS (TABLE segopt_target_pg EXCEPT TABLE segopt_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- Recompress and test with multiple segmentby values in source
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('segopt_target') ch;
+ count 
+-------
+     2
+
+TRUNCATE segopt_source;
+INSERT INTO segopt_source
+  SELECT t, 3.0, d
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 06:00:00', '1 minute') t
+  CROSS JOIN (VALUES (2), (4)) AS v(d);
+SET client_min_messages = DEBUG1;
+MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+LOG:  statement: MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+MERGE INTO segopt_target_pg t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+SELECT CASE WHEN EXISTS (TABLE segopt_target EXCEPT TABLE segopt_target_pg)
+              OR EXISTS (TABLE segopt_target_pg EXCEPT TABLE segopt_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- Test time range filtering specifically:
+-- Source covers only 1 hour out of 24 hours of data, and only device 3
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('segopt_target') ch;
+ count 
+-------
+     2
+
+TRUNCATE segopt_source;
+INSERT INTO segopt_source
+  SELECT t, 4.0, 3
+  FROM generate_series('2024-01-01 10:00:00'::timestamptz, '2024-01-01 11:00:00', '1 minute') t;
+SET client_min_messages = DEBUG1;
+MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+LOG:  statement: MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+MERGE INTO segopt_target_pg t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+SELECT CASE WHEN EXISTS (TABLE segopt_target EXCEPT TABLE segopt_target_pg)
+              OR EXISTS (TABLE segopt_target_pg EXCEPT TABLE segopt_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+-- cleanup
+DROP TABLE segopt_target;
+DROP TABLE segopt_target_pg;
+DROP TABLE segopt_source;
+-- Test multiple segmentby columns
+CREATE TABLE multi_seg_target (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL,
+    location_id INT NOT NULL
+);
+SELECT table_name FROM create_hypertable('multi_seg_target', 'time', chunk_time_interval => interval '1 day');
+    table_name    
+------------------
+ multi_seg_target
+
+ALTER TABLE multi_seg_target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id, location_id',
+    timescaledb.compress_orderby = 'time'
+);
+-- Insert data: 3 devices x 4 locations = 12 segmentby combinations
+INSERT INTO multi_seg_target
+  SELECT t, 1.0, d, l
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 23:59:00', '1 minute') t
+  CROSS JOIN generate_series(1, 3) d
+  CROSS JOIN generate_series(1, 4) l;
+SELECT count(compress_chunk(ch)) FROM show_chunks('multi_seg_target') ch;
+ count 
+-------
+     2
+
+CREATE TABLE multi_seg_pg AS SELECT * FROM multi_seg_target;
+-- Source with only device_id=1, location_id IN (2,3) — 2 out of 12 combos
+CREATE TABLE multi_seg_source (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL,
+    location_id INT NOT NULL
+);
+INSERT INTO multi_seg_source
+  SELECT t, 5.0, 1, l
+  FROM generate_series('2024-01-01 06:00:00'::timestamptz, '2024-01-01 12:00:00', '1 minute') t
+  CROSS JOIN (VALUES (2), (3)) AS v(l);
+SET client_min_messages = DEBUG1;
+MERGE INTO multi_seg_target t
+  USING multi_seg_source s
+  ON t.time = s.time AND t.device_id = s.device_id AND t.location_id = s.location_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+LOG:  statement: MERGE INTO multi_seg_target t
+  USING multi_seg_source s
+  ON t.time = s.time AND t.device_id = s.device_id AND t.location_id = s.location_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+MERGE INTO multi_seg_pg t
+  USING multi_seg_source s
+  ON t.time = s.time AND t.device_id = s.device_id AND t.location_id = s.location_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+SELECT CASE WHEN EXISTS (TABLE multi_seg_target EXCEPT TABLE multi_seg_pg)
+              OR EXISTS (TABLE multi_seg_pg EXCEPT TABLE multi_seg_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+DROP TABLE multi_seg_target;
+DROP TABLE multi_seg_pg;
+DROP TABLE multi_seg_source;
+-- Test hypertable without segmentby (orderby-only filtering)
+CREATE TABLE noseg_target (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+SELECT table_name FROM create_hypertable('noseg_target', 'time', chunk_time_interval => interval '1 day');
+  table_name  
+--------------
+ noseg_target
+
+ALTER TABLE noseg_target SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time'
+);
+INSERT INTO noseg_target
+  SELECT t, 1.0, d
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 23:59:00', '1 minute') t
+  CROSS JOIN generate_series(1, 3) d;
+SELECT count(compress_chunk(ch)) FROM show_chunks('noseg_target') ch;
+ count 
+-------
+     2
+
+CREATE TABLE noseg_pg AS SELECT * FROM noseg_target;
+-- Source covers only 2 hours out of 24
+CREATE TABLE noseg_source (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+INSERT INTO noseg_source
+  SELECT t, 9.0, 1
+  FROM generate_series('2024-01-01 10:00:00'::timestamptz, '2024-01-01 12:00:00', '1 minute') t;
+SET client_min_messages = DEBUG1;
+MERGE INTO noseg_target t
+  USING noseg_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+LOG:  statement: MERGE INTO noseg_target t
+  USING noseg_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+MERGE INTO noseg_pg t
+  USING noseg_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+SELECT CASE WHEN EXISTS (TABLE noseg_target EXCEPT TABLE noseg_pg)
+              OR EXISTS (TABLE noseg_pg EXCEPT TABLE noseg_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+
+DROP TABLE noseg_target;
+DROP TABLE noseg_pg;
+DROP TABLE noseg_source;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -66,7 +66,6 @@ set(TEST_FILES
     compression_trigger.sql
     create_table_with.sql
     decompress_index.sql
-    merge_compress.sql
     move.sql
     plan_skip_scan_notnull.sql
     policy_generalization.sql
@@ -168,6 +167,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     uuid_policies.sql
     license_tsl.sql
     merge_chunks.sql
+    merge_compress.sql
     fixed_schedules.sql
     recompress_chunk_segmentwise.sql
     feature_flags.sql

--- a/tsl/test/sql/merge_compress.sql
+++ b/tsl/test/sql/merge_compress.sql
@@ -2,6 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+-- Test MERGE on compressed hypertables
+SET timescaledb.enable_compressed_merge TO on;
+
 CREATE TABLE target (
     time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     value DOUBLE PRECISION NOT NULL,
@@ -29,6 +32,9 @@ INSERT INTO target (series_id, value, partition_column)
 -- compress chunks
 SELECT count(compress_chunk(ch)) FROM show_chunks('target') ch;
 
+-- create a plain PG table with same data for result comparison
+CREATE TABLE target_pg AS SELECT * FROM target;
+
 CREATE TABLE source (
         time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
         value DOUBLE PRECISION NOT NULL,
@@ -39,52 +45,117 @@ SELECT table_name FROM create_hypertable(
                                 'time'::name, chunk_time_interval=>interval '6 hours',
                                 create_default_indexes=> false);
 
-SELECT '2022-10-10 10:00:00.0123+05:30' as start_date \gset
+-- Use a small source that won't cause "cannot affect row a second time"
+-- by matching on partition_column (unique per series_id in target)
 INSERT INTO source (time, series_id, value)
-  SELECT t, s,1 from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
-    generate_series(1,2, 1) s;
+  SELECT t, s, 1 from generate_series('2022-10-10 14:33:44.1234+05:30'::timestamptz,
+    '2022-10-10 14:33:44.1234+05:30'::timestamptz + interval '2 hours', '5m') t
+    cross join generate_series(1, 2, 1) s;
 
-\set ON_ERROR_STOP 0
+-- total compressed chunks before any MERGE
+SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
+    hypertable_name = 'target' GROUP BY is_compressed ORDER BY is_compressed;
 
--- Merge UPDATE on compressed hypertables should report error
+-- Merge UPDATE on compressed hypertables should work
 MERGE INTO target t
             USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
+            ON t.partition_column = s.time AND t.series_id = s.series_id
             WHEN MATCHED THEN
-            UPDATE SET series_id = (t.series_id * 0.123);
+            UPDATE SET value = t.value + 1;
 
--- Merge DELETE on compressed hypertables should report error
+-- Apply same UPDATE on PG table for comparison
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET value = t.value + 1;
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress for next test
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+
+-- Merge DELETE on compressed hypertables should work
 MERGE INTO target t
             USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
+            ON t.partition_column = s.time AND t.series_id = s.series_id
             WHEN MATCHED THEN
             DELETE;
 
--- Merge UPDATE/INSERT on compressed hypertables should report error
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE;
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress for next test
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+
+-- Merge UPDATE/INSERT on compressed hypertables should work
 MERGE INTO target t
             USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
+            ON t.partition_column = s.time AND t.series_id = s.series_id
             WHEN MATCHED THEN
-            UPDATE SET series_id = (t.series_id * 0.123)
+            UPDATE SET value = t.value + 1
             WHEN NOT MATCHED THEN
             INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
 
--- Merge DELETE/INSERT on compressed hypertables should report error
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET value = t.value + 1
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress for next test
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+
+-- Merge DELETE/INSERT on compressed hypertables should work
 MERGE INTO target t
             USING source s
-            ON t.value = s.value AND t.series_id = s.series_id
+            ON t.partition_column = s.time AND t.series_id = s.series_id
             WHEN MATCHED THEN
             DELETE
             WHEN NOT MATCHED THEN
             INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
 
-\set ON_ERROR_STOP 1
+MERGE INTO target_pg t
+            USING source s
+            ON t.partition_column = s.time AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
 
--- total compressed chunks
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge INSERT on compressed hypertables should still work
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('target') ch;
+
 SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
-    hypertable_name = 'target' GROUP BY is_compressed;
+    hypertable_name = 'target' GROUP BY is_compressed ORDER BY is_compressed;
 
--- Merge INSERT on compressed hypertables should work
 MERGE INTO target t
             USING source s
             ON t.partition_column = s.time AND t.value = s.value
@@ -93,7 +164,698 @@ MERGE INTO target t
 
 -- you should notice 1 uncompressed chunk
 SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
-    hypertable_name = 'target' GROUP BY is_compressed;
+    hypertable_name = 'target' GROUP BY is_compressed ORDER BY is_compressed;
 
 DROP TABLE target;
+DROP TABLE target_pg;
 DROP TABLE source;
+
+-- Test MERGE DELETE on table with filler columns (different attribute numbering)
+CREATE TABLE target2(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int);
+SELECT create_hypertable('target2', 'time');
+ALTER TABLE target2 SET (timescaledb.compress, timescaledb.compress_segmentby='device_id', timescaledb.compress_orderby='time');
+INSERT INTO target2 SELECT 1,2,3, t, d, 0 FROM generate_series('2000-01-01'::timestamptz, '2000-01-02', '1h') t cross join generate_series(1,3) d;
+SELECT compress_chunk(ch) FROM show_chunks('target2') ch;
+
+CREATE TABLE source2(time timestamptz NOT NULL, device_id int);
+INSERT INTO source2 SELECT t, d FROM generate_series('2000-01-01'::timestamptz, '2000-01-01 12:00:00', '1h') t cross join generate_series(1,2) d;
+
+CREATE TABLE target2_pg AS SELECT * FROM target2;
+
+SELECT count(*) FROM target2;
+
+-- MERGE DELETE with filler columns
+MERGE INTO target2 t USING source2 s ON t.time = s.time AND t.device_id = s.device_id WHEN MATCHED THEN DELETE;
+MERGE INTO target2_pg t USING source2 s ON t.time = s.time AND t.device_id = s.device_id WHEN MATCHED THEN DELETE;
+
+SELECT CASE WHEN EXISTS (TABLE target2 EXCEPT TABLE target2_pg)
+              OR EXISTS (TABLE target2_pg EXCEPT TABLE target2)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+DROP TABLE target2;
+DROP TABLE target2_pg;
+DROP TABLE source2;
+
+-- ============================================================
+-- Additional correctness tests for MERGE on compressed hypertables
+-- ============================================================
+
+CREATE TABLE merge_target (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION,
+    label TEXT
+);
+
+SELECT create_hypertable('merge_target', 'time', chunk_time_interval => interval '1 day');
+ALTER TABLE merge_target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time'
+);
+
+INSERT INTO merge_target
+  SELECT t, d, d * 10.0 + extract(hour from t), 'orig'
+  FROM generate_series('2000-01-01'::timestamptz, '2000-01-03 23:00', '1h') t
+  CROSS JOIN generate_series(1, 3) d;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('merge_target') ch;
+
+CREATE TABLE merge_target_pg AS SELECT * FROM merge_target;
+
+CREATE TABLE merge_source (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION,
+    label TEXT
+);
+
+-- Source covers only part of the target's time range and some devices
+INSERT INTO merge_source
+  SELECT t, d, d * 100.0, 'new'
+  FROM generate_series('2000-01-01'::timestamptz, '2000-01-02 12:00', '1h') t
+  CROSS JOIN generate_series(2, 4) d;
+
+-- -----------------------------------------------------------
+-- Test 1: Conditional WHEN MATCHED AND ... UPDATE
+-- Only update rows where temp > 20
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 20 THEN
+    UPDATE SET temp = s.temp, label = 'cond_updated'
+  WHEN MATCHED THEN
+    DO NOTHING;
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 20 THEN
+    UPDATE SET temp = s.temp, label = 'cond_updated'
+  WHEN MATCHED THEN
+    DO NOTHING;
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 2: DO NOTHING for matched, INSERT for not matched
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DO NOTHING
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'inserted');
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DO NOTHING
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'inserted');
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 3: Multiple sequential MERGEs without recompression
+-- (tests that partially compressed chunks work correctly)
+-- -----------------------------------------------------------
+-- First MERGE: update some rows
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = t.temp + 1;
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = t.temp + 1;
+
+-- Second MERGE without recompression: delete some rows
+MERGE INTO merge_target t
+  USING (SELECT * FROM merge_source WHERE device_id = 2) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DELETE;
+
+MERGE INTO merge_target_pg t
+  USING (SELECT * FROM merge_source WHERE device_id = 2) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DELETE;
+
+-- Third MERGE without recompression: update again
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'triple_merge';
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'triple_merge';
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 4: MERGE with subquery as source
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING (SELECT time, device_id, temp * 2 as temp, label
+         FROM merge_source
+         WHERE device_id = 3 AND time < '2000-01-02'::timestamptz) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'sub_insert');
+
+MERGE INTO merge_target_pg t
+  USING (SELECT time, device_id, temp * 2 as temp, label
+         FROM merge_source
+         WHERE device_id = 3 AND time < '2000-01-02'::timestamptz) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'sub_insert');
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 5: MERGE UPDATE on orderby column (time)
+-- Updating the column used in compress_orderby
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET time = t.time + interval '30 seconds';
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET time = t.time + interval '30 seconds';
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 6: MERGE with all three actions: UPDATE + DELETE + INSERT
+-- -----------------------------------------------------------
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 500 THEN
+    DELETE
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp + t.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'all_three');
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED AND t.temp > 500 THEN
+    DELETE
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp + t.temp
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'all_three');
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 7: MERGE with source matching across all chunks
+-- (ensures multi-chunk decompression works)
+-- -----------------------------------------------------------
+CREATE TABLE merge_source_large (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION
+);
+
+INSERT INTO merge_source_large
+  SELECT t, d, -1.0
+  FROM generate_series('2000-01-01'::timestamptz, '2000-01-03 23:00', '3h') t
+  CROSS JOIN generate_series(1, 3) d;
+
+MERGE INTO merge_target t
+  USING merge_source_large s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp;
+
+MERGE INTO merge_target_pg t
+  USING merge_source_large s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp;
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 8: MERGE with NULL values in non-key columns
+-- -----------------------------------------------------------
+CREATE TABLE merge_source_nulls (
+    time TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    temp DOUBLE PRECISION,
+    label TEXT
+);
+
+INSERT INTO merge_source_nulls VALUES
+  ('2000-01-01 00:00'::timestamptz, 1, NULL, NULL),
+  ('2000-01-01 01:00'::timestamptz, 2, NULL, 'has_label'),
+  ('2000-01-01 02:00'::timestamptz, 3, 999.9, NULL);
+
+MERGE INTO merge_target t
+  USING merge_source_nulls s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp, label = s.label;
+
+MERGE INTO merge_target_pg t
+  USING merge_source_nulls s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp, label = s.label;
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 9: MERGE on partially compressed table
+-- (some chunks compressed, some not)
+-- -----------------------------------------------------------
+-- decompress one chunk to create mixed state
+SELECT decompress_chunk(ch) FROM show_chunks('merge_target') ch LIMIT 1;
+
+MERGE INTO merge_target t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp * 3
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'partial');
+
+MERGE INTO merge_target_pg t
+  USING merge_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET temp = s.temp * 3
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'partial');
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- recompress
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('merge_target') ch;
+
+-- -----------------------------------------------------------
+-- Test 10: MERGE with empty source (no rows should be affected)
+-- -----------------------------------------------------------
+SELECT count(*) AS before_count FROM merge_target;
+
+MERGE INTO merge_target t
+  USING (SELECT * FROM merge_source WHERE false) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    DELETE
+  WHEN NOT MATCHED THEN
+    INSERT (time, device_id, temp, label)
+    VALUES (s.time, s.device_id, s.temp, 'empty');
+
+SELECT count(*) AS after_count FROM merge_target;
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- -----------------------------------------------------------
+-- Test 11: MERGE with CTE as source
+-- -----------------------------------------------------------
+WITH ranked_source AS (
+  SELECT time, device_id, temp,
+         row_number() OVER (PARTITION BY device_id ORDER BY time) as rn
+  FROM merge_source
+)
+MERGE INTO merge_target t
+  USING (SELECT * FROM ranked_source WHERE rn <= 5) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'cte_updated';
+
+WITH ranked_source AS (
+  SELECT time, device_id, temp,
+         row_number() OVER (PARTITION BY device_id ORDER BY time) as rn
+  FROM merge_source
+)
+MERGE INTO merge_target_pg t
+  USING (SELECT * FROM ranked_source WHERE rn <= 5) s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET label = 'cte_updated';
+
+SELECT CASE WHEN EXISTS (TABLE merge_target EXCEPT TABLE merge_target_pg)
+              OR EXISTS (TABLE merge_target_pg EXCEPT TABLE merge_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- cleanup
+DROP TABLE merge_target;
+DROP TABLE merge_target_pg;
+DROP TABLE merge_source;
+DROP TABLE merge_source_large;
+DROP TABLE merge_source_nulls;
+
+-- Test MERGE segmentby batch filtering optimization
+-- When MERGE source only has a subset of segmentby values, only those
+-- batches should be decompressed instead of all batches.
+CREATE TABLE segopt_target (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+
+SELECT table_name FROM create_hypertable('segopt_target', 'time', chunk_time_interval => interval '1 day');
+
+ALTER TABLE segopt_target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id',
+    timescaledb.compress_orderby = 'time'
+);
+
+-- Insert data for devices 1-5
+INSERT INTO segopt_target
+  SELECT t, 1.0, d
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 23:59:00', '1 minute') t
+  CROSS JOIN generate_series(1, 5) d;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('segopt_target') ch;
+
+-- Plain PG copy for correctness verification
+CREATE TABLE segopt_target_pg AS SELECT * FROM segopt_target;
+
+-- Source with only device_id = 1 (1 out of 5 segmentby values)
+CREATE TABLE segopt_source (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+
+INSERT INTO segopt_source
+  SELECT t, 2.0, 1
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 12:00:00', '1 minute') t;
+
+-- Enable debug messages to verify optimization fires
+SET client_min_messages = DEBUG1;
+
+MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+RESET client_min_messages;
+
+-- Apply same to PG table for correctness check
+MERGE INTO segopt_target_pg t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+SELECT CASE WHEN EXISTS (TABLE segopt_target EXCEPT TABLE segopt_target_pg)
+              OR EXISTS (TABLE segopt_target_pg EXCEPT TABLE segopt_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Recompress and test with multiple segmentby values in source
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('segopt_target') ch;
+
+TRUNCATE segopt_source;
+INSERT INTO segopt_source
+  SELECT t, 3.0, d
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 06:00:00', '1 minute') t
+  CROSS JOIN (VALUES (2), (4)) AS v(d);
+
+SET client_min_messages = DEBUG1;
+
+MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+RESET client_min_messages;
+
+MERGE INTO segopt_target_pg t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+SELECT CASE WHEN EXISTS (TABLE segopt_target EXCEPT TABLE segopt_target_pg)
+              OR EXISTS (TABLE segopt_target_pg EXCEPT TABLE segopt_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Test time range filtering specifically:
+-- Source covers only 1 hour out of 24 hours of data, and only device 3
+SELECT count(compress_chunk(ch, true)) FROM show_chunks('segopt_target') ch;
+
+TRUNCATE segopt_source;
+INSERT INTO segopt_source
+  SELECT t, 4.0, 3
+  FROM generate_series('2024-01-01 10:00:00'::timestamptz, '2024-01-01 11:00:00', '1 minute') t;
+
+SET client_min_messages = DEBUG1;
+
+MERGE INTO segopt_target t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+RESET client_min_messages;
+
+MERGE INTO segopt_target_pg t
+  USING segopt_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+SELECT CASE WHEN EXISTS (TABLE segopt_target EXCEPT TABLE segopt_target_pg)
+              OR EXISTS (TABLE segopt_target_pg EXCEPT TABLE segopt_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- cleanup
+DROP TABLE segopt_target;
+DROP TABLE segopt_target_pg;
+DROP TABLE segopt_source;
+
+-- Test multiple segmentby columns
+CREATE TABLE multi_seg_target (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL,
+    location_id INT NOT NULL
+);
+SELECT table_name FROM create_hypertable('multi_seg_target', 'time', chunk_time_interval => interval '1 day');
+
+ALTER TABLE multi_seg_target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device_id, location_id',
+    timescaledb.compress_orderby = 'time'
+);
+
+-- Insert data: 3 devices x 4 locations = 12 segmentby combinations
+INSERT INTO multi_seg_target
+  SELECT t, 1.0, d, l
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 23:59:00', '1 minute') t
+  CROSS JOIN generate_series(1, 3) d
+  CROSS JOIN generate_series(1, 4) l;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('multi_seg_target') ch;
+
+CREATE TABLE multi_seg_pg AS SELECT * FROM multi_seg_target;
+
+-- Source with only device_id=1, location_id IN (2,3) — 2 out of 12 combos
+CREATE TABLE multi_seg_source (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL,
+    location_id INT NOT NULL
+);
+INSERT INTO multi_seg_source
+  SELECT t, 5.0, 1, l
+  FROM generate_series('2024-01-01 06:00:00'::timestamptz, '2024-01-01 12:00:00', '1 minute') t
+  CROSS JOIN (VALUES (2), (3)) AS v(l);
+
+SET client_min_messages = DEBUG1;
+
+MERGE INTO multi_seg_target t
+  USING multi_seg_source s
+  ON t.time = s.time AND t.device_id = s.device_id AND t.location_id = s.location_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+RESET client_min_messages;
+
+MERGE INTO multi_seg_pg t
+  USING multi_seg_source s
+  ON t.time = s.time AND t.device_id = s.device_id AND t.location_id = s.location_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+SELECT CASE WHEN EXISTS (TABLE multi_seg_target EXCEPT TABLE multi_seg_pg)
+              OR EXISTS (TABLE multi_seg_pg EXCEPT TABLE multi_seg_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+DROP TABLE multi_seg_target;
+DROP TABLE multi_seg_pg;
+DROP TABLE multi_seg_source;
+
+-- Test hypertable without segmentby (orderby-only filtering)
+CREATE TABLE noseg_target (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+SELECT table_name FROM create_hypertable('noseg_target', 'time', chunk_time_interval => interval '1 day');
+
+ALTER TABLE noseg_target SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time'
+);
+
+INSERT INTO noseg_target
+  SELECT t, 1.0, d
+  FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 23:59:00', '1 minute') t
+  CROSS JOIN generate_series(1, 3) d;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('noseg_target') ch;
+
+CREATE TABLE noseg_pg AS SELECT * FROM noseg_target;
+
+-- Source covers only 2 hours out of 24
+CREATE TABLE noseg_source (
+    time TIMESTAMPTZ NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    device_id INT NOT NULL
+);
+INSERT INTO noseg_source
+  SELECT t, 9.0, 1
+  FROM generate_series('2024-01-01 10:00:00'::timestamptz, '2024-01-01 12:00:00', '1 minute') t;
+
+SET client_min_messages = DEBUG1;
+
+MERGE INTO noseg_target t
+  USING noseg_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+RESET client_min_messages;
+
+MERGE INTO noseg_pg t
+  USING noseg_source s
+  ON t.time = s.time AND t.device_id = s.device_id
+  WHEN MATCHED THEN
+    UPDATE SET value = s.value;
+
+SELECT CASE WHEN EXISTS (TABLE noseg_target EXCEPT TABLE noseg_pg)
+              OR EXISTS (TABLE noseg_pg EXCEPT TABLE noseg_target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+DROP TABLE noseg_target;
+DROP TABLE noseg_pg;
+DROP TABLE noseg_source;


### PR DESCRIPTION
Since currently MERGE will lead to full decompression this will
be disabled by default and only available in debug builds. This
patch only adds the missing planner code to support MERGE.
Due to the way constraints are handled in MERGE they are currently
not picked up by our compressed DML code leading to full decompression
when MERGE is used on a compressed hypertable.

Disable-check: force-changelog-file
