### PR TITLE
UPDATE and DELETE command to benefit from bloom filters

### DIFF
--- a/.unreleased/pr_9399
+++ b/.unreleased/pr_9399
@@ -1,0 +1,1 @@
+Implements: #9399 Use bloom filters to reduce decompression during UPDATE/DELETE commands.

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -59,15 +59,16 @@ typedef struct CachedDecompressionState
 	Bitmapset *bloom_insert_attnums;
 	AttrNumber upsert_bloom_attnum;
 	Bloom1Hasher *bloom_hasher;
+
+	/* Pre-computed bloom filter checks for UPDATE/DELETE (List of BloomFilterCheck) */
+	List *bloom_filters;
 } CachedDecompressionState;
 
 typedef struct SharedCounters
 {
 	/* Number of batches deleted */
 	int64 batches_deleted;
-	/* Number of batches filtered */
-	int64 batches_filtered;
-	/* Number of batches decompressed */
+	/* Number of batches decompressed into the uncompressed table */
 	int64 batches_decompressed;
 	/* Number of tuples decompressed */
 	int64 tuples_decompressed;
@@ -79,6 +80,10 @@ typedef struct SharedCounters
 	int64 batches_without_bloom;
 	/* Number of batches bloom false positives */
 	int64 batches_bloom_false_positives;
+	/* Number of batches skipped by pre-decompression filters */
+	int64 batches_filtered_compressed;
+	/* Number of batches filtered after decompression */
+	int64 batches_filtered_decompressed;
 } SharedCounters;
 
 typedef struct ChunkInsertState

--- a/src/guc.c
+++ b/src/guc.c
@@ -98,6 +98,7 @@ bool ts_guc_enable_osm_reads = true;
 TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression = true;
 TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering = true;
+TSDLLEXPORT bool ts_guc_enable_dml_bloom_filter = true;
 TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml = 100000;
 TSDLLEXPORT bool ts_guc_enable_compression_wal_markers = false;
 TSDLLEXPORT bool ts_guc_enable_decompression_sorted_merge = true;
@@ -741,6 +742,19 @@ _guc_init(void)
 							 "Recheck tuples during DML decompression to only decompress batches "
 							 "with matching tuples",
 							 &ts_guc_enable_dml_decompression_tuple_filtering,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_dml_bloom_filter"),
+							 "Enable bloom filter pruning for DML on compressed chunks",
+							 "When enabled, bloom filters are used to skip compressed batches "
+							 "that definitely do not contain matching rows during DELETE and "
+							 "UPDATE operations, reducing decompression overhead.",
+							 &ts_guc_enable_dml_bloom_filter,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -38,6 +38,7 @@ extern TSDLLEXPORT bool ts_guc_enable_cagg_sort_pushdown;
 extern TSDLLEXPORT bool ts_guc_enable_cagg_watermark_constify;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_dml_decompression_tuple_filtering;
+extern TSDLLEXPORT bool ts_guc_enable_dml_bloom_filter;
 extern bool ts_guc_enable_direct_compress_copy;
 extern bool ts_guc_enable_direct_compress_copy_sort_batches;
 extern bool ts_guc_enable_direct_compress_copy_client_sorted;

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -285,7 +285,7 @@ modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *
 		SharedCounters *counters = state->ctr->counters;
 
 		state->batches_deleted += counters->batches_deleted;
-		state->batches_filtered += counters->batches_filtered;
+		state->batches_filtered_decompressed += counters->batches_filtered_decompressed;
 		state->batches_decompressed += counters->batches_decompressed;
 		state->tuples_decompressed += counters->tuples_decompressed;
 		state->batches_checked_by_bloom += counters->batches_checked_by_bloom;
@@ -293,8 +293,16 @@ modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *
 		state->batches_without_bloom += counters->batches_without_bloom;
 		state->batches_bloom_false_positives += counters->batches_bloom_false_positives;
 	}
