### PR TITLE
Set default segmentby during direct compress flush

### DIFF
--- a/.unreleased/pr_9403
+++ b/.unreleased/pr_9403
@@ -1,0 +1,1 @@
+Implements: #9403 Set default segmentby during direct compress flush

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -195,9 +195,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 				Hypertable *compressed_ht =
 					ts_hypertable_get_by_id(ctr->hypertable->fd.compressed_hypertable_id);
 				Chunk *compressed_chunk =
-					ts_cm_functions->compression_chunk_create(compressed_ht,
-															  chunk,
-															  true); /* skip_segmentby_default */
+					ts_cm_functions->compression_chunk_create(compressed_ht, chunk);
 				ts_chunk_set_compressed_chunk(chunk, compressed_chunk->fd.id);
 				chunk->fd.compressed_chunk_id = compressed_chunk->fd.id;
 				created_compressed_chunk = true;

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -142,8 +142,7 @@ typedef struct CrossModuleFunctions
 								TupleTableSlot *slot);
 	void (*compressor_flush)(RowCompressor *compressor, BulkWriter *bulk_writer);
 	void (*compressor_free)(RowCompressor *compressor, BulkWriter *bulk_writer);
-	Chunk *(*compression_chunk_create)(Hypertable *ht, Chunk *src_chunk,
-									   bool skip_segmentby_default);
+	Chunk *(*compression_chunk_create)(Hypertable *ht, Chunk *src_chunk);
 
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module

--- a/src/guc.c
+++ b/src/guc.c
@@ -73,6 +73,7 @@ TSDLLEXPORT bool ts_guc_enable_direct_compress_insert = false;
 bool ts_guc_enable_direct_compress_insert_sort_batches = true;
 TSDLLEXPORT bool ts_guc_enable_direct_compress_insert_client_sorted = false;
 TSDLLEXPORT bool ts_guc_enable_direct_compress_on_cagg_refresh = false;
+TSDLLEXPORT bool ts_guc_enable_direct_compress_auto_segmentby = true;
 int ts_guc_direct_compress_insert_tuple_sort_limit = 10000;
 bool ts_guc_enable_deprecation_warnings = true;
 bool ts_guc_enable_optimizations = true;
@@ -585,6 +586,18 @@ _guc_init(void)
 							 "Aggregate refresh",
 							 &ts_guc_enable_direct_compress_on_cagg_refresh,
 							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("enable_direct_compress_auto_segmentby"),
+							 "Enable automatic segmentby column selection during compression",
+							 "When enabled, automatically analyzes buffered tuples to pick "
+							 "an optimal segmentby column if none is configured.",
+							 &ts_guc_enable_direct_compress_auto_segmentby,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -49,6 +49,7 @@ extern TSDLLEXPORT bool ts_guc_enable_direct_compress_insert;
 extern bool ts_guc_enable_direct_compress_insert_sort_batches;
 extern TSDLLEXPORT bool ts_guc_enable_direct_compress_insert_client_sorted;
 extern TSDLLEXPORT bool ts_guc_enable_direct_compress_on_cagg_refresh;
+extern TSDLLEXPORT bool ts_guc_enable_direct_compress_auto_segmentby;
 extern int ts_guc_direct_compress_insert_tuple_sort_limit;
 extern TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete;
 extern TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml;

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1005,11 +1005,15 @@ get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 }
 
 Chunk *
-tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk,
-							 bool skip_segmentby_default)
+tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk)
 {
 	/* Create a new compressed chunk */
-	return create_compress_chunk(compressed_ht, src_chunk, InvalidOid, skip_segmentby_default);
+	return create_compress_chunk(
+		compressed_ht,
+		src_chunk,
+		InvalidOid,
+		ts_guc_enable_direct_compress_auto_segmentby); /* skip_segmentby_default
+														*/
 }
 
 Datum

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -16,8 +16,7 @@ extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_rebuild_columnstore(PG_FUNCTION_ARGS);
 extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress);
-extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk,
-										   bool skip_segmentby_default);
+extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk);
 
 extern Datum tsl_get_compressed_chunk_index_for_recompression(
 	PG_FUNCTION_ARGS); // arg is oid of uncompressed chunk

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -986,7 +986,7 @@ tsl_compressor_flush(RowCompressor *compressor, BulkWriter *bulk_writer)
 
 			if (compressor->needs_analyze_segmentby)
 			{
-				/* TODO: analyze segmentby and reinit compressor */
+				tsl_compressor_apply_segmentby_and_rebuild(compressor, bulk_writer);
 				compressor->needs_analyze_segmentby = false;
 			}
 			TupleTableSlot *slot = MakeTupleTableSlot(compressor->in_desc, &TTSOpsMinimalTuple);
