### PR TITLE
Fix deadlock between 2 refreshes that process  materialization inv log

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -929,7 +929,7 @@ process_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *sta
 	iterator.ctx.data = (void *) &state;
 	iterator.ctx.snapshot = state->snapshot;
 	ScanTupLock scantuplock = {
-		.waitpolicy = LockWaitBlock,
+		.waitpolicy = LockWaitSkip,
 		.lockmode = LockTupleExclusive,
 		.lockflags = TUPLE_LOCK_FLAG_FIND_LAST_VERSION,
 	};
@@ -940,7 +940,24 @@ process_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *sta
 	 * Concurrent refreshes on the same cagg are safe from deadlock because all
 	 * sessions scan the same index in ascending lowest_modified_value order,
 	 * ensuring exclusive tuple locks are always acquired in a consistent order.
-	 */
+         * However, we have this problem: 
+         * S1:  in txn3 materializing ranges  [ 40, 60 ].
+         *      so it will read rows from mat. inv log.
+         *      delete + insert rows into cagg's mat hypertable
+         *      delete row from mat inv log
+         * S2: in txn2 reading invalidation logs in [ 60 80]
+         *     this will read all the logs starting from the beginning
+         *      and < 80 so that it can process overlaps. 
+         * S1: locks row for tuple 45
+         *                              S2 : acquires ShareUpdateExlcusiveLock
+         *                              S2:  waits for lock for tuple 45
+         * S1: needs to create a new chunk in mat hypertable 
+         *     blocks on S2's ShareUpdateExclusiveLock
+         *     so we have a deadlock
+         * To prevent that in txn2 don't block on locks for mat inv log rows.
+         * it is being concurrently processed by another session.
+         * use waitpolicy = LockWaitSlip
+         */
 
 	MemoryContextReset(state->per_tuple_mctx);
 

--- a/tsl/test/isolation/expected/cagg_concurrent_register.out
+++ b/tsl/test/isolation/expected/cagg_concurrent_register.out
@@ -1,14 +1,15 @@
-unused step name: s1_run_cagg2_nonoverlap_refresh
 Parsed test spec with 5 sessions
 
 starting permutation: s2_insert_new_data_2020 s3_lock_before_register s1_run_cagg1_refresh s2_run_cagg2_overlap_refresh s4_enable_before_process_cagg_invalidations s3_release_after_register s5_show_running_jobs s4_release_before_process_cagg_invalidations
 step s2_insert_new_data_2020: 
+  -- Insert data that will fall into refresh range
   INSERT INTO temperature
     SELECT time, ceil(random() * 100)::int
       FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
                           '2020-01-07 00:59:59+0','1m') time;
 
 step s3_lock_before_register: 
+    -- lock jobs_refresh_ranges table to serialize registration
     BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 
 step s1_run_cagg1_refresh: 
@@ -25,18 +26,21 @@ debug_waitpoint_enable
                       
 
 step s3_release_after_register: 
+   -- release lock on jobs_refresh_ranges table
    ROLLBACK;
 
 step s5_show_running_jobs: 
-  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range,
+         to_timestamp(r.start_range / 1000000) AT TIME ZONE 'UTC' AS start_ts_utc,
+         to_timestamp(r.end_range / 1000000) AT TIME ZONE 'UTC' AS end_ts_utc
   FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
   JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
   ORDER BY ca.user_view_name;
 
-cagg_name|     start_range|       end_range
----------+----------------+----------------
-cagg_1   |1577836800000000|1578009600000000
-cagg_2   |1578009600000000|1578182400000000
+cagg_name|     start_range|       end_range|start_ts_utc            |end_ts_utc              
+---------+----------------+----------------+------------------------+------------------------
+cagg_1   |1577836800000000|1578009600000000|Wed Jan 01 00:00:00 2020|Fri Jan 03 00:00:00 2020
+cagg_2   |1578009600000000|1578182400000000|Fri Jan 03 00:00:00 2020|Sun Jan 05 00:00:00 2020
 
 step s4_release_before_process_cagg_invalidations: 
     SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
@@ -50,12 +54,14 @@ step s2_run_cagg2_overlap_refresh: <... completed>
 
 starting permutation: s2_insert_new_data_2020 s3_lock_before_register s1_run_cagg2_overlap_refresh s2_run_cagg2_overlap_refresh s4_enable_before_process_cagg_invalidations s3_release_after_register s5_show_running_jobs s4_release_before_process_cagg_invalidations
 step s2_insert_new_data_2020: 
+  -- Insert data that will fall into refresh range
   INSERT INTO temperature
     SELECT time, ceil(random() * 100)::int
       FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
                           '2020-01-07 00:59:59+0','1m') time;
 
 step s3_lock_before_register: 
+    -- lock jobs_refresh_ranges table to serialize registration
     BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 
 step s1_run_cagg2_overlap_refresh: 
@@ -72,19 +78,22 @@ debug_waitpoint_enable
                       
 
 step s3_release_after_register: 
+   -- release lock on jobs_refresh_ranges table
    ROLLBACK;
 
 step s2_run_cagg2_overlap_refresh: <... completed>
 ERROR:  could not refresh continuous aggregate "cagg_2" due to a concurrent refresh
 step s5_show_running_jobs: 
-  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range,
+         to_timestamp(r.start_range / 1000000) AT TIME ZONE 'UTC' AS start_ts_utc,
+         to_timestamp(r.end_range / 1000000) AT TIME ZONE 'UTC' AS end_ts_utc
   FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
   JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
   ORDER BY ca.user_view_name;
 
