### PR TITLE
Run compression after continuous aggregate refresh policy

### DIFF
--- a/.unreleased/pr_9437
+++ b/.unreleased/pr_9437
@@ -1,0 +1,1 @@
+Implements: #9437 Allow running compression as part of refresh policy for compressed continuous aggregates

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -38,6 +38,8 @@
 #define DEFAULT_MAX_BATCHES_PER_EXECUTION 0
 /* Default refresh newest first is true, which means from newest data to the oldest */
 #define DEFAULT_REFRESH_NEWEST_FIRST true
+/* Default compress after refresh is false, which means compression does not run after refresh */
+#define DEFAULT_COMPRESS_AFTER_REFRESH false
 
 int32
 policy_continuous_aggregate_get_mat_hypertable_id(const Jsonb *config)
@@ -184,6 +186,18 @@ policy_refresh_cagg_get_refresh_newest_first(const Jsonb *config)
 
 	if (!found)
 		res = DEFAULT_REFRESH_NEWEST_FIRST; /* default value */
+
+	return res;
+}
+
+bool
+policy_refresh_cagg_get_compress_after_refresh(const Jsonb *config)
+{
+	bool found;
+	bool res = ts_jsonb_get_bool_field(config, POL_REFRESH_CONF_KEY_COMPRESS_AFTER_REFRESH, &found);
+
+	if (!found)
+		res = DEFAULT_COMPRESS_AFTER_REFRESH; /* default value */
 
 	return res;
 }

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -32,6 +32,7 @@ bool policy_refresh_cagg_get_include_tiered_data(const Jsonb *config, bool *isnu
 int32 policy_refresh_cagg_get_buckets_per_batch(const Jsonb *config);
 int32 policy_refresh_cagg_get_max_batches_per_execution(const Jsonb *config);
 bool policy_refresh_cagg_get_refresh_newest_first(const Jsonb *config);
+bool policy_refresh_cagg_get_compress_after_refresh(const Jsonb *config);
 bool policy_refresh_cagg_exists(int32 materialization_id);
 
 Datum policy_refresh_cagg_add_internal(

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -484,6 +484,67 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 						PGC_S_SESSION);
 	}
 
+	/* Compress chunks that need it after the refresh if the cagg has compression enabled */
+	Hypertable *mat_ht = ts_hypertable_get_by_id(policy_data.cagg->data.mat_hypertable_id);
+
+	if (policy_data.compress_after_refresh && mat_ht &&
+		TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(mat_ht))
+	{
+		const Dimension *dim = hyperspace_get_open_dimension(mat_ht->space, 0);
+
+		StrategyNumber start_strategy = InvalidStrategy;
+		int64 start_value = -1;
+		StrategyNumber end_strategy = InvalidStrategy;
+		int64 end_value = -1;
+
+		if (!policy_data.refresh_window.start_isnull)
+		{
+			start_strategy = BTGreaterEqualStrategyNumber;
+			start_value = policy_data.refresh_window.start;
+		}
+		if (!policy_data.refresh_window.end_isnull)
+		{
+			end_strategy = BTLessStrategyNumber;
+			end_value = policy_data.refresh_window.end;
+		}
+
+		List *chunkid_lst = ts_dimension_slice_get_chunkids_to_compress(dim->fd.id,
+																		start_strategy,
+																		start_value,
+																		end_strategy,
+																		end_value,
+																		true, /* compress */
+																		true, /* recompress */
+																		0);	  /* all chunks */
+
+		if (chunkid_lst)
+		{
+			if (ActiveSnapshotSet())
+				PopActiveSnapshot();
+
+			/* Process each chunk in its own transaction */
+			foreach (lc, chunkid_lst)
+			{
+				PushActiveSnapshot(GetTransactionSnapshot());
+
+				int32 chunkid = lfirst_int(lc);
+				Chunk *chunk = ts_chunk_get_by_id(chunkid, true /* fail_if_not_found */);
+				tsl_compress_chunk_wrapper(chunk,
+										   true /* if_not_compressed */,
+										   false /* recompress */);
+
+				elog(DEBUG1,
+					 "compressed chunk \"%s.%s\" after continuous aggregate refresh",
+					 NameStr(chunk->fd.schema_name),
+					 NameStr(chunk->fd.table_name));
+
+				PopActiveSnapshot();
+				CommitTransactionCommand();
+				StartTransactionCommand();
+			}
+		}
+	}
+
 	return true;
 }
 
