### PR TITLE
Forbid Batch Sort Merge on nullable orderby columns

### DIFF
--- a/.unreleased/pr_9482
+++ b/.unreleased/pr_9482
@@ -1,0 +1,1 @@
+Fixes: #9482 Forbid Batch Sort Merge on nullable orderby columns

--- a/src/utils.c
+++ b/src/utils.c
@@ -2006,3 +2006,17 @@ ts_is_time_bucket_function(Expr *node)
 
 	return false;
 }
+
+#if PG17_LT
+bool
+ts_get_attnotnull(Oid relid, AttrNumber attno)
+{
+	HeapTuple tp = SearchSysCache2(ATTNUM, ObjectIdGetDatum(relid), Int16GetDatum(attno));
+	if (!HeapTupleIsValid(tp))
+		return false;
+	Form_pg_attribute att_tup = (Form_pg_attribute) GETSTRUCT(tp);
+	bool result = att_tup->attnotnull;
+	ReleaseSysCache(tp);
+	return result;
+}
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -374,3 +374,6 @@ extern TSDLLEXPORT char *ts_get_attr_expr(Relation rel, AttrNumber attno);
 extern TSDLLEXPORT char *ts_list_to_string(List *list, append_cell_func append);
 extern TSDLLEXPORT List *ts_find_aggrefs(Node *node);
 extern TSDLLEXPORT bool ts_is_time_bucket_function(Expr *node);
+#if PG17_LT
+extern TSDLLEXPORT bool ts_get_attnotnull(Oid relid, AttrNumber attno);
+#endif

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -13,6 +13,7 @@
 #include <nodes/bitmapset.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
+#include <optimizer/clauses.h>
 #include <optimizer/cost.h>
 #include <optimizer/optimizer.h>
 #include <optimizer/pathnode.h>
@@ -25,7 +26,9 @@
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
 #include <utils/typcache.h>
-
+#if PG16_GE
+#include <nodes/multibitmapset.h>
+#endif
 #include <planner.h>
 
 #include "compat/compat.h"
@@ -2673,6 +2676,54 @@ find_const_segmentby(RelOptInfo *chunk_rel, const CompressionInfo *info)
 	return segmentby_columns;
 }
 
+static bool
+is_var_notnull(const CompressionInfo *compression_info, Var *var)
+{
+	bool notnull = false;
+	/* Is it declared NOT NULL? */
+#if PG17_LT
+	notnull = ts_get_attnotnull(compression_info->chunk_rte->relid, var->varattno);
+#else
+	notnull = bms_is_member(var->varattno, compression_info->chunk_rel->notnullattnums);
+#endif
+
+	if (notnull)
+		return true;
+
+	/* even if this column is nullable it may participate in strict predicates which will exclude
+	 * NULL values */
+	RelOptInfo *chunk_rel = compression_info->chunk_rel;
+	ListCell *l;
+	foreach (l, chunk_rel->baserestrictinfo)
+	{
+		RestrictInfo *ri = castNode(RestrictInfo, lfirst(l));
+		Bitmapset *clause_attnos = NULL;
+		pull_varattnos((Node *) ri->clause, chunk_rel->relid, &clause_attnos);
+		if (bms_is_member(var->varattno - FirstLowInvalidHeapAttributeNumber, clause_attnos))
+		{
+			/* Is this column made non-nullable by the query predicates? */
+			List *nonnullable_vars = find_nonnullable_vars((Node *) ri->clause);
+#if PG16_GE
+			if (mbms_is_member(var->varno,
+							   var->varattno - FirstLowInvalidHeapAttributeNumber,
+							   nonnullable_vars))
+			{
+				return true;
+			}
+#else
+			ListCell *lv;
+			foreach (lv, nonnullable_vars)
+			{
+				Var *v = castNode(Var, lfirst(lv));
+				if (v->varno == var->varno && v->varattno == var->varattno)
+					return true;
+			}
+#endif
+		}
+	}
+	return false;
+}
+
 /*
  * Returns whether the pathkeys starting at the given offset match the compression
  * orderby, and whether the order is reverse.
@@ -2680,7 +2731,8 @@ find_const_segmentby(RelOptInfo *chunk_rel, const CompressionInfo *info)
 static bool
 match_pathkeys_to_compression_orderby(List *pathkeys, List *chunk_em_exprs,
 									  int starting_pathkey_offset,
-									  const CompressionInfo *compression_info, bool *out_reverse)
+									  const CompressionInfo *compression_info, bool for_bsm,
+									  bool *out_reverse)
 {
 	int compressed_pk_index = 0;
 	for (int i = starting_pathkey_offset; i < list_length(pathkeys); i++)
@@ -2709,17 +2761,28 @@ match_pathkeys_to_compression_orderby(List *pathkeys, List *chunk_em_exprs,
 			return false;
 		}
 
+		/* Bail out on BSM if orderby column is nullable,
+		 * as at the moment the minmax metadata we have doesn't include NULLs,
+		 * so it's difficult to use it for null-sensitive ordering.
+		 * But this restriction can be lifted in the future on new type of chunks
+		 * with NULL-handling metadata.
+		 */
+		if (for_bsm && !is_var_notnull(compression_info, var))
+		{
+			return false;
+		}
+
 		bool orderby_desc =
 			ts_array_get_element_bool(compression_info->settings->fd.orderby_desc, orderby_index);
 		bool orderby_nullsfirst =
 			ts_array_get_element_bool(compression_info->settings->fd.orderby_nullsfirst,
 									  orderby_index);
