### PR TITLE
Adding a new attribute for ModifyHypertable explain plans

### DIFF
--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -72,6 +72,8 @@ typedef struct SharedCounters
 	int64 batches_decompressed;
 	/* Number of tuples decompressed */
 	int64 tuples_decompressed;
+	/* Number of batches scanned */
+	int64 batches_scanned;
 	/* Number of batches checked by bloom */
 	int64 batches_checked_by_bloom;
 	/* Number of batches pruned by bloom */

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -288,11 +288,14 @@ modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *
 		state->batches_filtered_decompressed += counters->batches_filtered_decompressed;
 		state->batches_decompressed += counters->batches_decompressed;
 		state->tuples_decompressed += counters->tuples_decompressed;
+		state->batches_scanned += counters->batches_scanned;
 		state->batches_checked_by_bloom += counters->batches_checked_by_bloom;
 		state->batches_pruned_by_bloom += counters->batches_pruned_by_bloom;
 		state->batches_without_bloom += counters->batches_without_bloom;
 		state->batches_bloom_false_positives += counters->batches_bloom_false_positives;
 	}
+	if (state->batches_scanned > 0)
+		ExplainPropertyInteger("Batches scanned", NULL, state->batches_scanned, es);
 	if (state->batches_filtered_compressed > 0)
 		ExplainPropertyInteger("Compressed batches filtered",
 							   NULL,

--- a/src/nodes/modify_hypertable.h
+++ b/src/nodes/modify_hypertable.h
@@ -49,6 +49,7 @@ typedef struct ModifyHypertableState
 	int64 batches_filtered_decompressed;
 	int64 batches_deleted;
 	int64 tuples_deleted;
+	int64 batches_scanned;
 
 	/* bloom stats */
 	int64 batches_checked_by_bloom;

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -449,6 +449,7 @@ struct decompress_batches_stats
 {
 	int64 batches_deleted;
 	int64 batches_decompressed;
+	int64 batches_scanned;
 	int64 batches_checked_by_bloom;
 	int64 batches_pruned_by_bloom;
 	int64 batches_without_bloom;

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -510,6 +510,7 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 	cis->counters->batches_filtered_decompressed += stats.batches_filtered_decompressed;
 	cis->counters->batches_decompressed += stats.batches_decompressed;
 	cis->counters->tuples_decompressed += stats.tuples_decompressed;
+	cis->counters->batches_scanned += stats.batches_scanned;
 	cis->counters->batches_checked_by_bloom += stats.batches_checked_by_bloom;
 	cis->counters->batches_pruned_by_bloom += stats.batches_pruned_by_bloom;
 	cis->counters->batches_without_bloom += stats.batches_without_bloom;
@@ -677,6 +678,7 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	ht_state->batches_decompressed += stats.batches_decompressed;
 	ht_state->tuples_decompressed += stats.tuples_decompressed;
 	ht_state->tuples_deleted += stats.tuples_deleted;
+	ht_state->batches_scanned += stats.batches_scanned;
 	ht_state->batches_checked_by_bloom += stats.batches_checked_by_bloom;
 	ht_state->batches_pruned_by_bloom += stats.batches_pruned_by_bloom;
 	ht_state->batches_without_bloom += stats.batches_without_bloom;
@@ -779,7 +781,6 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 	RowDecompressor decompressor;
 	bool decompressor_initialized = false;
 	bool valid = false;
-	int num_scanned_rows = 0;
 	TM_Result result;
 	DecompressBatchScanDesc scan = NULL;
 	ScanKeyData *index_scankeys = cdst->index_scankeys.scankeys;
@@ -815,7 +816,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 
 	while (decompress_batch_scan_getnext_slot(scan, ForwardScanDirection, slot))
 	{
-		num_scanned_rows++;
+		stats.batches_scanned++;
 
 		/* Deconstruct the tuple */
 		Assert(slot->tts_ops->get_heap_tuple);
@@ -1067,10 +1068,10 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 	if (ts_guc_debug_compression_path_info)
 	{
 		elog(INFO,
-			 "Number of compressed rows fetched from %s: %d. "
+			 "Number of compressed rows fetched from %s: " INT64_FORMAT ". "
 			 "Number of compressed rows filtered%s: " INT64_FORMAT ".",
 			 index_rel ? "index" : "table scan",
-			 num_scanned_rows,
+			 stats.batches_scanned,
 			 index_rel ? " by heap filters" : "",
 			 stats.batches_filtered_compressed);
 	}

--- a/tsl/test/expected/compress_bloom_dml.out
+++ b/tsl/test/expected/compress_bloom_dml.out
@@ -40,6 +40,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 50
    ->  Update on dml_test (actual rows=0.00 loops=1)
          Update on _hyper_1_1_chunk dml_test_1
@@ -54,6 +55,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Compressed batches filtered: 50
    Batches checked by bloom: 50
    Batches pruned by bloom: 50
@@ -70,6 +72,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 DELETE FROM dml_test WHERE foo = 1001 AND boo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 50
    ->  Delete on dml_test (actual rows=0.00 loops=1)
          Delete on _hyper_1_1_chunk dml_test_1
@@ -83,6 +86,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 DELETE FROM dml_test WHERE foo = 1001 AND boo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Compressed batches filtered: 50
    Batches checked by bloom: 50
    Batches pruned by bloom: 50
@@ -107,6 +111,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 UPDATE dml_test SET foo = foo+1 WHERE foo = 12;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 50
    ->  Update on dml_test (actual rows=0.00 loops=1)
          Update on _hyper_1_1_chunk dml_test_1
@@ -121,6 +126,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 UPDATE dml_test SET foo = foo+1 WHERE foo = 12;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 50
    ->  Update on dml_test (actual rows=0.00 loops=1)
          Update on _hyper_1_1_chunk dml_test_1
@@ -135,6 +141,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 DELETE FROM dml_test WHERE foo = 12;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 50
    ->  Delete on dml_test (actual rows=0.00 loops=1)
          Delete on _hyper_1_1_chunk dml_test_1
@@ -148,6 +155,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 DELETE FROM dml_test WHERE foo = 12;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 50
    ->  Delete on dml_test (actual rows=0.00 loops=1)
          Delete on _hyper_1_1_chunk dml_test_1
@@ -170,6 +178,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 UPDATE dml_test SET foo = foo+1 WHERE foo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 49
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -187,6 +196,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 UPDATE dml_test SET foo = foo+1 WHERE foo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 49
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -204,6 +214,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 DELETE FROM dml_test WHERE foo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 49
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -220,6 +231,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
 DELETE FROM dml_test WHERE foo = 1002;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 50
    Batches filtered after decompression: 49
    Batches decompressed: 1
    Tuples decompressed: 1000

--- a/tsl/test/expected/compress_compbloom_upsert.out
+++ b/tsl/test/expected/compress_compbloom_upsert.out
@@ -27,6 +27,7 @@ INSERT INTO explain_test VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
 ON CONFLICT (device_id, metric, ts) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches checked by bloom: 2
    Batches pruned by bloom: 2
    ->  Insert on explain_test (actual rows=0.00 loops=1)
@@ -43,6 +44,7 @@ ON CONFLICT (device_id, metric, ts)
 DO UPDATE SET value = EXCLUDED.value;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches checked by bloom: 2
    Batches pruned by bloom: 2
    ->  Insert on explain_test (actual rows=0.00 loops=1)
@@ -94,6 +96,7 @@ INSERT INTO upsert_test VALUES ('2024-01-01 00:03:30', 50, 'login', 1)
 ON CONFLICT (uid, event, ts) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches checked by bloom: 3
    Batches pruned by bloom: 3
    ->  Insert on upsert_test (actual rows=0.00 loops=1)
@@ -139,6 +142,7 @@ INSERT INTO upsert_temporal VALUES ('2024-01-15 10:00:00', 1, 'temp', 26.0)
 ON CONFLICT (sensor_id, metric, time) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches checked by bloom: 1
    ->  Insert on upsert_temporal (actual rows=0.00 loops=1)
          Conflict Resolution: NOTHING
@@ -152,6 +156,7 @@ INSERT INTO upsert_temporal VALUES ('2024-01-15 10:30:00', 5, 'temp', 26.0)
 ON CONFLICT (sensor_id, metric, time) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches checked by bloom: 1
    Batches pruned by bloom: 1
    ->  Insert on upsert_temporal (actual rows=0.00 loops=1)
@@ -197,6 +202,7 @@ INSERT INTO upsert_demographics VALUES ('2024-01-01 00:01:00', 1, 18, 1, 200)
 ON CONFLICT (user_id, age, gender, time) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches checked by bloom: 1
    Batches pruned by bloom: 1
    ->  Insert on upsert_demographics (actual rows=0.00 loops=1)
@@ -211,6 +217,7 @@ INSERT INTO upsert_demographics VALUES ('2024-01-01 00:01:30', 50, 30, 1, 200)
 ON CONFLICT (user_id, age, gender, time) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches checked by bloom: 1
    Batches pruned by bloom: 1
    ->  Insert on upsert_demographics (actual rows=0.00 loops=1)
@@ -254,6 +261,7 @@ INSERT INTO explain_partial VALUES ('2024-01-01 00:05:30', 5, 'temp', 100)
 ON CONFLICT (device_id, metric, ts) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches filtered after decompression: 1
    Batches checked by bloom: 1
    Batches bloom false positives: 1
@@ -270,6 +278,7 @@ INSERT INTO explain_partial VALUES ('2024-01-01 00:05:00', 5, 'humidity', 100)
 ON CONFLICT (device_id, metric, ts) DO NOTHING;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches checked by bloom: 1
    Batches pruned by bloom: 1
    ->  Insert on explain_partial (actual rows=0.00 loops=1)

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -2662,6 +2662,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 30
    Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -2698,6 +2699,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2708,6 +2710,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2718,6 +2721,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2728,6 +2732,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2738,6 +2743,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device > 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2758,6 +2764,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = CURRENT_USER; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2768,6 +2775,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' <= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2780,6 +2788,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2792,6 +2801,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 05:00'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2802,6 +2812,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2817,6 +2828,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2841,6 +2853,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2866,6 +2879,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2887,6 +2901,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2910,6 +2925,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2921,6 +2937,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2939,6 +2956,7 @@ BEGIN; :EXPLAIN EXECUTE q1('not here'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2948,6 +2966,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2957,6 +2976,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2970,6 +2990,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-02'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2982,6 +3003,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2995,6 +3017,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBA
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query()); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3010,6 +3033,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
 BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3022,6 +3046,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3039,6 +3064,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3131,6 +3157,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
          Delete on _hyper_43_81_chunk delete_counter_1
@@ -3150,6 +3177,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 369
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
@@ -3190,6 +3218,7 @@ BEGIN
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1
@@ -3208,6 +3237,7 @@ CREATE MATERIALIZED VIEW
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -2662,6 +2662,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 30
    Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -2698,6 +2699,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2708,6 +2710,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2718,6 +2721,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2728,6 +2732,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2738,6 +2743,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device > 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2758,6 +2764,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = CURRENT_USER; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2768,6 +2775,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' <= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2780,6 +2788,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2792,6 +2801,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 05:00'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2802,6 +2812,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2817,6 +2828,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2841,6 +2853,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2866,6 +2879,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2887,6 +2901,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2910,6 +2925,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2921,6 +2937,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2939,6 +2956,7 @@ BEGIN; :EXPLAIN EXECUTE q1('not here'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2948,6 +2966,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2957,6 +2976,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2970,6 +2990,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-02'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2982,6 +3003,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2995,6 +3017,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBA
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query()); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3010,6 +3033,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
 BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3022,6 +3046,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3039,6 +3064,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3131,6 +3157,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
          Delete on _hyper_43_81_chunk delete_counter_1
@@ -3150,6 +3177,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 369
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
@@ -3190,6 +3218,7 @@ BEGIN
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1
@@ -3208,6 +3237,7 @@ CREATE MATERIALIZED VIEW
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -2668,6 +2668,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 30
    Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -2704,6 +2705,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2714,6 +2716,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2724,6 +2727,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2734,6 +2738,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2744,6 +2749,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device > 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2764,6 +2770,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = CURRENT_USER; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2774,6 +2781,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' <= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2786,6 +2794,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2798,6 +2807,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 05:00'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2808,6 +2818,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2823,6 +2834,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2847,6 +2859,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2872,6 +2885,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2893,6 +2907,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2916,6 +2931,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2927,6 +2943,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2945,6 +2962,7 @@ BEGIN; :EXPLAIN EXECUTE q1('not here'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2954,6 +2972,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2963,6 +2982,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2976,6 +2996,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-02'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2988,6 +3009,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3001,6 +3023,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBA
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query()); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3016,6 +3039,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
 BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3028,6 +3052,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3045,6 +3070,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3137,6 +3163,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
          Delete on _hyper_43_81_chunk delete_counter_1
@@ -3156,6 +3183,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 369
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
@@ -3196,6 +3224,7 @@ BEGIN
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1
@@ -3214,6 +3243,7 @@ CREATE MATERIALIZED VIEW
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -2668,6 +2668,7 @@ SELECT compress_chunk(show_chunks('test_meta_filters'));
 EXPLAIN (analyze, timing off, buffers off, costs off, summary off) DELETE FROM test_meta_filters WHERE device = 'd1' AND metric = 'm1' AND v1 < 100;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 30
    Compressed batches filtered: 29
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -2704,6 +2705,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2714,6 +2716,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'a' = device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2724,6 +2727,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device < 'c' ; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2734,6 +2738,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' > device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2744,6 +2749,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'c' >= device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device > 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2764,6 +2770,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = CURRENT_USER; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2774,6 +2781,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' < device; ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE 'b' <= device; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2786,6 +2794,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2798,6 +2807,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = 'a' OR device = 'b'; RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 05:00'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2808,6 +2818,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time = timestamptz('2020-01-01 0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = substring(CURRENT_USER,length(CURRENT_USER)+1) || 'c'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2823,6 +2834,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2847,6 +2859,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices3 d WHERE p.device=d.device; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2872,6 +2885,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2893,6 +2907,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown p USING devices d WHERE p.device=d.device AND d.device ='b'; SELECT * FROM test_pushdown p ORDER BY p; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown p (actual rows=0.00 loops=1)
@@ -2916,6 +2931,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2927,6 +2943,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN EXECUTE q1('a'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2945,6 +2962,7 @@ BEGIN; :EXPLAIN EXECUTE q1('not here'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2954,6 +2972,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a','d'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -2963,6 +2982,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = ANY('{a,d}'); ROLLBACK;
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 1
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2976,6 +2996,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',CURRENT_USER); RO
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-02'); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -2988,6 +3009,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time IN ('2020-01-01','2020-01-0
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3001,6 +3023,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device = current_query(); ROLLBA
 BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query()); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3016,6 +3039,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE device IN ('a',current_query());
 BEGIN; :EXPLAIN DELETE FROM test_pushdown; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3028,6 +3052,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
          Delete on _hyper_39_76_chunk test_pushdown_1
@@ -3045,6 +3070,7 @@ BEGIN; :EXPLAIN DELETE FROM test_pushdown WHERE time > '2019-01-01'; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 3
    ->  Delete on test_pushdown (actual rows=0.00 loops=1)
@@ -3137,6 +3163,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches deleted: 3
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
          Delete on _hyper_43_81_chunk delete_counter_1
@@ -3156,6 +3183,7 @@ BEGIN; :EXPLAIN DELETE FROM delete_counter WHERE random() < 1; ROLLBACK;
 BEGIN
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 3
    Batches decompressed: 3
    Tuples decompressed: 369
    ->  Delete on delete_counter (actual rows=0.00 loops=1)
@@ -3196,6 +3224,7 @@ BEGIN
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1
@@ -3214,6 +3243,7 @@ CREATE MATERIALIZED VIEW
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on cagg_inval (actual rows=0.00 loops=1)
          Delete on _hyper_45_86_chunk cagg_inval_1

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -580,6 +580,7 @@ SELECT count(*) FROM :CHUNK;
 EXPLAIN (analyze,buffers off,costs off,summary off,timing off) DELETE FROM :CHUNK WHERE time > '2025-01-01'::timestamptz;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches decompressed: 1
    Tuples decompressed: 101
    ->  Delete on _hyper_6_56_chunk (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/compress_unique_index.out
+++ b/tsl/test/shared/expected/compress_unique_index.out
@@ -27,6 +27,7 @@ ERROR:  duplicate key value violates unique constraint "_hyper_X_X_chunk_uniq_ex
 EXPLAIN (analyze,buffers off, costs off,summary off,timing off) INSERT INTO compress_unique VALUES ('2000-01-01','m1','c2','2000-01-02');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches filtered after decompression: 1
    ->  Insert on compress_unique (actual rows=0.00 loops=1)
          ->  Result (actual rows=1.00 loops=1)

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -209,6 +209,7 @@ SELECT count(compress_chunk(c)) FROM show_chunks('lazy_decompress') c;
 BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    ->  Insert on lazy_decompress (actual rows=0.00 loops=1)
          Conflict Resolution: NOTHING
          Tuples Inserted: 1
@@ -219,6 +220,7 @@ BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',r
 BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',random() ON CONFLICT(time,device) DO UPDATE SET value=EXCLUDED.value; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    ->  Insert on lazy_decompress (actual rows=0.00 loops=1)
          Conflict Resolution: UPDATE
          Conflict Arbiter Indexes: lazy_decompress_pkey
@@ -231,6 +233,7 @@ BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:00.5','d1',r
 BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:01','d1',random() ON CONFLICT DO NOTHING; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    ->  Insert on lazy_decompress (actual rows=0.00 loops=1)
          Conflict Resolution: NOTHING
          Tuples Inserted: 0
@@ -242,6 +245,7 @@ BEGIN; :ANALYZE INSERT INTO lazy_decompress SELECT '2024-01-01 0:00:01','d1',ran
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 6
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
          Update on _hyper_X_X_chunk lazy_decompress_1
@@ -252,6 +256,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0; ROLLBAC
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 6
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
          Update on _hyper_X_X_chunk lazy_decompress_1
@@ -263,6 +268,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND devi
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 2300; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -276,6 +282,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 2300; ROLL
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value > 3100 AND value < 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -289,6 +296,7 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value > 3100 AND v
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value BETWEEN 3100 AND 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -304,6 +312,7 @@ SET timescaledb.enable_dml_decompression_tuple_filtering TO off;
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 6000
    ->  Update on lazy_decompress (actual rows=0.00 loops=1)
@@ -318,6 +327,7 @@ RESET timescaledb.enable_dml_decompression_tuple_filtering;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 6
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk lazy_decompress_1
@@ -327,6 +337,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 6
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk lazy_decompress_1
@@ -337,6 +348,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROL
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 2300; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -349,6 +361,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 2300; ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value > 3100 AND value < 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -361,6 +374,7 @@ BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value > 3100 AND value < 3200;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value BETWEEN 3100 AND 3200; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 5
    Batches decompressed: 1
    Tuples decompressed: 1000
@@ -375,6 +389,7 @@ SET timescaledb.enable_dml_decompression_tuple_filtering TO off;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 6000
    ->  Delete on lazy_decompress (actual rows=0.00 loops=1)
@@ -419,6 +434,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE device='d1';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -437,6 +453,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE reading='r2';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -456,6 +473,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE reading <> 'r2';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -474,6 +492,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE reading IS NULL;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 2
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
@@ -493,6 +512,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE reading IS NOT NULL;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 6
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
@@ -512,6 +532,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE reading IN ('r1','r2');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -530,6 +551,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE reading NOT IN ('r1');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -549,6 +571,7 @@ BEGIN;
 :ANALYZE DELETE FROM direct_delete WHERE device='d1' AND reading='r2';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -566,6 +589,7 @@ ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE value = '1.0'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 8
    Batches deleted: 8
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -575,6 +599,7 @@ BEGIN; :ANALYZE DELETE FROM direct_delete WHERE value = '1.0'; ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1' AND value = '1.0'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches deleted: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -584,6 +609,7 @@ BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd1' AND value = '1.0';
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE reading = 'r1' AND value = '1.0'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -593,6 +619,7 @@ BEGIN; :ANALYZE DELETE FROM direct_delete WHERE reading = 'r1' AND value = '1.0'
 BEGIN; :ANALYZE DELETE FROM direct_delete WHERE device = 'd2' AND reading = 'r3' AND value = '1.0'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches deleted: 1
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
@@ -608,6 +635,7 @@ WARNING:  Trigger fired
 WARNING:  Trigger fired
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches decompressed: 4
    Tuples decompressed: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
@@ -625,6 +653,7 @@ WARNING:  Trigger fired
 WARNING:  Trigger fired
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches decompressed: 4
    Tuples decompressed: 4
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
@@ -665,6 +694,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading = 'r1';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 4
    Batches decompressed: 3
    Tuples decompressed: 7
    Batches deleted: 1
@@ -690,6 +720,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading <> 'r1';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches filtered after decompression: 2
    Batches decompressed: 3
    Tuples decompressed: 7
@@ -716,6 +747,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading IS NULL;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 11
    ->  Delete on compress_dml (actual rows=0.00 loops=1)
@@ -741,6 +773,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading IS NOT NULL;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 11
    ->  Delete on compress_dml (actual rows=0.00 loops=1)
@@ -761,6 +794,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading IN ('r2','r3');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 11
    ->  Delete on compress_dml (actual rows=0.00 loops=1)
@@ -785,6 +819,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading = ANY('{r2,r3}');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 11
    ->  Delete on compress_dml (actual rows=0.00 loops=1)
@@ -809,6 +844,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading NOT IN ('r2','r3');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 11
    ->  Delete on compress_dml (actual rows=0.00 loops=1)
@@ -833,6 +869,7 @@ BEGIN;
 :ANALYZE DELETE FROM compress_dml WHERE reading <> ALL('{r2,r3}');
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
    Batches decompressed: 6
    Tuples decompressed: 11
    ->  Delete on compress_dml (actual rows=0.00 loops=1)
@@ -937,6 +974,7 @@ RESET plan_cache_mode;
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where device_id IS NOT NULL AND device_id = 1;ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 14
    Batches decompressed: 14
    Tuples decompressed: 12076
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)
@@ -954,6 +992,7 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where device_id <> 1 AND device_id <> 2;ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 48
    Batches deleted: 48
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk metrics_compressed_1
@@ -971,6 +1010,7 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where device_id > 1 AND device_id < 3;ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 16
    Batches deleted: 16
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk metrics_compressed_1
@@ -987,6 +1027,7 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where v3 IS NOT NULL AND device_id IS NOT NULL AND device_id = 1;ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 14
    Batches decompressed: 14
    Tuples decompressed: 12076
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/decompress_tracking.out
+++ b/tsl/test/shared/expected/decompress_tracking.out
@@ -34,6 +34,7 @@ ANALYZE decompress_tracking;
 BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 5
    Batches decompressed: 5
    Tuples decompressed: 60
    ->  Update on decompress_tracking (actual rows=0.00 loops=1)
@@ -47,6 +48,7 @@ BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3; ROLLBA
 BEGIN; :EXPLAIN_ANALYZE UPDATE decompress_tracking SET value = value + 3 WHERE device = 'd2'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 20
    ->  Update on decompress_tracking (actual rows=0.00 loops=1)
@@ -63,6 +65,7 @@ SET timescaledb.enable_compressed_direct_batch_delete TO false;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 5
    Batches decompressed: 5
    Tuples decompressed: 60
    ->  Delete on decompress_tracking (actual rows=0.00 loops=1)
@@ -75,6 +78,7 @@ BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches decompressed: 2
    Tuples decompressed: 30
    ->  Delete on decompress_tracking (actual rows=0.00 loops=1)
@@ -90,6 +94,7 @@ RESET timescaledb.enable_compressed_direct_batch_delete;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 5
    Batches deleted: 5
    ->  Delete on decompress_tracking (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk decompress_tracking_1
@@ -101,6 +106,7 @@ BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking; ROLLBACK;
 BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches deleted: 2
    ->  Delete on decompress_tracking (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk decompress_tracking_1
@@ -114,6 +120,7 @@ BEGIN; :EXPLAIN_ANALYZE DELETE FROM decompress_tracking WHERE device = 'd3'; ROL
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30','d1',random(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    Batches filtered after decompression: 1
    ->  Insert on decompress_tracking (actual rows=0.00 loops=1)
          ->  Subquery Scan on "*SELECT*" (actual rows=1.00 loops=1)
@@ -122,6 +129,7 @@ BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01 1:30'
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d2',random(); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 1
    ->  Insert on decompress_tracking (actual rows=0.00 loops=1)
          ->  Subquery Scan on "*SELECT*" (actual rows=1.00 loops=1)
                ->  Result (actual rows=1.00 loops=1)
@@ -136,6 +144,7 @@ BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking SELECT '2020-01-01','d4'
 BEGIN; :EXPLAIN_ANALYZE INSERT INTO decompress_tracking (VALUES ('2020-01-01 1:30','d1',random()),('2020-01-01 1:30','d2',random())); ROLLBACK;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 2
    Batches filtered after decompression: 2
    ->  Insert on decompress_tracking (actual rows=0.00 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2.00 loops=1)


### PR DESCRIPTION
`batches_scanned` will be displayed as `Batches scanned:` like this <<<:

```
EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
UPDATE dml_test SET foo = foo+1 WHERE foo = 1001 AND boo = 1002; --- QUERY PLAN ---
 Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
   Batches scanned: 50   <<<
   Compressed batches filtered: 50
   Batches checked by bloom: 50
   Batches pruned by bloom: 50
   ->  Update on dml_test (actual rows=0.00 loops=1)
         Update on _hyper_1_1_chunk dml_test_1
         ->  Result (actual rows=0.00 loops=1)
               ->  Seq Scan on _hyper_1_1_chunk dml_test_1 (actual rows=0.00 loops=1)
                     Filter: ((foo = 1001) AND (boo = 1002))
```

This represents the compressed rows we scanned. With this, the filtered counters make more sense, because we can see the total.

Disable-check: force-changelog-file