### PR TITLE
Remove special handling for post_update_stage

### DIFF
--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -60,8 +60,7 @@ function(generate_downgrade_script)
     ${CMAKE_BINARY_DIR}/v${_downgrade_TARGET_VERSION}/cmake/ScriptFiles.cmake)
 
   set(_downgrade_PRE_FILES "header.sql;${PRE_DOWNGRADE_FILES}")
-  set(_downgrade_POST_FILES "${PRE_INSTALL_FUNCTION_FILES};${SOURCE_FILES}" ${SET_POST_UPDATE_STAGE}
-                            ${POST_UPDATE_FILES} ${UNSET_UPDATE_STAGE})
+  set(_downgrade_POST_FILES "${PRE_INSTALL_FUNCTION_FILES};${SOURCE_FILES}" ${POST_UPDATE_FILES})
 
   # Fetch epilog from target version.
   git_versioned_get(

--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -92,6 +92,4 @@ set(PRE_DOWNGRADE_FILES updates/pre-version-change.sql)
 
 # The POST_UPDATE_FILES should be executed as the last part of the update
 # script. sets state for executing POST_UPDATE_FILES during ALTER EXTENSION
-set(SET_POST_UPDATE_STAGE updates/set_post_update_stage.sql)
-set(UNSET_UPDATE_STAGE updates/unset_update_stage.sql)
 set(POST_UPDATE_FILES updates/post-update.sql)

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -185,9 +185,7 @@ set(CURR_MOD_FILES "${LASTEST_MOD_VERSIONED}")
 
 # Generate the post-update file once (same for all update scripts)
 set(POST_FILES_PROCESSED ${POST_UPDATE_FILES_VERSIONED}.processed)
-cat_files(
-  "${SET_POST_UPDATE_STAGE};${POST_UPDATE_FILES_VERSIONED};${UNSET_UPDATE_STAGE}"
-  ${POST_FILES_PROCESSED})
+cat_files("${POST_UPDATE_FILES_VERSIONED}" ${POST_FILES_PROCESSED})
 
 # Now loop through the modfiles and generate the update files
 foreach(transition_mod_file ${MOD_FILES_LIST})

--- a/sql/updates/README.md
+++ b/sql/updates/README.md
@@ -48,11 +48,6 @@ by using multiple modfiles in order. There are two types of modfiles:
   version, but are no longer present in the transition modfiles.
 
 Notes on post_update.sql
-   We use a special config var (timescaledb.update_script_stage )
-to notify that dependencies have been setup and now timescaledb
-specific queries can be enabled. This is useful if we want to,
-for example, modify objects that need timescaledb specific syntax as
-part of the extension update).
 The scripts in post_update.sql are executed as part of the `ALTER
 EXTENSION` stmt.
 
@@ -93,33 +88,12 @@ variable in the target version of `cmake/ScriptFiles.cmake`.
 The version-specific code is found in the source version of the file
 `sql/updates/reverse-dev.sql`.
 
-The epilog consists of the files in variables `SOURCE_FILES`,
-`SET_POST_UPDATE_STAGE`, `POST_UPDATE_FILES`, and `UNSET_UPDATE_STAGE`
-in that order.
-
-For downgrades to work correctly, some rules need to be followed:
-
-1. If you add new objects in `sql/updates/latest-dev.sql`, you need to
-   remove them in the version-specific downgrade file. The
-   `sql/updates/pre-update.sql` in the target version do not know
-   about objects created in the source version, so they need to be
-   dropped explicitly.
-2. Since `sql/updates/pre-update.sql` can be executed on a later
-   version of the extension, it might be that some objects have been
-   removed and do not exist. Hence `DROP` calls need to use `IF NOT
-   EXISTS`.
+The epilog consists of the files in variables `SOURCE_FILES` and
+`POST_UPDATE_FILES`.
 
 Note that, in contrast to update scripts, downgrade scripts are not
 built by composing several downgrade scripts into a more extensive
