### PR TITLE
Remove tam special handling in downgrade script generation

### DIFF
--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -160,10 +160,6 @@ function(generate_downgrade_script)
     _epilog_files
     IGNORE_ERRORS)
 
-  if(_downgrade_TARGET_VERSION VERSION_EQUAL 2.18.0)
-    list(TRANSFORM _epilog_files REPLACE "^.*/hypercore.sql" "${CMAKE_CURRENT_SOURCE_DIR}/pre_install/tam.functions.sql")
-  endif()
-
   foreach(_downgrade_file ${_downgrade_PRE_FILES})
     get_filename_component(_downgrade_filename ${_downgrade_file} NAME)
     configure_file(${_downgrade_file} ${_downgrade_INPUT_DIRECTORY}/${_downgrade_filename} COPYONLY)


### PR DESCRIPTION
Since TAM is removed this is no longer needed.

Disable-check: force-changelog-file