### PR TITLE
Allow ALTER TABLE RESET on materialization hypertables

### DIFF
--- a/.unreleased/pr_9504
+++ b/.unreleased/pr_9504
@@ -1,0 +1,1 @@
+Implements: #9504 Allow ALTER TABLE RESET on materialization hypertables

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -250,6 +250,7 @@ check_continuous_agg_alter_table_allowed(Hypertable *ht, AlterTableStmt *stmt)
 			case AT_AddIndex:
 			case AT_ReAddIndex:
 			case AT_SetRelOptions:
+			case AT_ResetRelOptions:
 			case AT_ReplicaIdentity:
 				/* allowed on materialization tables */
 				continue;

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -353,6 +353,8 @@ SELECT * FROM truncate_partitioned;
 -------
 
 -- ALTER TABLE tests
+ALTER TABLE :drop_chunks_mat_table_u SET (parallel_workers = 4);
+ALTER TABLE :drop_chunks_mat_table_u RESET (parallel_workers);
 \set ON_ERROR_STOP 0
 -- test a variety of ALTER TABLE statements
 ALTER TABLE :drop_chunks_mat_table_u RENAME time_bucket TO bad_name;

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -353,6 +353,8 @@ SELECT * FROM truncate_partitioned;
 -------
 
 -- ALTER TABLE tests
+ALTER TABLE :drop_chunks_mat_table_u SET (parallel_workers = 4);
+ALTER TABLE :drop_chunks_mat_table_u RESET (parallel_workers);
 \set ON_ERROR_STOP 0
 -- test a variety of ALTER TABLE statements
 ALTER TABLE :drop_chunks_mat_table_u RENAME time_bucket TO bad_name;

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -353,6 +353,8 @@ SELECT * FROM truncate_partitioned;
 -------
 
 -- ALTER TABLE tests
+ALTER TABLE :drop_chunks_mat_table_u SET (parallel_workers = 4);
+ALTER TABLE :drop_chunks_mat_table_u RESET (parallel_workers);
 \set ON_ERROR_STOP 0
 -- test a variety of ALTER TABLE statements
 ALTER TABLE :drop_chunks_mat_table_u RENAME time_bucket TO bad_name;

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -353,6 +353,8 @@ SELECT * FROM truncate_partitioned;
 -------
 
 -- ALTER TABLE tests
+ALTER TABLE :drop_chunks_mat_table_u SET (parallel_workers = 4);
+ALTER TABLE :drop_chunks_mat_table_u RESET (parallel_workers);
 \set ON_ERROR_STOP 0
 -- test a variety of ALTER TABLE statements
 ALTER TABLE :drop_chunks_mat_table_u RENAME time_bucket TO bad_name;

--- a/tsl/test/sql/cagg_ddl.sql.in
+++ b/tsl/test/sql/cagg_ddl.sql.in
@@ -272,6 +272,9 @@ TRUNCATE truncate_partitioned;
 SELECT * FROM truncate_partitioned;
 
 -- ALTER TABLE tests
+ALTER TABLE :drop_chunks_mat_table_u SET (parallel_workers = 4);
+ALTER TABLE :drop_chunks_mat_table_u RESET (parallel_workers);
+
 \set ON_ERROR_STOP 0
 -- test a variety of ALTER TABLE statements
 ALTER TABLE :drop_chunks_mat_table_u RENAME time_bucket TO bad_name;


### PR DESCRIPTION
Since we allow ALTER TABLE SET no reason not to allow ALTER TABLE
RESET too.
