### PR TITLE
Fix off-by-one error when building object name

### DIFF
--- a/.unreleased/pr_9500
+++ b/.unreleased/pr_9500
@@ -1,0 +1,1 @@
+Fixes: #9500 Fix off-by-one error when building object name

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -42,7 +42,7 @@
 	do                                                                                             \
 	{                                                                                              \
 		int ret = snprintf(buf, NAMEDATALEN, prefix, hypertable_id);                               \
-		if (ret < 0 || ret > NAMEDATALEN)                                                          \
+		if (ret < 0 || ret >= NAMEDATALEN)                                                         \
 		{                                                                                          \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INTERNAL_ERROR),                                              \

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -112,7 +112,7 @@ compression_column_segment_metadata_name(const char *type, int16 column_index)
 	Assert(column_index > 0);
 	int ret =
 		snprintf(buf, NAMEDATALEN, COMPRESSION_COLUMN_METADATA_PATTERN_V1, type, column_index);
-	if (ret < 0 || ret > NAMEDATALEN)
+	if (ret < 0 || ret >= NAMEDATALEN)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR), errmsg("bad segment metadata column name")));

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -108,7 +108,7 @@ static void
 makeMaterializedTableName(char *buf, const char *prefix, int hypertable_id)
 {
 	int ret = snprintf(buf, NAMEDATALEN, prefix, hypertable_id);
-	if (ret < 0 || ret > NAMEDATALEN)
+	if (ret < 0 || ret >= NAMEDATALEN)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR), errmsg("bad materialization internal name")));


### PR DESCRIPTION
Return value of NAMEDATALEN or more means the output was truncated
by snprintf. This change is for correctness the relevant code
locations couldn't overflow cause the pattern was fixed and could
never reach NAMEDATALEN.