@@ -549,6 +610,8 @@ policy_refresh_cagg_read_and_validate_config(Jsonb *config, PolicyContinuousAggD
 
 	refresh_newest_first = policy_refresh_cagg_get_refresh_newest_first(config);
 
+	bool compress_after_refresh = policy_refresh_cagg_get_compress_after_refresh(config);
+
 	if (policy_data)
 	{
 		policy_data->refresh_window.type = dim_type;
@@ -562,6 +625,7 @@ policy_refresh_cagg_read_and_validate_config(Jsonb *config, PolicyContinuousAggD
 		policy_data->buckets_per_batch = buckets_per_batch;
 		policy_data->max_batches_per_execution = max_batches_per_execution;
 		policy_data->refresh_newest_first = refresh_newest_first;
+		policy_data->compress_after_refresh = compress_after_refresh;
 	}
 }
 

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -41,6 +41,7 @@ typedef struct PolicyContinuousAggData
 	int32 buckets_per_batch;
 	int32 max_batches_per_execution;
 	bool refresh_newest_first;
+	bool compress_after_refresh;
 } PolicyContinuousAggData;
 
 typedef struct PolicyCompressionData

--- a/tsl/src/bgw_policy/policies_v2.h
+++ b/tsl/src/bgw_policy/policies_v2.h
@@ -23,6 +23,7 @@
 #define POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH "buckets_per_batch"
 #define POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION "max_batches_per_execution"
 #define POL_REFRESH_CONF_KEY_REFRESH_NEWEST_FIRST "refresh_newest_first"
+#define POL_REFRESH_CONF_KEY_COMPRESS_AFTER_REFRESH "compress_after_refresh"
 
 #define POLICY_COMPRESSION_PROC_NAME "policy_compression"
 #define POLICY_COMPRESSION_CHECK_NAME "policy_compression_check"

--- a/tsl/test/expected/cagg_policy_run.out
+++ b/tsl/test/expected/cagg_policy_run.out
@@ -63,3 +63,198 @@ SELECT * FROM max_mat_view_timestamp;
  Mon Sep 02 00:00:00 2019 |     7
 
 RESET client_min_messages ;
