### PR TITLE
Fix: remove columnstore policy when disabling compression (#8960)

### DIFF
--- a/.unreleased/pr_9422
+++ b/.unreleased/pr_9422
@@ -1,0 +1,1 @@
+Fixes: #8960 Remove columnstore policy when disabling columnstore on a hypertable

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -36,7 +36,9 @@
 #include <utils/typcache.h>
 
 #include "compat/compat.h"
+#include "bgw/job.h"
 #include "bgw_policy/policies_v2.h"
+#include "extension_constants.h"
 #include "chunk.h"
 #include "chunk_index.h"
 #include "compression.h"
@@ -1039,6 +1041,16 @@ disable_compression(Hypertable *ht, WithClauseResult *with_clause_options)
 	}
 
 	ts_compression_settings_delete(ht->main_table_relid);
+
+	/* If a columnstore policy is attached, drop it so it does not continue
+	 * running against a hypertable that no longer has columnstore enabled.
+	 * Check first to avoid emitting a "policy not found" NOTICE in the common
+	 * case where no policy is attached. */
+	List *compression_jobs = ts_bgw_job_find_by_proc_and_hypertable_id(POLICY_COMPRESSION_PROC_NAME,
+																	   FUNCTIONS_SCHEMA_NAME,
+																	   ht->fd.id);
+	if (compression_jobs != NIL)
+		policy_compression_remove_internal(ht->main_table_relid, true);
 
 	return true;
 }

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1050,7 +1050,7 @@ disable_compression(Hypertable *ht, WithClauseResult *with_clause_options)
 																	   FUNCTIONS_SCHEMA_NAME,
 																	   ht->fd.id);
 	if (compression_jobs != NIL)
-		policy_compression_remove_internal(ht->main_table_relid, true);
+		policy_compression_remove_internal(ht->main_table_relid, false);
 
 	return true;
 }

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -563,10 +563,13 @@ select add_compression_policy('test1', interval '1 day');
 \set ON_ERROR_STOP 0
 ALTER table test1 set (timescaledb.compress='f');
 \set ON_ERROR_STOP 1
-select remove_compression_policy('test1');
+-- Disabling columnstore removes any attached columnstore policy, so the
+-- explicit remove call below is a no-op and must use if_exists => true.
+select remove_compression_policy('test1', if_exists => true);
+NOTICE:  columnstore policy not found for hypertable "test1", skipping
  remove_compression_policy 
 ---------------------------
- t
+ f
 
 ALTER table test1 set (timescaledb.compress='f');
 --only one hypertable left

--- a/tsl/test/expected/compression_policy_on_disable.out
+++ b/tsl/test/expected/compression_policy_on_disable.out
@@ -1,0 +1,38 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test that disabling columnstore on a hypertable automatically removes
+-- any associated columnstore policy (regression test for issue #8960).
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE compress_policy_disable_test (
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+);
+SELECT create_hypertable('compress_policy_disable_test', 'time');
+             create_hypertable             
+-------------------------------------------
+ (1,public,compress_policy_disable_test,t)
+
+ALTER TABLE compress_policy_disable_test SET (timescaledb.compress = true);
+-- Add a compression policy
+SELECT add_compression_policy('compress_policy_disable_test', '7 days'::interval) AS policyid \gset
+-- Verify the policy exists before disabling compression
+SELECT count(*) AS policy_count
+FROM _timescaledb_catalog.bgw_job
+WHERE id = :policyid;
+ policy_count 
+--------------
+            1
+
+-- Disable columnstore/compression — this should also remove the policy
+ALTER TABLE compress_policy_disable_test SET (timescaledb.compress = 'f');
+-- Verify the policy has been removed (should be 0 after fix)
+SELECT count(*) AS policy_count
+FROM _timescaledb_catalog.bgw_job
+WHERE id = :policyid;
+ policy_count 
+--------------
+            0
+
+DROP TABLE compress_policy_disable_test;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -143,6 +143,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compress_composite_bloom_debug.sql
     compression_algos.sql
     compression_bgw.sql
+    compression_policy_on_disable.sql
     compression_bools.sql
     compression_bool_vectorized.sql
     compression_ddl.sql

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -391,7 +391,9 @@ select add_compression_policy('test1', interval '1 day');
 ALTER table test1 set (timescaledb.compress='f');
 \set ON_ERROR_STOP 1
 
-select remove_compression_policy('test1');
+-- Disabling columnstore removes any attached columnstore policy, so the
+-- explicit remove call below is a no-op and must use if_exists => true.
+select remove_compression_policy('test1', if_exists => true);
 ALTER table test1 set (timescaledb.compress='f');
 
 --only one hypertable left

--- a/tsl/test/sql/compression_policy_on_disable.sql
+++ b/tsl/test/sql/compression_policy_on_disable.sql
@@ -1,0 +1,35 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test that disabling columnstore on a hypertable automatically removes
+-- any associated columnstore policy (regression test for issue #8960).
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE compress_policy_disable_test (
+    time TIMESTAMPTZ NOT NULL,
+    device TEXT,
+    value FLOAT
+);
+SELECT create_hypertable('compress_policy_disable_test', 'time');
+
+ALTER TABLE compress_policy_disable_test SET (timescaledb.compress = true);
+
+-- Add a compression policy
+SELECT add_compression_policy('compress_policy_disable_test', '7 days'::interval) AS policyid \gset
+
+-- Verify the policy exists before disabling compression
+SELECT count(*) AS policy_count
+FROM _timescaledb_catalog.bgw_job
+WHERE id = :policyid;
+
+-- Disable columnstore/compression — this should also remove the policy
+ALTER TABLE compress_policy_disable_test SET (timescaledb.compress = 'f');
+
+-- Verify the policy has been removed (should be 0 after fix)
+SELECT count(*) AS policy_count
+FROM _timescaledb_catalog.bgw_job
+WHERE id = :policyid;
+
+DROP TABLE compress_policy_disable_test;


### PR DESCRIPTION
Fixes #8960

When compression is disabled via `ALTER TABLE ... SET (timescaledb.compress = 'f')`, any existing columnstore policy job should be removed.

This PR updates `disable_compression()` to remove the policy with `policy_compression_remove_internal(..., true)` and adds a regression test (`compression_policy_on_disable`) to verify the policy row is gone after disabling compression.