### PR TITLE
Fix null window end

### DIFF
--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1501,6 +1501,25 @@ ts_compute_beginning_of_the_next_bucket_variable(int64 timeval,
 	return ts_time_value_to_internal(val_new, TIMESTAMPOID);
 }
 
+/*
+ * Calculates the beginning of the current bucket (i.e., floors timeval to the
+ * nearest bucket boundary).
+ *
+ * The algorithm is just:
+ *
+ * val = time_bucket(bucket_size, val)
+ */
+int64
+ts_compute_start_of_current_bucket_variable(int64 timeval, const ContinuousAggBucketFunction *bf)
+{
+	/*
+	 * It's OK to use TIMESTAMPOID here.
+	 * See the comment in ts_compute_inscribed_bucketed_refresh_window_variable()
+	 */
+	Datum val_beg = ts_internal_to_time_value(timeval, TIMESTAMPOID);
+	return ts_time_value_to_internal(generic_time_bucket(bf, val_beg), TIMESTAMPOID);
+}
+
 Oid
 ts_cagg_permissions_check(Oid cagg_oid, Oid userid)
 {

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -188,6 +188,8 @@ ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *e
 														  const ContinuousAggBucketFunction *bf);
 extern TSDLLEXPORT int64 ts_compute_beginning_of_the_next_bucket_variable(
 	int64 timeval, const ContinuousAggBucketFunction *bf);
+extern TSDLLEXPORT int64
+ts_compute_start_of_current_bucket_variable(int64 timeval, const ContinuousAggBucketFunction *bf);
 
 extern TSDLLEXPORT Query *ts_continuous_agg_get_query(ContinuousAgg *cagg);
 

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -801,7 +801,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 		{
 			int64 bucket_width = ts_continuous_agg_fixed_bucket_width(cagg->bucket_function);
 			refresh_window.end =
-				ts_time_saturating_add(refresh_window.end, bucket_width - 1, refresh_window.type);
+				ts_time_saturating_add(refresh_window.end, bucket_width, refresh_window.type);
 		}
 	}
 
