### PR TITLE
Make sure jobs are cleaned up after registration

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -869,12 +869,13 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 						   ts_internal_to_time_string(refresh_window.start, refresh_window.type),
 						   ts_internal_to_time_string(refresh_window.end, refresh_window.type))));
 
-	/* Commit and Start a new transaction */
-	SPI_commit_and_chain();
-
-	volatile bool refreshed = false;
 	PG_TRY();
 	{
+		/* Commit and Start a new transaction */
+		SPI_commit_and_chain();
+
+		volatile bool refreshed = false;
+
 		/* Set the new invalidation threshold. Note that this only updates the
 		 * threshold if the new value is greater than the old one. Otherwise, the
 		 * existing threshold is returned. */


### PR DESCRIPTION
Commit the transaction that registers the job in a try block to ensure the job can be unregistered in case of a failure.