@@ -1033,6 +1033,126 @@ tsl_compressor_free(RowCompressor *compressor, BulkWriter *bulk_writer)
 }
 
 /*
+ * Determine the segmentby column from tuples in Tuplesortstate in the RowCompressor,
+ * then rebuild the compressed chunk and compressor to use it.
+ */
+void
+tsl_compressor_apply_segmentby_and_rebuild(RowCompressor *compressor, BulkWriter *bulk_writer)
+{
+	if (compressor->sort_state == NULL || compressor->tuples_to_sort == 0)
+	{
+		return;
+	}
+
+	Oid old_compressed_relid = RelationGetRelid(bulk_writer->out_rel);
+	CompressionSettings *settings =
+		ts_compression_settings_get_by_compress_relid(old_compressed_relid);
+	Chunk *src_chunk = ts_chunk_get_by_relid(settings->fd.relid, true);
+	Chunk *old_compressed_chunk = ts_chunk_get_by_relid(old_compressed_relid, true);
+	Hypertable *ht = ts_hypertable_get_by_id(src_chunk->fd.hypertable_id);
+	Hypertable *compress_ht = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
+
+	if (settings->fd.segmentby)
+	{
+		/* Something went wrong, but just throw a warning to not stop workflow */
+		elog(WARNING, "trying to apply segmentby when segmentby is not NULL");
+		return;
+	}
+
+	/* Can happen for partial chunks, but problematic if happening otherwise */
+	if (!CheckRelationOidLockedByMe(src_chunk->table_id, AccessExclusiveLock, false))
+	{
+		/* Since the segmentby rebuild is triggered by a DML, expect at least RowExclusiveLock */
+		Ensure(CheckRelationOidLockedByMe(src_chunk->table_id, RowExclusiveLock, true),
+			   "hypertable chunk \"%s\".\"%s\" must have at least a RowExclusiveLock "
+			   "to apply segmentby",
+			   NameStr(src_chunk->fd.schema_name),
+			   NameStr(src_chunk->fd.table_name));
+
+		elog(DEBUG1,
+			 "chunk \"%s\".\"%s\" does not have AccessExclusiveLock "
+			 "but trying to apply segmentby",
+			 NameStr(src_chunk->fd.schema_name),
+			 NameStr(src_chunk->fd.table_name));
+	}
+
+	Ensure(CheckRelationOidLockedByMe(old_compressed_relid, AccessExclusiveLock, false),
+		   "compressed chunk \"%s\".\"%s\" must have AccessExclusiveLock "
+		   "to apply segmentby",
+		   NameStr(old_compressed_chunk->fd.schema_name),
+		   NameStr(old_compressed_chunk->fd.table_name));
+
+	settings->fd.segmentby = tsl_compression_setting_segmentby_get_default(ht);
+
+	/* nothing qualified as segmentby */
+	if (!settings->fd.segmentby)
+	{
+		return;
+	}
+
+	if (ts_array_length(settings->fd.segmentby) != 1)
+	{
+		elog(WARNING,
+			 "expected exactly one segmentby column, got %d",
+			 ts_array_length(settings->fd.segmentby));
+		settings->fd.segmentby = NULL;
+		return;
+	}
+
+	if (ts_array_is_member(settings->fd.orderby,
+						   ts_array_get_element_text(settings->fd.segmentby, 1)))
+	{
+		elog(DEBUG1, "selected segmentby column is also an orderby column, skipping");
+		settings->fd.segmentby = NULL;
+		return;
+	}
+
+	Relation in_rel = table_open(src_chunk->table_id, NoLock);
+
+	/* Tear down old internals */
+	Tuplesortstate *old_sort_state = compressor->sort_state;
+	int saved_tuple_sort_limit = compressor->tuple_sort_limit;
+	TupleDesc old_in_desc = compressor->in_desc;
+	compressor->sort_state = NULL;
+	row_compressor_close(compressor);
+	bulk_writer_close(bulk_writer);
+	table_close(bulk_writer->out_rel, NoLock);
+
+	/* Create before drop. We must update settings first to point to the new chunk. */
+	Chunk *new_compressed_chunk =
+		create_compress_chunk_with_settings(compress_ht, src_chunk, settings);
+	ts_chunk_set_compressed_chunk(src_chunk, new_compressed_chunk->fd.id);
+	ts_chunk_drop(old_compressed_chunk, DROP_RESTRICT, -1);
+
+	/* Re-init bulk writer in place and compressor against the new compressed relation */
+	Relation out_rel = table_open(new_compressed_chunk->table_id, RowExclusiveLock);
+	*bulk_writer = bulk_writer_build(out_rel, 0);
+	row_compressor_init(compressor, settings, RelationGetDescr(in_rel), RelationGetDescr(out_rel));
+	compressor->sort_state = compression_create_tuplesort_state(settings, in_rel);
+	compressor->tuple_sort_limit = saved_tuple_sort_limit;
+
+	/* Transfer from old sort state into the new one with segmentby settings */
+	TupleTableSlot *slot = MakeTupleTableSlot(old_in_desc, &TTSOpsMinimalTuple);
+
+	while (tuplesort_gettupleslot(old_sort_state,
+								  true /*=forward*/,
+								  false /*=copy*/,
+								  slot,
+								  NULL /*=abbrev*/))
+	{
+		tuplesort_puttupleslot(compressor->sort_state, slot);
+		compressor->tuples_to_sort++;
+	}
+
+	ExecDropSingleTupleTableSlot(slot);
+	tuplesort_performsort(compressor->sort_state);
+	tuplesort_end(old_sort_state);
+
+	FreeTupleDesc(old_in_desc);
+	table_close(in_rel, NoLock);
+}
+
+/*
  * Initialize a RowCompressor for compressing tuples
  *
  * When `sort` is true, the compressor will buffer all the tuples in a
@@ -1051,12 +1171,12 @@ tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort, int so
 	if (sort)
 	{
 		/*
-		 * Schedule segmentby analysis on the first flush if no segmentby is
-		 * configured. When the client is responsible for ordering
-		 * (sort=false), we skip analysis entirely.
+		 * Analyze segmentby on first flush if none is configured
+		 * and if client is not responsible for sorting (sort = true)
 		 */