-	if (state->batches_filtered > 0)
-		ExplainPropertyInteger("Batches filtered", NULL, state->batches_filtered, es);
+	if (state->batches_filtered_compressed > 0)
+		ExplainPropertyInteger("Compressed batches filtered",
+							   NULL,
+							   state->batches_filtered_compressed,
+							   es);
+	if (state->batches_filtered_decompressed > 0)
+		ExplainPropertyInteger("Batches filtered after decompression",
+							   NULL,
+							   state->batches_filtered_decompressed,
+							   es);
 	if (state->batches_decompressed > 0)
 		ExplainPropertyInteger("Batches decompressed", NULL, state->batches_decompressed, es);
 	if (state->tuples_decompressed > 0)

--- a/src/nodes/modify_hypertable.h
+++ b/src/nodes/modify_hypertable.h
@@ -46,7 +46,7 @@ typedef struct ModifyHypertableState
 	Snapshot snapshot;
 	int64 tuples_decompressed;
 	int64 batches_decompressed;
-	int64 batches_filtered;
+	int64 batches_filtered_decompressed;
 	int64 batches_deleted;
 	int64 tuples_deleted;
 
@@ -55,6 +55,9 @@ typedef struct ModifyHypertableState
 	int64 batches_pruned_by_bloom;
 	int64 batches_without_bloom;
 	int64 batches_bloom_false_positives;
