### PR TITLE
Fix now() constification for continuous aggregate queries

### DIFF
--- a/.unreleased/pr_9515
+++ b/.unreleased/pr_9515
@@ -1,0 +1,2 @@
+Fixes: #9515 Fix now() constification for continuous aggregate queries
+Thanks: @ivaaaan for reporting an issue with cosntraint pushdown in continuous aggregate queries

--- a/src/planner/constify_now.c
+++ b/src/planner/constify_now.c
@@ -81,8 +81,12 @@ is_valid_now_expr(OpExpr *op, List *rtable)
 	 * If this query on a view we might have a subquery here
 	 * and need to peek into the subquery range table to check
 	 * if the constraints are on a hypertable.
+	 *
+	 * We use a loop to handle multiple levels of subquery nesting,
+	 * such as continuous aggregate views which have the structure:
+	 * outer query -> UNION subquery -> materialization/raw subqueries.
 	 */
-	if (rte->rtekind == RTE_SUBQUERY)
+	while (rte->rtekind == RTE_SUBQUERY)
 	{
 		/*
 		 * Unfortunately the mechanism used to warm up the

--- a/test/runner_cleanup_output.sh
+++ b/test/runner_cleanup_output.sh
@@ -32,7 +32,8 @@ grep -av 'DEBUG:  done creating and filling new WAL file' | \
 grep -av 'DEBUG:  flushed relation because a checkpoint occurred concurrently' | \
 grep -av 'NOTICE:  cancelling the background worker for job' | \
 if [ "${RUNNER}" = "shared" ]; then \
-    sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g'; \
+    sed -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \
+        -e 's!_materialized_hypertable_[0-9]\{1,\}!_materialized_hypertable_X!g'; \
 else \
     cat; \
 fi | \

--- a/tsl/test/shared/expected/constify_now-15.out
+++ b/tsl/test/shared/expected/constify_now-15.out
@@ -572,6 +572,172 @@ CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP
 
 DROP TABLE now_view_test CASCADE;
 NOTICE:  drop cascades to view now_view
+-- test now constification with real time continuous aggregates (#7651)
+-- now() constraints on cagg queries should enable chunk exclusion
+-- in the UNION subqueries
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_now_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_now_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE MATERIALIZED VIEW cagg_now_view WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device FROM cagg_now_test GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_now_view', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_now_view;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Seq Scan on _hyper_X_X_chunk
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+         Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket > (ts_now_mock() - '@ 168 hours'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+
+DROP TABLE cagg_now_test CASCADE;
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
+-- test now constification with hierarchical continuous aggregates (CAGG on CAGG)
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_hierarch_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_hierarch_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+-- 1st level CAGG on the hypertable
+CREATE MATERIALIZED VIEW cagg_hierarch_l1 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device, avg(value) AS avg_val FROM cagg_hierarch_test GROUP BY 1, 2 WITH NO DATA;
+-- 2nd level CAGG on the 1st level CAGG (hierarchical)
+CREATE MATERIALIZED VIEW cagg_hierarch_l2 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 month', bucket) AS bucket, device, avg(avg_val) AS avg_val FROM cagg_hierarch_l1 GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_hierarch_l1', NULL, '2004-01-01');
+CALL refresh_continuous_aggregate('cagg_hierarch_l2', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_hierarch_l2;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+   ->  Result
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket >= (ts_now_mock() - '@ 1 year'::interval))
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+
+DROP TABLE cagg_hierarch_test CASCADE;
+NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 4 other objects
 -- #4709
 -- test queries with constraints involving columns from different nesting levels
 SELECT * FROM

--- a/tsl/test/shared/expected/constify_now-16.out
+++ b/tsl/test/shared/expected/constify_now-16.out
@@ -572,6 +572,172 @@ CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP
 
 DROP TABLE now_view_test CASCADE;
 NOTICE:  drop cascades to view now_view
+-- test now constification with real time continuous aggregates (#7651)
+-- now() constraints on cagg queries should enable chunk exclusion
+-- in the UNION subqueries
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_now_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_now_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE MATERIALIZED VIEW cagg_now_view WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device FROM cagg_now_test GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_now_view', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_now_view;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Seq Scan on _hyper_X_X_chunk
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+         Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket > (ts_now_mock() - '@ 168 hours'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+
+DROP TABLE cagg_now_test CASCADE;
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
+-- test now constification with hierarchical continuous aggregates (CAGG on CAGG)
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_hierarch_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_hierarch_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+-- 1st level CAGG on the hypertable
+CREATE MATERIALIZED VIEW cagg_hierarch_l1 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device, avg(value) AS avg_val FROM cagg_hierarch_test GROUP BY 1, 2 WITH NO DATA;
+-- 2nd level CAGG on the 1st level CAGG (hierarchical)
+CREATE MATERIALIZED VIEW cagg_hierarch_l2 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 month', bucket) AS bucket, device, avg(avg_val) AS avg_val FROM cagg_hierarch_l1 GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_hierarch_l1', NULL, '2004-01-01');
+CALL refresh_continuous_aggregate('cagg_hierarch_l2', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_hierarch_l2;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+   ->  Result
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket >= (ts_now_mock() - '@ 1 year'::interval))
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+
+DROP TABLE cagg_hierarch_test CASCADE;
+NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 4 other objects
 -- #4709
 -- test queries with constraints involving columns from different nesting levels
 SELECT * FROM

--- a/tsl/test/shared/expected/constify_now-17.out
+++ b/tsl/test/shared/expected/constify_now-17.out
@@ -572,6 +572,172 @@ CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP
 
 DROP TABLE now_view_test CASCADE;
 NOTICE:  drop cascades to view now_view
+-- test now constification with real time continuous aggregates (#7651)
+-- now() constraints on cagg queries should enable chunk exclusion
+-- in the UNION subqueries
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_now_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_now_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE MATERIALIZED VIEW cagg_now_view WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device FROM cagg_now_test GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_now_view', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_now_view;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Seq Scan on _hyper_X_X_chunk
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+         Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket > (ts_now_mock() - '@ 168 hours'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+
+DROP TABLE cagg_now_test CASCADE;
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
+-- test now constification with hierarchical continuous aggregates (CAGG on CAGG)
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_hierarch_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_hierarch_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+-- 1st level CAGG on the hypertable
+CREATE MATERIALIZED VIEW cagg_hierarch_l1 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device, avg(value) AS avg_val FROM cagg_hierarch_test GROUP BY 1, 2 WITH NO DATA;
+-- 2nd level CAGG on the 1st level CAGG (hierarchical)
+CREATE MATERIALIZED VIEW cagg_hierarch_l2 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 month', bucket) AS bucket, device, avg(avg_val) AS avg_val FROM cagg_hierarch_l1 GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_hierarch_l1', NULL, '2004-01-01');
+CALL refresh_continuous_aggregate('cagg_hierarch_l2', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_hierarch_l2;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+   ->  Result
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket >= (ts_now_mock() - '@ 1 year'::interval))
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+
+DROP TABLE cagg_hierarch_test CASCADE;
+NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 4 other objects
 -- #4709
 -- test queries with constraints involving columns from different nesting levels
 SELECT * FROM

--- a/tsl/test/shared/expected/constify_now-18.out
+++ b/tsl/test/shared/expected/constify_now-18.out
@@ -562,6 +562,172 @@ CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP
 
 DROP TABLE now_view_test CASCADE;
 NOTICE:  drop cascades to view now_view
+-- test now constification with real time continuous aggregates (#7651)
+-- now() constraints on cagg queries should enable chunk exclusion
+-- in the UNION subqueries
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_now_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_now_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE MATERIALIZED VIEW cagg_now_view WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device FROM cagg_now_test GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_now_view', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_now_view;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Seq Scan on _hyper_X_X_chunk
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+         Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket > (ts_now_mock() - '@ 168 hours'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") > (ts_now_mock() - '@ 168 hours'::interval))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+   ->  Finalize HashAggregate
+         Group Key: (time_bucket('@ 1 day'::interval, cagg_now_test."time")), cagg_now_test.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+               ->  Partial HashAggregate
+                     Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                     ->  Index Scan using _hyper_X_X_chunk_cagg_now_test_time_idx on _hyper_X_X_chunk
+                           Filter: (time_bucket('@ 1 day'::interval, "time") >= (ts_now_mock() - '@ 1 year'::interval))
+
+DROP TABLE cagg_now_test CASCADE;
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
+-- test now constification with hierarchical continuous aggregates (CAGG on CAGG)
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_hierarch_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_hierarch_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+-- 1st level CAGG on the hypertable
+CREATE MATERIALIZED VIEW cagg_hierarch_l1 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device, avg(value) AS avg_val FROM cagg_hierarch_test GROUP BY 1, 2 WITH NO DATA;
+-- 2nd level CAGG on the 1st level CAGG (hierarchical)
+CREATE MATERIALIZED VIEW cagg_hierarch_l2 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 month', bucket) AS bucket, device, avg(avg_val) AS avg_val FROM cagg_hierarch_l1 GROUP BY 1, 2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cagg_hierarch_l1', NULL, '2004-01-01');
+CALL refresh_continuous_aggregate('cagg_hierarch_l2', NULL, '2004-01-01');
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_hierarch_l2;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: (time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket > now() - '168h'::interval;
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+   ->  Result
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+               ->  Append
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                           ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                 Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                 Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) > (ts_now_mock() - '@ 168 hours'::interval)))
+
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket >= now() - '1 year'::interval;
+--- QUERY PLAN ---
+ Append
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: ((bucket < 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (bucket >= (ts_now_mock() - '@ 1 year'::interval)))
+         ->  Index Scan using _hyper_X_X_chunk__materialized_hypertable_X_bucket_idx on _hyper_X_X_chunk
+               Index Cond: (bucket >= (ts_now_mock() - '@ 1 year'::interval))
+   ->  HashAggregate
+         Group Key: time_bucket('@ 1 mon'::interval, (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time"))), cagg_hierarch_test.device
+         ->  Result
+               ->  Finalize HashAggregate
+                     Group Key: (time_bucket('@ 1 day'::interval, cagg_hierarch_test."time")), cagg_hierarch_test.device
+                     ->  Append
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: (("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone))
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+                           ->  Partial HashAggregate
+                                 Group Key: time_bucket('@ 1 day'::interval, _hyper_X_X_chunk."time"), _hyper_X_X_chunk.device
+                                 ->  Index Scan using _hyper_X_X_chunk_cagg_hierarch_test_time_idx on _hyper_X_X_chunk
+                                       Index Cond: ("time" >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone)
+                                       Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Wed Jan 01 01:00:00 2003 UTC'::timestamp with time zone) AND (time_bucket('@ 1 mon'::interval, time_bucket('@ 1 day'::interval, "time")) >= (ts_now_mock() - '@ 1 year'::interval)))
+
+DROP TABLE cagg_hierarch_test CASCADE;
+NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 4 other objects
 -- #4709
 -- test queries with constraints involving columns from different nesting levels
 SELECT * FROM

--- a/tsl/test/shared/sql/constify_now.sql.in
+++ b/tsl/test/shared/sql/constify_now.sql.in
@@ -197,6 +197,54 @@ CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP
 :PREFIX SELECT * FROM now_view WHERE time > now() - '168h'::interval;
 DROP TABLE now_view_test CASCADE;
 
+-- test now constification with real time continuous aggregates (#7651)
+-- now() constraints on cagg queries should enable chunk exclusion
+-- in the UNION subqueries
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_now_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_now_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+
+CREATE MATERIALIZED VIEW cagg_now_view WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device FROM cagg_now_test GROUP BY 1, 2 WITH NO DATA;
+
+CALL refresh_continuous_aggregate('cagg_now_view', NULL, '2004-01-01');
+
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_now_view;
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket > now() - '168h'::interval;
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_now_view WHERE bucket >= now() - '1 year'::interval;
+
+DROP TABLE cagg_now_test CASCADE;
+
+-- test now constification with hierarchical continuous aggregates (CAGG on CAGG)
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE cagg_hierarch_test(time timestamptz NOT NULL, device text, value float) WITH (tsdb.hypertable);
+-- create 5 chunks (1 per year)
+INSERT INTO cagg_hierarch_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+
+-- 1st level CAGG on the hypertable
+CREATE MATERIALIZED VIEW cagg_hierarch_l1 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 day', time) AS bucket, device, avg(value) AS avg_val FROM cagg_hierarch_test GROUP BY 1, 2 WITH NO DATA;
+
+-- 2nd level CAGG on the 1st level CAGG (hierarchical)
+CREATE MATERIALIZED VIEW cagg_hierarch_l2 WITH (tsdb.continuous, tsdb.materialized_only=false)
+AS SELECT time_bucket('1 month', bucket) AS bucket, device, avg(avg_val) AS avg_val FROM cagg_hierarch_l1 GROUP BY 1, 2 WITH NO DATA;
+
+CALL refresh_continuous_aggregate('cagg_hierarch_l1', NULL, '2004-01-01');
+CALL refresh_continuous_aggregate('cagg_hierarch_l2', NULL, '2004-01-01');
+
+-- should have all chunks in EXPLAIN (no filter)
+:PREFIX SELECT * FROM cagg_hierarch_l2;
+-- with now() filter, should show chunk exclusion (fewer chunks)
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket > now() - '168h'::interval;
+-- with now() and interval arithmetic
+:PREFIX SELECT * FROM cagg_hierarch_l2 WHERE bucket >= now() - '1 year'::interval;
+
+DROP TABLE cagg_hierarch_test CASCADE;
+
 -- #4709
 -- test queries with constraints involving columns from different nesting levels
 SELECT * FROM


### PR DESCRIPTION
Fix now() constification for continuous aggregate queries
The now() constification optimization converts expressions like
`column > now()` into `column > now() AND column > <const>` to
enable plan-time chunk exclusion. This did not work for continuous
aggregate views because is_valid_now_expr() only traversed one
level of subquery nesting, while continuous aggregate views have
a double-nested structure: outer query -> UNION subquery ->
materialization/raw subqueries.

Change the single `if (rte->rtekind == RTE_SUBQUERY)` check to a
`while` loop so the function traces through all subquery levels
until it reaches the underlying hypertable relation.

Fixes #7651
