### PR TITLE
Bump mininum release age for renovate to 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "matchUpdateTypes": ["patch", "minor", "major", "digest"],
       "groupName": "dependencies",
       "schedule": ["on monday"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     }
   ],
   "pinDigests": true


### PR DESCRIPTION
Since the 3 days include the weekend bump the mininum release age
to 7 days.

Disable-check: force-changelog-file
Disable-check: approval-count