+
+	/* bloom, betadata and null filters */
+	int64 batches_filtered_compressed;
 
 	/*
 	 * When EXPLAIN VERBOSE is used, we temporarily nullify the targetlist of the

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -448,7 +448,6 @@ const CompressionAlgorithmDefinition *algorithm_definition(CompressionAlgorithm 
 struct decompress_batches_stats
 {
 	int64 batches_deleted;
-	int64 batches_filtered;
 	int64 batches_decompressed;
 	int64 batches_checked_by_bloom;
 	int64 batches_pruned_by_bloom;
@@ -456,4 +455,6 @@ struct decompress_batches_stats
 	int64 batches_bloom_false_positives;
 	int64 tuples_decompressed;
 	int64 tuples_deleted;
+	int64 batches_filtered_compressed;
+	int64 batches_filtered_decompressed;
 };

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -14,12 +14,14 @@
 #include <parser/parse_coerce.h>
 #include <parser/parse_relation.h>
 #include <parser/parsetree.h>
+#include <utils/datum.h>
 #include <utils/lsyscache.h>
 #include <utils/relcache.h>
 #include <utils/snapmgr.h>
 #include <utils/typcache.h>
 
 #include <compat/compat.h>
+#include "foreach_ptr.h"
 #include <chunk_insert_state.h>
 #include <compression/arrow_c_data_interface.h>
 #include <compression/compression.h>
@@ -69,7 +71,8 @@ static BatchQualSummary batch_matches_vectorized(RowDecompressor *decompressor,
 												 bool check_full_match, bool *skip_current_tuple);
 static void process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							   ScanKeyData **mem_scankeys, int *num_mem_scankeys,
-							   List **heap_filters, List **index_filters, List **is_null);
+							   List **heap_filters, List **index_filters, List **is_null,
+							   List **bloom_filters);
 static Relation find_matching_index(Relation comp_chunk_rel, List **index_filters,
 									List **heap_filters);
 static tuple_filtering_constraints *get_batch_keys_for_unique_constraints(Relation relation);
@@ -109,6 +112,42 @@ typedef struct MatchedBloom
 	AttrNumber compressed_attnum;
 	int num_cols;
 } MatchedBloom;
+
+/*
+ * Pre-computed bloom filter check for UPDATE/DELETE batch pruning.
+ * The hash is computed once in process_predicates() and checked
+ * per batch in decompress_batches_scan() via bloom1_contains_hash().
+ */
+typedef struct BloomFilterCheck
+{
+	AttrNumber bloom_attno; /* attnum of bloom metadata column in compressed chunk */
+	uint64 hash;			/* pre-computed hash of the search value(s) */
+	int num_columns;		/* number of columns in the bloom filter (for sort order) */
+} BloomFilterCheck;
+
+/*
+ * Comparator for list_sort(): order BloomFilterCheck by column count
+ * in descending order, assuming this reflects the selectivity order.
+ */
+static int
+bloom_filter_check_cmp(const ListCell *a, const ListCell *b)
+{
+	BloomFilterCheck *ca = lfirst(a);
+	BloomFilterCheck *cb = lfirst(b);
+	/* Descending order: more columns first */
+	return cb->num_columns - ca->num_columns;
+}
+
+/*
+ * Collects equality predicates during process_predicates() for the
+ * post-loop bloom matching pass. Type OIDs are resolved via
+ * get_atttype() at hash computation time.
+ */
+typedef struct EqualityPredicate
+{
+	AttrNumber attno; /* column attno in uncompressed chunk */
+	Datum constvalue; /* the constant value from WHERE col = <value> */
+} EqualityPredicate;
 
 /*
  * Get arbiter index column attnums from the arbiter index list.
@@ -468,13 +507,14 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 	}
 
 	cis->counters->batches_deleted += stats.batches_deleted;
-	cis->counters->batches_filtered += stats.batches_filtered;
+	cis->counters->batches_filtered_decompressed += stats.batches_filtered_decompressed;
 	cis->counters->batches_decompressed += stats.batches_decompressed;
 	cis->counters->tuples_decompressed += stats.tuples_decompressed;
 	cis->counters->batches_checked_by_bloom += stats.batches_checked_by_bloom;
 	cis->counters->batches_pruned_by_bloom += stats.batches_pruned_by_bloom;
 	cis->counters->batches_without_bloom += stats.batches_without_bloom;
 	cis->counters->batches_bloom_false_positives += stats.batches_bloom_false_positives;
+	cis->counters->batches_filtered_compressed += stats.batches_filtered_compressed;
 
 	CommandCounterIncrement();
 	table_close(in_rel, NoLock);
@@ -513,6 +553,7 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	struct decompress_batches_stats stats = { 0 };
 	int num_mem_scankeys = 0;
 	ScanKeyData *mem_scankeys = NULL;
+	List *bloom_filters = NIL;
 
 	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
 	bool delete_only = ht_state->mt->operation == CMD_DELETE && !has_joins &&
@@ -553,7 +594,8 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 					   &num_mem_scankeys,
 					   &heap_filters,
 					   &index_filters,
-					   &is_null);
+					   &is_null,
+					   &bloom_filters);
 
 	chunk_rel = table_open(chunk->table_id, RowExclusiveLock);
 	comp_chunk_rel = table_open(settings->fd.compress_relid, RowExclusiveLock);
@@ -587,6 +629,7 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	temp_cdst.mem_scankeys.num_scankeys = num_mem_scankeys;
 	temp_cdst.constraints = NULL;
 	temp_cdst.columns_with_null_check = null_columns;
+	temp_cdst.bloom_filters = bloom_filters;
 
 	PushActiveSnapshot(GetTransactionSnapshot());
 	stats = decompress_batches_scan(comp_chunk_rel,
@@ -626,11 +669,19 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 		filter = lfirst(lc);
 		pfree(filter);
 	}
+
+	list_free_deep(bloom_filters);
+
 	ht_state->batches_deleted += stats.batches_deleted;
-	ht_state->batches_filtered += stats.batches_filtered;
+	ht_state->batches_filtered_decompressed += stats.batches_filtered_decompressed;
 	ht_state->batches_decompressed += stats.batches_decompressed;
 	ht_state->tuples_decompressed += stats.tuples_decompressed;
 	ht_state->tuples_deleted += stats.tuples_deleted;
+	ht_state->batches_checked_by_bloom += stats.batches_checked_by_bloom;
+	ht_state->batches_pruned_by_bloom += stats.batches_pruned_by_bloom;
+	ht_state->batches_without_bloom += stats.batches_without_bloom;
+	ht_state->batches_bloom_false_positives += stats.batches_bloom_false_positives;
+	ht_state->batches_filtered_compressed += stats.batches_filtered_compressed;
 
 	return stats.batches_decompressed > 0;
 }
@@ -729,7 +780,6 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 	bool decompressor_initialized = false;
 	bool valid = false;
 	int num_scanned_rows = 0;
-	int num_filtered_rows = 0;
 	TM_Result result;
 	DecompressBatchScanDesc scan = NULL;
 	ScanKeyData *index_scankeys = cdst->index_scankeys.scankeys;
@@ -789,7 +839,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 #endif
 			if (!valid)
 			{
-				num_filtered_rows++;
+				stats.batches_filtered_compressed++;
 				continue;
 			}
 		}
@@ -822,8 +872,40 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 
 		if (!valid)
 		{
-			num_filtered_rows++;
+			stats.batches_filtered_compressed++;
 			continue;
+		}
+
+		/* To track false positives */
+		bool bloom_passed = false;
+
+		/*
+		 * Bloom filter pruning for UPDATE/DELETE. Pre-computed hashes
+		 * are checked against bloom metadata via slot_getattr().
+		 */
+		if (cdst->bloom_filters != NIL)
+		{
+			bool bloom_pruned = false;
+			foreach_ptr(BloomFilterCheck, check, cdst->bloom_filters)
+			{
+				bool isnull;
+				Datum bloom_datum = slot_getattr(slot, check->bloom_attno, &isnull);
+				stats.batches_checked_by_bloom++;
+				if (!isnull && !bloom1_contains_hash(bloom_datum, check->hash))
+				{
+					bloom_pruned = true;
+					break;
+				}
+				if (isnull)
+					stats.batches_without_bloom++;
+			}
+			if (bloom_pruned)
+			{
+				stats.batches_pruned_by_bloom++;
+				stats.batches_filtered_compressed++;
+				continue;
+			}
+			bloom_passed = true;
 		}
 
 		if (!decompressor_initialized)
