### PR TITLE
Fix SWITCH_TO_TS_USER macro

### DIFF
--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -29,7 +29,7 @@
 		if (OidIsValid((newuid)))                                                                  \
 		{                                                                                          \
 			GetUserIdAndSecContext(&(saved_uid), &(saved_secctx));                                 \
-			SetUserIdAndSecContext(uid, (saved_secctx) | SECURITY_LOCAL_USERID_CHANGE);            \
+			SetUserIdAndSecContext(newuid, (saved_secctx) | SECURITY_LOCAL_USERID_CHANGE);         \
 		}                                                                                          \
 	} while (0)
 


### PR DESCRIPTION
The macro referenced a variable that was not a macro argument.
All callers had the expected variable as a local variable so none
of the callers was affected.

Disable-check: force-changelog-file