### PR TITLE
Fix chunk skipping with dropped columns

### DIFF
--- a/.unreleased/pr_9510
+++ b/.unreleased/pr_9510
@@ -1,0 +1,1 @@
+Fixes: #9510 Fix chunk skipping with dropped columns

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -553,7 +553,6 @@ create_col_stats_check_constraint(const Form_chunk_column_stats info, Oid main_t
 	ColumnRef *colref;
 	List *compexprs = NIL;
 	Oid col_type;
-	int attno;
 
 	if (info->range_start == PG_INT64_MIN && info->range_end == PG_INT64_MAX)
 		return NULL;
@@ -565,12 +564,9 @@ create_col_stats_check_constraint(const Form_chunk_column_stats info, Oid main_t
 	/*
 	 * Get the column type for later converting the internal format
 	 * to string.
-	 *
-	 * Get the attribute number in the HT for this column, and map to the chunk
 	 */
-	attno = get_attnum(main_table_relid, NameStr(info->column_name));
-	attno = ts_map_attno(main_table_relid, chunk_relid, attno);
-	col_type = get_atttype(main_table_relid, attno);
+	const int ht_attno = get_attnum(main_table_relid, NameStr(info->column_name));
+	col_type = get_atttype(main_table_relid, ht_attno);
 
 	rangedef = (Node *) colref;
 

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -754,3 +754,25 @@ SELECT * from chunk_skipping where updated_at < '2026-01-01';
 ------------------------------+--------+------------------------------
  Wed Jan 01 00:00:00 2025 PST | d1     | Wed Jan 01 00:00:00 2025 PST
 
+-- Check chunk skipping with dropped columns
+CREATE TABLE attno (id int, dropped_col text, start timestamptz) WITH (tsdb.hypertable, tsdb.segmentby='id');
+NOTICE:  using column "start" as partitioning column
+SET timescaledb.enable_chunk_skipping = true;
+SELECT * FROM enable_chunk_skipping('attno', 'start');
+ column_stats_id | enabled 
+-----------------+---------
+              15 | t
+
+ALTER TABLE attno DROP COLUMN dropped_col;
+INSERT INTO attno SELECT i % 5, '2026-01-01'::timestamptz + format('%s minutes', i)::interval FROM generate_series(1, 10) i;
+SELECT count(compress_chunk(ch)) FROM show_chunks('attno') ch;
+ count 
+-------
+     1
+
+SELECT * FROM attno WHERE id = 1 AND start > '2025-02-02T11:53:28Z'::date ORDER BY start;
+ id |            start             
+----+------------------------------
+  1 | Thu Jan 01 00:01:00 2026 PST
+  1 | Thu Jan 01 00:06:00 2026 PST
+

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -336,3 +336,18 @@ INSERT INTO chunk_skipping SELECT '2025-01-01', 'd2', '2026-01-01';
 SELECT compress_chunk(show_chunks('chunk_skipping'));
 
 SELECT * from chunk_skipping where updated_at < '2026-01-01';
+
+-- Check chunk skipping with dropped columns
+CREATE TABLE attno (id int, dropped_col text, start timestamptz) WITH (tsdb.hypertable, tsdb.segmentby='id');
+
+SET timescaledb.enable_chunk_skipping = true;
+SELECT * FROM enable_chunk_skipping('attno', 'start');
+
+ALTER TABLE attno DROP COLUMN dropped_col;
+
+INSERT INTO attno SELECT i % 5, '2026-01-01'::timestamptz + format('%s minutes', i)::interval FROM generate_series(1, 10) i;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('attno') ch;
+
+SELECT * FROM attno WHERE id = 1 AND start > '2025-02-02T11:53:28Z'::date ORDER BY start;
+


### PR DESCRIPTION
When using chunk skipping on hypertables with dropped columns
constraint on the chunk skip column could fail with the error
`cache lookup failed for type 0`. This was due to mixup of chunk
and hypertable attribute numbers.
