### PR TITLE
Test registration and cleanup of refresh ranges

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -668,10 +668,12 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 	invalidation_process_cagg_log(cagg, refresh_window);
 
 	DEBUG_WAITPOINT("before_process_cagg_invalidations_for_refresh_lock");
+	DEBUG_ERROR_INJECTION("cagg_refresh_fail_in_txn2");
 
 	SPI_commit_and_chain();
 
 	DEBUG_WAITPOINT("after_process_cagg_invalidations_for_refresh_lock");
+	DEBUG_ERROR_INJECTION("cagg_refresh_fail_in_txn3");
 
 	InvalidationStore *invalidations =
 		collect_and_delete_cagg_invalidations_in_window(cagg, refresh_window, force);
@@ -869,6 +871,8 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 						   ts_internal_to_time_string(refresh_window.start, refresh_window.type),
 						   ts_internal_to_time_string(refresh_window.end, refresh_window.type))));
 
+	DEBUG_ERROR_INJECTION("cagg_refresh_fail_in_registration");
+
 	volatile bool refreshed = false;
 	PG_TRY();
 	{
@@ -952,6 +956,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 													refresh_window.type);
 			}
 
+			DEBUG_ERROR_INJECTION("cagg_refresh_fail_in_txn1");
 			/* Commit and Start a new transaction */
 			SPI_commit_and_chain();
 

--- a/tsl/test/expected/cagg_refresh_cleanup.out
+++ b/tsl/test/expected/cagg_refresh_cleanup.out
@@ -1,0 +1,161 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for job registration cleanup in the continuous aggregate refresh
+-- procedure. Verifies that the entry in continuous_aggs_jobs_refresh_ranges
+-- is correctly cleaned up when a refresh fails at each transaction phase.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE conditions (
+    time TIMESTAMPTZ NOT NULL,
+    value FLOAT);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '6 hours');
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+
+INSERT INTO conditions
+SELECT ts, extract(epoch from ts)::int % 10
+FROM generate_series('2026-01-01'::timestamptz, '2026-04-10'::timestamptz, INTERVAL '1 day') ts;
+CREATE MATERIALIZED VIEW cond_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, avg(value) AS avg_val
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+-- Set the invalidation threshold via an initial refresh
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-01', '2026-04-01');
+-- Add invalidations inside the threshold range so future refreshes have real work
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 999), ('2026-01-20', 999), ('2026-01-30', 999); COMMIT;
+BEGIN; INSERT INTO conditions VALUES ('2026-02-10', 999), ('2026-02-20', 999); COMMIT;
+SELECT count(*) AS jobs_count
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_count 
+------------
+          0
+
+-- Test 1: refresh fails in Txn1 (invalidation processing)
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_txn1');
+ debug_waitpoint_enable 
+------------------------
+ 
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+ERROR:  error injected at debug point 'cagg_refresh_fail_in_txn1'
+\set ON_ERROR_STOP 1
+-- Job should be cleaned up after the failed refresh
+SELECT count(*) AS jobs_after_txn1_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_txn1_fail 
+----------------------
+                    0
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_txn1');
+ debug_waitpoint_release 
+-------------------------
+ 
+
+-- Next refresh should succeed
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 777), ('2026-01-20', 777); COMMIT;
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+-- No job should be left behind after the successful refresh
+SELECT count(*) AS jobs_after_next_refresh
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_next_refresh 
+-------------------------
+                       0
+
+-- Test 2: refresh fails in Txn2 (cagg invalidation log cutting)
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 666), ('2026-01-20', 666); COMMIT;
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_txn2');
+ debug_waitpoint_enable 
+------------------------
+ 
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+ERROR:  error injected at debug point 'cagg_refresh_fail_in_txn2'
+\set ON_ERROR_STOP 1
+SELECT count(*) AS jobs_after_txn2_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_txn2_fail 
+----------------------
+                    0
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_txn2');
+ debug_waitpoint_release 
+-------------------------
+ 
+
+-- Test 3: refresh fails in Txn3 (materialization)
+BEGIN; INSERT INTO conditions VALUES ('2026-01-30', 555), ('2026-02-10', 555); COMMIT;
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_txn3');
+ debug_waitpoint_enable 
+------------------------
+ 
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+ERROR:  error injected at debug point 'cagg_refresh_fail_in_txn3'
+\set ON_ERROR_STOP 1
+SELECT count(*) AS jobs_after_txn3_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_txn3_fail 
+----------------------
+                    0
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_txn3');
+ debug_waitpoint_release 
+-------------------------
+ 
+
+-- Test 4: refresh fails in registration before Txn1
+BEGIN; INSERT INTO conditions VALUES ('2026-02-20', 888), ('2026-03-01', 888); COMMIT;
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_registration');
+ debug_waitpoint_enable 
+------------------------
+ 
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+ERROR:  error injected at debug point 'cagg_refresh_fail_in_registration'
+\set ON_ERROR_STOP 1
+SELECT count(*) AS jobs_after_registration_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_registration_fail 
+------------------------------
+                            0
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_registration');
+ debug_waitpoint_release 
+-------------------------
+ 
+
+-- Test 5: stale entry with a dead PID is cleaned up by the next refresh.
+-- Inserting a row with PID 0 as a dummy job.
+INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+    (materialization_id, start_range, end_range, pid)
+SELECT mat_hypertable_id,
+       _timescaledb_functions.to_unix_microseconds('2026-01-05'::timestamptz),
+       _timescaledb_functions.to_unix_microseconds('2026-03-15'::timestamptz),
+       0
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond_daily';
+SELECT count(*) AS stale_jobs_before_refresh
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ stale_jobs_before_refresh 
+---------------------------
+                         1
+
+-- Refresh detects BackendPidGetProc(0) == NULL, removes the stale row, and succeeds
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 444), ('2026-01-20', 444); COMMIT;
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+SELECT count(*) AS jobs_after_dead_pid_cleanup
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_dead_pid_cleanup 
+-----------------------------
+                           0
+
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 36 other objects

