### PR TITLE
Fix renovate.json config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
       "matchUpdateTypes": ["patch", "minor", "major", "digest"],
       "groupName": "dependencies",
       "schedule": ["on monday"],
-      "minimumReleaseAge": "7 days",
-      "versioning": "semver"
+      "minimumReleaseAge": "7 days"
     }
   ],
   "pinDigests": true


### PR DESCRIPTION
Renovate packageRules cannot combine both matchUpdateTypes and versioning
so remove versioning since semver should be default already.

Fixes #9471

Disable-check: force-changelog-file
Disable-check: approval-count
