### PR TITLE
Disallow sub-day offset for time-bucket on Date

### DIFF
--- a/.unreleased/pr_9479
+++ b/.unreleased/pr_9479
@@ -1,0 +1,1 @@
+Fixes: #9479 Disallow sub-day offset for time-bucket on Date

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -465,17 +465,22 @@ ts_date_offset_bucket(PG_FUNCTION_ARGS)
 {
 	Datum period = PG_GETARG_DATUM(0);
 	Datum date = PG_GETARG_DATUM(1);
+	Interval *offset = PG_GETARG_INTERVAL_P(2);
+
+	/* Validate the offset is day-aligned, same as the bucket width requirement. */
+	int64 offset_period = get_interval_period_timestamp_units(offset);
+	check_period_is_daily(offset_period);
 
 	if (DATE_NOT_FINITE(DatumGetDateADT(date)))
 		PG_RETURN_DATUM(date);
 
 	/* Apply offset. */
-	Datum time = DirectFunctionCall2(date_mi_interval, date, PG_GETARG_DATUM(2));
+	Datum time = DirectFunctionCall2(date_mi_interval, date, IntervalPGetDatum(offset));
 	date = DirectFunctionCall1(timestamp_date, time);
 	date = DirectFunctionCall2(ts_date_bucket, period, date);
 
 	/* Remove offset. */
-	time = DirectFunctionCall2(date_pl_interval, date, PG_GETARG_DATUM(2));
+	time = DirectFunctionCall2(date_pl_interval, date, IntervalPGetDatum(offset));
 	date = DirectFunctionCall1(timestamp_date, time);
 	PG_RETURN_DATUM(date);
 }

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -89,14 +89,6 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('5 minutes', time, INTERV
     23.4 | Mon Mar 20 09:16:00 2017 PDT
       30 | Mon Mar 20 09:36:00 2017 PDT
 
-SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '-0.5 day') AS ten_min FROM test_dt GROUP BY ten_min ORDER BY avg_tmp;
- avg_tmp |  ten_min   
----------+------------
-    21.2 | 03-21-2017
-      22 | 03-20-2017
-    23.4 | 03-19-2017
-      30 | 03-22-2017
-
 -- testing time_bucket END
 -- testing drop_chunks START
 -- show_chunks and drop_chunks output should be the same

--- a/test/expected/timestamp-15.out
+++ b/test/expected/timestamp-15.out
@@ -234,6 +234,11 @@ SELECT time_bucket('1 hour', DATE '2012-01-01');
 ERROR:  interval must not have sub-day precision
 SELECT time_bucket('25 hour', DATE '2012-01-01');
 ERROR:  interval must be a multiple of a day
+-- sub-day offset not supported for time_bucket of type Date
+SELECT time_bucket('1 day', DATE '2012-01-01', '1 hour'::interval);
+ERROR:  interval must not have sub-day precision
+SELECT time_bucket('1 week', DATE '2012-01-01', '30 minutes'::interval);
+ERROR:  interval must not have sub-day precision
 \set ON_ERROR_STOP 1
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');
        time_bucket        

--- a/test/expected/timestamp-16.out
+++ b/test/expected/timestamp-16.out
@@ -237,6 +237,11 @@ SELECT time_bucket('1 hour', DATE '2012-01-01');
 ERROR:  interval must not have sub-day precision
 SELECT time_bucket('25 hour', DATE '2012-01-01');
 ERROR:  interval must be a multiple of a day
+-- sub-day offset not supported for time_bucket of type Date
+SELECT time_bucket('1 day', DATE '2012-01-01', '1 hour'::interval);
+ERROR:  interval must not have sub-day precision
+SELECT time_bucket('1 week', DATE '2012-01-01', '30 minutes'::interval);
+ERROR:  interval must not have sub-day precision
 \set ON_ERROR_STOP 1
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');
        time_bucket        

--- a/test/expected/timestamp-17.out
+++ b/test/expected/timestamp-17.out
@@ -237,6 +237,11 @@ SELECT time_bucket('1 hour', DATE '2012-01-01');
 ERROR:  interval must not have sub-day precision
 SELECT time_bucket('25 hour', DATE '2012-01-01');
 ERROR:  interval must be a multiple of a day
+-- sub-day offset not supported for time_bucket of type Date
+SELECT time_bucket('1 day', DATE '2012-01-01', '1 hour'::interval);
+ERROR:  interval must not have sub-day precision
+SELECT time_bucket('1 week', DATE '2012-01-01', '30 minutes'::interval);
+ERROR:  interval must not have sub-day precision
 \set ON_ERROR_STOP 1
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');
        time_bucket        

--- a/test/expected/timestamp-18.out
+++ b/test/expected/timestamp-18.out
@@ -237,6 +237,11 @@ SELECT time_bucket('1 hour', DATE '2012-01-01');
 ERROR:  interval must not have sub-day precision
 SELECT time_bucket('25 hour', DATE '2012-01-01');
 ERROR:  interval must be a multiple of a day
+-- sub-day offset not supported for time_bucket of type Date
+SELECT time_bucket('1 day', DATE '2012-01-01', '1 hour'::interval);
+ERROR:  interval must not have sub-day precision
+SELECT time_bucket('1 week', DATE '2012-01-01', '30 minutes'::interval);
+ERROR:  interval must not have sub-day precision
 \set ON_ERROR_STOP 1
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');
        time_bucket        

--- a/test/sql/relocate_extension.sql
+++ b/test/sql/relocate_extension.sql
@@ -47,7 +47,6 @@ SELECT * FROM test_dt ORDER BY time;
 -- testing time_bucket START
 SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('5 minutes', time, INTERVAL '1 minutes') AS ten_min FROM test_ts GROUP BY ten_min ORDER BY avg_tmp;
 SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('5 minutes', time, INTERVAL '1 minutes') AS ten_min FROM test_tz GROUP BY ten_min ORDER BY avg_tmp;
-SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '-0.5 day') AS ten_min FROM test_dt GROUP BY ten_min ORDER BY avg_tmp;
 -- testing time_bucket END
 
 -- testing drop_chunks START

--- a/test/sql/timestamp.sql.in
+++ b/test/sql/timestamp.sql.in
@@ -153,6 +153,10 @@ SELECT _timescaledb_functions.to_unix_microseconds(timestamp '294247-01-01 23:59
 SELECT time_bucket('1 hour', DATE '2012-01-01');
 SELECT time_bucket('25 hour', DATE '2012-01-01');
 
+-- sub-day offset not supported for time_bucket of type Date
+SELECT time_bucket('1 day', DATE '2012-01-01', '1 hour'::interval);
+SELECT time_bucket('1 week', DATE '2012-01-01', '30 minutes'::interval);
+
 \set ON_ERROR_STOP 1
 
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');


### PR DESCRIPTION
We disallow sub-day interval for time-bucket on Date datatype, yet still allow sub-day offset which doesn't make sense. This patch checks and raises an error in that case.