@@ -840,9 +922,6 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 						  decompressor.in_desc,
 						  decompressor.compressed_datums,
 						  decompressor.compressed_is_nulls);
-
-		/* To track false positives */
-		bool bloom_passed = false;
 
 		/* Bloom pre-filtering for UPSERT conflict detection */
 		if (insert_slot != NULL && cdst->bloom_hasher != NULL)
@@ -898,7 +977,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 				if (bloom_passed)
 					stats.batches_bloom_false_positives++;
 				row_decompressor_reset(&decompressor);
-				stats.batches_filtered++;
+				stats.batches_filtered_decompressed++;
 				continue;
 			}
 		}
@@ -989,11 +1068,11 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 	{
 		elog(INFO,
 			 "Number of compressed rows fetched from %s: %d. "
-			 "Number of compressed rows filtered%s: %d.",
+			 "Number of compressed rows filtered%s: " INT64_FORMAT ".",
 			 index_rel ? "index" : "table scan",
 			 num_scanned_rows,
 			 index_rel ? " by heap filters" : "",
-			 num_filtered_rows);
+			 stats.batches_filtered_compressed);
 	}
 
 	return stats;
@@ -1123,6 +1202,12 @@ batch_matches_vectorized(RowDecompressor *decompressor, ScanKeyData *scankeys, i
 	memset(result, 0xFF, bitmap_bytes);
 	bool single_value = false;
 	bool batch_failed = false;
+
+	/* batch_matches() calls decompress_batch_next_row() which increments
+	 * the decompressor's batched_decompressed variable. To match that
+	 * behaviour we need to bump it here.
+	 */
+	decompressor->batches_decompressed++;
 
 	for (int sk = 0; sk < num_scankeys; sk++)
 	{
@@ -1470,7 +1555,7 @@ get_batch_keys_for_unique_constraints(Relation relation)
 static void
 process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				   ScanKeyData **mem_scankeys, int *num_mem_scankeys, List **heap_filters,
-				   List **index_filters, List **is_null)
+				   List **index_filters, List **is_null, List **bloom_filters)
 {
 	ListCell *lc;
 	if (ts_guc_enable_dml_decompression_tuple_filtering)
@@ -1478,6 +1563,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 		*mem_scankeys = palloc0(sizeof(ScanKeyData) * list_length(predicates));
 	}
 	*num_mem_scankeys = 0;