-downgrade script. The downgrade scripts are intended to be use only in
-special cases and are not intended to be use to move up and down
-between versions at will, which is why we only generate a downgrade
-script to the immediately preceeding version.
+downgrade script. We only build a downgrade script to the immediate
+preceeding version. To downgrade multiple versions multiple downgrades
+need to be chained.
 
-### When releasing a new version
-
-When releasing a new version, please rename the file `reverse-dev.sql`
-to `<version>--<previous_version>.sql` and add that name to
-`REV_FILES` variable in the `sql/CMakeLists.txt`. This will allow
-generation of downgrade scripts for any version in that list, but it
-is currently not added.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,67 @@
 
 DROP PROCEDURE IF EXISTS _timescaledb_functions.repair_relation_acls();
 DROP FUNCTION IF EXISTS _timescaledb_functions.makeaclitem(regrole, regrole, text, bool);
+
+-- Create watermark record when required. This uses pure SQL to avoid calling
+-- C functions that need catalog access during ALTER EXTENSION UPDATE.
+-- this is only needed for users upgrading from before 2.11.0, as the watermark
+-- was added in that version.
+DO
+$$
+DECLARE
+  ts_version TEXT;
+  cagg_rec RECORD;
+  max_val BIGINT;
+  watermark_val BIGINT;
+  bucket_width_val BIGINT;
+BEGIN
+    SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+    IF ts_version < '2.11.0' THEN
+      RETURN;
+    END IF;
+
+    FOR cagg_rec IN
+      SELECT a.mat_hypertable_id,
+             h.schema_name, h.table_name,
+             d.column_name, d.column_type,
+             bf.bucket_width, bf.bucket_fixed_width
+      FROM _timescaledb_catalog.continuous_agg a
+      LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark w ON w.mat_hypertable_id = a.mat_hypertable_id
+      JOIN _timescaledb_catalog.hypertable h ON h.id = a.mat_hypertable_id
+      JOIN _timescaledb_catalog.dimension d ON d.hypertable_id = a.mat_hypertable_id AND d.num_slices IS NULL
+      LEFT JOIN _timescaledb_catalog.continuous_aggs_bucket_function bf ON bf.mat_hypertable_id = a.mat_hypertable_id
+      WHERE w.mat_hypertable_id IS NULL
+      ORDER BY a.mat_hypertable_id
+    LOOP
+      -- Get max value from materialization hypertable converted to internal representation
+      IF cagg_rec.column_type IN ('timestamptz'::regtype, 'timestamp'::regtype, 'date'::regtype) THEN
+        EXECUTE format(
+          'SELECT (pg_catalog.date_part(''epoch'', pg_catalog.max(%I)) * 1000000)::bigint FROM %I.%I',
+          cagg_rec.column_name, cagg_rec.schema_name, cagg_rec.table_name
+        ) INTO max_val;
+      ELSE
+        EXECUTE format(
+          'SELECT pg_catalog.max(%I)::bigint FROM %I.%I',
+          cagg_rec.column_name, cagg_rec.schema_name, cagg_rec.table_name
+        ) INTO max_val;
+      END IF;
+
+      IF max_val IS NULL OR cagg_rec.bucket_width IS NULL OR NOT cagg_rec.bucket_fixed_width THEN
+        -- No data, no bucket function info, or variable-width bucket: use minimum value.
+        -- The next cagg refresh will compute the correct watermark.
+        watermark_val := '-9223372036854775808'::bigint;
+      ELSE
+        -- Fixed-width bucket: watermark is max value + bucket width
+        IF cagg_rec.column_type IN ('timestamptz'::regtype, 'timestamp'::regtype, 'date'::regtype) THEN
+          bucket_width_val := (pg_catalog.date_part('epoch', cagg_rec.bucket_width::interval) * 1000000)::bigint;
+        ELSE
+          bucket_width_val := cagg_rec.bucket_width::bigint;
+        END IF;
+        watermark_val := max_val + bucket_width_val;
+      END IF;
+
+      INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
+      VALUES (cagg_rec.mat_hypertable_id, watermark_val);
+    END LOOP;
+END;
+$$;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -65,3 +65,13 @@ BEGIN
     END LOOP;
 END;
 $$;
