### PR TITLE
Fix forced refresh not consuming invalidations

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1012,7 +1012,8 @@ cut_cagg_invalidation_and_compute_remainder(const ContinuousAggInvalidationState
 
 	if (!IsValidInvalidation(&remainder))
 		remainder = new_remainder;
-	else if (!invalidation_entry_try_merge(&remainder, &new_remainder))
+	else if (IsValidInvalidation(&new_remainder) &&
+			 !invalidation_entry_try_merge(&remainder, &new_remainder))
 	{
 		save_invalidation_for_refresh(state, &remainder);
 		remainder = new_remainder;
@@ -1064,17 +1065,30 @@ clear_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *state
 
 	MemoryContextReset(state->per_tuple_mctx);
 
-	/* Force refresh within the entire window */
+	/*
+	 * Force refresh within the entire window.
+	 *
+	 * At this point the refresh window has already been inscribed to bucket
+	 * boundaries by the caller, so [start, end) covers exactly the set of
+	 * buckets to materialize.
+	 *
+	 * Synthesize an invalidation covering [start, end-1] (inclusive) and use
+	 * it as the initial remainder.  We use end-1 because greatest_modified_value
+	 * is inclusive while refresh_window->end is exclusive.
+	 *
+	 * By seeding the remainder with this forced entry, any cagg invalidation
+	 * log entries whose inside parts overlap the window will be merged into it
+	 * in the scan loop below rather than being saved as separate entries.
+	 * The single merged remainder is then saved once at the end of this function.
+	 */
 	if (force)
 	{
-		mergedentry.hyper_id = state->cagg->data.mat_hypertable_id;
-		mergedentry.lowest_modified_value = refresh_window->start;
-		mergedentry.greatest_modified_value = refresh_window->end;
-		mergedentry.is_modified = false;
-		ItemPointerSet(&mergedentry.tid, InvalidBlockNumber, 0);
-
-		/* Jump to process remainder to properly cut the invalidation */
-		goto process_remainder;
+		remainder.hyper_id = state->cagg->data.mat_hypertable_id;
+		remainder.lowest_modified_value = refresh_window->start;
+		remainder.greatest_modified_value =
+			ts_time_saturating_sub(refresh_window->end, 1, refresh_window->type);
+		remainder.is_modified = false;
+		ItemPointerSetInvalid(&remainder.tid);
 	}
 
 	/* Process all invalidations for the continuous aggregate */
@@ -1115,7 +1129,6 @@ clear_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *state
 
 	ts_scan_iterator_close(&iterator);
 
-process_remainder:
 	/* Handle the last (merged) invalidation */
 	if (IsValidInvalidation(&mergedentry))
 		remainder = cut_cagg_invalidation_and_compute_remainder(state,

--- a/tsl/test/expected/cagg_refresh_using_merge.out
+++ b/tsl/test/expected/cagg_refresh_using_merge.out
@@ -604,6 +604,8 @@ VALUES
   -- daily bucket 2025-07-04 12:00:00+00
   ('2025-07-04 12:00:00+00', 1, 1),
   ('2025-07-04 12:05:00+00', 1, 1);
+SELECT current_setting('timezone') AS original_timezone \gset
+SET timezone TO 'UTC';
 CREATE MATERIALIZED VIEW conditions_by_hour
 WITH (timescaledb.continuous) AS
 SELECT
@@ -620,17 +622,80 @@ CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 10:00:00+00'
 SELECT * FROM conditions_by_hour ORDER BY bucket;
             bucket            | device | max | min | count 
 ------------------------------+--------+-----+-----+-------
- Fri Jul 04 03:00:00 2025 PDT |      1 |   1 |   1 |     2
- Fri Jul 04 04:00:00 2025 PDT |      1 |   1 |   1 |     2
+ Fri Jul 04 10:00:00 2025 UTC |      1 |   1 |   1 |     2
+ Fri Jul 04 11:00:00 2025 UTC |      1 |   1 |   1 |     2
 
+-- Show invalidation log state after initial refresh
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end,
+  lowest_modified_value AS start_raw,
+  greatest_modified_value AS end_raw
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+            start             |                 end                 |      start_raw       |       end_raw       
+------------------------------+-------------------------------------+----------------------+---------------------
+ -infinity                    | Fri Jul 04 09:59:59.999999 2025 UTC | -9223372036854775808 |    1751623199999999
+ Fri Jul 04 12:00:00 2025 UTC | infinity                            |     1751630400000000 | 9223372036854775807
+
+-- Insert below the watermark to generate an invalidation, then run a no-op refresh
+-- to move the invalidation into the cagg invalidation log.
+INSERT INTO conditions VALUES ('2025-07-04 10:30:00+00', 1, 2);
+CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 01:00:00+00'::timestamptz, '2025-07-04 06:00:00+00'::timestamptz);
+-- Cagg invalidation log before the force refresh, should have an entry
+-- that contains the bucket from 10:00 to 10:59:59.99
+-- which is 3:00:00 - 3:59:59.99 PDT
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end,
+  lowest_modified_value AS start_raw,
+  greatest_modified_value AS end_raw
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+            start             |                 end                 |      start_raw       |       end_raw       
+------------------------------+-------------------------------------+----------------------+---------------------
+ -infinity                    | Fri Jul 04 00:59:59.999999 2025 UTC | -9223372036854775808 |    1751590799999999
+ Fri Jul 04 06:00:00 2025 UTC | Fri Jul 04 10:59:59.999999 2025 UTC |     1751608800000000 |    1751626799999999
+ Fri Jul 04 12:00:00 2025 UTC | infinity                            |     1751630400000000 | 9223372036854775807
+
+-- generate invalidations that will overlap the force refresh range,
+-- fully contained and fully outside the forced refresh range
+INSERT INTO conditions VALUES ('2025-07-04 09:30:00+00', 1, 2), ('2025-07-04 10:40:00+00', 1, 30);
+INSERT INTO conditions VALUES ('2025-07-04 10:50:00+00', 1, 40), ('2025-07-04 11:20:00+00', 1, 50);
+INSERT INTO conditions VALUES ('2025-07-04 11:50:00+00', 1, 60), ('2025-07-04 12:20:00+00', 1, 70);
 CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 10:00:00+00'::timestamptz, '2025-07-04 12:00:00+00'::timestamptz, force=>true);
--- It should return the same 2 buckets of previous query
+-- It should return the same 2 buckets of previous query (with updated count for 10:00 and 11:00 buckets)
 SELECT * FROM conditions_by_hour ORDER BY bucket;
             bucket            | device | max | min | count 
 ------------------------------+--------+-----+-----+-------
- Fri Jul 04 03:00:00 2025 PDT |      1 |   1 |   1 |     2
- Fri Jul 04 04:00:00 2025 PDT |      1 |   1 |   1 |     2
+ Fri Jul 04 10:00:00 2025 UTC |      1 |  40 |   1 |     5
+ Fri Jul 04 11:00:00 2025 UTC |      1 |  60 |   1 |     4
 
+-- After force refresh: any invalidation range that fall into the refreshed range should be
+-- removed from the invalidation log,
+-- thus there should be no entry that covers the bucket from 10:00 to 11:59:59.99 UTC
+-- And there should be no entry with lowest = highest
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+            start             |                 end                 
+------------------------------+-------------------------------------
+ -infinity                    | Fri Jul 04 00:59:59.999999 2025 UTC
+ Fri Jul 04 06:00:00 2025 UTC | Fri Jul 04 09:59:59.999999 2025 UTC
+ Fri Jul 04 12:00:00 2025 UTC | infinity
+
+SET timezone TO :'original_timezone';
 -- Monthly buckets
 INSERT INTO conditions
 VALUES

--- a/tsl/test/expected/cagg_refresh_using_trigger.out
+++ b/tsl/test/expected/cagg_refresh_using_trigger.out
@@ -602,6 +602,8 @@ VALUES
   -- daily bucket 2025-07-04 12:00:00+00
   ('2025-07-04 12:00:00+00', 1, 1),
   ('2025-07-04 12:05:00+00', 1, 1);
+SELECT current_setting('timezone') AS original_timezone \gset
+SET timezone TO 'UTC';
 CREATE MATERIALIZED VIEW conditions_by_hour
 WITH (timescaledb.continuous) AS
 SELECT
@@ -618,17 +620,80 @@ CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 10:00:00+00'
 SELECT * FROM conditions_by_hour ORDER BY bucket;
             bucket            | device | max | min | count 
 ------------------------------+--------+-----+-----+-------
- Fri Jul 04 03:00:00 2025 PDT |      1 |   1 |   1 |     2
- Fri Jul 04 04:00:00 2025 PDT |      1 |   1 |   1 |     2
+ Fri Jul 04 10:00:00 2025 UTC |      1 |   1 |   1 |     2
+ Fri Jul 04 11:00:00 2025 UTC |      1 |   1 |   1 |     2
 
+-- Show invalidation log state after initial refresh
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end,
+  lowest_modified_value AS start_raw,
+  greatest_modified_value AS end_raw
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+            start             |                 end                 |      start_raw       |       end_raw       
+------------------------------+-------------------------------------+----------------------+---------------------
+ -infinity                    | Fri Jul 04 09:59:59.999999 2025 UTC | -9223372036854775808 |    1751623199999999
+ Fri Jul 04 12:00:00 2025 UTC | infinity                            |     1751630400000000 | 9223372036854775807
+
+-- Insert below the watermark to generate an invalidation, then run a no-op refresh
+-- to move the invalidation into the cagg invalidation log.
+INSERT INTO conditions VALUES ('2025-07-04 10:30:00+00', 1, 2);
+CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 01:00:00+00'::timestamptz, '2025-07-04 06:00:00+00'::timestamptz);
+-- Cagg invalidation log before the force refresh, should have an entry
+-- that contains the bucket from 10:00 to 10:59:59.99
+-- which is 3:00:00 - 3:59:59.99 PDT
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end,
+  lowest_modified_value AS start_raw,
+  greatest_modified_value AS end_raw
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+            start             |                 end                 |      start_raw       |       end_raw       
+------------------------------+-------------------------------------+----------------------+---------------------
+ -infinity                    | Fri Jul 04 00:59:59.999999 2025 UTC | -9223372036854775808 |    1751590799999999
+ Fri Jul 04 06:00:00 2025 UTC | Fri Jul 04 10:59:59.999999 2025 UTC |     1751608800000000 |    1751626799999999
+ Fri Jul 04 12:00:00 2025 UTC | infinity                            |     1751630400000000 | 9223372036854775807
+
+-- generate invalidations that will overlap the force refresh range,
+-- fully contained and fully outside the forced refresh range
+INSERT INTO conditions VALUES ('2025-07-04 09:30:00+00', 1, 2), ('2025-07-04 10:40:00+00', 1, 30);
+INSERT INTO conditions VALUES ('2025-07-04 10:50:00+00', 1, 40), ('2025-07-04 11:20:00+00', 1, 50);
+INSERT INTO conditions VALUES ('2025-07-04 11:50:00+00', 1, 60), ('2025-07-04 12:20:00+00', 1, 70);
 CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 10:00:00+00'::timestamptz, '2025-07-04 12:00:00+00'::timestamptz, force=>true);
--- It should return the same 2 buckets of previous query
+-- It should return the same 2 buckets of previous query (with updated count for 10:00 and 11:00 buckets)
 SELECT * FROM conditions_by_hour ORDER BY bucket;
             bucket            | device | max | min | count 
 ------------------------------+--------+-----+-----+-------
- Fri Jul 04 03:00:00 2025 PDT |      1 |   1 |   1 |     2
- Fri Jul 04 04:00:00 2025 PDT |      1 |   1 |   1 |     2
+ Fri Jul 04 10:00:00 2025 UTC |      1 |  40 |   1 |     5
+ Fri Jul 04 11:00:00 2025 UTC |      1 |  60 |   1 |     4
 
+-- After force refresh: any invalidation range that fall into the refreshed range should be
+-- removed from the invalidation log,
+-- thus there should be no entry that covers the bucket from 10:00 to 11:59:59.99 UTC
+-- And there should be no entry with lowest = highest
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+            start             |                 end                 
+------------------------------+-------------------------------------
+ -infinity                    | Fri Jul 04 00:59:59.999999 2025 UTC
+ Fri Jul 04 06:00:00 2025 UTC | Fri Jul 04 09:59:59.999999 2025 UTC
+ Fri Jul 04 12:00:00 2025 UTC | infinity
+
+SET timezone TO :'original_timezone';
 -- Monthly buckets
 INSERT INTO conditions
 VALUES

--- a/tsl/test/sql/include/cagg_refresh_common.sql
+++ b/tsl/test/sql/include/cagg_refresh_common.sql
@@ -433,6 +433,9 @@ VALUES
   ('2025-07-04 12:00:00+00', 1, 1),
   ('2025-07-04 12:05:00+00', 1, 1);
 
+SELECT current_setting('timezone') AS original_timezone \gset
+SET timezone TO 'UTC';
+
 CREATE MATERIALIZED VIEW conditions_by_hour
 WITH (timescaledb.continuous) AS
 SELECT
@@ -449,9 +452,61 @@ CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 10:00:00+00'
 -- It should return 2 buckets
 SELECT * FROM conditions_by_hour ORDER BY bucket;
 
+-- Show invalidation log state after initial refresh
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end,
+  lowest_modified_value AS start_raw,
+  greatest_modified_value AS end_raw
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+
+-- Insert below the watermark to generate an invalidation, then run a no-op refresh
+-- to move the invalidation into the cagg invalidation log.
+INSERT INTO conditions VALUES ('2025-07-04 10:30:00+00', 1, 2);
+CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 01:00:00+00'::timestamptz, '2025-07-04 06:00:00+00'::timestamptz);
+
+-- Cagg invalidation log before the force refresh, should have an entry
+-- that contains the bucket from 10:00 to 10:59:59.99
+-- which is 3:00:00 - 3:59:59.99 PDT
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end,
+  lowest_modified_value AS start_raw,
+  greatest_modified_value AS end_raw
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+
+-- generate invalidations that will overlap the force refresh range,
+-- fully contained and fully outside the forced refresh range
+INSERT INTO conditions VALUES ('2025-07-04 09:30:00+00', 1, 2), ('2025-07-04 10:40:00+00', 1, 30);
+INSERT INTO conditions VALUES ('2025-07-04 10:50:00+00', 1, 40), ('2025-07-04 11:20:00+00', 1, 50);
+INSERT INTO conditions VALUES ('2025-07-04 11:50:00+00', 1, 60), ('2025-07-04 12:20:00+00', 1, 70);
 CALL refresh_continuous_aggregate('conditions_by_hour', '2025-07-04 10:00:00+00'::timestamptz, '2025-07-04 12:00:00+00'::timestamptz, force=>true);
--- It should return the same 2 buckets of previous query
+-- It should return the same 2 buckets of previous query (with updated count for 10:00 and 11:00 buckets)
 SELECT * FROM conditions_by_hour ORDER BY bucket;
+
+-- After force refresh: any invalidation range that fall into the refreshed range should be
+-- removed from the invalidation log,
+-- thus there should be no entry that covers the bucket from 10:00 to 11:59:59.99 UTC
+-- And there should be no entry with lowest = highest
+SELECT
+  _timescaledb_functions.to_timestamp(lowest_modified_value) AS start,
+  _timescaledb_functions.to_timestamp(greatest_modified_value) AS end
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+  SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+  WHERE user_view_name = 'conditions_by_hour')
+ORDER BY 1;
+
+
+SET timezone TO :'original_timezone';
 
 -- Monthly buckets
 INSERT INTO conditions


### PR DESCRIPTION
Commit 1718120fc fixed a bug about forced refresh not refreshing at bucket boundary. However that fix caused force refresh not consuming invalidation within its range, and adding a bogus entry with start=end in the materialization invalidation log. This patch fixes those issues.

Disable-check: force-changelog-file