### PR TITLE
Don't lose other clauses when using IN for chunk exclusion

### DIFF
--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -155,10 +155,18 @@ dimension_restrict_info_open_add(DimensionRestrictInfoOpen *dri, StrategyNumber 
 			if (value > max_val)
 				max_val = value;
 		}
-		dri->lower_bound = min_val;
-		dri->upper_bound = max_val;
-		dri->lower_strategy = BTGreaterEqualStrategyNumber;
-		dri->upper_strategy = BTLessEqualStrategyNumber;
+
+		DimensionValues range_values = (DimensionValues) {
+			.values = list_make1(DatumGetPointer(Int64GetDatum(min_val))),
+			.use_or = false,
+			.type = dimvalues->type
+		};
+
+		dimension_restrict_info_open_add(dri, BTGreaterEqualStrategyNumber, &range_values);
+
+		linitial(range_values.values) = DatumGetPointer(Int64GetDatum(max_val));
+		dimension_restrict_info_open_add(dri, BTLessEqualStrategyNumber, &range_values);
+
 		return true;
 	}
 

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -156,11 +156,10 @@ dimension_restrict_info_open_add(DimensionRestrictInfoOpen *dri, StrategyNumber 
 				max_val = value;
 		}
 
-		DimensionValues range_values = (DimensionValues) {
-			.values = list_make1(DatumGetPointer(Int64GetDatum(min_val))),
-			.use_or = false,
-			.type = dimvalues->type
-		};
+		DimensionValues range_values =
+			(DimensionValues){ .values = list_make1(DatumGetPointer(Int64GetDatum(min_val))),
+							   .use_or = false,
+							   .type = dimvalues->type };
 
 		dimension_restrict_info_open_add(dri, BTGreaterEqualStrategyNumber, &range_values);
 

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -573,6 +573,20 @@ Time dimension chunk exclusion with IN/ANY equality uses bounding range
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: ("time" = ANY ('{25,15,5}'::integer[]))
 
+:PREFIX SELECT * FROM hyper WHERE time < 10 AND time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) AND time < 10 ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
 :PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
 --- QUERY PLAN ---
  Sort

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -573,6 +573,20 @@ Time dimension chunk exclusion with IN/ANY equality uses bounding range
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: ("time" = ANY ('{25,15,5}'::integer[]))
 
+:PREFIX SELECT * FROM hyper WHERE time < 10 AND time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) AND time < 10 ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
 :PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
 --- QUERY PLAN ---
  Sort

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -573,6 +573,20 @@ Time dimension chunk exclusion with IN/ANY equality uses bounding range
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: ("time" = ANY ('{25,15,5}'::integer[]))
 
+:PREFIX SELECT * FROM hyper WHERE time < 10 AND time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) AND time < 10 ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
 :PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
 --- QUERY PLAN ---
  Sort

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -573,6 +573,20 @@ Time dimension chunk exclusion with IN/ANY equality uses bounding range
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: ("time" = ANY ('{25,15,5}'::integer[]))
 
+:PREFIX SELECT * FROM hyper WHERE time < 10 AND time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) AND time < 10 ORDER BY value;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Seq Scan on _hyper_1_1_chunk
+         Filter: (("time" < 10) AND ("time" = ANY ('{5,15,25}'::integer[])))
+
 :PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
 --- QUERY PLAN ---
  Sort

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -109,6 +109,8 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM hyper WHERE time IN (5, 15) ORDER BY value;
 :PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
 :PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[25, 15, 5]) ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE time < 10 AND time = ANY(ARRAY[5, 15, 25]) ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE time = ANY(ARRAY[5, 15, 25]) AND time < 10 ORDER BY value;
 :PREFIX SELECT * FROM hyper_w_space WHERE time IN (5, 15) ORDER BY value;
 :PREFIX SELECT * FROM metrics_timestamp WHERE time IN ('2000-01-05'::timestamp, '2000-01-15'::timestamp) ORDER BY time;
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time IN ('2000-01-05'::timestamptz, '2000-01-15'::timestamptz) ORDER BY time;


### PR DESCRIPTION
At the moment we're just overwriting the entire dimension restriction when seeing a single IN clause which loses the dimension restrictions collected from other clauses.

The original PR https://github.com/timescale/timescaledb/pull/9398 is in 2.26.0, so need to backport the fix. No changelog entry is required because the bug is not released.

Disable-check: force-changelog-file