### PR TITLE
Release cache entries in asan builds

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -138,7 +138,7 @@ jobs:
           patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation-PG18GE.patch
         fi
         cd ~/$PG_SRC_DIR
-        export CFLAGS=${CFLAGS} ${CFLAGS_EXTRA}
+        export CFLAGS="${CFLAGS} ${CFLAGS_EXTRA}"
         ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml
         make -j$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
This will help catch a potential use-after-free when a cache entry is used after unpinning it. In normal builds, it is not released eagerly, so the Address Sanitizer cannot detect it as a use after free.


Helpful for finding things like https://github.com/timescale/timescaledb/pull/9487 and https://github.com/timescale/timescaledb/pull/9486