### PR TITLE
Fix memory leak in ColumnarScan

### DIFF
--- a/.unreleased/pr_9455
+++ b/.unreleased/pr_9455
@@ -1,0 +1,1 @@
+Fixes: #9455 Fix memory leak in ColumnarScan

--- a/tsl/src/nodes/columnar_scan/exec.c
+++ b/tsl/src/nodes/columnar_scan/exec.c
@@ -464,6 +464,7 @@ columnar_scan_exec_impl(ColumnarScanState *chunk_state, const BatchQueueFunction
 	if (chunk_state->csstate.ss.ps.ps_ProjInfo)
 	{
 		ExprContext *econtext = chunk_state->csstate.ss.ps.ps_ExprContext;
+		ResetExprContext(econtext);
 		econtext->ecxt_scantuple = result_slot;
 		return ExecProject(chunk_state->csstate.ss.ps.ps_ProjInfo);
 	}


### PR DESCRIPTION
When ColumnarScan is doing projection it would not reset the
expression context leading to a memory leak. This commit adds
the missing expression context reset to ColumnarScan.