+	List *eq_preds = NIL;
 
 	/*
 	 * We dont want to forward boundParams from the execution state here
@@ -1575,6 +1661,29 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 										   arg_value->constcollid,
 										   opcode,
 										   arg_value->constisnull ? 0 : arg_value->constvalue);
+				}
+
+				/*
+				 * Collect equality predicates for the post-loop
+				 * bloom filter matching pass.
+				 */
+				if (op_strategy == BTEqualStrategyNumber && !arg_value->constisnull &&
+					ts_guc_enable_dml_bloom_filter)
+				{
+					EqualityPredicate *ep = palloc(sizeof(EqualityPredicate));
+					ep->attno = var->varattno;
+#ifdef USE_FLOAT8_BYVAL
+					ep->constvalue = arg_value->constvalue;
+#else
+					if (arg_value->constbyval)
+						ep->constvalue = Int64GetDatum(arg_value->constvalue);
+					else
+						ep->constvalue = datumCopy(arg_value->constvalue,
+												   arg_value->constbyval,
+												   arg_value->constlen);
+#endif
+
+					eq_preds = lappend(eq_preds, ep);
 				}
 
 				int min_attno = compressed_column_metadata_attno(settings,
@@ -1773,6 +1882,105 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				break;
 		}
 	}
+
+	/*
+	 * Bloom filter matching pass: iterate all bloom configs from
+	 * SparseIndexSettings, check which ones are fully covered by
+	 * equality predicates, compute hashes, and collect matches.
+	 * Results are sorted by selectivity (most columns first).
+	 */
+	if (eq_preds != NIL && settings->fd.index != NULL && ts_guc_enable_dml_bloom_filter)
+	{
+		SparseIndexSettings *parsed = ts_convert_to_sparse_index_settings(settings->fd.index);
+		TsBmsList per_column_attnos =
+			ts_resolve_columns_to_attnos_from_parsed_settings(parsed, ch->table_id);
+
+		/* Build a Bitmapset of equality predicate attnums for bms_is_subset() */
+		Bitmapset *eq_pred_attnos = NULL;
+		foreach_ptr(EqualityPredicate, ep, eq_preds) eq_pred_attnos =
+			bms_add_member(eq_pred_attnos, ep->attno);
+
+		ListCell *obj_cell;
+		ListCell *attno_cell;
+		forboth (obj_cell, parsed->objects, attno_cell, per_column_attnos)
+		{
+			SparseIndexSettingsObject *obj = lfirst(obj_cell);
+			Bitmapset *bloom_attnos = lfirst(attno_cell);
+
+			/* Check if bloom type */
+			List *type_values = ts_get_values_by_key_from_parsed_object(obj, "type");
+			if (type_values == NIL || strcmp((char *) linitial(type_values), "bloom") != 0)
+				continue;
+
+			int num_columns = bms_num_members(bloom_attnos);
+
+			/* Skip composite blooms if the GUC is off */
+			if (num_columns > 1 && !ts_guc_enable_composite_bloom_indexes)
+				continue;
+
+			/* Check if ALL bloom columns have equality predicates */
+			if (!bms_is_subset(bloom_attnos, eq_pred_attnos))
+				continue;
+
+			/*
+			 * All columns covered. Collect type OIDs and values in
+			 * ascending attnum order (via bms_next_member) to match
+			 * the order used during compression.
+			 */
+			Oid type_oids[MAX_BLOOM_FILTER_COLUMNS];
+			NullableDatum values[MAX_BLOOM_FILTER_COLUMNS];
+			int col_idx = 0;
+			int attnum = -1;
+			while ((attnum = bms_next_member(bloom_attnos, attnum)) >= 0)
+			{
+				type_oids[col_idx] = get_atttype(ch->table_id, attnum);
+
+				/* Find the matching equality predicate for this attnum */
+				foreach_ptr(EqualityPredicate, ep, eq_preds)
+				{
+					if (ep->attno == attnum)
+					{
+						values[col_idx].value = ep->constvalue;
+						values[col_idx].isnull = false;
+						break;
+					}
+				}
+				col_idx++;
+			}
+
+			Bloom1Hasher *hasher = bloom1_hasher_create(type_oids, num_columns);
+			uint64 hash = hasher->hash_values(hasher, values);
+
+			/* Resolve bloom metadata column attno in compressed chunk */
+			List *column_names = ts_get_column_names_from_parsed_object(obj);
+			char *bloom_col_name =
+				compressed_column_metadata_name_list_v2(bloom1_column_prefix, column_names);
+			AttrNumber bloom_attno = get_attnum(settings->fd.compress_relid, bloom_col_name);
+
+			if (AttributeNumberIsValid(bloom_attno))
+			{
+				BloomFilterCheck *check = palloc(sizeof(BloomFilterCheck));
+				check->bloom_attno = bloom_attno;
+				check->hash = hash;
+				check->num_columns = num_columns;
+				*bloom_filters = lappend(*bloom_filters, check);
+			}
+
+			pfree(hasher);
+		}
+
+		bms_free(eq_pred_attnos);
+		ts_bmslist_free(per_column_attnos);
+		ts_free_sparse_index_settings(parsed);
+		list_free_deep(eq_preds);
+	}
+
+	/*
+	 * Sort bloom filters by number of columns (descending) assuming they
+	 * are more selective.
+	 */
+	if (list_length(*bloom_filters) > 1)
+		list_sort(*bloom_filters, bloom_filter_check_cmp);
 }
 
 static BatchFilter *

