### PR TITLE
Sanitize DT_NOBEGIN next_start to fix jobs stuck after failover (#9360)

### DIFF
--- a/.unreleased/pr_9424
+++ b/.unreleased/pr_9424
@@ -1,0 +1,1 @@
+Fixes: #9360 Sanitize DT_NOBEGIN next_start to recover jobs stuck after primary failover

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -815,5 +815,16 @@ ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job, int32 consecutive_f
 		return calculate_next_start_on_crash(jobstat->fd.consecutive_crashes, job);
 	}
 
+	/*
+	 * A next_start of DT_NOBEGIN in a persisted job stat row means the value
+	 * was never legitimately set — this can happen after a primary failover
+	 * where the replica inherits sentinel values from a job that was running
+	 * when the primary crashed.  Propagating DT_NOBEGIN downstream causes
+	 * ts_bgw_job_stat_upsert_next_start to error ("next_start cannot be
+	 * -infinity"), leaving the job permanently stuck.  Treat it as "run now".
+	 */
+	if (jobstat->fd.next_start == DT_NOBEGIN)
+		return GetCurrentTimestamp();
+
 	return jobstat->fd.next_start;
 }

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -42,6 +42,8 @@ TS_FUNCTION_INFO_V1(ts_bgw_db_scheduler_test_main);
 TS_FUNCTION_INFO_V1(ts_bgw_job_execute_test);
 /* function for testing the correctness of the next_scheduled_slot calculation */
 TS_FUNCTION_INFO_V1(ts_test_next_scheduled_execution_slot);
+/* function for directly observing ts_bgw_job_stat_next_start's return value */
+TS_FUNCTION_INFO_V1(ts_test_bgw_job_stat_next_start);
 
 typedef enum TestJobType
 {
@@ -152,6 +154,33 @@ ts_test_next_scheduled_execution_slot(PG_FUNCTION_ARGS)
 		result = DirectFunctionCall2(timestamptz_pl_interval, result, schedint_datum);
 	}
 	return result;
+}
+
+/*
+ * Expose ts_bgw_job_stat_next_start to SQL so tests can assert on its return
+ * value directly. This is needed to verify fixes to that function that would
+ * otherwise be masked by downstream paths (e.g. mark_end) overwriting the
+ * next_start before any assertion against the persisted row is visible.
+ *
+ * Takes a job_id and the consecutive_failed_launches parameter (to mirror the
+ * scheduler's call site at scheduler.c:301) and returns the computed next
+ * start timestamp.
+ */
+extern Datum
+ts_test_bgw_job_stat_next_start(PG_FUNCTION_ARGS)
+{
+	int32 job_id = PG_GETARG_INT32(0);
+	int32 consecutive_failed_launches = PG_ARGISNULL(1) ? 0 : PG_GETARG_INT32(1);
+
+	BgwJob *job = ts_bgw_job_find(job_id, CurrentMemoryContext, true);
+	if (job == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("job %d not found", job_id)));
+
+	BgwJobStat *jobstat = ts_bgw_job_stat_find(job_id);
+
+	PG_RETURN_TIMESTAMPTZ(
+		ts_bgw_job_stat_next_start(jobstat, job, consecutive_failed_launches));
 }
 
 extern Datum

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -904,6 +904,34 @@ SELECT * FROM sorted_bgw_log;
       0 | test_job_3_long  | Before sleep job 3
       1 | test_job_3_long  | After sleep job 3
 
+-- Simulate a failover-inherited sentinel (next_start = -infinity) with no
+-- crash counter. ts_bgw_job_stat_next_start must sanitize DT_NOBEGIN rather
+-- than propagate it, otherwise on_failure_to_start_job's
+-- `sjob->next_start != DT_NOBEGIN` guard (scheduler.c) would skip the
+-- set_next_start call and leave the job's DB row stuck at -infinity.
+CREATE FUNCTION ts_test_bgw_job_stat_next_start(
+    job_id INT4,
+    consecutive_failed_launches INT4 DEFAULT 0)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+UPDATE _timescaledb_internal.bgw_job_stat
+SET next_start = '-infinity', consecutive_crashes = 0
+WHERE job_id = 1005;
+SELECT job_id,
+       (next_start = '-infinity'::timestamptz) AS next_start_is_infinity
+FROM _timescaledb_internal.bgw_job_stat
+WHERE job_id = 1005;
+ job_id | next_start_is_infinity
+--------+------------------------
+   1005 | t
+
+-- Directly observe the function's return value: must not be -infinity.
+SELECT (ts_test_bgw_job_stat_next_start(1005) = '-infinity'::timestamptz)
+         AS returns_infinity;
+ returns_infinity
+------------------
+ f
+
+DROP FUNCTION ts_test_bgw_job_stat_next_start(INT4, INT4);
 CREATE FUNCTION wait_for_timer_to_run(started_at INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -408,6 +408,31 @@ SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_succ
 FROM _timescaledb_internal.bgw_job_stat;
 SELECT * FROM sorted_bgw_log;
 
+-- Simulate a failover-inherited sentinel (next_start = -infinity) with no
+-- crash counter. ts_bgw_job_stat_next_start must sanitize DT_NOBEGIN rather
+-- than propagate it, otherwise on_failure_to_start_job's
+-- `sjob->next_start != DT_NOBEGIN` guard (scheduler.c) would skip the
+-- set_next_start call and leave the job's DB row stuck at -infinity.
+CREATE FUNCTION ts_test_bgw_job_stat_next_start(
+    job_id INT4,
+    consecutive_failed_launches INT4 DEFAULT 0)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+UPDATE _timescaledb_internal.bgw_job_stat
+SET next_start = '-infinity', consecutive_crashes = 0
+WHERE job_id = 1005;
+
+SELECT job_id,
+       (next_start = '-infinity'::timestamptz) AS next_start_is_infinity
+FROM _timescaledb_internal.bgw_job_stat
+WHERE job_id = 1005;
+
+-- Directly observe the function's return value: must not be -infinity.
+SELECT (ts_test_bgw_job_stat_next_start(1005) = '-infinity'::timestamptz)
+         AS returns_infinity;
+
+DROP FUNCTION ts_test_bgw_job_stat_next_start(INT4, INT4);
+
 
 CREATE FUNCTION wait_for_timer_to_run(started_at INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$


### PR DESCRIPTION
Closes #9360

## Problem

After a primary failover, bgw job stat rows can have `next_start = -infinity` (DT_NOBEGIN) inherited from a job that was mid-execution when the primary crashed. `ts_bgw_job_stat_upsert_next_start` explicitly rejects DT_NOBEGIN values, causing an error on the first scheduling cycle and leaving the job permanently stuck.

## Fix

In `ts_bgw_job_stat_next_start()` (src/bgw/job_stat.c): when `consecutive_crashes == 0` and the stored `next_start` is DT_NOBEGIN, return `GetCurrentTimestamp()` instead of propagating the sentinel. This causes the job to run immediately on the next cycle.

The existing crash-backoff path (`consecutive_crashes > 0`) is unchanged — it already calculates a proper backoff timestamp.