-
 		/*
 		 * In PG18+: pk_cmptype is either COMPARE_LT (for ASC) or COMPARE_GT (for DESC)
 		 * For previous PG versions we have compatibility macros to make these new names available.
 		 */
 		bool this_pathkey_reverse = false;
+
 		if (pk->pk_cmptype == COMPARE_LT)
 		{
 			if (!orderby_desc && orderby_nullsfirst == pk->pk_nulls_first)
@@ -2909,6 +2972,7 @@ build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 														  chunk_em_exprs,
 														  /* starting_pathkey_offset = */ 0,
 														  compression_info,
+														  /* for_bsm = */ true,
 														  &sort_info.reverse);
 			}
 			return sort_info;
@@ -2936,6 +3000,7 @@ build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 																		  chunk_em_exprs,
 																		  i,
 																		  compression_info,
+																		  /* for_bsm = */ false,
 																		  &sort_info.reverse);
 
 	return sort_info;

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -31,6 +31,7 @@
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/constraint_aware_append/constraint_aware_append.h"
 #include "nodes/skip_scan/skip_scan.h"
+#include "utils.h"
 #include <import/planner.h>
 
 #include <math.h>
@@ -778,20 +779,6 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 	}
 }
 
-#if PG17_LT
-static bool
-attr_is_notnull(Oid relid, AttrNumber attno)
-{
-	HeapTuple tp = SearchSysCache2(ATTNUM, ObjectIdGetDatum(relid), Int16GetDatum(attno));
-	if (!HeapTupleIsValid(tp))
-		return false;
-	Form_pg_attribute att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-	bool result = att_tup->attnotnull;
-	ReleaseSysCache(tp);
-	return result;
-}
-#endif
-
 /* Check if skip key is guaranteed not-null */
 static void
 check_notnull_skipkey(SkipKeyInfo *skinfo, Path *child_path, IndexPath *index_path)