--- a/tsl/test/expected/compress_bloom_dml.out
+++ b/tsl/test/expected/compress_bloom_dml.out
@@ -1,0 +1,232 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+create table dml_test(
+    ts int,
+    o bigint,
+    boo bigint,
+    foo bigint,
+    sby bigint);
+select create_hypertable('dml_test', 'ts', create_default_indexes=>false);
+   create_hypertable   
+-----------------------
+ (1,public,dml_test,t)
+
+insert into dml_test select x, (30000-x), x%2000, x+100, x%5 from generate_series(1, 50000) x;
+alter table dml_test set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(foo, boo), bloom(boo)');
+select count(compress_chunk(x)) from show_chunks('dml_test') x;
+ count 
+-------
+     1
+
+vacuum analyze dml_test;
+-- 2 filter clauses
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+select * from dml_test where foo = 1001 and boo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+   Vectorized Filter: ((foo = 1001) AND (boo = 1002))
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
+         Filter: (_timescaledb_functions.bloom1_contains(regress-test-bloom_boo_foo, ROW(1002, 1001)) AND _timescaledb_functions.bloom1_contains(regress-test-bloom_boo, 1002))
+         Rows Removed by Filter: 50
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 50
+   ->  Update on dml_test (actual rows=0.00 loops=1)
+         Update on _hyper_1_1_chunk dml_test_1
+         ->  Result (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+                     Filter: ((foo = 1001) AND (boo = 1002))
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Compressed batches filtered: 50
+   Batches checked by bloom: 50
+   Batches pruned by bloom: 50
+   ->  Update on dml_test (actual rows=0.00 loops=1)
+         Update on _hyper_1_1_chunk dml_test_1
+         ->  Result (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+                     Filter: ((foo = 1001) AND (boo = 1002))
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1001 AND boo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 50
+   ->  Delete on dml_test (actual rows=0.00 loops=1)
+         Delete on _hyper_1_1_chunk dml_test_1
+         ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+               Filter: ((foo = 1001) AND (boo = 1002))
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1001 AND boo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Compressed batches filtered: 50
+   Batches checked by bloom: 50
+   Batches pruned by bloom: 50
+   ->  Delete on dml_test (actual rows=0.00 loops=1)
+         Delete on _hyper_1_1_chunk dml_test_1
+         ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+               Filter: ((foo = 1001) AND (boo = 1002))
+
+ROLLBACK;
+-- 1 filter clause
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+select * from dml_test where foo = 12;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
+   Vectorized Filter: (foo = 12)
+   Rows Removed by Filter: 50000
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=50.00 loops=1)
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 12;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 50
+   ->  Update on dml_test (actual rows=0.00 loops=1)
+         Update on _hyper_1_1_chunk dml_test_1
+         ->  Result (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+                     Filter: (foo = 12)
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 12;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 50
+   ->  Update on dml_test (actual rows=0.00 loops=1)
+         Update on _hyper_1_1_chunk dml_test_1
+         ->  Result (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+                     Filter: (foo = 12)
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 12;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 50
+   ->  Delete on dml_test (actual rows=0.00 loops=1)
+         Delete on _hyper_1_1_chunk dml_test_1
+         ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+               Filter: (foo = 12)
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 12;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 50
+   ->  Delete on dml_test (actual rows=0.00 loops=1)
+         Delete on _hyper_1_1_chunk dml_test_1
+         ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
+               Filter: (foo = 12)
+
+ROLLBACK;
+-- 1 filter clause, real updates
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+select * from dml_test where foo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1.00 loops=1)
+   Vectorized Filter: (foo = 1002)
+   Rows Removed by Filter: 49999
+   ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=50.00 loops=1)
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 49
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Update on dml_test (actual rows=0.00 loops=1)
+         Update on _hyper_1_1_chunk dml_test_1
+         ->  Result (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=1.00 loops=1)
+                     Filter: (foo = 1002)
+                     Rows Removed by Filter: 999
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 49
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Update on dml_test (actual rows=0.00 loops=1)
+         Update on _hyper_1_1_chunk dml_test_1
+         ->  Result (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=1.00 loops=1)
+                     Filter: (foo = 1002)
+                     Rows Removed by Filter: 999
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 49
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Delete on dml_test (actual rows=0.00 loops=1)
+         Delete on _hyper_1_1_chunk dml_test_1
+         ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=1.00 loops=1)
+               Filter: (foo = 1002)
+               Rows Removed by Filter: 999
+
+ROLLBACK;
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1002;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches filtered after decompression: 49
+   Batches decompressed: 1
+   Tuples decompressed: 1000
+   ->  Delete on dml_test (actual rows=0.00 loops=1)
+         Delete on _hyper_1_1_chunk dml_test_1
+         ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=1.00 loops=1)
+               Filter: (foo = 1002)
+               Rows Removed by Filter: 999
+
+ROLLBACK;

