### PR TITLE
Fix VARSIZE on wrong datum after detoast

### DIFF
--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -342,9 +342,10 @@ bool_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
 	uint64 *decompressed_values = NULL;
 
 	CheckCompressedData(DatumGetPointer(compressed) != NULL);
+	/* detoasting is caller responsibility */
+	CheckCompressedData(!VARATT_IS_EXTERNAL(compressed));
 
-	void *detoasted = PG_DETOAST_DATUM(compressed);
-	StringInfoData si = { .data = detoasted, .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
 	BoolCompressed *header = consumeCompressedData(&si, sizeof(BoolCompressed));
 
 	Assert(header->has_nulls == 0 || header->has_nulls == 1);

--- a/tsl/src/compression/algorithms/uuid_compress.c
+++ b/tsl/src/compression/algorithms/uuid_compress.c
@@ -575,10 +575,12 @@ uuid_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
 
 	MemoryContext old_context;
 	ArrowArray *timestamp_array = NULL;
-	CheckCompressedData(DatumGetPointer(compressed) != NULL);
 
-	void *detoasted = PG_DETOAST_DATUM(compressed);
-	StringInfoData si = { .data = detoasted, .len = VARSIZE_ANY(compressed) };
+	CheckCompressedData(DatumGetPointer(compressed) != NULL);
+	/* detoasting is caller responsibility */
+	CheckCompressedData(!VARATT_IS_EXTERNAL(compressed));
+
+	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE_ANY(compressed) };
 	UuidCompressed *header = consumeCompressedData(&si, sizeof(UuidCompressed));
 	char *timestamp_compressed_data = NULL;
 	char *rand_b_and_variant_compressed_data;


### PR DESCRIPTION
bool_decompress_all and uuid_decompress_all detoast the compressed Datum
into a new pointer but compute si.len from the original (possibly toasted)
Datum. If compressed is toasted, VARSIZE(compressed) returns the TOAST
pointer size (~18 bytes), not the actual data size. This causes truncated
reads during decompression.

Currently not exploitable because all callers pre-detoast the data (making
PG_DETOAST_DATUM a no-op).

Disable-check: force-changelog-file