+--- Test compress_after_refresh config option ---
+CREATE TABLE conditions(time TIMESTAMPTZ NOT NULL, device INT, temp FLOAT);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
+    create_hypertable    
+-------------------------
+ (5,public,conditions,t)
+
+INSERT INTO conditions
+SELECT t, d, 1.0
+FROM generate_series('2025-01-01'::timestamptz, '2025-01-05'::timestamptz, INTERVAL '1 hour') t,
+     generate_series(1, 3) d;
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1, 2 WITH NO DATA;
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.compress = true);
+NOTICE:  defaulting compress_orderby to bucket,device
+CREATE VIEW cagg_chunks AS
+SELECT chunk_name, is_compressed
+FROM timescaledb_information.chunks
+WHERE hypertable_name = (
+    SELECT materialization_hypertable_name FROM timescaledb_information.continuous_aggregates
+    WHERE view_name = 'conditions_daily')
+ORDER BY chunk_name;
+-- Default compress_after_refresh = false: chunks must remain uncompressed after refresh
+SELECT add_continuous_aggregate_policy('conditions_daily',
+    start_offset => NULL, end_offset => NULL,
+    schedule_interval => INTERVAL '1 day') AS job_id \gset
+-- Key is absent until explicitly set; default value lives in C code
+SELECT config ? 'compress_after_refresh' AS has_key
+FROM _timescaledb_catalog.bgw_job WHERE id = :job_id;
+ has_key 
+---------
+ f
+
+CALL run_job(:job_id);
+SELECT * FROM cagg_chunks;
+    chunk_name     | is_compressed 
+-------------------+---------------
+ _hyper_6_12_chunk | f
+ _hyper_6_13_chunk | f
+
+-- Flip to true: next run compresses the chunks
+SELECT config FROM alter_job(:job_id,
+    config => jsonb_set(
+        (SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :job_id),
+        '{compress_after_refresh}', 'true'));
+                                               config                                               
+----------------------------------------------------------------------------------------------------
+ {"end_offset": null, "start_offset": null, "mat_hypertable_id": 6, "compress_after_refresh": true}
+
+INSERT INTO conditions
+SELECT t, 4, 2.0 FROM generate_series('2025-01-01'::timestamptz, '2025-01-05'::timestamptz, INTERVAL '1 hour') t;
+CALL run_job(:job_id);
+SELECT * FROM cagg_chunks;
+    chunk_name     | is_compressed 
+-------------------+---------------
+ _hyper_6_12_chunk | t
+ _hyper_6_13_chunk | t
+
+-- Flip back to false: chunks stay uncompressed across the next refresh
+SELECT config FROM alter_job(:job_id,
+    config => jsonb_set(
+        (SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :job_id),
+        '{compress_after_refresh}', 'false'));
+                                               config                                                
+-----------------------------------------------------------------------------------------------------
+ {"end_offset": null, "start_offset": null, "mat_hypertable_id": 6, "compress_after_refresh": false}
+
+SELECT decompress_chunk(ch) FROM show_chunks('conditions_daily') ch;
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_6_12_chunk
+ _timescaledb_internal._hyper_6_13_chunk
+
+INSERT INTO conditions
+SELECT t, 5, 3.0 FROM generate_series('2025-01-01'::timestamptz, '2025-01-05'::timestamptz, INTERVAL '1 hour') t;
+CALL run_job(:job_id);
+SELECT * FROM cagg_chunks;
+    chunk_name     | is_compressed 
+-------------------+---------------
+ _hyper_6_12_chunk | f
+ _hyper_6_13_chunk | f
+
+SELECT delete_job(:job_id);
+ delete_job 
+------------
+ 
+
+DROP VIEW cagg_chunks;
+DROP MATERIALIZED VIEW conditions_daily;
+NOTICE:  drop cascades to 2 other objects
+DROP TABLE conditions;
+--- Test that compression honors the refresh window time range ---
+-- With compress_after_refresh enabled, only cagg chunks intersecting
+-- [now - start_offset, now - end_offset) should be compressed. Chunks outside
+-- that window must remain uncompressed.
+SET timezone TO 'UTC';
+CREATE TABLE measurements(time TIMESTAMPTZ NOT NULL, device INT, val FLOAT);
+SELECT create_hypertable('measurements', 'time', chunk_time_interval => INTERVAL '1 day');
+     create_hypertable     
+---------------------------
+ (8,public,measurements,t)
+
+INSERT INTO measurements
+SELECT t, 1, 1.0
+FROM generate_series('2025-01-01'::timestamptz, '2025-01-13 23:00'::timestamptz, INTERVAL '1 hour') t;
+CREATE MATERIALIZED VIEW measurements_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, device, avg(val) AS avg_val
+FROM measurements
+GROUP BY 1, 2 WITH NO DATA;
+-- Use 1-day chunks on the cagg so each daily bucket lands in its own chunk,
+-- giving us clear in-window vs out-of-window chunks for the assertion.
+SELECT set_chunk_time_interval('measurements_daily', INTERVAL '1 day');
+ set_chunk_time_interval 
+-------------------------
+ 
+
+ALTER MATERIALIZED VIEW measurements_daily SET (timescaledb.compress = true);
+NOTICE:  defaulting compress_orderby to bucket,device
+-- Materialize all chunks first so they exist before the policy runs.
+CALL refresh_continuous_aggregate('measurements_daily', NULL, NULL);
+CREATE VIEW measurements_chunks AS
+SELECT chunk_name, range_start::date AS range_start, is_compressed
+FROM timescaledb_information.chunks
+WHERE hypertable_name = (
+    SELECT materialization_hypertable_name FROM timescaledb_information.continuous_aggregates
+    WHERE view_name = 'measurements_daily')
+ORDER BY range_start;
+-- Baseline: 13 cagg chunks, none compressed yet.
+SELECT * FROM measurements_chunks;
+    chunk_name     | range_start | is_compressed 
+-------------------+-------------+---------------
+ _hyper_9_33_chunk | 01-01-2025  | f
+ _hyper_9_34_chunk | 01-02-2025  | f
+ _hyper_9_35_chunk | 01-03-2025  | f
+ _hyper_9_32_chunk | 01-04-2025  | f
+ _hyper_9_29_chunk | 01-05-2025  | f
+ _hyper_9_37_chunk | 01-06-2025  | f
+ _hyper_9_31_chunk | 01-07-2025  | f
+ _hyper_9_38_chunk | 01-08-2025  | f
+ _hyper_9_40_chunk | 01-09-2025  | f
+ _hyper_9_39_chunk | 01-10-2025  | f
+ _hyper_9_30_chunk | 01-11-2025  | f
+ _hyper_9_36_chunk | 01-12-2025  | f
+ _hyper_9_41_chunk | 01-13-2025  | f
+
+-- Mock now() at 2025-01-15. With start_offset = 8 days and end_offset = 4 days
+-- the refresh window is [2025-01-07, 2025-01-11). Chunks 01-07..01-10 should
+-- be compressed; chunks before 01-07 and on/after 01-11 must stay uncompressed.
+SET timescaledb.current_timestamp_mock = '2025-01-15 00:00:00+00';
+SELECT add_continuous_aggregate_policy('measurements_daily',
+    start_offset => INTERVAL '8 days',
+    end_offset => INTERVAL '4 days',
+    schedule_interval => INTERVAL '1 day') AS job_id \gset
+-- Opt in to running compression after the refresh.
+SELECT config FROM alter_job(:job_id,
+    config => jsonb_set(
+        (SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :job_id),
+        '{compress_after_refresh}', 'true'));
+                                                     config                                                     
+----------------------------------------------------------------------------------------------------------------
+ {"end_offset": "@ 4 days", "start_offset": "@ 8 days", "mat_hypertable_id": 9, "compress_after_refresh": true}
+
+CALL run_job(:job_id);
+SELECT * FROM measurements_chunks;
+    chunk_name     | range_start | is_compressed 
+-------------------+-------------+---------------
+ _hyper_9_33_chunk | 01-01-2025  | f
+ _hyper_9_34_chunk | 01-02-2025  | f
+ _hyper_9_35_chunk | 01-03-2025  | f
+ _hyper_9_32_chunk | 01-04-2025  | f
+ _hyper_9_29_chunk | 01-05-2025  | f
+ _hyper_9_37_chunk | 01-06-2025  | f
+ _hyper_9_31_chunk | 01-07-2025  | t
+ _hyper_9_38_chunk | 01-08-2025  | t
+ _hyper_9_40_chunk | 01-09-2025  | t
+ _hyper_9_39_chunk | 01-10-2025  | t
+ _hyper_9_30_chunk | 01-11-2025  | f
+ _hyper_9_36_chunk | 01-12-2025  | f
+ _hyper_9_41_chunk | 01-13-2025  | f
+
+SELECT delete_job(:job_id);
+ delete_job 
+------------
+ 
+
+SET timescaledb.current_timestamp_mock = '';
+RESET timezone;
+DROP VIEW measurements_chunks;
+DROP MATERIALIZED VIEW measurements_daily;
+NOTICE:  drop cascades to 13 other objects
+DROP TABLE measurements;