@@ -829,10 +829,58 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	/* We must also cap the refresh window at the invalidation threshold. If
 	 * we process invalidations after the threshold, the continuous aggregates
 	 * won't be refreshed when the threshold is moved forward in the
-	 * future. The invalidation threshold should already be aligned on bucket
-	 * boundary. */
-	if (refresh_window.end > invalidation_threshold)
-		refresh_window.end = invalidation_threshold;
+	 * future.
+	 *
+	 * However, we cannot just set refresh_window.end to the invalidation_threshold,
+	 * because the invalidation_threshold returned from invalidation_threshold_set_or_get()
+	 * can be one that set by a sibling cagg with a different bucket width and thus
+	 * not aligned to this cagg's bucket boundary.
+	 * For example, assuming the hypertable has two caggs, one with 4 hour bucket
+	 * and the other with 6hour bucket. If the 6 hour cagg had a refresh that advanced
+	 * the threshold, the threshold would be at a 6 hour boundary (e.g, 2000-01-01 06:00:00).
+	 * If we then refresh the 4 hour cagg on the same range, the threshold calculated by
+	 * the 4 hour cagg would be at a 4 hour boundary (e.g., 2000-01-01 04:00:00), which is
+	 * smaller than the 6 hour stored threshold. In that case, invalidation_threshold_set_or_get()
+	 * would return the stored threshold.
+	 *
+	 * Therefore, we need to floor the invalidation_threshold to this cagg's own bucket boundary
+	 * before using it to cap the cagg's refresh window.
+	 *
+	 */
+	/*
+	 * Skip flooring when the threshold is at type min (no data) or type max
+	 * (data inserted near the type's maximum value — we need to cover that
+	 * last bucket).
+	 */
+	int64 computed_invalidation_threshold_for_cagg = invalidation_threshold;
+	if (invalidation_threshold > ts_time_get_min(refresh_window.type) &&
+		invalidation_threshold < ts_time_get_max(refresh_window.type))
+	{
+		if (cagg->bucket_function->bucket_fixed_interval)
+		{
+			NullableDatum offset = INIT_NULL_DATUM;
+			NullableDatum origin = INIT_NULL_DATUM;
+			fill_bucket_offset_origin(cagg->bucket_function, refresh_window.type, &offset, &origin);
+			int64 bucket_width = ts_continuous_agg_fixed_bucket_width(cagg->bucket_function);
+			computed_invalidation_threshold_for_cagg =
+				ts_time_bucket_by_type_extended(bucket_width,
+												invalidation_threshold,
+												refresh_window.type,
+												offset,
+												origin);
+		}
+		else
+		{
+			computed_invalidation_threshold_for_cagg =
+				ts_compute_start_of_current_bucket_variable(invalidation_threshold,
+															cagg->bucket_function);
+		}
+	}
+
+	if (refresh_window.end > computed_invalidation_threshold_for_cagg)
+	{
+		refresh_window.end = computed_invalidation_threshold_for_cagg;
+	}
 
 	/* Capping the end might have made the window 0, or negative, so nothing to refresh in that
 	 * case.

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1527,4 +1527,104 @@ DROP TABLE test_data CASCADE;
 NOTICE:  drop cascades to 4 other objects
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to 3 other objects
+-- Test: threshold misalignment when two caggs with different bucket widths share
+-- a hypertable.
+--
+-- 4h boundaries: 00:00, 04:00, 08:00, 12:00, ...
+-- 6h boundaries: 00:00, 06:00, 12:00, 18:00, ...
+--
+-- With data at 2020-01-01 02:30 UTC:
+--   cagg_4hrs (4h buckets): bucket [00:00, 04:00), computed threshold = 2020-01-01 04:00 UTC
+--   cagg_6hrs (6h buckets): bucket [00:00, 06:00), computed threshold = 2020-01-01 06:00 UTC
+--
+-- After refreshing cagg_6hrs first, the shared threshold advances to
+-- 2020-01-01 06:00 UTC (cagg_6hrs boundary, NOT a cagg_4hrs boundary).
+--
+-- A subsequent NULL,NULL refresh of cagg_4hrs should cap the window end to
+-- cagg_4hrs's own bucket boundary (2020-01-01 04:00 UTC), not use the stored
+-- threshold (2020-01-01 06:00 UTC) which doesn't align with bucket boundaries of cagg_4hrs.
+CREATE TABLE test_data  (ts TIMESTAMPTZ, val INT);
+SELECT create_hypertable('test_data', 'ts');
+    create_hypertable    
+-------------------------
+ (31,public,test_data,t)
+
+CREATE MATERIALIZED VIEW cagg_4hrs
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('4 hours', ts) AS bucket, max(val)
+FROM test_data
+GROUP BY 1
+WITH NO DATA;
+CREATE MATERIALIZED VIEW cagg_6hrs
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('6 hours', ts) AS bucket, max(val)
+FROM test_data
+GROUP BY 1
+WITH NO DATA;
+-- Insert data whose max timestamp is 2020-01-01 02:30 UTC.
+-- cagg_4hrs bucket: [00:00, 04:00), threshold T4 = 04:00 UTC
+-- cagg_6hrs bucket: [00:00, 06:00), threshold T6 = 06:00 UTC
+INSERT INTO test_data VALUES ('2020-01-01 02:30:00+00', 1);
+-- Refresh cagg_6hrs first: sets shared threshold to 2020-01-01 06:00 UTC.
+CALL refresh_continuous_aggregate('cagg_6hrs', NULL, NULL);
+-- Stored threshold = 2020-01-01 06:00 UTC (cagg_6hrs boundary, NOT cagg_4hrs boundary).
+SELECT _timescaledb_functions.to_timestamp(watermark) AS threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'cagg_4hrs');
+       threshold        
+------------------------
+ 2020-01-01 06:00:00+00
+
+-- Now refresh cagg_4hrs with NULL,NULL.
+-- cagg_4hrs computes its own threshold = 04:00, but stored threshold = 06:00 > 04:00,
+-- so the stored (misaligned) value is used as window_end instead.
+-- BUG:   window_end = 2020-01-01 06:00 UTC (stored threshold, mid-bucket for cagg_4hrs)
+--        -> materializes bucket [00:00, 04:00) but leaves residual at misaligned 06:00
+-- FIXED: window_end = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+SET client_min_messages TO DEBUG1;
+CALL refresh_continuous_aggregate('cagg_4hrs', NULL, NULL);
+LOG:  statement: CALL refresh_continuous_aggregate('cagg_4hrs', NULL, NULL);
+DEBUG:  hypertable 31 existing watermark >= new invalidation threshold 1577858400000000 1577851200000000
+DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4hrs" in window [ 4714-11-24 00:00:00+00 BC, 2020-01-01 08:00:00+00 ]
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_32"
+DEBUG:  building index "_hyper_32_94_chunk__materialized_hypertable_32_bucket_idx" on table "_hyper_32_94_chunk" serially
+DEBUG:  index "_hyper_32_94_chunk__materialized_hypertable_32_bucket_idx" can safely use deduplication
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_32"
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+-- Show invalidations left in cagg_4hrs's invalidation log,
+-- BUG:   lowest = 2020-01-01 06:00 UTC (stored threshold, not cagg_4hrs-aligned)
+-- FIXED: lowest = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+SELECT
+    CASE
+        WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+            THEN '-infinity'::timestamptz
+        WHEN lowest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+            THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS low,
+    CASE
+        WHEN greatest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+            THEN '-infinity'::timestamptz
+        WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+            THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS high
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'cagg_4hrs'
+)
+ORDER BY 1,2;
+          low           |   high    
+------------------------+-----------
+ -infinity              | -infinity
+ 2020-01-01 06:00:00+00 | infinity
+
+DROP TABLE test_data CASCADE;
+NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_32_94_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_33_93_chunk
 RESET timezone;

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1579,15 +1579,13 @@ WHERE hypertable_id = (
 
 -- Now refresh cagg_4hrs with NULL,NULL.
 -- cagg_4hrs computes its own threshold = 04:00, but stored threshold = 06:00 > 04:00,
--- so the stored (misaligned) value is used as window_end instead.
--- BUG:   window_end = 2020-01-01 06:00 UTC (stored threshold, mid-bucket for cagg_4hrs)
---        -> materializes bucket [00:00, 04:00) but leaves residual at misaligned 06:00
--- FIXED: window_end = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+-- so the stored (misaligned) value is used but capped to the start of the current bucket of cagg_4hrs,
+-- which is 2020-01-01 04:00 UTC.
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4hrs', NULL, NULL);
 LOG:  statement: CALL refresh_continuous_aggregate('cagg_4hrs', NULL, NULL);
 DEBUG:  hypertable 31 existing watermark >= new invalidation threshold 1577858400000000 1577851200000000
-DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4hrs" in window [ 4714-11-24 00:00:00+00 BC, 2020-01-01 08:00:00+00 ]
+DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4hrs" in window [ 4714-11-24 00:00:00+00 BC, 2020-01-01 04:00:00+00 ]
 LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_32"
 DEBUG:  building index "_hyper_32_94_chunk__materialized_hypertable_32_bucket_idx" on table "_hyper_32_94_chunk" serially
 DEBUG:  index "_hyper_32_94_chunk__materialized_hypertable_32_bucket_idx" can safely use deduplication
@@ -1596,7 +1594,7 @@ RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 -- Show invalidations left in cagg_4hrs's invalidation log,
 -- BUG:   lowest = 2020-01-01 06:00 UTC (stored threshold, not cagg_4hrs-aligned)
--- FIXED: lowest = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+-- FIXED: lowest = 2020-01-01 04:00 UTC (at cagg_4hrs bucket boundary)
 SELECT
     CASE
         WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
@@ -1621,7 +1619,7 @@ ORDER BY 1,2;
           low           |   high    
 ------------------------+-----------
  -infinity              | -infinity
- 2020-01-01 06:00:00+00 | infinity
+ 2020-01-01 04:00:00+00 | infinity
 
 DROP TABLE test_data CASCADE;
 NOTICE:  drop cascades to 4 other objects

--- a/tsl/test/expected/cagg_query-15.out
+++ b/tsl/test/expected/cagg_query-15.out
@@ -984,14 +984,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1659,9 +1659,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1673,9 +1670,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1863,9 +1857,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1884,10 +1878,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query-16.out
+++ b/tsl/test/expected/cagg_query-16.out
@@ -978,14 +978,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1653,9 +1653,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1667,9 +1664,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1857,9 +1851,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1878,10 +1872,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query-17.out
+++ b/tsl/test/expected/cagg_query-17.out
@@ -978,14 +978,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1653,9 +1653,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1667,9 +1664,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1857,9 +1851,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1878,10 +1872,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query-18.out
+++ b/tsl/test/expected/cagg_query-18.out
@@ -978,14 +978,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1653,9 +1653,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1667,9 +1664,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (in
 psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1857,9 +1851,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1878,10 +1872,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query_using_merge-15.out
+++ b/tsl/test/expected/cagg_query_using_merge-15.out
@@ -986,14 +986,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1658,8 +1658,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1669,8 +1667,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1856,9 +1852,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1877,10 +1873,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query_using_merge-16.out
+++ b/tsl/test/expected/cagg_query_using_merge-16.out
@@ -980,14 +980,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1652,8 +1652,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1663,8 +1661,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1850,9 +1846,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1871,10 +1867,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query_using_merge-17.out
+++ b/tsl/test/expected/cagg_query_using_merge-17.out
@@ -980,14 +980,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1652,8 +1652,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1663,8 +1661,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1850,9 +1846,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1871,10 +1867,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/expected/cagg_query_using_merge-18.out
+++ b/tsl/test/expected/cagg_query_using_merge-18.out
@@ -980,14 +980,14 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 psql:include/cagg_query_common.sql:493: NOTICE:  drop cascades to table _timescaledb_internal._hyper_24_28_chunk
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:499: NOTICE:  refreshing continuous aggregate "cagg_4_hours_date_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';
  user_view_schema |      user_view_name      |                      bucket_func                      | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------------+-------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
- public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 30 mins     |                 | t
+ public           | cagg_4_hours_date_offset | public.time_bucket(interval,pg_catalog.date,interval) | @ 4 days     |               | @ 1 day       |                 | t
 
 DROP MATERIALIZED VIEW cagg_4_hours_date_offset;
 psql:include/cagg_query_common.sql:501: NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_29_chunk
@@ -1652,8 +1652,6 @@ psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark
 psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
 psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 12:00:00 2020 PST, Thu Jan 02 16:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL);
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
@@ -1663,8 +1661,6 @@ psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark
 psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
 psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 12:30:00 2020 PST, Thu Jan 02 16:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL);
 psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
@@ -1850,9 +1846,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |  -9223372036854775808 |     -210866803200000001
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |      1577998800000000 |     9223372036854775807
 
@@ -1871,10 +1867,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   3 |      1541289600000000 |     9223372036854775807
                  33 |  -9223372036854775808 |     -210866803200000001
                  33 |  -9223372036854775808 |     9223372036854775807
-                 33 |      1577998800000000 |     9223372036854775807
+                 33 |      1577995200000000 |     9223372036854775807
                  34 |  -9223372036854775808 |     -210866803200000001
                  34 |  -9223372036854775808 |     9223372036854775807
-                 34 |      1577998800000000 |     9223372036854775807
+                 34 |      1577997000000000 |     9223372036854775807
                  35 |  -9223372036854775808 |     -210866803200000001
                  35 |  -9223372036854775808 |     9223372036854775807
                  35 |      1577998800000000 |     9223372036854775807

--- a/tsl/test/sql/cagg_invalidation.sql
+++ b/tsl/test/sql/cagg_invalidation.sql
@@ -1074,17 +1074,15 @@ WHERE hypertable_id = (
 
 -- Now refresh cagg_4hrs with NULL,NULL.
 -- cagg_4hrs computes its own threshold = 04:00, but stored threshold = 06:00 > 04:00,
--- so the stored (misaligned) value is used as window_end instead.
--- BUG:   window_end = 2020-01-01 06:00 UTC (stored threshold, mid-bucket for cagg_4hrs)
---        -> materializes bucket [00:00, 04:00) but leaves residual at misaligned 06:00
--- FIXED: window_end = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+-- so the stored (misaligned) value is used but capped to the start of the current bucket of cagg_4hrs,
+-- which is 2020-01-01 04:00 UTC.
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4hrs', NULL, NULL);
 RESET client_min_messages;
 
 -- Show invalidations left in cagg_4hrs's invalidation log,
 -- BUG:   lowest = 2020-01-01 06:00 UTC (stored threshold, not cagg_4hrs-aligned)
--- FIXED: lowest = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+-- FIXED: lowest = 2020-01-01 04:00 UTC (at cagg_4hrs bucket boundary)
 SELECT
     CASE
         WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)

--- a/tsl/test/sql/cagg_invalidation.sql
+++ b/tsl/test/sql/cagg_invalidation.sql
@@ -1022,4 +1022,91 @@ WHERE hypertable_id IN (
 
 --clean up
 DROP TABLE test_data CASCADE;
+
+-- Test: threshold misalignment when two caggs with different bucket widths share
+-- a hypertable.
+--
+-- 4h boundaries: 00:00, 04:00, 08:00, 12:00, ...
+-- 6h boundaries: 00:00, 06:00, 12:00, 18:00, ...
+--
+-- With data at 2020-01-01 02:30 UTC:
+--   cagg_4hrs (4h buckets): bucket [00:00, 04:00), computed threshold = 2020-01-01 04:00 UTC
+--   cagg_6hrs (6h buckets): bucket [00:00, 06:00), computed threshold = 2020-01-01 06:00 UTC
+--
+-- After refreshing cagg_6hrs first, the shared threshold advances to
+-- 2020-01-01 06:00 UTC (cagg_6hrs boundary, NOT a cagg_4hrs boundary).
+--
+-- A subsequent NULL,NULL refresh of cagg_4hrs should cap the window end to
+-- cagg_4hrs's own bucket boundary (2020-01-01 04:00 UTC), not use the stored
+-- threshold (2020-01-01 06:00 UTC) which doesn't align with bucket boundaries of cagg_4hrs.
+
+CREATE TABLE test_data  (ts TIMESTAMPTZ, val INT);
+SELECT create_hypertable('test_data', 'ts');
+
+CREATE MATERIALIZED VIEW cagg_4hrs
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('4 hours', ts) AS bucket, max(val)
+FROM test_data
+GROUP BY 1
+WITH NO DATA;
+
+CREATE MATERIALIZED VIEW cagg_6hrs
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('6 hours', ts) AS bucket, max(val)
+FROM test_data
+GROUP BY 1
+WITH NO DATA;
+
+-- Insert data whose max timestamp is 2020-01-01 02:30 UTC.
+-- cagg_4hrs bucket: [00:00, 04:00), threshold T4 = 04:00 UTC
+-- cagg_6hrs bucket: [00:00, 06:00), threshold T6 = 06:00 UTC
+INSERT INTO test_data VALUES ('2020-01-01 02:30:00+00', 1);
+
+-- Refresh cagg_6hrs first: sets shared threshold to 2020-01-01 06:00 UTC.
+CALL refresh_continuous_aggregate('cagg_6hrs', NULL, NULL);
+
+-- Stored threshold = 2020-01-01 06:00 UTC (cagg_6hrs boundary, NOT cagg_4hrs boundary).
+SELECT _timescaledb_functions.to_timestamp(watermark) AS threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'cagg_4hrs');
+
+-- Now refresh cagg_4hrs with NULL,NULL.
+-- cagg_4hrs computes its own threshold = 04:00, but stored threshold = 06:00 > 04:00,
+-- so the stored (misaligned) value is used as window_end instead.
+-- BUG:   window_end = 2020-01-01 06:00 UTC (stored threshold, mid-bucket for cagg_4hrs)
+--        -> materializes bucket [00:00, 04:00) but leaves residual at misaligned 06:00
+-- FIXED: window_end = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+SET client_min_messages TO DEBUG1;
+CALL refresh_continuous_aggregate('cagg_4hrs', NULL, NULL);
+RESET client_min_messages;
+
+-- Show invalidations left in cagg_4hrs's invalidation log,
+-- BUG:   lowest = 2020-01-01 06:00 UTC (stored threshold, not cagg_4hrs-aligned)
+-- FIXED: lowest = 2020-01-01 04:00 UTC (cagg_4hrs bucket boundary)
+SELECT
+    CASE
+        WHEN lowest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+            THEN '-infinity'::timestamptz
+        WHEN lowest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+            THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(lowest_modified_value)
+    END AS low,
+    CASE
+        WHEN greatest_modified_value <= _timescaledb_functions.get_internal_time_min('timestamptz'::regtype)
+            THEN '-infinity'::timestamptz
+        WHEN greatest_modified_value >= _timescaledb_functions.get_internal_time_max('timestamptz'::regtype)
+            THEN 'infinity'::timestamptz
+        ELSE _timescaledb_functions.to_timestamp(greatest_modified_value)
+    END AS high
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'cagg_4hrs'
+)
+ORDER BY 1,2;
+DROP TABLE test_data CASCADE;
+
+
 RESET timezone;

--- a/tsl/test/sql/include/cagg_query_common.sql
+++ b/tsl/test/sql/include/cagg_query_common.sql
@@ -494,7 +494,7 @@ DROP MATERIALIZED VIEW cagg_4_hours_date_origin2;
 
 CREATE MATERIALIZED VIEW cagg_4_hours_date_offset
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
-  SELECT time_bucket('4 days', time, "offset"=>'30m'::interval), max(value)
+  SELECT time_bucket('4 days', time, "offset"=>'1 day'::interval), max(value)
     FROM temperature_date
     GROUP BY 1 ORDER BY 1;
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_4_hours_date_offset';


### PR DESCRIPTION
Fix the capping of window end
    
    When refresh NULL, NULL, the end of the window was capped at by the
    hypertable invalidation threshold. However, if the hypertable have
    multiple caggs, a cagg with farther bucket boundary could have set
    the invalidation threshold, so using the invalidation threshold as
    the end of the refresh window caused the window to not align with
    the cagg's bucket boundary, which then could produce invalidations
    not at bucket bouundary too.
    
    This patch fixes the issue by flooring the capped window end to
    the start of the bucket.

Disable-check: force-changelog-file
Disable-check: commit-count