--- a/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
+++ b/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
@@ -1,0 +1,242 @@
+Parsed test spec with 7 sessions
+
+starting permutation: WP_mat_enable R2_refresh L1_lock WP_mat_disable R3_refresh R4_refresh check_locks check_jobs L1_unlock check_locks check_jobs
+step WP_mat_enable: SELECT debug_waitpoint_enable('after_process_cagg_materializations');
+debug_waitpoint_enable
+----------------------
+                      
+
+step R2_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-02-15');
+ <waiting ...>
+step L1_lock: 
+    BEGIN;
+    LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+        IN ACCESS EXCLUSIVE MODE;
+
+step WP_mat_disable: SELECT debug_waitpoint_release('after_process_cagg_materializations');
+debug_waitpoint_release
+-----------------------
+                       
+
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-02-15', '2026-03-15');
+ <waiting ...>
+step R4_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-03-15', '2026-03-30');
+ <waiting ...>
+step check_locks: 
+    SELECT l.mode, l.granted
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE c.relname = 'continuous_aggs_jobs_refresh_ranges'
+    ORDER BY l.mode;
+
+mode                    |granted
+------------------------+-------
+AccessExclusiveLock     |t      
+RowExclusiveLock        |f      
+ShareUpdateExclusiveLock|f      
+ShareUpdateExclusiveLock|f      
+
+step check_jobs: 
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|start_time                  |end_time                    
+--------------+----------------------------+----------------------------
+cond_daily    |Mon Jan 05 16:00:00 2026 PST|Sat Feb 14 16:00:00 2026 PST
+
+step L1_unlock: 
+    COMMIT;
+
+step R2_refresh: <... completed>
+step R3_refresh: <... completed>
+step R4_refresh: <... completed>
+step check_locks: 
+    SELECT l.mode, l.granted
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE c.relname = 'continuous_aggs_jobs_refresh_ranges'
+    ORDER BY l.mode;
+
+mode|granted
+----+-------
+
+step check_jobs: 
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|start_time|end_time
+--------------+----------+--------
+
+
+starting permutation: WP_mat_enable R2_refresh L1_lock WP_mat_disable R3_refresh R4_overlapping_refresh check_locks check_jobs L1_unlock check_locks check_jobs
+step WP_mat_enable: SELECT debug_waitpoint_enable('after_process_cagg_materializations');
+debug_waitpoint_enable
+----------------------
+                      
+
+step R2_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-02-15');
+ <waiting ...>
+step L1_lock: 
+    BEGIN;
+    LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+        IN ACCESS EXCLUSIVE MODE;
+
+step WP_mat_disable: SELECT debug_waitpoint_release('after_process_cagg_materializations');
+debug_waitpoint_release
+-----------------------
+                       
+
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-02-15', '2026-03-15');
+ <waiting ...>
+step R4_overlapping_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-02-15', '2026-03-05');
+ <waiting ...>
+step check_locks: 
+    SELECT l.mode, l.granted
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE c.relname = 'continuous_aggs_jobs_refresh_ranges'
+    ORDER BY l.mode;
+
+mode                    |granted
+------------------------+-------
+AccessExclusiveLock     |t      
+RowExclusiveLock        |f      
+ShareUpdateExclusiveLock|f      
+ShareUpdateExclusiveLock|f      
+
+step check_jobs: 
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|start_time                  |end_time                    
+--------------+----------------------------+----------------------------
+cond_daily    |Mon Jan 05 16:00:00 2026 PST|Sat Feb 14 16:00:00 2026 PST
+
+step L1_unlock: 
+    COMMIT;
+
+step R2_refresh: <... completed>
+step R3_refresh: <... completed>
+step R4_overlapping_refresh: <... completed>
+ERROR:  could not refresh continuous aggregate "cond_daily" due to a concurrent refresh
+step check_locks: 
+    SELECT l.mode, l.granted
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE c.relname = 'continuous_aggs_jobs_refresh_ranges'
+    ORDER BY l.mode;
+
+mode|granted
+----+-------
+
+step check_jobs: 
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|start_time|end_time
+--------------+----------+--------
+
+
+starting permutation: WP_before_txn3_enable R1_refresh K1_terminate check_jobs WP_before_txn3_disable L1_lock R2_refresh R3_refresh L1_unlock check_jobs
+step WP_before_txn3_enable: SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');
+debug_waitpoint_enable
+----------------------
+                      
+
+step R1_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+ <waiting ...>
+step K1_terminate: 
+    DO $$
+    DECLARE
+        target_pid int;
+    BEGIN
+        SELECT pid INTO target_pid FROM cancelpid;
+        PERFORM pg_terminate_backend(target_pid);
+        LOOP
+            EXIT WHEN NOT EXISTS (
+                SELECT 1 FROM pg_stat_activity WHERE pid = target_pid
+            );
+            PERFORM pg_sleep(0.05);
+        END LOOP;
+    END;
+    $$;
+
+step R1_refresh: <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+step check_jobs: 
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|start_time                  |end_time                    
+--------------+----------------------------+----------------------------
+cond_daily    |Mon Jan 05 16:00:00 2026 PST|Sat Mar 14 17:00:00 2026 PDT
+
+step WP_before_txn3_disable: SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
+debug_waitpoint_release
+-----------------------
+                       
+
+step L1_lock: 
+    BEGIN;
+    LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+        IN ACCESS EXCLUSIVE MODE;
+
+step R2_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-02-15');
+ <waiting ...>
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-02-15', '2026-03-15');
+ <waiting ...>
+step L1_unlock: 
+    COMMIT;
+
+step R2_refresh: <... completed>
+step R3_refresh: <... completed>
+step check_jobs: 
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|start_time|end_time
+--------------+----------+--------
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -40,6 +40,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     cagg_concurrent_refresh.spec
     cagg_hierarchical_concurrent_refresh.spec
     cagg_incremental_concurrent.spec