-		compressor->needs_analyze_segmentby =
-			(settings->fd.segmentby == NULL) && created_compressed_chunk;
+		compressor->needs_analyze_segmentby = ts_guc_enable_direct_compress_auto_segmentby &&
+											  (settings->fd.segmentby == NULL) &&
+											  created_compressed_chunk;
 		compressor->sort_state = compression_create_tuplesort_state(settings, in_rel);
 		compressor->tuple_sort_limit = sort_limit;
 	}

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -384,6 +384,8 @@ extern void row_compressor_init(RowCompressor *row_compressor, const Compression
 
 extern RowCompressor *tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort,
 										  int tuple_sort_limit, bool created_compressed_chunk);
+extern void tsl_compressor_apply_segmentby_and_rebuild(RowCompressor *compressor,
+													   BulkWriter *bulk_writer);
 extern void tsl_compressor_set_invalidation(RowCompressor *compressor, Hypertable *ht,
 											Oid chunk_relid);
 extern void tsl_compressor_add_slot(RowCompressor *compressor, BulkWriter *bulk_writer,

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -685,6 +685,69 @@ build_columndef_singlecolumn(const char *colname, Oid typid)
 }
 
 /*
+ * Create compress chunk with specific settings.
+ *
+ * Same as create_compress_chunk but with an extra CompressionSettings parameter
+ *
+ */
+Chunk *
+create_compress_chunk_with_settings(Hypertable *compress_ht, Chunk *src_chunk,
+									CompressionSettings *settings)
+{
+	Catalog *catalog = ts_catalog_get();
+	CatalogSecurityContext sec_ctx;
+	Chunk *compress_chunk;
+	int namelen;
+	Oid tablespace_oid;
+
+	Assert(compress_ht->space->num_dimensions == 0);
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	compress_chunk =
+		ts_chunk_create_base(ts_catalog_table_next_seq_id(catalog, CHUNK), 0, RELKIND_RELATION);
+	ts_catalog_restore_user(&sec_ctx);
+
+	compress_chunk->fd.hypertable_id = compress_ht->fd.id;
+	compress_chunk->hypertable_relid = compress_ht->main_table_relid;
+	namestrcpy(&compress_chunk->fd.schema_name, INTERNAL_SCHEMA_NAME);
+
+	namelen = snprintf(NameStr(compress_chunk->fd.table_name),
+					   NAMEDATALEN,
+					   "compress%s_%d_chunk",
+					   NameStr(compress_ht->fd.associated_table_prefix),
+					   compress_chunk->fd.id);
+
+	if (namelen >= NAMEDATALEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("invalid name \"%s\" for compressed chunk",
+						NameStr(compress_chunk->fd.table_name)),
+				 errdetail("The associated table prefix is too long.")));
+
+	ts_chunk_insert_lock(compress_chunk, RowExclusiveLock);
+
+	tablespace_oid = get_rel_tablespace(src_chunk->table_id);
+
+	List *column_defs = build_columndefs(settings, src_chunk->table_id);
+	compress_chunk->table_id =
+		compression_chunk_create(src_chunk, compress_chunk, column_defs, tablespace_oid, settings);
+
+	if (!OidIsValid(compress_chunk->table_id))
+		elog(ERROR, "could not create columnstore chunk table");
+
+	settings->fd.compress_relid = compress_chunk->table_id;
+	ts_compression_settings_update(settings);
+
+	ts_chunk_index_create_all(compress_chunk->fd.hypertable_id,
+							  compress_chunk->hypertable_relid,
+							  compress_chunk->fd.id,
+							  compress_chunk->table_id,
+							  tablespace_oid);
+
+	return compress_chunk;
+}
+
+/*
  * Create compress chunk for specific table.
  *
  * If table_id is InvalidOid, create a new table.
@@ -1352,8 +1415,8 @@ validate_hypertable_for_compression(Hypertable *ht)
 /*
  * Get the default segment by value for a hypertable
  */
