### PR TITLE
Fix chunk exclusion for IN/ANY on open dimensions

### DIFF
--- a/.unreleased/in-any-chunk-exclusion
+++ b/.unreleased/in-any-chunk-exclusion
@@ -1,0 +1,1 @@
+Implements: #9398 Fix chunk exclusion for IN/ANY on open (time) dimensions

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -133,9 +133,34 @@ dimension_restrict_info_open_add(DimensionRestrictInfoOpen *dri, StrategyNumber 
 	ListCell *item;
 	bool restriction_added = false;
 
-	/* can't handle IN/ANY with multiple values */
+	/*
+	 * For IN/ANY with multiple equality values on an open dimension,
+	 * use the bounding range [min, max] as an over-approximation.
+	 * This may include extra chunks, which PG constraint exclusion
+	 * will prune later. Much better than returning all chunks.
+	 */
 	if (dimvalues->use_or && list_length(dimvalues->values) > 1)
-		return false;
+	{
+		if (strategy != BTEqualStrategyNumber)
+			return false;
+
+		int64 min_val = PG_INT64_MAX;
+		int64 max_val = PG_INT64_MIN;
+		ListCell *lc;
+		foreach (lc, dimvalues->values)
+		{
+			int64 value = DatumGetInt64(PointerGetDatum(lfirst(lc)));
+			if (value < min_val)
+				min_val = value;
+			if (value > max_val)
+				max_val = value;
+		}
+		dri->lower_bound = min_val;
+		dri->upper_bound = max_val;
+		dri->lower_strategy = BTGreaterEqualStrategyNumber;
+		dri->upper_strategy = BTLessEqualStrategyNumber;
+		return true;
+	}
 
 	foreach (item, dimvalues->values)
 	{

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -503,8 +503,8 @@ Multi AND
          ->  Seq Scan on _hyper_2_106_chunk
                Filter: (("time" < 10) AND ("time" < 100))
 
-\qecho Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
-Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
+\qecho Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
+Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
 :PREFIX SELECT * FROM hyper_w_space WHERE time < ANY(ARRAY[1,2]) ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -536,6 +536,109 @@ Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
                Filter: ("time" < ANY ('{1,2}'::integer[]))
          ->  Seq Scan on _hyper_2_115_chunk
                Filter: ("time" < ANY ('{1,2}'::integer[]))
+
+\qecho Time dimension chunk exclusion with IN/ANY equality uses bounding range
+Time dimension chunk exclusion with IN/ANY equality uses bounding range
+:PREFIX SELECT * FROM hyper WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[25, 15, 5]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+
+:PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper_w_space.value
+   ->  Append
+         ->  Seq Scan on _hyper_2_103_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_104_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_105_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_106_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_107_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_108_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_109_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_110_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamptz, '2000-01-15'::timestamptz) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+
+:PREFIX SELECT * FROM metrics_date WHERE time IN ('2000-01-05'::date, '2000-01-15'::date) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_date
+   Order: metrics_date."time"
+   ->  Index Only Scan Backward using _hyper_8_171_chunk_metrics_date_time_idx on _hyper_8_171_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_172_chunk_metrics_date_time_idx on _hyper_8_172_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_173_chunk_metrics_date_time_idx on _hyper_8_173_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+
+\qecho cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
 
 \qecho Time dimension chunk filtering works for ANY with single argument
 Time dimension chunk filtering works for ANY with single argument

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -503,8 +503,8 @@ Multi AND
          ->  Seq Scan on _hyper_2_106_chunk
                Filter: (("time" < 10) AND ("time" < 100))
 
-\qecho Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
-Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
+\qecho Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
+Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
 :PREFIX SELECT * FROM hyper_w_space WHERE time < ANY(ARRAY[1,2]) ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -536,6 +536,109 @@ Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
                Filter: ("time" < ANY ('{1,2}'::integer[]))
          ->  Seq Scan on _hyper_2_115_chunk
                Filter: ("time" < ANY ('{1,2}'::integer[]))
+
+\qecho Time dimension chunk exclusion with IN/ANY equality uses bounding range
+Time dimension chunk exclusion with IN/ANY equality uses bounding range
+:PREFIX SELECT * FROM hyper WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[25, 15, 5]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+
+:PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper_w_space.value
+   ->  Append
+         ->  Seq Scan on _hyper_2_103_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_104_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_105_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_106_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_107_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_108_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_109_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_110_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamptz, '2000-01-15'::timestamptz) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+
+:PREFIX SELECT * FROM metrics_date WHERE time IN ('2000-01-05'::date, '2000-01-15'::date) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_date
+   Order: metrics_date."time"
+   ->  Index Only Scan Backward using _hyper_8_171_chunk_metrics_date_time_idx on _hyper_8_171_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_172_chunk_metrics_date_time_idx on _hyper_8_172_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_173_chunk_metrics_date_time_idx on _hyper_8_173_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+
+\qecho cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
 
 \qecho Time dimension chunk filtering works for ANY with single argument
 Time dimension chunk filtering works for ANY with single argument

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -503,8 +503,8 @@ Multi AND
          ->  Seq Scan on _hyper_2_106_chunk
                Filter: (("time" < 10) AND ("time" < 100))
 
