### PR TITLE
Fix chunk creation failure after replica identity invalidation

### DIFF
--- a/.unreleased/pr_9382
+++ b/.unreleased/pr_9382
@@ -1,0 +1,1 @@
+Implements: #9382 Fix chunk creation failure after replica identity invalidation

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -950,11 +950,15 @@ chunk_set_replica_identity(const Chunk *chunk)
 
 	if (stmt.identity_type == REPLICA_IDENTITY_INDEX)
 	{
-		/* Lookup the corresponding chunk index. If this index is
-		 * dropped, the behavior is the same as NOTHING (as per PG
-		 * documentation). */
-		Oid chunk_index_relid =
-			ts_chunk_index_get_by_hypertable_indexrelid(ch_rel, ht_rel->rd_replidindex);
+		/* Use RelationGetReplicaIndex() instead of rd_replidindex
+		 * directly to ensure the index list is loaded after any
+		 * relcache invalidation. */
+		Oid ht_indexoid = RelationGetReplicaIndex(ht_rel);
+		Oid chunk_index_relid = InvalidOid;
+
+		if (OidIsValid(ht_indexoid))
+			chunk_index_relid = ts_chunk_index_get_by_hypertable_indexrelid(ch_rel, ht_indexoid);
+
 		if (OidIsValid(chunk_index_relid))
 			stmt.name = get_rel_name(chunk_index_relid);
 		else

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -819,6 +819,20 @@ ORDER BY index_name;
  index_name 
 ------------
 
+-- recreate the unique index after drop and insert to create a new chunk.
+-- This is a regression test for a bug where rd_replidindex was stale
+-- after relcache invalidation from chunk index creation, leading to
+-- "could not open relation with OID 0" error.
+CREATE UNIQUE INDEX time_key ON replid (time);
+INSERT INTO replid VALUES ('2023-01-04', 4);
+SELECT relname, relreplident FROM show_chunks('replid') ch INNER JOIN pg_class c ON (ch = c.oid) ORDER BY relname;
+      relname       | relreplident 
+--------------------+--------------
+ _hyper_16_31_chunk | i
+ _hyper_16_32_chunk | i
+ _hyper_16_33_chunk | n
+ _hyper_16_34_chunk | n
+
 -- Alter replica identity directly on a chunk is not supported
 SELECT ch AS chunk_name FROM show_chunks('replid') ch ORDER BY chunk_name LIMIT 1 \gset
 \set ON_ERROR_STOP 0
@@ -831,6 +845,7 @@ SELECT relname, relreplident FROM show_chunks('replid') ch INNER JOIN pg_class c
  _hyper_16_31_chunk | i
  _hyper_16_32_chunk | i
  _hyper_16_33_chunk | n
+ _hyper_16_34_chunk | n
 
 -- test implicit constraints gh issue #9132
 CREATE TABLE i9132(time timestamptz) WITH (tsdb.hypertable);

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -508,6 +508,15 @@ FROM show_chunks('replid') chid
 INNER JOIN pg_index i ON (i.indrelid = chid) AND indisreplident=true
 ORDER BY index_name;
 
+-- recreate the unique index after drop and insert to create a new chunk.
+-- This is a regression test for a bug where rd_replidindex was stale
+-- after relcache invalidation from chunk index creation, leading to
+-- "could not open relation with OID 0" error.
+CREATE UNIQUE INDEX time_key ON replid (time);
+INSERT INTO replid VALUES ('2023-01-04', 4);
+
+SELECT relname, relreplident FROM show_chunks('replid') ch INNER JOIN pg_class c ON (ch = c.oid) ORDER BY relname;
+
 -- Alter replica identity directly on a chunk is not supported
 SELECT ch AS chunk_name FROM show_chunks('replid') ch ORDER BY chunk_name LIMIT 1 \gset
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
Accessing ht_rel->rd_replidindex directly could return InvalidOid after relcache invalidation, causing "could not open relation with OID 0". Use RelationGetReplicaIndex() to ensure the index list is loaded and guard against InvalidOid before looking up the chunk index.