@@ -1110,7 +1097,7 @@ get_distinct_var(PlannerInfo *root, Expr *tlexpr, IndexPath *index_path, Path *c
 	 *  as NOT NULL constraint will be propagated to and checked on all chunks
 	 */
 #if PG17_LT
-	skinfo->notnull = attr_is_notnull(ht_rte->relid, var->varattno);
+	skinfo->notnull = ts_get_attnotnull(ht_rte->relid, var->varattno);
 #else
 	RelOptInfo *baserel = ((Index) var->varno == rel->relid ? rel : rel->parent);
 	skinfo->notnull = bms_is_member(var->varattno, baserel->notnullattnums);

--- a/tsl/test/expected/compression_sorted_merge.out
+++ b/tsl/test/expected/compression_sorted_merge.out
@@ -10,8 +10,8 @@ CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 SELECT FROM create_hypertable('test1', 'time');
 --
@@ -31,8 +31,8 @@ CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 SELECT FROM create_hypertable('test2', 'time');
 --
@@ -309,10 +309,12 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
 
 -- Should be optimized
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 ASC NULLS FIRST;
 --- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4.00 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=2.00 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Filter: (_hyper_5_5_chunk.x2 IS NOT NULL)
+   Rows Removed by Filter: 2
    Batch Sorted Merge: true
    Bulk Decompression: false
    ->  Sort (actual rows=2.00 loops=1)
@@ -324,10 +326,12 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
 
 -- Should be optimized (backward scan)
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 DESC NULLS LAST;
 --- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=4.00 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=2.00 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Filter: (_hyper_5_5_chunk.x2 IS NOT NULL)
+   Rows Removed by Filter: 2
    Batch Sorted Merge: true
    Reverse: true
    Bulk Decompression: false
@@ -937,39 +941,39 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
    1 |   2 |     3 |  3 |  1 | 43 | Fri Dec 31 17:00:00 1999 PST
    1 |   2 |     3 |  2 |  1 | 43 | Fri Dec 31 16:00:00 1999 PST
 
--- Test with null values
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
-
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
-
+-- Test with null values: should not optimize
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  2
 
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  1
 
 ------
 -- Tests based on compressed chunk state
@@ -1364,7 +1368,7 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
 -- Condition that filter the first tuple of a batch - Issue 5797
 CREATE TABLE test (
     id      bigint,
-    dttm    timestamp,
+    dttm    timestamp NOT NULL,
     otherId    int,
     valueFk int,
     otherFk int,

--- a/tsl/test/expected/compression_sorted_merge_columns.out
+++ b/tsl/test/expected/compression_sorted_merge_columns.out
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Test various corner cases of sorting.
-create table t(x int, time timestamp, timetz timestamptz, int32 int4, int64 int8, s text);
+create table t(x int, time timestamp NOT NULL, timetz timestamptz NOT NULL, int32 int4 NOT NULL, int64 int8 NOT NULL, s text NOT NULL);
 select create_hypertable('t', 'x');
 WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_hypertable 

--- a/tsl/test/expected/compression_sorted_merge_unordered.out
+++ b/tsl/test/expected/compression_sorted_merge_unordered.out
@@ -11,8 +11,8 @@ CREATE TABLE test1 (
     time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 SELECT FROM create_hypertable('test1', 'time');
 --
@@ -43,8 +43,8 @@ CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 SELECT FROM create_hypertable('test2', 'time');
 --
@@ -354,12 +354,14 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
          ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3.00 loops=1)
                Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
 
--- Should be optimized
+-- Should be optimized as we exclude NULLs from x2
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 ASC NULLS FIRST;
 --- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=12.00 loops=1)
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=6.00 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Filter: (_hyper_5_5_chunk.x2 IS NOT NULL)
+   Rows Removed by Filter: 6
    Chunk Status: UNORDERED
    Batch Sorted Merge: true
    Bulk Decompression: false
@@ -370,12 +372,34 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
 
--- Should be optimized (backward scan)
+-- Should not be optimized (NULL order wrong)
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 ASC NULLS LAST;
 --- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=12.00 loops=1)