-\qecho Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
-Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
+\qecho Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
+Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
 :PREFIX SELECT * FROM hyper_w_space WHERE time < ANY(ARRAY[1,2]) ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -536,6 +536,109 @@ Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
                Filter: ("time" < ANY ('{1,2}'::integer[]))
          ->  Seq Scan on _hyper_2_115_chunk
                Filter: ("time" < ANY ('{1,2}'::integer[]))
+
+\qecho Time dimension chunk exclusion with IN/ANY equality uses bounding range
+Time dimension chunk exclusion with IN/ANY equality uses bounding range
+:PREFIX SELECT * FROM hyper WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[25, 15, 5]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+
+:PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper_w_space.value
+   ->  Append
+         ->  Seq Scan on _hyper_2_103_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_104_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_105_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_106_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_107_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_108_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_109_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_110_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamptz, '2000-01-15'::timestamptz) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+
+:PREFIX SELECT * FROM metrics_date WHERE time IN ('2000-01-05'::date, '2000-01-15'::date) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_date
+   Order: metrics_date."time"
+   ->  Index Only Scan Backward using _hyper_8_171_chunk_metrics_date_time_idx on _hyper_8_171_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_172_chunk_metrics_date_time_idx on _hyper_8_172_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_173_chunk_metrics_date_time_idx on _hyper_8_173_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+
+\qecho cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
 
 \qecho Time dimension chunk filtering works for ANY with single argument
 Time dimension chunk filtering works for ANY with single argument

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -503,8 +503,8 @@ Multi AND
          ->  Seq Scan on _hyper_2_106_chunk
                Filter: (("time" < 10) AND ("time" < 100))
 
-\qecho Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
-Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
+\qecho Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
+Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
 :PREFIX SELECT * FROM hyper_w_space WHERE time < ANY(ARRAY[1,2]) ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -536,6 +536,109 @@ Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
                Filter: ("time" < ANY ('{1,2}'::integer[]))
          ->  Seq Scan on _hyper_2_115_chunk
                Filter: ("time" < ANY ('{1,2}'::integer[]))
+
+\qecho Time dimension chunk exclusion with IN/ANY equality uses bounding range
+Time dimension chunk exclusion with IN/ANY equality uses bounding range
+:PREFIX SELECT * FROM hyper WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{5,15,25}'::integer[]))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[25, 15, 5]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" = ANY ('{25,15,5}'::integer[]))
+
+:PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: hyper_w_space.value
+   ->  Append
+         ->  Seq Scan on _hyper_2_103_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_104_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_105_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_106_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_107_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_108_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_109_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+         ->  Seq Scan on _hyper_2_110_chunk
+               Filter: ("time" = ANY ('{5,15}'::bigint[]))
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamp
+   Order: metrics_timestamp."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+   ->  Index Only Scan Backward using _hyper_5_157_chunk_metrics_timestamp_time_idx on _hyper_5_157_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000","Sat Jan 15 00:00:00 2000"}'::timestamp without time zone[]))
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamptz, '2000-01-15'::timestamptz) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY ('{"Wed Jan 05 00:00:00 2000 PST","Sat Jan 15 00:00:00 2000 PST"}'::timestamp with time zone[]))
+
+:PREFIX SELECT * FROM metrics_date WHERE time IN ('2000-01-05'::date, '2000-01-15'::date) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_date
+   Order: metrics_date."time"
+   ->  Index Only Scan Backward using _hyper_8_171_chunk_metrics_date_time_idx on _hyper_8_171_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_172_chunk_metrics_date_time_idx on _hyper_8_172_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+   ->  Index Only Scan Backward using _hyper_8_173_chunk_metrics_date_time_idx on _hyper_8_173_chunk
+         Index Cond: ("time" = ANY ('{01-05-2000,01-15-2000}'::date[]))
+
+\qecho cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
+   ->  Index Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: ("time" = ANY (ARRAY[('Wed Jan 05 00:00:00 2000'::timestamp without time zone)::timestamp with time zone, ('Sat Jan 15 00:00:00 2000'::timestamp without time zone)::timestamp with time zone]))
 
 \qecho Time dimension chunk filtering works for ANY with single argument
 Time dimension chunk filtering works for ANY with single argument

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -102,8 +102,20 @@ SELECT * FROM cte ORDER BY value;
 \qecho Multi AND
 :PREFIX SELECT * FROM hyper_w_space WHERE time < 10 AND time < 100 ORDER BY value;
 
