### PR TITLE
Mark `hypertable` and `chunk` as user catalog tables

### DIFF
--- a/.unreleased/pr_9410
+++ b/.unreleased/pr_9410
@@ -1,0 +1,1 @@
+Implements: #9410 Mark `hypertable` and `chunk` as user catalog tables

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -61,7 +61,7 @@ CREATE TABLE _timescaledb_catalog.hypertable (
   CONSTRAINT hypertable_dim_compress_check CHECK (num_dimensions > 0 OR compression_state = 2),
   CONSTRAINT hypertable_chunk_target_size_check CHECK (chunk_target_size >= 0),
   CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL))
-);
+) WITH (user_catalog_table = true);
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
 
@@ -153,7 +153,7 @@ CREATE TABLE _timescaledb_catalog.chunk (
   CONSTRAINT chunk_pkey PRIMARY KEY (id),
   CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name),
   CONSTRAINT chunk_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id)
-);
+) WITH (user_catalog_table = true);
 ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
 
 CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -49,3 +49,9 @@ WHERE cc.chunk_id = c.id
   AND cc.dimension_slice_id IS NULL
   AND cc.hypertable_constraint_name IS NOT NULL;
 
+--
+-- Include the `hypertable` and the `chunk` catalog tables in the historical
+-- snapshot during logical replication
+--
+ALTER TABLE _timescaledb_catalog.hypertable SET (user_catalog_table = true);
+ALTER TABLE _timescaledb_catalog.chunk SET (user_catalog_table = true);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -26,3 +26,5 @@ JOIN pg_constraint child
     AND child.conname = parent.conname
 ON CONFLICT DO NOTHING;
 
+ALTER TABLE _timescaledb_catalog.hypertable RESET (user_catalog_table);
+ALTER TABLE _timescaledb_catalog.chunk RESET (user_catalog_table);


### PR DESCRIPTION
Mark tables `_timescaledb_catalog.hypertable` and `_timescaledb_catalog.chunk` with `WITH (user_catalog_table = true)` (see [doc](https://www.postgresql.org/docs/18/logicaldecoding-output-plugin.html#LOGICALDECODING-CAPABILITIES)) so they can be accessed during logical decoding using historic snapshot. This is required for a consistent view of timescaledb catalog from logical decoding plugins.