+
+-- Cleanup orphaned compression settings
+WITH orphaned_settings AS (
+     SELECT cs.relid, cl.relname
+     FROM _timescaledb_catalog.compression_settings cs
+     LEFT JOIN pg_class cl ON (cs.relid = cl.oid)
+     WHERE cl.relname IS NULL
+)
+DELETE FROM _timescaledb_catalog.compression_settings AS cs
+USING orphaned_settings AS os WHERE cs.relid = os.relid;

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -56,12 +56,3 @@ UPDATE pg_class cl SET relacl = tmpacl
 
 DROP TABLE _timescaledb_internal.saved_privs;
 
--- Cleanup orphaned compression settings
-WITH orphaned_settings AS (
-     SELECT cs.relid, cl.relname
-     FROM _timescaledb_catalog.compression_settings cs
-     LEFT JOIN pg_class cl ON (cs.relid = cl.oid)
-     WHERE cl.relname IS NULL
-)
-DELETE FROM _timescaledb_catalog.compression_settings AS cs
-USING orphaned_settings AS os WHERE cs.relid = os.relid;

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -56,24 +56,6 @@ UPDATE pg_class cl SET relacl = tmpacl
 
 DROP TABLE _timescaledb_internal.saved_privs;
 
--- Create watermark record when required
-DO
-$$
-DECLARE
-  ts_version TEXT;
-BEGIN
-    SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
-    IF ts_version >= '2.11.0' THEN
-      INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
-      SELECT a.mat_hypertable_id, _timescaledb_functions.cagg_watermark_materialized(a.mat_hypertable_id)
-      FROM _timescaledb_catalog.continuous_agg a
-      LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark b ON b.mat_hypertable_id = a.mat_hypertable_id
-      WHERE b.mat_hypertable_id IS NULL
-      ORDER BY 1;
-    END IF;
-END;
-$$;
-
 -- Cleanup orphaned compression settings
 WITH orphaned_settings AS (
      SELECT cs.relid, cl.relname

--- a/sql/updates/set_post_update_stage.sql
+++ b/sql/updates/set_post_update_stage.sql
@@ -1,1 +1,0 @@
-set timescaledb.update_script_stage = 'post';

--- a/sql/updates/unset_update_stage.sql
+++ b/sql/updates/unset_update_stage.sql
@@ -1,1 +1,0 @@
-set timescaledb.update_script_stage = '';

--- a/src/extension.c
+++ b/src/extension.c
@@ -36,7 +36,6 @@
 #include "guc.h"
 #include "ts_catalog/catalog.h"
 
-#define TS_UPDATE_SCRIPT_CONFIG_VAR MAKE_EXTOPTION("update_script_stage")
 #define POST_UPDATE "post"
 /*
  * The name of the experimental schema.
@@ -309,21 +308,6 @@ ts_extension_is_loaded(void)
 			 * that, for example, the catalog does not go looking for things
 			 * that aren't yet there.
 			 */
-			if (extstate == EXTENSION_STATE_TRANSITIONING)
-			{
-				/* when we are updating the extension, we execute
-				 * scripts in post_update.sql after setting up the
-				 * the dependencies. At this stage, TS
-				 * specific functionality is permitted as we now have
-				 * all catalogs and functions in place
-				 */
-				const char *update_script_stage =
-					GetConfigOption(TS_UPDATE_SCRIPT_CONFIG_VAR, true, false);
-				if (update_script_stage &&
-					(strncmp(update_script_stage, POST_UPDATE, strlen(POST_UPDATE)) == 0) &&
-					(strlen(POST_UPDATE) == strlen(update_script_stage)))
-					return true;
-			}
 			return false;
 		default:
 			elog(ERROR, "unknown state: %d", extstate);


### PR DESCRIPTION
With the removal of repair_relation_acls function we no longer
need special handling for update stage in update procedure
allowing us to simplify the update script generation a bit.

Disable-check: force-changelog-file
Disable-check: commit-count
