### PR TITLE
Fix incorrect decompress markers on full batch delete

### DIFF
--- a/.unreleased/pr_9413
+++ b/.unreleased/pr_9413
@@ -1,0 +1,1 @@
+Fixes: #9413 Fix incorrect decompress markers on full batch delete

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -849,6 +849,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 		int pos = 0;
 		bool is_null_condition = 0;
 		bool seg_col_is_null = false;
+		bool complete_batch_delete;
 		valid = true;
 		/*
 		 * Since the heap scan API does not support SK_SEARCHNULL we have to check
@@ -982,6 +983,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 				continue;
 			}
 		}
+		complete_batch_delete = (delete_only && summary == AllRowsPass);
 
 		row_decompressor_reset(&decompressor);
 
@@ -993,7 +995,11 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			ExecDropSingleTupleTableSlot(slot);
 			return stats;
 		}
-		write_logical_replication_msg_decompression_start();
+
+		if (!complete_batch_delete)
+		{
+			write_logical_replication_msg_decompression_start();
+		}
 
 		TM_FailureData tmfd;
 		result = table_tuple_delete(in_rel,
@@ -1025,7 +1031,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			return stats;
 		}
 		/* If all rows pass, complete batch can be deleted */
-		if (delete_only && summary == AllRowsPass)
+		if (complete_batch_delete)
 		{
 			stats.batches_deleted++;
 			stats.tuples_deleted += DatumGetInt32(
@@ -1054,8 +1060,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			stats.tuples_decompressed +=
 				row_decompressor_decompress_row_to_table(&decompressor, &writer);
 			stats.batches_decompressed++;
+			write_logical_replication_msg_decompression_end();
 		}
-		write_logical_replication_msg_decompression_end();
 	}
 	ExecDropSingleTupleTableSlot(slot);
 	decompress_batch_endscan(scan);

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -189,6 +189,17 @@ table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time
 table _timescaledb_internal._hyper_1_1_chunk: DELETE: "time"[timestamp with time zone]:'2023-06-30 17:00:00-07' device_id[bigint]:1 value[double precision]:22)
 );
 
+run_queries(
+	qq(SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk'::regclass, TRUE);)
+);
+discard_wal();
+
+query_generates_wal(
+	"delete complete batch from a compressed chunk",
+	qq(DELETE FROM metrics WHERE device_id = 1;),
+	qq(table _timescaledb_internal.compress_hyper_2_3_chunk: DELETE: (no-tuple-data))
+);
+
 # switch to PK on time for insert with PK decompression test
 run_queries(
 	qq/


### PR DESCRIPTION
Internal compression and decompression operations write special markers in the WAL denoting the beginning and the end of series of primitive operations (inserts and deletes) on compressed and uncompressed chunks. This is used by logical replication subscribers to ignore internal operations that are not associated with data modification. However DELETE operations on compressed chunks that resulted in complete batch being deleted would still write special markers even though the data was modified, which would be incorrectly interpreted on the subscriber side.

Fixes #9397