### PR TITLE
Delete stale .gcda on recompile in coverage builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,8 +665,8 @@ if(CODECOVERAGE)
   # When a source file is recompiled, the compiler regenerates the .gcno file
   # but any .gcda file from a previous test run remains with a stale checksum.
   # lcov then silently produces incorrect coverage data.  Delete the .gcda
-  # alongside the .o to prevent this.  The $$ escaping produces a literal $
-  # for the shell in both Ninja and Make generators.
+  # alongside the .o to prevent this.  The $$ escaping produces a literal $ for
+  # the shell in both Ninja and Make generators.
   set(CMAKE_C_COMPILE_OBJECT
       "${CMAKE_C_COMPILE_OBJECT} && o=<OBJECT> && rm -f \$\${o%.o}.gcda")
 endif(CODECOVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,6 +662,13 @@ if(CODECOVERAGE)
   # -fprofile-arcs -ftest-coverage when compiling and -lgcov when linking
   add_compile_options(--coverage -O0)
   add_link_options(--coverage)
+  # When a source file is recompiled, the compiler regenerates the .gcno file
+  # but any .gcda file from a previous test run remains with a stale checksum.
+  # lcov then silently produces incorrect coverage data.  Delete the .gcda
+  # alongside the .o to prevent this.  The $$ escaping produces a literal $
+  # for the shell in both Ninja and Make generators.
+  set(CMAKE_C_COMPILE_OBJECT
+      "${CMAKE_C_COMPILE_OBJECT} && o=<OBJECT> && rm -f \$\${o%.o}.gcda")
 endif(CODECOVERAGE)
 
 # TAP test support


### PR DESCRIPTION
When a source file is recompiled with CODECOVERAGE=ON, the compiler regenerates the .gcno but the .gcda from a previous test run stays behind with a mismatched checksum.  lcov then silently produces incorrect coverage data.

Append an rm -f of the corresponding .gcda to CMAKE_C_COMPILE_OBJECT so that every object recompile automatically cleans the stale file. The $$ escaping produces a literal $ for the shell in both the Ninja and Unix Makefiles generators.

Tested with both generators: fake .gcda is deleted on recompile, non-coverage builds are unaffected.

Disable-check: force-changelog-file