### PR TITLE
Isolation test for registration

### DIFF
--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
@@ -29,7 +29,7 @@ init_scan_by_materialization_id(ScanIterator *iterator, const int32 materializat
 								   Int32GetDatum(materialization_id));
 }
 
-TSDLLEXPORT void
+static void
 ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id, int64 start_range, int64 end_range,
 								   int32 pid)
 {
@@ -55,23 +55,6 @@ ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id, int64 start_range, 
 	ts_catalog_restore_user(&sec_ctx);
 
 	table_close(rel, NoLock);
-}
-
-TSDLLEXPORT void
-ts_cagg_jobs_refresh_ranges_delete_by_materialization_id(int32 materialization_id)
-{
-	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_JOBS_REFRESH_RANGES,
-													RowExclusiveLock,
-													CurrentMemoryContext);
-
-	init_scan_by_materialization_id(&iterator, materialization_id);
-
-	ts_scanner_foreach(&iterator)
-	{
-		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
-	}
-	ts_scan_iterator_close(&iterator);
 }
 
 TSDLLEXPORT void

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
@@ -9,6 +9,7 @@
 #include <miscadmin.h>
 #include <storage/lmgr.h>
 #include <storage/procarray.h>
+#include <utils/snapmgr.h>
 
 #include "scan_iterator.h"
 #include "ts_catalog/catalog.h"
@@ -136,6 +137,14 @@ ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id, int64 st
 								CurrentMemoryContext);
 	init_scan_by_materialization_id(&iterator, materialization_id);
 
+	/*
+	 * Use the latest snapshot so that we can see rows committed by the
+	 * transaction that previously held the ShareUpdateExclusiveLock.
+	 * Without this, our scan would use the statement snapshot taken before
+	 * we blocked on the lock, missing their inserts entirely.
+	 */
+	iterator.ctx.snapshot = RegisterSnapshot(GetLatestSnapshot());
+
 	bool overlap_found = false;
 
 	ts_scanner_foreach(&iterator)
@@ -179,6 +188,7 @@ ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id, int64 st
 		}
 	}
 	ts_scan_iterator_close(&iterator);
+	UnregisterSnapshot(iterator.ctx.snapshot);
 
 	if (overlap_found)
 		return false;

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.h
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.h
@@ -9,13 +9,8 @@
 
 #include "export.h"
 
-extern TSDLLEXPORT void ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id,
-														   int64 start_range, int64 end_range,
-														   int32 pid);
 extern TSDLLEXPORT bool ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id,
 																	  int64 start_range,
 																	  int64 end_range, int32 pid);
-extern TSDLLEXPORT void
-ts_cagg_jobs_refresh_ranges_delete_by_materialization_id(int32 materialization_id);
 extern TSDLLEXPORT void ts_cagg_jobs_refresh_ranges_delete_by_pid(int32 materialization_id,
 																  int32 pid);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -795,14 +795,6 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 		}
 	}
 
