### PR TITLE
Fix flaky bgw_job_stat_history_retention_isolation test

### DIFF
--- a/tsl/test/isolation/specs/bgw_job_stat_history_retention_isolation.spec
+++ b/tsl/test/isolation/specs/bgw_job_stat_history_retention_isolation.spec
@@ -10,10 +10,10 @@
 setup {
     INSERT INTO _timescaledb_internal.bgw_job_stat_history(job_id, pid, succeeded, execution_start, execution_finish)
         SELECT 100 as job_id, 12345 as pid, true as succeeded, ts as execution_start, ts + interval '5 minutes' as execution_finish
-        FROM generate_series(now() - interval '2 months', now(), interval '1 week') as ts;
+        FROM generate_series(now() - interval '60 days', now(), interval '1 week') as ts;
 
     -- Verify # of rows that should be kept
-    SELECT count(*) as expected_count FROM _timescaledb_internal.bgw_job_stat_history WHERE execution_finish > now() - interval '1 month';
+    SELECT count(*) as expected_count FROM _timescaledb_internal.bgw_job_stat_history WHERE execution_finish > now() - interval '30 days';
 }
 
 teardown {


### PR DESCRIPTION
The test checks how many jobs fit an intervals, and they are recorded as calendar months. The interval length is variable which leads to flakiness. Use days instead.

https://github.com/timescale/timescaledb/actions/runs/23797275566/job/69347780369?pr=9373#step:21:34