### PR TITLE
Fix NULL compression handling in estimate_uncompressed_size

### DIFF
--- a/.unreleased/pr_9414
+++ b/.unreleased/pr_9414
@@ -1,0 +1,1 @@
+Fixes: #9414 Fix NULL compression handling in estimate_uncompressed_size

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2470,6 +2470,12 @@ tsl_compressed_data_column_size(PG_FUNCTION_ARGS)
 	/* Get compressed data header and validate */
 	header = get_compressed_data_header(compressed_data);
 
+	if (header->compression_algorithm == COMPRESSION_ALGORITHM_NULL)
+	{
+		/* All values are NULL, so size is 0 */
+		PG_RETURN_INT32(0);
+	}
+
 	/* Initialize the decompression iterator */
 	iter = definitions[header->compression_algorithm].iterator_init_forward(PointerGetDatum(header),
 																			element_type);

--- a/tsl/test/expected/uncompressed_size.out
+++ b/tsl/test/expected/uncompressed_size.out
@@ -25,3 +25,24 @@ SELECT ccs.compressed_chunk_id, l.relation_size, l.index_size, l.total_size FROM
                    3 |       5980000 |    2000000 |    7980000
                    4 |       5520000 |    2000000 |    7520000
 
+-- test NULL compression does not error and returns NULL
+INSERT INTO t1 SELECT '2026-01-01'::timestamptz + format('%s ms', i)::interval, NULL, NULL FROM generate_series(1, 3000) i;
+SELECT compress_chunk(chunk) FROM show_chunks('t1') AS chunk;
+NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+
+SELECT _timescaledb_functions.compressed_data_info(time), _timescaledb_functions.compressed_data_info(device), _timescaledb_functions.compressed_data_info(value) FROM _timescaledb_internal.compress_hyper_2_6_chunk;
+ compressed_data_info | compressed_data_info | compressed_data_info 
+----------------------+----------------------+----------------------
+ (DELTADELTA,f)       | (NULL,t)             | (NULL,t)
+ (DELTADELTA,f)       | (NULL,t)             | (NULL,t)
+ (DELTADELTA,f)       | (NULL,t)             | (NULL,t)
+
+SELECT * FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_6_chunk');
+ tuples | relation_size | index_size | total_size 
+--------+---------------+------------+------------
+   3000 |        138000 |      60000 |     198000
+

--- a/tsl/test/sql/uncompressed_size.sql
+++ b/tsl/test/sql/uncompressed_size.sql
@@ -17,3 +17,8 @@ SELECT compress_chunk(chunk) FROM show_chunks('t2') AS chunk;
 
 SELECT ccs.compressed_chunk_id, l.relation_size, l.index_size, l.total_size FROM _timescaledb_catalog.compression_chunk_size ccs JOIN _timescaledb_catalog.chunk ch ON ch.id=ccs.compressed_chunk_id JOIN LATERAL (SELECT * FROM _timescaledb_functions.estimate_uncompressed_size(format('%I.%I',ch.schema_name,ch.table_name))) l ON true;
 
+-- test NULL compression does not error and returns NULL
+INSERT INTO t1 SELECT '2026-01-01'::timestamptz + format('%s ms', i)::interval, NULL, NULL FROM generate_series(1, 3000) i;
+SELECT compress_chunk(chunk) FROM show_chunks('t1') AS chunk;
+SELECT _timescaledb_functions.compressed_data_info(time), _timescaledb_functions.compressed_data_info(device), _timescaledb_functions.compressed_data_info(value) FROM _timescaledb_internal.compress_hyper_2_6_chunk;
+SELECT * FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_6_chunk');


### PR DESCRIPTION
Previously estimate_uncompressed_size would error out with
`null decompression iterator not implemented`