-	if (refresh_window.start >= refresh_window.end)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("refresh window too small"),
-				 errdetail("The refresh window must cover at least one bucket of data."),
-				 errhint("Align the refresh window with the bucket"
-						 " time zone or use at least two buckets.")));
-
 	/* If there is no other policy defined after this, the inscribed bucket calculated above
 	 * is correct. However, in the case of concurrent policies, if this isn't the last
 	 * policy defined then we should extend the end of the window to include the partial
@@ -825,6 +817,15 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 				ts_time_saturating_add(refresh_window.end, bucket_width - 1, refresh_window.type);
 		}
 	}
+
+	if (refresh_window.start >= refresh_window.end)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("refresh window too small"),
+				 errdetail("The refresh window must cover at least one bucket of data."),
+				 errhint("Align the refresh window with the bucket"
+						 " time zone or use at least two buckets.")));
+
 
 	/*
 	 * Perform the refresh across three transactions.
@@ -862,11 +863,14 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 													   MyProcPid))
 		ereport(ERROR,
 				(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
-				 errmsg("could not refresh continuous aggregate \"%s\"",
+				 errmsg("could not refresh continuous aggregate \"%s\" due to a concurrent refresh",
 						NameStr(cagg->data.user_view_name)),
 				 errdetail("A concurrent refresh on window [%s, %s) is already in progress.",
 						   ts_internal_to_time_string(refresh_window.start, refresh_window.type),
 						   ts_internal_to_time_string(refresh_window.end, refresh_window.type))));
+
+	/* Commit and Start a new transaction */
+	SPI_commit_and_chain();
 
 	/* Set the new invalidation threshold. Note that this only updates the
 	 * threshold if the new value is greater than the old one. Otherwise, the

--- a/tsl/test/isolation/expected/cagg_concurrent_register.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_register.out
@@ -1,0 +1,96 @@
+unused step name: s1_run_cagg2_nonoverlap_refresh
+Parsed test spec with 5 sessions
+
+starting permutation: s2_insert_new_data_2020 s3_lock_before_register s1_run_cagg1_refresh s2_run_cagg2_overlap_refresh s4_enable_before_process_cagg_invalidations s3_release_after_register s5_show_running_jobs s4_release_before_process_cagg_invalidations
+step s2_insert_new_data_2020: 
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
+                          '2020-01-07 00:59:59+0','1m') time;
+
+step s3_lock_before_register: 
+    BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+step s1_run_cagg1_refresh: 
+   CALL refresh_continuous_aggregate('cagg_1', '2020-01-01 00:00:00+00', '2020-01-03 00:00:00+00');
+ <waiting ...>
+step s2_run_cagg2_overlap_refresh: 
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-03 00:00:00+00', '2020-01-05 00:00:00+00');
+ <waiting ...>
+step s4_enable_before_process_cagg_invalidations: 
+    SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s3_release_after_register: 
+   ROLLBACK;
+
+step s5_show_running_jobs: 
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+  FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+  JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+  ORDER BY ca.user_view_name;
+
+cagg_name|     start_range|       end_range
+---------+----------------+----------------
+cagg_1   |1577836800000000|1578009600000000
+cagg_2   |1578009600000000|1578182400000000
+
+step s4_release_before_process_cagg_invalidations: 
+    SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_run_cagg1_refresh: <... completed>
+step s2_run_cagg2_overlap_refresh: <... completed>
+
+starting permutation: s2_insert_new_data_2020 s3_lock_before_register s1_run_cagg2_overlap_refresh s2_run_cagg2_overlap_refresh s4_enable_before_process_cagg_invalidations s3_release_after_register s5_show_running_jobs s4_release_before_process_cagg_invalidations
+step s2_insert_new_data_2020: 
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
+                          '2020-01-07 00:59:59+0','1m') time;
+
+step s3_lock_before_register: 
+    BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+step s1_run_cagg2_overlap_refresh: 
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-01 00:00:00+00', '2020-01-07 00:00:00+00');
+ <waiting ...>
+step s2_run_cagg2_overlap_refresh: 
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-03 00:00:00+00', '2020-01-05 00:00:00+00');
+ <waiting ...>
+step s4_enable_before_process_cagg_invalidations: 
+    SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s3_release_after_register: 
+   ROLLBACK;
+
+step s2_run_cagg2_overlap_refresh: <... completed>
+ERROR:  could not refresh continuous aggregate "cagg_2" due to a concurrent refresh
+step s5_show_running_jobs: 
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+  FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+  JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+  ORDER BY ca.user_view_name;
+
+cagg_name|     start_range|       end_range
+---------+----------------+----------------
+cagg_2   |1577836800000000|1578355200000000
+
+step s4_release_before_process_cagg_invalidations: 
+    SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_run_cagg2_overlap_refresh: <... completed>

--- a/tsl/test/isolation/expected/cagg_incremental_concurrent.out
+++ b/tsl/test/isolation/expected/cagg_incremental_concurrent.out
@@ -36,13 +36,14 @@ step r1_run:
     $$;
  <waiting ...>
 step s1_refresh_ranges: 
-    SELECT materialization_id, start_range, end_range
-    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    ORDER BY materialization_id;
+    SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name;
 
-materialization_id|start_range|end_range
-------------------+-----------+---------
-                 2|         50|       60
+cagg_name|start_range|end_range
+---------+-----------+---------
+cond_10  |         50|       60
 
 step s1_count: 
     SELECT count(*) AS row_count FROM cond_10;
@@ -147,13 +148,14 @@ step i1_insert:
          generate_series(1, 3) AS d;
 
 step s1_refresh_ranges: 
-    SELECT materialization_id, start_range, end_range
-    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    ORDER BY materialization_id;
+    SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name;
 
-materialization_id|start_range|end_range
-------------------+-----------+---------
-                 4|         50|       60
+cagg_name|start_range|end_range
+---------+-----------+---------
+cond_10  |         50|       60
 
 R2: LOG:  statement: 
     -- Non-overlapping with R1's registered batch range [50, 60)
@@ -166,13 +168,14 @@ step r2_refresh:
     CALL refresh_continuous_aggregate('cond_10', 1, 50);
 
 step s1_refresh_ranges: 
-    SELECT materialization_id, start_range, end_range
-    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    ORDER BY materialization_id;
+    SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name;
 
-materialization_id|start_range|end_range
-------------------+-----------+---------
-                 4|         50|       60
+cagg_name|start_range|end_range
+---------+-----------+---------
+cond_10  |         50|       60
 
 step s1_count: 
     SELECT count(*) AS row_count FROM cond_10;
@@ -261,13 +264,14 @@ step r1_run:
     $$;
  <waiting ...>
 step s1_refresh_ranges: 
-    SELECT materialization_id, start_range, end_range
-    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    ORDER BY materialization_id;
+    SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name;
 
-materialization_id|start_range|end_range
-------------------+-----------+---------
-                 6|         50|       60
+cagg_name|start_range|end_range
+---------+-----------+---------
+cond_10  |         50|       60
 
 R2: LOG:  statement: 
     -- Overlapping with R1's registered batch range [50, 60)
@@ -277,7 +281,7 @@ step r2_refresh_overlap:
     -- Overlapping with R1's registered batch range [50, 60)
     CALL refresh_continuous_aggregate('cond_10', 40, 60);
 
-ERROR:  could not refresh continuous aggregate "cond_10"
+ERROR:  could not refresh continuous aggregate "cond_10" due to a concurrent refresh
 step wp_release: 
     SELECT debug_waitpoint_release('cagg_policy_batch_2_after_txn_1_wait');
 

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -18,6 +18,7 @@ list(
   compression_conflicts_iso.spec
   cagg_insert.spec
   cagg_multi_iso.spec
+  cagg_concurrent_register.spec
   deadlock_drop_chunks_compress.spec
   deadlock_drop_index_vacuum.spec
   fk_hypertable_lock.spec

--- a/tsl/test/isolation/specs/cagg_concurrent_register.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_register.spec
@@ -1,0 +1,125 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+
+#
+# Test concurrent CAgg refreshes and invalidation threshold updates. This isolation test
+# checks that we don't skip CAgg updates when two sessions are trying to modify the
+# invalidation threshold at the same time.
+#
+setup
+{
+  CREATE TABLE temperature (
+    time timestamptz NOT NULL,
+    value float
+  );
+
+  SELECT create_hypertable('temperature', 'time');
+
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,
+                          '2000-01-01 23:59:59+0','1m') time;
+
+  CREATE MATERIALIZED VIEW cagg_1
+    WITH (timescaledb.continuous) AS
+    SELECT time_bucket('4 hour', time), avg(value)
+      FROM temperature
+      GROUP BY 1 ORDER BY 1
+    WITH NO DATA;
+
+  CREATE MATERIALIZED VIEW cagg_2
+    WITH (timescaledb.continuous) AS
+    SELECT time_bucket('4 hour', time), avg(value)
+      FROM temperature
+      GROUP BY 1 ORDER BY 1
+    WITH NO DATA;
+}
+
+# Refresh CAGGs in separate transactions
+setup
+{
+     CALL refresh_continuous_aggregate('cagg_1', NULL, NULL);
+}
+
+setup
+{
+     CALL refresh_continuous_aggregate('cagg_2', NULL, NULL);
+}
+
+# Add new data to hypertable. This time in the year 2020 instead of 2000 as we
+# did for the setup of the CAgg.
+setup
+{
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
+                          '2020-01-01 23:59:59+0','1m') time;
+}
+
+teardown {
+    DROP TABLE temperature CASCADE;
+}
+
+session "S1"
+step "s1_run_cagg1_refresh" {
+   CALL refresh_continuous_aggregate('cagg_1', '2020-01-01 00:00:00+00', '2020-01-03 00:00:00+00');
+}
+step "s1_run_cagg2_overlap_refresh" {
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-01 00:00:00+00', '2020-01-07 00:00:00+00');
+}
+step "s1_run_cagg2_nonoverlap_refresh" {
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-01 00:00:00+00', '2020-01-02 00:00:00+00');
+}
+
+session "S2"
+
+step "s2_run_cagg2_overlap_refresh" {
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-03 00:00:00+00', '2020-01-05 00:00:00+00');
+}
+
+step "s2_insert_new_data_2020" {
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
+                          '2020-01-07 00:59:59+0','1m') time;
+}
+
+session "S3"
+step "s3_lock_before_register" {
+    BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+}
+
+step "s3_release_after_register" {
+   ROLLBACK;
+}
+
+session "S4"
+step "s4_enable_before_process_cagg_invalidations" {
+    SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');
+}
+
+step "s4_release_before_process_cagg_invalidations" {
+    SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
+}
+
+session "S5"
+step "s5_show_running_jobs" {
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+  FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+  JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+  ORDER BY ca.user_view_name;
+}
+
+# TEST: when 2 concurrent refresh processes on cagg1 and cagg2 start, 1 will wait for the other one to finish registration
+## block the processes before they register, then block again before they finish cagg invalidation processing
+## so that we can see the active ranges before the refresh processes exit.
+permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg1_refresh" "s2_run_cagg2_overlap_refresh" "s4_enable_before_process_cagg_invalidations" "s3_release_after_register" "s5_show_running_jobs" "s4_release_before_process_cagg_invalidations"
+
+# TEST: Check that two overlapping refresh on cagg2 will not run concurrently. overlap refresh job will fail.
+## so we will see only 1 running job.
+permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg2_overlap_refresh" "s2_run_cagg2_overlap_refresh" "s4_enable_before_process_cagg_invalidations" "s3_release_after_register" "s5_show_running_jobs" "s4_release_before_process_cagg_invalidations"
+
+# TEST: Check that two non-overlapping refresh on cagg2 will run concurrently.
+#permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg2_nonoverlap_refresh" "s2_run_cagg2_overlap_refresh" "s4_enable_before_process_cagg_invalidations" "s3_release_after_register" "s5_show_running_jobs" "s4_release_before_process_cagg_invalidations"

--- a/tsl/test/isolation/specs/cagg_incremental_concurrent.spec
+++ b/tsl/test/isolation/specs/cagg_incremental_concurrent.spec
@@ -155,9 +155,10 @@ step "s1_check_duplicates"
 }
 step "s1_refresh_ranges"
 {
-    SELECT materialization_id, start_range, end_range
-    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    ORDER BY materialization_id;
+    SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name;
 }
 
 # Test 1: Run 1 pauses after batch 1. Manual refresh on overlapping range [1,50).


### PR DESCRIPTION
Move the registration to its own transaction.
use latest snapshot while processing the refresh_jobs_ranges table.