### PR TITLE
Add condition to check for .unreleased files

### DIFF
--- a/.github/workflows/prerelease-sanity.yaml
+++ b/.github/workflows/prerelease-sanity.yaml
@@ -29,6 +29,7 @@ jobs:
     # The combined changelog must reference all changes, and the respective
     # change files in the .unreleased folder must be deleted.
     - name: No .unreleased files are left behind
+      if: ${{ startsWith(github.head_ref, 'release/') && endsWith(github.head_ref, '-changelog') }}
       run: |
         ! compgen -G .unreleased/*
 


### PR DESCRIPTION
Currently we check on both release artefacts and changelog PRs, but it only makes sense to check that there are no unreleased changelog in the changelog pr, which is the only one that's suppose to leave the .unreleased directory cleaned.