### PR TITLE
Fix alter_job failing for retention policy with drop_created_before

### DIFF
--- a/.unreleased/pr_9511
+++ b/.unreleased/pr_9511
@@ -1,0 +1,2 @@
+Fixes: #9511 Fix alter_job failing for retention policy with drop_created_before
+Thanks: @sebastian-ederer for reporting an issue with alter_job and drop_created_before

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -359,6 +359,17 @@ policy_retention_read_and_validate_config(Jsonb *config, PolicyRetentionData *po
 		 */
 		if (IS_UUID_TYPE(boundary_type))
 			boundary_type = TIMESTAMPTZOID;
+
+		/*
+		 * Check if the policy was created with drop_created_before instead of
+		 * drop_after. This can happen for hypertables with an open time dimension
+		 * when the user explicitly chose creation-time-based retention.
+		 */
+		if (ts_jsonb_get_interval_field(config, POL_RETENTION_CONF_KEY_DROP_CREATED_BEFORE))
+		{
+			interval_getter = policy_retention_get_drop_created_before_interval;
+			use_creation_time = true;
+		}
 	}
 
 	boundary =

--- a/tsl/test/expected/policy_generalization.out
+++ b/tsl/test/expected/policy_generalization.out
@@ -174,3 +174,24 @@ SELECT remove_compression_policy('test');
  t
 
 DROP TABLE test;
+-- Test that alter_job works with drop_created_before on a TIMESTAMPTZ hypertable
+-- Regression test for https://github.com/timescale/timescaledb/issues/9446
+CREATE TABLE test_retention_ts(time TIMESTAMPTZ NOT NULL, value DOUBLE PRECISION);
+SELECT create_hypertable('test_retention_ts', 'time');
+       create_hypertable        
+--------------------------------
+ (3,public,test_retention_ts,t)
+
+SELECT add_retention_policy('test_retention_ts', drop_created_before => INTERVAL '30 days') AS ret_job_id \gset
+-- This should succeed without "could not find drop_after in config for job" error
+SELECT alter_job(:ret_job_id, max_retries => 5);
+                                                                                             alter_job                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1003,"@ 1 day","@ 5 mins",5,"@ 5 mins",t,"{""hypertable_id"": 3, ""drop_created_before"": ""@ 30 days""}",-infinity,_timescaledb_functions.policy_retention_check,f,,,"Retention Policy [1003]")
+
+SELECT remove_retention_policy('test_retention_ts');
+ remove_retention_policy 
+-------------------------
+ 
+
+DROP TABLE test_retention_ts;

--- a/tsl/test/sql/policy_generalization.sql
+++ b/tsl/test/sql/policy_generalization.sql
@@ -81,3 +81,13 @@ SELECT add_compression_policy('test', compress_created_before => INTERVAL '20 se
 SELECT remove_compression_policy('test');
 
 DROP TABLE test;
+
+-- Test that alter_job works with drop_created_before on a TIMESTAMPTZ hypertable
+-- Regression test for https://github.com/timescale/timescaledb/issues/9446
+CREATE TABLE test_retention_ts(time TIMESTAMPTZ NOT NULL, value DOUBLE PRECISION);
+SELECT create_hypertable('test_retention_ts', 'time');
+SELECT add_retention_policy('test_retention_ts', drop_created_before => INTERVAL '30 days') AS ret_job_id \gset
+-- This should succeed without "could not find drop_after in config for job" error
+SELECT alter_job(:ret_job_id, max_retries => 5);
+SELECT remove_retention_policy('test_retention_ts');
+DROP TABLE test_retention_ts;


### PR DESCRIPTION
When a retention policy was created with drop_created_before on a
hypertable with a time dimension, alter_job would fail with "could not
find drop_after in config for job". The config validation only checked
for drop_created_before when the open dimension was NULL (integer
partitions without int_now), but hypertables with time columns always
have a valid open dimension. Add a check in the else branch to detect
drop_created_before in the config and use the correct interval getter.

Fixes #9446