-\qecho Time dimension doesnt filter chunks when using IN/ANY with multiple arguments
+\qecho Time dimension doesnt filter chunks when using non-equality IN/ANY with multiple arguments
 :PREFIX SELECT * FROM hyper_w_space WHERE time < ANY(ARRAY[1,2]) ORDER BY value;
+
+\qecho Time dimension chunk exclusion with IN/ANY equality uses bounding range
+:PREFIX SELECT * FROM hyper WHERE time IN (5, 15) ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[25, 15, 5]) ORDER BY value;
+:PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamptz, '2000-01-15'::timestamptz) ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE time IN ('2000-01-05'::date, '2000-01-15'::date) ORDER BY time;
+
+\qecho cross-type IN/ANY: timestamp to timestamptz column does not use bounding range (stable cast)
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
 
 \qecho Time dimension chunk filtering works for ANY with single argument
 :PREFIX SELECT * FROM hyper_w_space WHERE time < ANY(ARRAY[1]) ORDER BY value;

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -480,24 +480,16 @@ SELECT clear_hypertable_cache();
                            Filter: (sensor_id > length("substring"(version(), 1, 9)))
 
 SET timescaledb.enable_chunk_skipping to ON;
--- IN/ANY is not supported for now
+-- IN/ANY uses bounding range [min, max] for chunk exclusion
 :PREFIX SELECT * FROM sample_table WHERE sensor_id IN (9, 10, 11);
 --- QUERY PLAN ---
- Append
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_3_chunk_sensor_id__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk
-               Index Cond: (sensor_id = ANY ('{9,10,11}'::integer[]))
-   ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (sensor_id = ANY ('{9,10,11}'::integer[]))
+ Seq Scan on _hyper_1_2_chunk
+   Filter: (sensor_id = ANY ('{9,10,11}'::integer[]))
 
 :PREFIX SELECT * FROM sample_table WHERE sensor_id = ANY(ARRAY[9, 10, 11]);
 --- QUERY PLAN ---
- Append
-   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         ->  Index Scan using compress_hyper_2_3_chunk_sensor_id__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk
-               Index Cond: (sensor_id = ANY ('{9,10,11}'::integer[]))
-   ->  Seq Scan on _hyper_1_2_chunk
-         Filter: (sensor_id = ANY ('{9,10,11}'::integer[]))
+ Seq Scan on _hyper_1_2_chunk
+   Filter: (sensor_id = ANY ('{9,10,11}'::integer[]))
 
 -- Newly added chunks should also have MIN/MAX entry
 \set start_date '2024-01-28 01:09:51.583252+05:30'

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -205,7 +205,7 @@ SELECT clear_hypertable_cache();
 :PREFIX UPDATE sample_table set sensor_id = 10 WHERE sensor_id > length(substring(version(),1,9));
 SET timescaledb.enable_chunk_skipping to ON;
 
--- IN/ANY is not supported for now
+-- IN/ANY uses bounding range [min, max] for chunk exclusion
 :PREFIX SELECT * FROM sample_table WHERE sensor_id IN (9, 10, 11);
 :PREFIX SELECT * FROM sample_table WHERE sensor_id = ANY(ARRAY[9, 10, 11]);
 


### PR DESCRIPTION
Previously, dimension_restrict_info_open_add() rejected IN/ANY expressions with multiple values on open dimensions, causing the planner to expand ALL chunks before PG constraint exclusion prunes.

For equality IN/ANY, compute the bounding range [min, max] as an over-approximation. Extra chunks are pruned by PG constraint exclusion.

On an 8k-chunk hypertable with time IN (t1, t2, t3):
  Planning buffers: 395k -> 20k (95% reduction)
  Planning time:    ~500ms -> ~25ms (20x faster)