### PR TITLE
Use glob matching consistently when comparing test names

### DIFF
--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -142,7 +142,7 @@ else
       if ! matches "${SKIPS}" "${test_name}"; then
         if [[ $test_name == $test_pattern ]]; then
           current_tests="${current_tests} ${test_name}"
-        elif [[ $test_name =~ ^${test_pattern}-[1-9][0-9]$ ]]; then
+        elif [[ $test_name == ${test_pattern}-[1-9][0-9] ]]; then
           current_tests="${current_tests} ${test_name}"
         fi
       fi


### PR DESCRIPTION
When specifying a test pattern like `"*foo*"` the check for version
specific tests would error out because it would use regular
expression matching to check for match instead of glob matching
used in all the other places when comparing test names.
