### PR TITLE
Allow CREATE EXTENSION after drop in the same session

### DIFF
--- a/.unreleased/pr_9376
+++ b/.unreleased/pr_9376
@@ -1,0 +1,2 @@
+Fixes: #9376 Allow CREATE EXTENSION after drop in the same session
+Thanks: @janpio for reporting an issue with CREATE EXTENSION after dropping and recreating schema

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -353,6 +353,37 @@ should_load_on_create_extension(Node const *const utility_stmt, TsExtension cons
 	if (extension_exists(ext->name) && stmt->if_not_exists)
 		return false;
 
+	/*
+	 * If the extension does not exist (e.g., was dropped via DROP SCHEMA
+	 * CASCADE) but the same version of the shared library is already loaded
+	 * in this session, allow the CREATE EXTENSION to proceed without
+	 * reloading. The .so is already in memory with all hooks in place, so
+	 * CREATE EXTENSION just needs to install the SQL objects.
+	 *
+	 * We only allow this when no explicit VERSION is specified (meaning the
+	 * default version from the control file will be used, which matches the
+	 * loaded .so) or when the specified VERSION matches the loaded version.
+	 */
+	if (!extension_exists(ext->name))
+	{
+		char *requested_version = NULL;
+		ListCell *lc;
+
+		foreach (lc, stmt->options)
+		{
+			DefElem *d = (DefElem *) lfirst(lc);
+
+			if (strcmp(d->defname, "new_version") == 0)
+			{
+				requested_version = defGetString(d);
+				break;
+			}
+		}
+
+		if (requested_version == NULL || strcmp(requested_version, ext->soversion) == 0)
+			return false;
+	}
+
 	/* disallow loading two .so from different versions */
 	ereport(ERROR,
 			(errcode(ERRCODE_DUPLICATE_OBJECT),

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -85,3 +85,38 @@ NOTICE:  drop cascades to 3 other objects
 ------+------------
  test | super_user
 
+-- Recreate the public schema and extension in the same session.
+-- This should work without requiring a reconnect (issue #5884).
+CREATE SCHEMA public;
+SET client_min_messages=error;
+CREATE EXTENSION timescaledb SCHEMA public;
+RESET client_min_messages;
+SELECT extname FROM pg_extension WHERE extname = 'timescaledb';
+   extname   
+-------------
+ timescaledb
+
+-- Verify the extension is functional after re-creation
+CREATE TABLE drop_test2(time timestamptz, temp float8);
+SELECT create_hypertable('drop_test2', 'time');
+    create_hypertable    
+-------------------------
+ (1,public,drop_test2,t)
+
+INSERT INTO drop_test2 VALUES('2024-01-01', 23.4);
+SELECT * FROM drop_test2;
+             time             | temp 
+------------------------------+------
+ Mon Jan 01 00:00:00 2024 PST | 23.4
+
+DROP TABLE drop_test2;
+-- Test that dropping and recreating extension directly also works in the same session
+DROP EXTENSION timescaledb CASCADE;
+SET client_min_messages=error;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+SELECT extname FROM pg_extension WHERE extname = 'timescaledb';
+   extname   
+-------------
+ timescaledb
+

--- a/test/sql/drop_extension.sql
+++ b/test/sql/drop_extension.sql
@@ -53,3 +53,25 @@ RESET client_min_messages;
 -- drop the public schema and all its objects
 DROP SCHEMA public CASCADE;
 \dn
+
+-- Recreate the public schema and extension in the same session.
+-- This should work without requiring a reconnect (issue #5884).
+CREATE SCHEMA public;
+SET client_min_messages=error;
+CREATE EXTENSION timescaledb SCHEMA public;
+RESET client_min_messages;
+SELECT extname FROM pg_extension WHERE extname = 'timescaledb';
+
+-- Verify the extension is functional after re-creation
+CREATE TABLE drop_test2(time timestamptz, temp float8);
+SELECT create_hypertable('drop_test2', 'time');
+INSERT INTO drop_test2 VALUES('2024-01-01', 23.4);
+SELECT * FROM drop_test2;
+DROP TABLE drop_test2;
+
+-- Test that dropping and recreating extension directly also works in the same session
+DROP EXTENSION timescaledb CASCADE;
+SET client_min_messages=error;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+SELECT extname FROM pg_extension WHERE extname = 'timescaledb';


### PR DESCRIPTION
When the timescaledb extension was dropped (e.g., via DROP SCHEMA
CASCADE) and recreated in the same session, the loader would error
with "has already been loaded with another version" even though the
same .so version was still loaded in memory.

Fix by checking whether the loaded .so version matches the requested
version before erroring. If the versions match (or no explicit version
is requested), skip reloading and let CREATE EXTENSION proceed since
the .so and hooks are already in place.

Fixes #5884

Disable-check: loader-change