+    cagg_refresh_cleanup_register.spec
     compression_chunk_race.spec
     direct_compress_copy.spec
     compression_freeze.spec

--- a/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
+++ b/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
@@ -1,0 +1,154 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+setup
+{
+    SELECT _timescaledb_functions.stop_background_workers();
+
+    CREATE TABLE conditions (
+        time TIMESTAMPTZ NOT NULL,
+        value FLOAT);
+    SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 week');
+
+    INSERT INTO conditions
+    SELECT ts, extract(epoch from ts)::int % 10
+    FROM generate_series('2026-01-01'::timestamptz, '2026-04-10'::timestamptz, INTERVAL '1 day') ts;
+
+    -- Table used to pass R1's backend PID to the terminator session
+    CREATE TABLE cancelpid (pid int);
+
+    CREATE MATERIALIZED VIEW cond_daily
+    WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+    SELECT time_bucket('1 day', time) AS bucket, avg(value) AS avg_val
+    FROM conditions
+    GROUP BY 1
+    WITH NO DATA;
+}
+
+setup
+{
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-01', '2026-04-01');
+}
+
+setup
+{
+    BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 111), ('2026-01-20', 111), ('2026-01-30', 111); COMMIT;
+    BEGIN; INSERT INTO conditions VALUES ('2026-02-10', 222), ('2026-02-20', 222); COMMIT;
+    BEGIN; INSERT INTO conditions VALUES ('2026-03-01', 333), ('2026-03-10', 333), ('2026-03-15', 333); COMMIT;
+    BEGIN; INSERT INTO conditions VALUES ('2026-03-20', 444), ('2026-03-25', 444), ('2026-03-30', 444); COMMIT;
+}
+
+teardown {
+    DROP TABLE conditions CASCADE;
+    DROP TABLE IF EXISTS cancelpid;
+}
+
+# Session R1: stores its PID then runs a refresh that will left PID behind.
+session "R1"
+setup {
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    INSERT INTO cancelpid SELECT pg_backend_pid();
+}
+step "R1_refresh" {
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+}
+
+# Session WP: enables / disables waitpoints
+session "WP"
+step "WP_before_txn3_enable"  { SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock'); }
+step "WP_before_txn3_disable"  { SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock'); }
+step "WP_mat_enable"  { SELECT debug_waitpoint_enable('after_process_cagg_materializations'); }
+step "WP_mat_disable"  { SELECT debug_waitpoint_release('after_process_cagg_materializations'); }
+
+# Session K1: terminate R1's backend so its PID becomes dead in the
+# registration table, then wait until the process is gone.
+session "K1"
+step "K1_terminate" {
+    DO $$
+    DECLARE
+        target_pid int;
+    BEGIN
+        SELECT pid INTO target_pid FROM cancelpid;
+        PERFORM pg_terminate_backend(target_pid);
+        LOOP
+            EXIT WHEN NOT EXISTS (
+                SELECT 1 FROM pg_stat_activity WHERE pid = target_pid
+            );
+            PERFORM pg_sleep(0.05);
+        END LOOP;
+    END;
+    $$;
+}
+
+# Refresh sessions
+session "R2"
+setup {
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+}
+step "R2_refresh" {
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-02-15');
+}
+
+session "R3"
+setup {
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+}
+step "R3_refresh" {
+    CALL refresh_continuous_aggregate('cond_daily', '2026-02-15', '2026-03-15');
+}
+
+session "R4"
+setup {
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+}
+step "R4_refresh" {
+    CALL refresh_continuous_aggregate('cond_daily', '2026-03-15', '2026-03-30');
+}
+step "R4_overlapping_refresh" {
+    CALL refresh_continuous_aggregate('cond_daily', '2026-02-15', '2026-03-05');
+}
+
+# Check session for jobs and locks
+session "CHECK"
+step "check_jobs" {
+    SELECT ca.user_view_name,
+           _timescaledb_functions.to_timestamp(r.start_range) AS start_time,
+           _timescaledb_functions.to_timestamp(r.end_range) AS end_time
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+}
+step "check_locks" {
+    SELECT l.mode, l.granted
+    FROM pg_locks l
+    JOIN pg_class c ON c.oid = l.relation
+    WHERE c.relname = 'continuous_aggs_jobs_refresh_ranges'
+    ORDER BY l.mode;
+}
+step "L1_lock" {
+    BEGIN;
+    LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+        IN ACCESS EXCLUSIVE MODE;
+}
+step "L1_unlock" {
+    COMMIT;
+}
+
+
+# Two refreshes wait for registration, one waits for cleanup before exiting. All blocked on an AccessExclusiveLock on continuous_aggs_jobs_refresh_ranges.
+# None of those refreshes overlaps, so all should succeed.
+permutation "WP_mat_enable" "R2_refresh" "L1_lock" "WP_mat_disable" "R3_refresh" "R4_refresh" "check_locks" "check_jobs" "L1_unlock" "check_locks" "check_jobs"
+
+# Two refreshes wait for registration, one waits for cleanup before exiting. All blocked on an AccessExclusiveLock on continuous_aggs_jobs_refresh_ranges.
+# Refreshes waiting for registration overlap with each other, so one should fail.
+permutation "WP_mat_enable" "R2_refresh" "L1_lock" "WP_mat_disable" "R3_refresh" "R4_overlapping_refresh" "check_locks" "check_jobs" "L1_unlock" "check_locks" "check_jobs"
+
+# Stale registration cleanup by concurrent refreshes.
+# Kill a backend during refresh to end up with a pid left behind. Later two concurrent refreshes run, only one removes the stale pid.
+permutation "WP_before_txn3_enable" "R1_refresh" "K1_terminate" "check_jobs" "WP_before_txn3_disable" "L1_lock" "R2_refresh" "R3_refresh" "L1_unlock" "check_jobs"

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -130,6 +130,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     bgw_reorder_drop_chunks.sql
     scheduler_fixed.sql
     cagg_policy_incremental.sql
+    cagg_refresh_cleanup.sql
     chunk_column_stats.sql
     compress_bgw_reorder_drop_chunks.sql
     compress_bloom_legacy_v1.sql

--- a/tsl/test/sql/cagg_refresh_cleanup.sql
+++ b/tsl/test/sql/cagg_refresh_cleanup.sql
@@ -1,0 +1,121 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Tests for job registration cleanup in the continuous aggregate refresh
+-- procedure. Verifies that the entry in continuous_aggs_jobs_refresh_ranges
+-- is correctly cleaned up when a refresh fails at each transaction phase.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE TABLE conditions (
+    time TIMESTAMPTZ NOT NULL,
+    value FLOAT);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 week');
+
+INSERT INTO conditions
+SELECT ts, extract(epoch from ts)::int % 10
+FROM generate_series('2026-01-01'::timestamptz, '2026-04-10'::timestamptz, INTERVAL '1 day') ts;
+
+CREATE MATERIALIZED VIEW cond_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, avg(value) AS avg_val
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+
+-- Set the invalidation threshold via an initial refresh
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-01', '2026-04-01');
+
+-- Add invalidations inside the threshold range so future refreshes have real work
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 999), ('2026-01-20', 999), ('2026-01-30', 999); COMMIT;
+BEGIN; INSERT INTO conditions VALUES ('2026-02-10', 999), ('2026-02-20', 999); COMMIT;
+
+SELECT count(*) AS jobs_count
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+-- Test 1: refresh fails in Txn1 (invalidation processing)
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_txn1');
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+\set ON_ERROR_STOP 1
+
+-- Job should be cleaned up after the failed refresh
+SELECT count(*) AS jobs_after_txn1_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_txn1');
+
+-- Next refresh should succeed
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 777), ('2026-01-20', 777); COMMIT;
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+
+-- No job should be left behind after the successful refresh
+SELECT count(*) AS jobs_after_next_refresh
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+-- Test 2: refresh fails in Txn2 (cagg invalidation log cutting)
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 666), ('2026-01-20', 666); COMMIT;
+
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_txn2');
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+\set ON_ERROR_STOP 1
+
+SELECT count(*) AS jobs_after_txn2_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_txn2');
+
+-- Test 3: refresh fails in Txn3 (materialization)
+BEGIN; INSERT INTO conditions VALUES ('2026-01-30', 555), ('2026-02-10', 555); COMMIT;
+
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_txn3');
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+\set ON_ERROR_STOP 1
+
+SELECT count(*) AS jobs_after_txn3_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_txn3');
+
+-- Test 4: refresh fails in registration before Txn1
+BEGIN; INSERT INTO conditions VALUES ('2026-02-20', 888), ('2026-03-01', 888); COMMIT;
+
+SELECT debug_waitpoint_enable('cagg_refresh_fail_in_registration');
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+\set ON_ERROR_STOP 1
+
+SELECT count(*) AS jobs_after_registration_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_in_registration');
+
+-- Test 5: stale entry with a dead PID is cleaned up by the next refresh.
+-- Inserting a row with PID 0 as a dummy job.
+INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+    (materialization_id, start_range, end_range, pid)
+SELECT mat_hypertable_id,
+       _timescaledb_functions.to_unix_microseconds('2026-01-05'::timestamptz),
+       _timescaledb_functions.to_unix_microseconds('2026-03-15'::timestamptz),
+       0
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond_daily';
+
+SELECT count(*) AS stale_jobs_before_refresh
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+-- Refresh detects BackendPidGetProc(0) == NULL, removes the stale row, and succeeds
+BEGIN; INSERT INTO conditions VALUES ('2026-01-10', 444), ('2026-01-20', 444); COMMIT;
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+
+SELECT count(*) AS jobs_after_dead_pid_cleanup
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+DROP TABLE conditions CASCADE;


### PR DESCRIPTION
Regression and isolation tests for testing registration of refresh jobs in continuous_aggs_jobs_refresh_ranges catalog. Also cleaning up such jobs when refresh exits