### PR TITLE
Emit NOTICE when segmentby is auto-selected for columnstore (#9217)

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1438,6 +1438,12 @@ compression_setting_segmentby_get_default(const Hypertable *ht)
 		 get_namespace_name(get_func_namespace(default_segmentby_fn)),
 		 get_func_name(default_segmentby_fn),
 		 confidence);
+
+	if (result.data[0] != '\0')
+		ereport(NOTICE,
+				(errmsg("automatically selected \"%s\" as the default segmentby for columnstore",
+						result.data)));
+
 	pfree(result.data);
 	return column_res;
 }

--- a/tsl/test/expected/compression_defaults.out
+++ b/tsl/test/expected/compression_defaults.out
@@ -39,6 +39,33 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY['devi
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
  count 
 -------
     27
@@ -105,6 +132,33 @@ RESET timescaledb.compression_segmentby_default_function;
 SET timescaledb.compression_orderby_default_function = '';
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
  count 
 -------
     27
@@ -216,6 +270,33 @@ SELECT _timescaledb_functions.get_orderby_defaults('public.metrics', ARRAY[]::te
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
  count 
 -------
     27
@@ -470,6 +551,44 @@ SELECT _timescaledb_functions.get_segmentby_defaults('public.metrics');
 
 ALTER TABLE metrics SET (timescaledb.compress = true);
 select count(compress_chunk(x)) from show_chunks('metrics') x;
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id2" as the default segmentby for columnstore
  count 
 -------
     38
@@ -758,6 +877,16 @@ SELECT _timescaledb_functions.get_segmentby_defaults('public.test_exclude_datety
 
 ALTER TABLE test_exclude_datetype SET (timescaledb.compress = true);
 SELECT count(compress_chunk(x)) FROM show_chunks('test_exclude_datetype') x;
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
+NOTICE:  automatically selected "device_id" as the default segmentby for columnstore
  count 
 -------
     10


### PR DESCRIPTION
Closes #9217

## What this does

When a hypertable uses lazy compression settings (no explicit `segmentby` specified), the algorithm silently picks the best column. This PR adds a `NOTICE` so users know which column was chosen, consistent with how other auto-configuration decisions in TimescaleDB are communicated.

## Change

One `ereport(NOTICE, ...)` call added in `compression_setting_segmentby_get_default()` (tsl/src/compression/create.c), reusing the string that was already built for the existing `LOG_SERVER_ONLY` elog.

The guard `result.data[0] != '\0'` skips the NOTICE when no suitable column was found, avoiding a confusing empty-string message.

## Test

```sql
CREATE TABLE t (time TIMESTAMPTZ NOT NULL, device_id INT, val FLOAT)
  WITH (tsdb.hypertable, tsdb.partition_column='time', tsdb.enable_columnstore);
CREATE INDEX ON t (device_id);
INSERT INTO t SELECT ...;
SELECT compress_chunk(i) FROM show_chunks('t') i LIMIT 1;
-- NOTICE: automatically selected "device_id" as the default segmentby for columnstore
```