-static ArrayType *
-compression_setting_segmentby_get_default(const Hypertable *ht)
+ArrayType *
+tsl_compression_setting_segmentby_get_default(const Hypertable *ht)
 {
 	StringInfoData command;
 	StringInfoData result;
@@ -1815,7 +1878,7 @@ compression_settings_set_defaults(Hypertable *ht, CompressionSettings *settings,
 		if (!skip_segmentby_default && !settings->fd.segmentby &&
 			with_clause_options[AlterTableFlagSegmentBy].is_default)
 		{
-			settings->fd.segmentby = compression_setting_segmentby_get_default(ht);
+			settings->fd.segmentby = tsl_compression_setting_segmentby_get_default(ht);
 		}
 		settings->fd.index = ts_remove_orderby_sparse_index(settings);
 		OrderBySettings obs = compression_setting_orderby_get_default(ht, settings->fd.segmentby);

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -32,6 +32,8 @@ char *compressed_column_metadata_name_v2(const char *metadata_type, const char *
 char *compressed_column_metadata_name_list_v2(const char *metadata_type, List *column_names_list);
 
 typedef struct CompressionSettings CompressionSettings;
+Chunk *create_compress_chunk_with_settings(Hypertable *compress_ht, Chunk *src_chunk,
+										   CompressionSettings *settings);
 int compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_reloid,
 									 AttrNumber chunk_attno, Oid compressed_reloid,
 									 char const *metadata_type);
@@ -41,3 +43,4 @@ void tsl_columnstore_setup(Hypertable *ht, WithClauseResult *with_clause_options
 void compression_settings_set_defaults(Hypertable *ht, CompressionSettings *settings,
 									   WithClauseResult *with_clause_options,
 									   bool skip_segmentby_default);
+ArrayType *tsl_compression_setting_segmentby_get_default(const Hypertable *ht);

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -710,7 +710,7 @@ SELECT t, (i % 5), random()
 FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
      generate_series(1, 5) i;
 ANALYZE test_segmentby_stats;
--- will have no segment by as default segmentby for direct compressed chunk;
+-- will have default segmentby set for a newly created direct compressed chunk (should observe a skipped chunk id);
 SELECT * FROM _timescaledb_catalog.compression_settings;
                   relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
 ------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
@@ -720,7 +720,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  metrics_chunk                            |                                                  |             |         |              |                    | 
  test_segmentby_stats                     |                                                  |             |         |              |                    | 
  _timescaledb_internal._hyper_12_89_chunk | _timescaledb_internal.compress_hyper_13_90_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
- _timescaledb_internal._hyper_12_91_chunk | _timescaledb_internal.compress_hyper_13_92_chunk |             | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_12_91_chunk | _timescaledb_internal.compress_hyper_13_93_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 ROLLBACK;
 BEGIN;
@@ -737,7 +737,7 @@ SELECT t, (i % 5), random()
 FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
      generate_series(1, 5) i;
 ANALYZE test_segmentby_stats;
--- will have device_id by as configured segmentby for direct compressed chunk;
+-- will have device_id by as configured segmentby for direct compressed chunk (should not observe skipped chunk id);
 SELECT * FROM _timescaledb_catalog.compression_settings;
                   relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
 ------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
@@ -746,6 +746,31 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  _timescaledb_internal._hyper_4_54_chunk  | _timescaledb_internal.compress_hyper_5_55_chunk  |             | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
  metrics_chunk                            |                                                  |             |         |              |                    | 
  test_segmentby_stats                     |                                                  | {device_id} |         |              |                    | 
- _timescaledb_internal._hyper_14_93_chunk | _timescaledb_internal.compress_hyper_15_94_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_14_94_chunk | _timescaledb_internal.compress_hyper_15_95_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+ROLLBACK;
+-- Test orderby columns are not selected by DC segmentby default
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_orderby_not_segmentby(time timestamptz NOT NULL, device_id int NOT NULL,
+    value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+CREATE INDEX ON test_orderby_not_segmentby(device_id);
+INSERT INTO test_orderby_not_segmentby SELECT '2024-01-01'::timestamptz + (i||' min')::interval,
+    (i%5)+1, random() FROM generate_series(1,500) i;
+ANALYZE test_orderby_not_segmentby;
+ALTER TABLE test_orderby_not_segmentby SET (timescaledb.compress);
+SET timescaledb.enable_direct_compress_insert = on;
+INSERT INTO test_orderby_not_segmentby SELECT '2024-06-01'::timestamptz + (i||' min')::interval,
+    (i%5)+1, random() FROM generate_series(1,2000) i;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  | segmentby |     orderby      | orderby_desc | orderby_nullsfirst |                                                            index                                                            
+------------------------------------------+--------------------------------------------------+-----------+------------------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------
+ metrics                                  |                                                  |           | {time}           | {f}          | {f}                | 
+ metrics_status                           |                                                  |           |                  |              |                    | 
+ _timescaledb_internal._hyper_4_54_chunk  | _timescaledb_internal.compress_hyper_5_55_chunk  |           | {time}           | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics_chunk                            |                                                  |           |                  |              |                    | 
+ test_orderby_not_segmentby               |                                                  |           |                  |              |                    | 
+ _timescaledb_internal._hyper_16_97_chunk | _timescaledb_internal.compress_hyper_17_98_chunk |           | {time,device_id} | {t,f}        | {t,f}              | [{"type": "minmax", "column": "time", "source": "orderby"}, {"type": "minmax", "column": "device_id", "source": "orderby"}]
 
 ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -401,7 +401,7 @@ SELECT t, (i % 5), random()
 FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
      generate_series(1, 5) i;
 ANALYZE test_segmentby_stats;
--- will have no segment by as default segmentby for direct compressed chunk;
+-- will have default segmentby set for a newly created direct compressed chunk (should observe a skipped chunk id);
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ROLLBACK;
 
@@ -419,7 +419,23 @@ SELECT t, (i % 5), random()
 FROM generate_series('2024-01-06'::timestamptz, '2024-01-07'::timestamptz, '1 minute') t,
      generate_series(1, 5) i;
 ANALYZE test_segmentby_stats;
--- will have device_id by as configured segmentby for direct compressed chunk;
+-- will have device_id by as configured segmentby for direct compressed chunk (should not observe skipped chunk id);
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ROLLBACK;
+
+-- Test orderby columns are not selected by DC segmentby default
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_orderby_not_segmentby(time timestamptz NOT NULL, device_id int NOT NULL,
+    value float) WITH (tsdb.hypertable);
+CREATE INDEX ON test_orderby_not_segmentby(device_id);
+INSERT INTO test_orderby_not_segmentby SELECT '2024-01-01'::timestamptz + (i||' min')::interval,
+    (i%5)+1, random() FROM generate_series(1,500) i;
+ANALYZE test_orderby_not_segmentby;
+ALTER TABLE test_orderby_not_segmentby SET (timescaledb.compress);
+SET timescaledb.enable_direct_compress_insert = on;
+INSERT INTO test_orderby_not_segmentby SELECT '2024-06-01'::timestamptz + (i||' min')::interval,
+    (i%5)+1, random() FROM generate_series(1,2000) i;
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ROLLBACK;
 


### PR DESCRIPTION
When no segmentby is configured, calculate the default at first
RowCompressor flush. If a default is selected, rebuild the
compressed chunk, RowCompressor, and BulkWriter with the new
settings and re-sort buffered tuples before flushing.

Second cut into segmentby analysis
Future work https://github.com/timescale/timescaledb/pull/9396

#9355 needs to be merged first