### PR TITLE
Store composite bloom filter data inline if possible

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -380,6 +380,12 @@ create_sparse_index_column_def(List *attributes, const char *metadata_type)
 		 * result is almost incompressible with lz4 (~2%), so disable it.
 		 */
 		column_def->storage = TYPSTORAGE_EXTERNAL;
+
+		/* Composite bloom filters are more selective, try to store them inline. */
+		if (list_length(column_names) > 1)
+		{
+			column_def->storage = TYPSTORAGE_MAIN;
+		}
 	}
 	else /* either min or max */
 	{


### PR DESCRIPTION
These should be selective enough so the gain we get from not TOASTing them by default outweigh the potential of other data being TOASTed instead.

Disable-check: force-changelog-file