-cagg_name|     start_range|       end_range
----------+----------------+----------------
-cagg_2   |1577836800000000|1578355200000000
+cagg_name|     start_range|       end_range|start_ts_utc            |end_ts_utc              
+---------+----------------+----------------+------------------------+------------------------
+cagg_2   |1577836800000000|1578355200000000|Wed Jan 01 00:00:00 2020|Tue Jan 07 00:00:00 2020
 
 step s4_release_before_process_cagg_invalidations: 
     SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
@@ -94,3 +103,55 @@ debug_waitpoint_release
                        
 
 step s1_run_cagg2_overlap_refresh: <... completed>
+
+starting permutation: s2_insert_new_data_2020 s3_lock_before_register s1_run_cagg2_nonoverlap_refresh s2_run_cagg2_overlap_refresh s4_enable_before_process_cagg_invalidations s3_release_after_register s5_show_running_jobs s4_release_before_process_cagg_invalidations
+step s2_insert_new_data_2020: 
+  -- Insert data that will fall into refresh range
+  INSERT INTO temperature
+    SELECT time, ceil(random() * 100)::int
+      FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
+                          '2020-01-07 00:59:59+0','1m') time;
+
+step s3_lock_before_register: 
+    -- lock jobs_refresh_ranges table to serialize registration
+    BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+step s1_run_cagg2_nonoverlap_refresh: 
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-01 00:00:00+00', '2020-01-02 00:00:00+00');
+ <waiting ...>
+step s2_run_cagg2_overlap_refresh: 
+   CALL refresh_continuous_aggregate('cagg_2', '2020-01-03 00:00:00+00', '2020-01-05 00:00:00+00');
+ <waiting ...>
+step s4_enable_before_process_cagg_invalidations: 
+    SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s3_release_after_register: 
+   -- release lock on jobs_refresh_ranges table
+   ROLLBACK;
+
+step s5_show_running_jobs: 
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range,
+         to_timestamp(r.start_range / 1000000) AT TIME ZONE 'UTC' AS start_ts_utc,
+         to_timestamp(r.end_range / 1000000) AT TIME ZONE 'UTC' AS end_ts_utc
+  FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+  JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
+  ORDER BY ca.user_view_name;
+
+cagg_name|     start_range|       end_range|start_ts_utc            |end_ts_utc              
+---------+----------------+----------------+------------------------+------------------------
+cagg_2   |1577836800000000|1577923200000000|Wed Jan 01 00:00:00 2020|Thu Jan 02 00:00:00 2020
+cagg_2   |1578009600000000|1578182400000000|Fri Jan 03 00:00:00 2020|Sun Jan 05 00:00:00 2020
+
+step s4_release_before_process_cagg_invalidations: 
+    SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s2_run_cagg2_overlap_refresh: <... completed>
+step s1_run_cagg2_nonoverlap_refresh: <... completed>

--- a/tsl/test/isolation/specs/cagg_concurrent_register.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_register.spec
@@ -80,6 +80,7 @@ step "s2_run_cagg2_overlap_refresh" {
 }
 
 step "s2_insert_new_data_2020" {
+  -- Insert data that will fall into refresh range
   INSERT INTO temperature
     SELECT time, ceil(random() * 100)::int
       FROM generate_series('2020-01-01 0:00:00+0'::timestamptz,
@@ -88,10 +89,12 @@ step "s2_insert_new_data_2020" {
 
 session "S3"
 step "s3_lock_before_register" {
+    -- lock jobs_refresh_ranges table to serialize registration
     BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 }
 
 step "s3_release_after_register" {
+   -- release lock on jobs_refresh_ranges table
    ROLLBACK;
 }
 
@@ -106,7 +109,9 @@ step "s4_release_before_process_cagg_invalidations" {
 
 session "S5"
 step "s5_show_running_jobs" {
-  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
+  SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range,
+         to_timestamp(r.start_range / 1000000) AT TIME ZONE 'UTC' AS start_ts_utc,
+         to_timestamp(r.end_range / 1000000) AT TIME ZONE 'UTC' AS end_ts_utc
   FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
   JOIN _timescaledb_catalog.continuous_agg ca ON r.materialization_id = ca.mat_hypertable_id
   ORDER BY ca.user_view_name;
@@ -121,5 +126,6 @@ permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg1_re
 ## so we will see only 1 running job.
 permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg2_overlap_refresh" "s2_run_cagg2_overlap_refresh" "s4_enable_before_process_cagg_invalidations" "s3_release_after_register" "s5_show_running_jobs" "s4_release_before_process_cagg_invalidations"
 
-# TEST: Check that two non-overlapping refresh on cagg2 will run concurrently.
-#permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg2_nonoverlap_refresh" "s2_run_cagg2_overlap_refresh" "s4_enable_before_process_cagg_invalidations" "s3_release_after_register" "s5_show_running_jobs" "s4_release_before_process_cagg_invalidations"
+# TEST: Check that two non-overlapping refresh on cagg2 will run concurrently
+## we should see both jobs
+permutation "s2_insert_new_data_2020" "s3_lock_before_register" "s1_run_cagg2_nonoverlap_refresh" "s2_run_cagg2_overlap_refresh" "s4_enable_before_process_cagg_invalidations" "s3_release_after_register" "s5_show_running_jobs" "s4_release_before_process_cagg_invalidations"


### PR DESCRIPTION
When 1 process cuts the invalidation logs, another could be deleting them as part of the actual materialization. Skip tuples that cannot be locked during materialization inv log cutting.  It means that another session in working on that entry.