### PR TITLE
Fix segfault in Vectorized Aggregation

### DIFF
--- a/tsl/src/nodes/vector_agg/plan.c
+++ b/tsl/src/nodes/vector_agg/plan.c
@@ -12,6 +12,7 @@
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
 #include <nodes/plannodes.h>
+#include <optimizer/optimizer.h>
 #include <optimizer/planner.h>
 #include <parser/parsetree.h>
 #include <utils/fmgroids.h>
@@ -625,12 +626,47 @@ insert_vector_agg(Plan *plan, void *context)
 	}
 
 	/*
+	 * When converting AGGSPLIT_SIMPLE to partial+finalize, the finalize Agg
+	 * needs all grouping columns in its input (VectorAgg output). The Agg's
+	 * output targetlist may not include grouping columns that aren't needed by
+	 * parent nodes. Add any missing ones before validation so they are checked
+	 * for vectorizability. If validation fails, undo the modification.
+	 */
+	List *partial_agg_targetlist = list_copy(agg->plan.targetlist);
+	if (agg->aggsplit == AGGSPLIT_SIMPLE)
+	{
+		Bitmapset *tlist_attnos = NULL;
+		pull_varattnos((Node *) agg->plan.targetlist, OUTER_VAR, &tlist_attnos);
+
+		for (int k = 0; k < agg->numCols; k++)
+		{
+			AttrNumber grp_attno = agg->grpColIdx[k];
+			if (bms_is_member(grp_attno - FirstLowInvalidHeapAttributeNumber, tlist_attnos))
+				continue;
+
+			TargetEntry *child_tle =
+				list_nth(childplan->targetlist, AttrNumberGetAttrOffset(grp_attno));
+			AttrNumber new_resno = AttrOffsetGetAttrNumber(list_length(partial_agg_targetlist));
+			Var *var = makeVar(OUTER_VAR,
+							   grp_attno,
+							   exprType((Node *) child_tle->expr),
+							   exprTypmod((Node *) child_tle->expr),
+							   exprCollation((Node *) child_tle->expr),
+							   0);
+			partial_agg_targetlist =
+				lappend(partial_agg_targetlist,
+						makeTargetEntry((Expr *) var, new_resno, child_tle->resname, true));
+		}
+		bms_free(tlist_attnos);
+	}
+
+	/*
 	 * To make it easier to examine the variables participating in the aggregation,
 	 * the subsequent checks are performed on the aggregated targetlist with
 	 * all variables resolved to uncompressed chunk variables.
 	 */
 	List *resolved_targetlist =
-		castNode(List, ts_resolve_outer_special_vars((Node *) agg->plan.targetlist, childplan));
+		castNode(List, ts_resolve_outer_special_vars((Node *) partial_agg_targetlist, childplan));
 
 	const VectorAggGroupingType grouping_type =
 		get_vectorized_grouping_type(&vqi, agg, resolved_targetlist);
@@ -673,6 +709,7 @@ insert_vector_agg(Plan *plan, void *context)
 	 * Finally, all requirements are satisfied and we can vectorize this
 	 * aggregation node.
 	 */
+	agg->plan.targetlist = partial_agg_targetlist;
 	Plan *vector_agg_plan =
 		vector_agg_plan_create(childplan, agg, resolved_targetlist, grouping_type);
 

--- a/tsl/test/expected/vector_agg_planning-15.out
+++ b/tsl/test/expected/vector_agg_planning-15.out
@@ -196,6 +196,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Seq Scan on compress_hyper_2_2_chunk
 
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
+
 -- run queries with single chunk
 \set EXPLAIN ''
 \set ECHO errors
@@ -471,6 +484,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
                ->  Custom Scan (VectorAgg)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                            ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
 
 \set EXPLAIN ''
 \set ECHO errors

--- a/tsl/test/expected/vector_agg_planning-16.out
+++ b/tsl/test/expected/vector_agg_planning-16.out
@@ -195,6 +195,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Seq Scan on compress_hyper_2_2_chunk
 
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
+
 -- run queries with single chunk
 \set EXPLAIN ''
 \set ECHO errors
@@ -469,6 +482,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
                ->  Custom Scan (VectorAgg)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                            ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
 
 \set EXPLAIN ''
 \set ECHO errors

--- a/tsl/test/expected/vector_agg_planning-17.out
+++ b/tsl/test/expected/vector_agg_planning-17.out
@@ -195,6 +195,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Seq Scan on compress_hyper_2_2_chunk
 
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
+
 -- run queries with single chunk
 \set EXPLAIN ''
 \set ECHO errors
@@ -469,6 +482,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
                ->  Custom Scan (VectorAgg)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                            ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
 
 \set EXPLAIN ''
 \set ECHO errors

--- a/tsl/test/expected/vector_agg_planning-18.out
+++ b/tsl/test/expected/vector_agg_planning-18.out
@@ -195,6 +195,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Seq Scan on compress_hyper_2_2_chunk
 
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
+
 -- run queries with single chunk
 \set EXPLAIN ''
 \set ECHO errors
@@ -469,6 +482,19 @@ SHOW timescaledb.enable_vectorized_aggregation;
                ->  Custom Scan (VectorAgg)
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                            ->  Seq Scan on compress_hyper_2_4_chunk
+
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+--- QUERY PLAN ---
+ Hash Join
+   Hash Cond: (CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END = (12))
+   ->  HashAggregate
+         Group Key: CASE WHEN (_hyper_1_1_chunk.value = '1'::double precision) THEN NULL::smallint ELSE NULL::smallint END
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_2_chunk
+   ->  Hash
+         ->  Limit
+               ->  Seq Scan on pg_class
 
 \set EXPLAIN ''
 \set ECHO errors

--- a/tsl/test/sql/include/vector_agg_planning_query.sql
+++ b/tsl/test/sql/include/vector_agg_planning_query.sql
@@ -43,3 +43,6 @@ SHOW timescaledb.enable_vectorized_aggregation;
 -- HAVING with segmentby grouping.
 :EXPLAIN SELECT device, sum(value) from metrics GROUP BY device HAVING sum(value) > 10000 ORDER BY device;
 
+-- Correlated Subquery on single chunk
+:EXPLAIN SELECT FROM (SELECT 12 AS c7 FROM pg_class LIMIT 1) AS subq_1 WHERE EXISTS(SELECT FROM _timescaledb_internal._hyper_1_1_chunk WHERE subq_1.c7 = CASE WHEN value = 1 THEN NULL::int2 END);
+


### PR DESCRIPTION
When converting AGGSPLIT_SIMPLE to partial+finalize, the finalize Agg
needs all grouping columns in its input (VectorAgg output).
set_plan_refs prunes unused columns from the Agg's output targetlist
since the parent doesn't use it, but grpColIdx still references it for
hashing. When VectorAgg converts this to partial+finalize, the stale
grpColIdx entry points past the VectorAgg output, crashing in
find_hash_columns.

Found by sqlsmith

Disable-check: force-changelog-file