+ Sort (actual rows=6.00 loops=1)
    Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Sort Key: _hyper_5_5_chunk.x2
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=6.00 loops=1)
+         Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+         Vectorized Filter: (_hyper_5_5_chunk.x2 IS NOT NULL)
+         Rows Removed by Filter: 6
+         Batches Removed by Filter: 1
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+
+set timescaledb.debug_require_batch_sorted_merge to 'force';
+-- Should be optimized (backward scan) as we exclude NULLs from x2
+:PREFIX
+SELECT * FROM test_with_defined_null  WHERE (x2 + 1) IS NOT NULL ORDER BY x2 DESC NULLS LAST;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=6.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Filter: ((_hyper_5_5_chunk.x2 + 1) IS NOT NULL)
+   Rows Removed by Filter: 6
    Chunk Status: UNORDERED
    Batch Sorted Merge: true
    Reverse: true
@@ -386,6 +410,44 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
          Sort Method: quicksort 
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+
+-- Should be optimized as we exlude NULLs from x2 via strict functions
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2 > 0 ORDER BY x2 ASC NULLS FIRST;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=6.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Filter: (_hyper_5_5_chunk.x2 > 0)
+   Rows Removed by Filter: 3
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+         Sort Key: compress_hyper_6_6_chunk._ts_meta_min_1 NULLS FIRST
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+               Filter: (compress_hyper_6_6_chunk._ts_meta_max_1 > 0)
+               Rows Removed by Filter: 1
+
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2::float + x1 > 1.0  AND time = '2000-01-01' ORDER BY x2 ASC NULLS FIRST;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=6.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Filter: ((_hyper_5_5_chunk."time" = 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND (((_hyper_5_5_chunk.x2)::double precision + (_hyper_5_5_chunk.x1)::double precision) > '1'::double precision))
+   Rows Removed by Filter: 6
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=2.00 loops=1)
+         Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+         Sort Key: compress_hyper_6_6_chunk._ts_meta_min_1 NULLS FIRST
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+               Filter: ((compress_hyper_6_6_chunk._ts_meta_min_2 <= 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND (compress_hyper_6_6_chunk._ts_meta_max_2 >= 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone))
 
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 -- Should not be optimized (wrong order for x3 in backward scan)
@@ -508,7 +570,21 @@ SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS FIRST, x4 DESC;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3.00 loops=1)
                Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
 
--- Should not be optimized
+-- Should not be optimized as x2 is nullable
+:PREFIX
+SELECT * FROM test_with_defined_null ORDER BY x2 ASC;
+--- QUERY PLAN ---
+ Sort (actual rows=12.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Sort Key: _hyper_5_5_chunk.x2
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=12.00 loops=1)
+         Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
 --- QUERY PLAN ---
@@ -523,7 +599,6 @@ SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
 
--- Should not be optimized
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 --- QUERY PLAN ---
@@ -533,6 +608,54 @@ SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
    Sort Method: quicksort 
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=12.00 loops=1)
          Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+