--- a/tsl/test/sql/cagg_policy_run.sql
+++ b/tsl/test/sql/cagg_policy_run.sql
@@ -50,3 +50,128 @@ CALL run_job(:job_id);
 SELECT * FROM max_mat_view_timestamp;
 RESET client_min_messages ;
 
+--- Test compress_after_refresh config option ---
+CREATE TABLE conditions(time TIMESTAMPTZ NOT NULL, device INT, temp FLOAT);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
+INSERT INTO conditions
+SELECT t, d, 1.0
+FROM generate_series('2025-01-01'::timestamptz, '2025-01-05'::timestamptz, INTERVAL '1 hour') t,
+     generate_series(1, 3) d;
+
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1, 2 WITH NO DATA;
+
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.compress = true);
+
+CREATE VIEW cagg_chunks AS
+SELECT chunk_name, is_compressed
+FROM timescaledb_information.chunks
+WHERE hypertable_name = (
+    SELECT materialization_hypertable_name FROM timescaledb_information.continuous_aggregates
+    WHERE view_name = 'conditions_daily')
+ORDER BY chunk_name;
+
+-- Default compress_after_refresh = false: chunks must remain uncompressed after refresh
+SELECT add_continuous_aggregate_policy('conditions_daily',
+    start_offset => NULL, end_offset => NULL,
+    schedule_interval => INTERVAL '1 day') AS job_id \gset
+
+-- Key is absent until explicitly set; default value lives in C code
+SELECT config ? 'compress_after_refresh' AS has_key
+FROM _timescaledb_catalog.bgw_job WHERE id = :job_id;
+
+CALL run_job(:job_id);
+SELECT * FROM cagg_chunks;
+
+-- Flip to true: next run compresses the chunks
+SELECT config FROM alter_job(:job_id,
+    config => jsonb_set(
+        (SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :job_id),
+        '{compress_after_refresh}', 'true'));
+
+INSERT INTO conditions
+SELECT t, 4, 2.0 FROM generate_series('2025-01-01'::timestamptz, '2025-01-05'::timestamptz, INTERVAL '1 hour') t;
+CALL run_job(:job_id);
+SELECT * FROM cagg_chunks;
+
+-- Flip back to false: chunks stay uncompressed across the next refresh
+SELECT config FROM alter_job(:job_id,
+    config => jsonb_set(
+        (SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :job_id),
+        '{compress_after_refresh}', 'false'));
+
+SELECT decompress_chunk(ch) FROM show_chunks('conditions_daily') ch;
+INSERT INTO conditions
+SELECT t, 5, 3.0 FROM generate_series('2025-01-01'::timestamptz, '2025-01-05'::timestamptz, INTERVAL '1 hour') t;
+CALL run_job(:job_id);
+SELECT * FROM cagg_chunks;
+
+SELECT delete_job(:job_id);
+DROP VIEW cagg_chunks;
+DROP MATERIALIZED VIEW conditions_daily;
+DROP TABLE conditions;
+
+--- Test that compression honors the refresh window time range ---
+-- With compress_after_refresh enabled, only cagg chunks intersecting
+-- [now - start_offset, now - end_offset) should be compressed. Chunks outside
+-- that window must remain uncompressed.
+SET timezone TO 'UTC';
+CREATE TABLE measurements(time TIMESTAMPTZ NOT NULL, device INT, val FLOAT);
+SELECT create_hypertable('measurements', 'time', chunk_time_interval => INTERVAL '1 day');
+INSERT INTO measurements
+SELECT t, 1, 1.0
+FROM generate_series('2025-01-01'::timestamptz, '2025-01-13 23:00'::timestamptz, INTERVAL '1 hour') t;
+
+CREATE MATERIALIZED VIEW measurements_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, device, avg(val) AS avg_val
+FROM measurements
+GROUP BY 1, 2 WITH NO DATA;
+
+-- Use 1-day chunks on the cagg so each daily bucket lands in its own chunk,
+-- giving us clear in-window vs out-of-window chunks for the assertion.
+SELECT set_chunk_time_interval('measurements_daily', INTERVAL '1 day');
+ALTER MATERIALIZED VIEW measurements_daily SET (timescaledb.compress = true);
+
+-- Materialize all chunks first so they exist before the policy runs.
+CALL refresh_continuous_aggregate('measurements_daily', NULL, NULL);
+
+CREATE VIEW measurements_chunks AS
+SELECT chunk_name, range_start::date AS range_start, is_compressed
+FROM timescaledb_information.chunks
+WHERE hypertable_name = (
+    SELECT materialization_hypertable_name FROM timescaledb_information.continuous_aggregates
+    WHERE view_name = 'measurements_daily')
+ORDER BY range_start;
+
+-- Baseline: 13 cagg chunks, none compressed yet.
+SELECT * FROM measurements_chunks;
+
+-- Mock now() at 2025-01-15. With start_offset = 8 days and end_offset = 4 days
+-- the refresh window is [2025-01-07, 2025-01-11). Chunks 01-07..01-10 should
+-- be compressed; chunks before 01-07 and on/after 01-11 must stay uncompressed.
+SET timescaledb.current_timestamp_mock = '2025-01-15 00:00:00+00';
+SELECT add_continuous_aggregate_policy('measurements_daily',
+    start_offset => INTERVAL '8 days',
+    end_offset => INTERVAL '4 days',
+    schedule_interval => INTERVAL '1 day') AS job_id \gset
+
+-- Opt in to running compression after the refresh.
+SELECT config FROM alter_job(:job_id,
+    config => jsonb_set(
+        (SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :job_id),
+        '{compress_after_refresh}', 'true'));
+
+CALL run_job(:job_id);
+SELECT * FROM measurements_chunks;
+
+SELECT delete_job(:job_id);
+SET timescaledb.current_timestamp_mock = '';
+RESET timezone;
+DROP VIEW measurements_chunks;
+DROP MATERIALIZED VIEW measurements_daily;
+DROP TABLE measurements;
+


### PR DESCRIPTION
After the refresh completed, find chunks in the refresh window
that need compression or recompression and compress them, committing
each chunk in its own transaction.