--- a/tsl/test/expected/compress_compbloom_upsert.out
+++ b/tsl/test/expected/compress_compbloom_upsert.out
@@ -254,7 +254,7 @@ INSERT INTO explain_partial VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
 ON CONFLICT (device_id, metric, ts) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 1
+   Batches filtered after decompression: 1
    Batches checked by bloom: 1
    Batches bloom false positives: 1
    ->  Insert on explain_partial (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -2662,6 +2662,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on test_meta_filters (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -2662,6 +2662,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on test_meta_filters (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -2668,6 +2668,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on test_meta_filters (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -2668,6 +2668,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on test_meta_filters (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/compress_unique_index.out
+++ b/tsl/test/shared/expected/compress_unique_index.out
@@ -27,7 +27,7 @@ ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_uniq_ex
 EXPLAIN (analyze,buffers off, costs off,summary off,timing off) INSERT INTO compress_unique VALUES ('2000-01-01','m1','c2','2000-01-02');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 1
+   Batches filtered after decompression: 1
    ->  Insert on compress_unique (actual rows=0.00 loops=1)
          ->  Result (actual rows=1.00 loops=1)
 

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -242,7 +242,7 @@ BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:01','d1',ran
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 6
+   Batches filtered after decompression: 6
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
          Update on _hyper_X_X_chunk lazy_decompress_1
          ->  Result (actual rows=0.00 loops=1)
@@ -252,7 +252,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0; ROLLBAC
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 6
+   Batches filtered after decompression: 6
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
          Update on _hyper_X_X_chunk lazy_decompress_1
          ->  Result (actual rows=0.00 loops=1)
@@ -263,7 +263,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND devi
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 2300; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 5
+   Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
@@ -276,7 +276,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 2300; ROLL
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value > 3100 AND value < 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 5
+   Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
@@ -289,7 +289,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value > 3100 AND v
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value BETWEEN 3100 AND 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 5
+   Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
@@ -318,7 +318,7 @@ RESET timescaledb.enable_dml_decompression_tuple_filtering;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 6
+   Batches filtered after decompression: 6
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk lazy_decompress_1
          ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0.00 loops=1)
@@ -327,7 +327,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 6
+   Batches filtered after decompression: 6
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk lazy_decompress_1
          ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0.00 loops=1)
@@ -337,7 +337,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROL
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 2300; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 5
+   Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
@@ -349,7 +349,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 2300; ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value > 3100 AND value < 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 5
+   Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
@@ -361,7 +361,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value > 3100 AND value < 3200;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value BETWEEN 3100 AND 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 5
+   Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
@@ -690,7 +690,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading <> 'r1';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 2
+   Batches filtered after decompression: 2
    Batches decompressed: 3
    Tuples decompressed: 7
    Batches deleted: 1

--- a/tsl/test/shared/expected/decompress_tracking.out
+++ b/tsl/test/shared/expected/decompress_tracking.out
@@ -114,7 +114,7 @@ BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROL
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 1
+   Batches filtered after decompression: 1
    ->  Insert on decompress_tracking (actual rows=0.00 loops=1)
          ->  Subquery Scan on "*SELECT*" (actual rows=1.00 loops=1)
                ->  Result (actual rows=1.00 loops=1)
@@ -136,7 +136,7 @@ BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d4'
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking (VALUES ('2020-01-01 1:30','d1',random()),('2020-01-01 1:30','d2',random())); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
-   Batches filtered: 2
+   Batches filtered after decompression: 2
    ->  Insert on decompress_tracking (actual rows=0.00 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)
 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_FILES
     compress_auto_sparse_index.sql
     compress_batch_size.sql
     compress_bitmap_scan.sql
+    compress_bloom_dml.sql
     compress_bloom_hash.sql
     compress_compbloom_basics.sql
     compress_compbloom_config.sql

--- a/tsl/test/sql/compress_bloom_dml.sql
+++ b/tsl/test/sql/compress_bloom_dml.sql
@@ -1,0 +1,105 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+create table dml_test(
+    ts int,
+    o bigint,
+    boo bigint,
+    foo bigint,
+    sby bigint);
+select create_hypertable('dml_test', 'ts', create_default_indexes=>false);
+insert into dml_test select x, (30000-x), x%2000, x+100, x%5 from generate_series(1, 50000) x;
+alter table dml_test set (
+    timescaledb.compress,
+    timescaledb.order_by='o',
+    timescaledb.segment_by='sby',
+    timescaledb.compress_index = 'bloom(foo, boo), bloom(boo)');
+
+select count(compress_chunk(x)) from show_chunks('dml_test') x;
+vacuum analyze dml_test;
+
+-- 2 filter clauses
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+select * from dml_test where foo = 1001 and boo = 1002;
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1001 AND boo = 1002;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1001 AND boo = 1002;
+ROLLBACK;
+
+
+-- 1 filter clause
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+select * from dml_test where foo = 12;
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 12;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 12;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 12;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 12;
+ROLLBACK;
+
+-- 1 filter clause, real updates
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+select * from dml_test where foo = 1002;
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1002;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+UPDATE dml_test SET foo = foo+1 WHERE foo = 1002;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = off;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1002;
+ROLLBACK;
+
+SET timescaledb.enable_dml_bloom_filter = on;
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+DELETE FROM dml_test WHERE foo = 1002;
+ROLLBACK;


### PR DESCRIPTION
This change allows us to skip decompressing batches in scenarios where the UPDATE/DELETE clauses have equal predicates and we have bloom filters for them. There may be more than one applicable composite/single column bloom filters, so this change checks them in decreasing number of columns they built on. The idea is that I hope the more columns in a bloom filter it is the more selective.

Once a bloom filter check determines that the batch (compressed row) doesn't satisfy the predicates, then it stops checking more bloom filters, and it will also skip decompressing the batch.