+:PREFIX
+SELECT * FROM test_with_defined_null ORDER BY x2 DESC;
+--- QUERY PLAN ---
+ Sort (actual rows=12.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Sort Key: _hyper_5_5_chunk.x2 DESC
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=12.00 loops=1)
+         Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+
+-- Should not be optimized as x2 is nullable with non-strict-only predicates over x2
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL OR x2 > 1 ORDER BY x2;
+--- QUERY PLAN ---
+ Sort (actual rows=6.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Sort Key: _hyper_5_5_chunk.x2
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=6.00 loops=1)
+         Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+         Vectorized Filter: ((_hyper_5_5_chunk.x2 IS NOT NULL) OR (_hyper_5_5_chunk.x2 > 1))
+         Rows Removed by Filter: 6
+         Batches Removed by Filter: 1
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
+               Output: compress_hyper_6_6_chunk._ts_meta_count, compress_hyper_6_6_chunk.x1, compress_hyper_6_6_chunk._ts_meta_min_2, compress_hyper_6_6_chunk._ts_meta_max_2, compress_hyper_6_6_chunk."time", compress_hyper_6_6_chunk._ts_meta_min_1, compress_hyper_6_6_chunk._ts_meta_max_1, compress_hyper_6_6_chunk.x2, compress_hyper_6_6_chunk.x3
+
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2 IS NULL OR x2 > 1 ORDER BY x2;
+--- QUERY PLAN ---
+ Sort (actual rows=9.00 loops=1)
+   Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+   Sort Key: _hyper_5_5_chunk.x2
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_5_5_chunk (actual rows=9.00 loops=1)
+         Output: _hyper_5_5_chunk."time", _hyper_5_5_chunk.x1, _hyper_5_5_chunk.x2, _hyper_5_5_chunk.x3
+         Vectorized Filter: ((_hyper_5_5_chunk.x2 IS NULL) OR (_hyper_5_5_chunk.x2 > 1))
+         Rows Removed by Filter: 3
          Chunk Status: UNORDERED
          Bulk Decompression: true
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_6_chunk (actual rows=2.00 loops=1)
@@ -1172,71 +1295,71 @@ SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time
    1 |   2 |     3 |  2 |  1 | 43 | Fri Dec 31 16:00:00 1999 PST
    1 |   2 |     3 |  2 |  1 | 43 | Fri Dec 31 16:00:00 1999 PST
 
--- Test with null values
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
-
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
-
+-- Test with null values in x2
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
 
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
-             time             | x1 | x2 | x3 
-------------------------------+----+----+----
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  2 |    |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  2 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
- Sat Jan 01 00:00:00 2000 PST |  1 |  1 |   
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
+             time             | x2 
+------------------------------+----
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |   
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  2
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
+ Sat Jan 01 00:00:00 2000 PST |  1
 
 ------
 -- Tests based on compressed chunk state
@@ -1494,3 +1617,51 @@ SELECT * FROM test_segby ORDER BY segby, time;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_8_8_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_8_8_chunk._ts_meta_count, compress_hyper_8_8_chunk.segby, compress_hyper_8_8_chunk._ts_meta_min_1, compress_hyper_8_8_chunk._ts_meta_max_1, compress_hyper_8_8_chunk."time", compress_hyper_8_8_chunk.val
 
+-- Tests for #9445: forbid BSM on nullable orderby columns
+CREATE TABLE t(time int NOT NULL, device int, val int);
+SELECT create_hypertable('t', 'time', chunk_time_interval => 10000);
+ create_hypertable 
+-------------------
+ (9,public,t,t)
+
+ALTER TABLE t SET (timescaledb.compress,
+    timescaledb.compress_segmentby='device',
+    timescaledb.compress_orderby='val DESC');
+-- One batch: 200 NULLs + values 1..300. _ts_meta_max = 300.
+-- In DESC order the first decompressed tuple is NULL, not 300.
+SET timescaledb.enable_direct_compress_insert = false;
+INSERT INTO t SELECT 1, 1, NULL FROM generate_series(1, 200);
+INSERT INTO t SELECT 1, 1, g FROM generate_series(1, 300) g;
+SELECT compress_chunk(show_chunks('t'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_9_9_chunk
+
+-- Two more batches via direct compress (chunk becomes unordered).
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO t SELECT 1, 1, g FROM generate_series(500, 800) g;
+INSERT INTO t SELECT 1, 1, g FROM generate_series(900, 1000) g;
+SET timescaledb.debug_require_batch_sorted_merge = 'forbid';
+-- In DESC order NULLs come first; a NULL after a non-NULL is wrong.
+-- Should not use BSM here, should return 0
+SELECT count(*) AS wrong_rows FROM (
+    SELECT val, lag(val) OVER (ORDER BY val DESC) AS prev FROM t
+) t WHERE val IS NULL AND prev IS NOT NULL;
+ wrong_rows 
+------------
+          0
+
+-- Can use BSM if we can exclude NULLs from val
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+SELECT val, lag(val) OVER (ORDER BY val DESC NULLS FIRST) AS prev FROM t where val > 995;
+ val  | prev 
+------+------
+ 1000 |     
+  999 | 1000
+  998 |  999
+  997 |  998
+  996 |  997
+
+drop table t cascade;
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.debug_require_batch_sorted_merge;

--- a/tsl/test/sql/compression_sorted_merge.sql
+++ b/tsl/test/sql/compression_sorted_merge.sql
@@ -13,8 +13,8 @@ CREATE TABLE test1 (
 time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 
 SELECT FROM create_hypertable('test1', 'time');
@@ -33,8 +33,8 @@ CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 
 SELECT FROM create_hypertable('test2', 'time');
@@ -139,11 +139,11 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS 
 
 -- Should be optimized
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 ASC NULLS FIRST;
 
 -- Should be optimized (backward scan)
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 DESC NULLS LAST;
 
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 
@@ -331,13 +331,13 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
 
--- Test with null values
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
-
+-- Test with null values: should not optimize
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 
 ------
 -- Tests based on compressed chunk state
@@ -558,7 +558,7 @@ SELECT "time","hin"::text,"model"::text,"block"::text,"message_name"::text,"sign
 -- Condition that filter the first tuple of a batch - Issue 5797
 CREATE TABLE test (
     id      bigint,
-    dttm    timestamp,
+    dttm    timestamp NOT NULL,
     otherId    int,
     valueFk int,
     otherFk int,

--- a/tsl/test/sql/compression_sorted_merge_columns.sql
+++ b/tsl/test/sql/compression_sorted_merge_columns.sql
@@ -4,7 +4,7 @@
 
 -- Test various corner cases of sorting.
 
-create table t(x int, time timestamp, timetz timestamptz, int32 int4, int64 int8, s text);
+create table t(x int, time timestamp NOT NULL, timetz timestamptz NOT NULL, int32 int4 NOT NULL, int64 int8 NOT NULL, s text NOT NULL);
 select create_hypertable('t', 'x');
 
 insert into t values

--- a/tsl/test/sql/compression_sorted_merge_unordered.sql
+++ b/tsl/test/sql/compression_sorted_merge_unordered.sql
@@ -15,8 +15,8 @@ CREATE TABLE test1 (
     time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 
 SELECT FROM create_hypertable('test1', 'time');
@@ -47,8 +47,8 @@ CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
     x2 integer,
-    x3 integer,
-    x4 integer,
+    x3 integer NOT NULL,
+    x4 integer NOT NULL,
     x5 integer);
 
 SELECT FROM create_hypertable('test2', 'time');
@@ -171,13 +171,26 @@ SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST;
 :PREFIX
 SELECT * FROM test2 ORDER BY time DESC NULLS FIRST, x3 ASC NULLS LAST, x4 NULLS LAST;
 
--- Should be optimized
+-- Should be optimized as we exclude NULLs from x2
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 ASC NULLS FIRST;
 
--- Should be optimized (backward scan)
+-- Should not be optimized (NULL order wrong)
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 :PREFIX
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL ORDER BY x2 ASC NULLS LAST;
+
+set timescaledb.debug_require_batch_sorted_merge to 'force';
+-- Should be optimized (backward scan) as we exclude NULLs from x2
+:PREFIX
+SELECT * FROM test_with_defined_null  WHERE (x2 + 1) IS NOT NULL ORDER BY x2 DESC NULLS LAST;
+
+-- Should be optimized as we exlude NULLs from x2 via strict functions
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2 > 0 ORDER BY x2 ASC NULLS FIRST;
+
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2::float + x1 > 1.0  AND time = '2000-01-01' ORDER BY x2 ASC NULLS FIRST;
 
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 
@@ -212,14 +225,26 @@ SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS LAST, x4 DESC;
 -- Should not be optimized (wrong order for x3)
 :PREFIX
 SELECT * FROM test2 ORDER BY time ASC, x3 ASC NULLS FIRST, x4 DESC;
--- Should not be optimized
+
+-- Should not be optimized as x2 is nullable
+:PREFIX
+SELECT * FROM test_with_defined_null ORDER BY x2 ASC;
+
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
 
--- Should not be optimized
 :PREFIX
 SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 
+:PREFIX
+SELECT * FROM test_with_defined_null ORDER BY x2 DESC;
+
+-- Should not be optimized as x2 is nullable with non-strict-only predicates over x2
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2 IS NOT NULL OR x2 > 1 ORDER BY x2;
+
+:PREFIX
+SELECT * FROM test_with_defined_null WHERE x2 IS NULL OR x2 > 1 ORDER BY x2;
 
 ------
 -- Tests based on attributes
@@ -359,13 +384,14 @@ SELECT x2, x1, c2, time FROM test1 ORDER BY time DESC;
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
 SELECT 1 as one, 2 as two, 3 as three, x2, x1, c2, time FROM test1 ORDER BY time DESC;
 
--- Test with null values
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
-
+-- Test with null values in x2
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
-SELECT * FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
-SELECT * FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS FIRST;
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS LAST;
+
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 ASC NULLS LAST;
+SELECT time, x2 FROM test_with_defined_null ORDER BY x2 DESC NULLS FIRST;
 
 ------
 -- Tests based on compressed chunk state
@@ -460,3 +486,37 @@ SELECT * FROM test_segby ORDER BY time ASC NULLS FIRST;
 :PREFIX
 SELECT * FROM test_segby ORDER BY segby, time;
 
+-- Tests for #9445: forbid BSM on nullable orderby columns
+CREATE TABLE t(time int NOT NULL, device int, val int);
+SELECT create_hypertable('t', 'time', chunk_time_interval => 10000);
+ALTER TABLE t SET (timescaledb.compress,
+    timescaledb.compress_segmentby='device',
+    timescaledb.compress_orderby='val DESC');
+
+-- One batch: 200 NULLs + values 1..300. _ts_meta_max = 300.
+-- In DESC order the first decompressed tuple is NULL, not 300.
+SET timescaledb.enable_direct_compress_insert = false;
+INSERT INTO t SELECT 1, 1, NULL FROM generate_series(1, 200);
+INSERT INTO t SELECT 1, 1, g FROM generate_series(1, 300) g;
+SELECT compress_chunk(show_chunks('t'));
+
+-- Two more batches via direct compress (chunk becomes unordered).
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO t SELECT 1, 1, g FROM generate_series(500, 800) g;
+INSERT INTO t SELECT 1, 1, g FROM generate_series(900, 1000) g;
+
+SET timescaledb.debug_require_batch_sorted_merge = 'forbid';
+
+-- In DESC order NULLs come first; a NULL after a non-NULL is wrong.
+-- Should not use BSM here, should return 0
+SELECT count(*) AS wrong_rows FROM (
+    SELECT val, lag(val) OVER (ORDER BY val DESC) AS prev FROM t
+) t WHERE val IS NULL AND prev IS NOT NULL;
+
+-- Can use BSM if we can exclude NULLs from val
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+SELECT val, lag(val) OVER (ORDER BY val DESC NULLS FIRST) AS prev FROM t where val > 995;
+
+drop table t cascade;
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.debug_require_batch_sorted_merge;


### PR DESCRIPTION
Fixes timescale/timescaledb#9445

Forbid BSM on nullable orderby columns.

Check whether orderby columns are declared NOT NULL, if they are not declared NOT NULL check whether they  appear as non-nullable vars in the query predicates.

As an additional optimization in a separate PR, we can skip NULL direction check on non-nullable columns but it is out of scope for this bug fix. Opened Enhancement request timescale/eng-database#809.

`compression_sorted_merge*` tests were adjusted to reflect new BSM logic in regards to NULLs in orderby columns.