### PR TITLE
Remove self-referential FOREIGN KEY constraints from catalog

### DIFF
--- a/.unreleased/pr_9519
+++ b/.unreleased/pr_9519
@@ -1,0 +1,1 @@
+Fixes: #9519 Remove self-referential FOREIGN KEY constraints from catalog

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -60,8 +60,7 @@ CREATE TABLE _timescaledb_catalog.hypertable (
   -- internal compressed hypertables have compression state = 2
   CONSTRAINT hypertable_dim_compress_check CHECK (num_dimensions > 0 OR compression_state = 2),
   CONSTRAINT hypertable_chunk_target_size_check CHECK (chunk_target_size >= 0),
-  CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL)),
-  CONSTRAINT hypertable_compressed_hypertable_id_fkey FOREIGN KEY (compressed_hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id)
+  CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL))
 );
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
@@ -153,7 +152,6 @@ CREATE TABLE _timescaledb_catalog.chunk (
   -- table constraints
   CONSTRAINT chunk_pkey PRIMARY KEY (id),
   CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name),
-  CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk (id),
   CONSTRAINT chunk_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id)
 );
 ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -75,3 +75,8 @@ WITH orphaned_settings AS (
 )
 DELETE FROM _timescaledb_catalog.compression_settings AS cs
 USING orphaned_settings AS os WHERE cs.relid = os.relid;
+
+-- Remove self-referential foreign keys to eliminate pg_dump circular dependency warnings
+ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT IF EXISTS hypertable_compressed_hypertable_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk DROP CONSTRAINT IF EXISTS chunk_compressed_chunk_id_fkey;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,4 @@
+
+-- Re-add self-referential foreign keys
+ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_compressed_hypertable_id_fkey FOREIGN KEY (compressed_hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk (id);

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -36,12 +36,10 @@ Indexes:
     "chunk_osm_chunk_idx" btree (osm_chunk, hypertable_id)
     "chunk_schema_name_table_name_key" UNIQUE CONSTRAINT, btree (schema_name, table_name)
 Foreign-key constraints:
-    "chunk_compressed_chunk_id_fkey" FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
     "chunk_hypertable_id_fkey" FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable(id)
 Referenced by:
     TABLE "_timescaledb_internal.bgw_policy_chunk_stats" CONSTRAINT "bgw_policy_chunk_stats_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
     TABLE "_timescaledb_catalog.chunk_column_stats" CONSTRAINT "chunk_column_stats_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
-    TABLE "_timescaledb_catalog.chunk" CONSTRAINT "chunk_compressed_chunk_id_fkey" FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
     TABLE "_timescaledb_catalog.chunk_constraint" CONSTRAINT "chunk_constraint_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id)
     TABLE "_timescaledb_catalog.compression_chunk_size" CONSTRAINT "compression_chunk_size_chunk_id_fkey" FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE
     TABLE "_timescaledb_catalog.compression_chunk_size" CONSTRAINT "compression_chunk_size_compressed_chunk_id_fkey" FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE

--- a/tsl/test/expected/compression_null_dump_restore.out
+++ b/tsl/test/expected/compression_null_dump_restore.out
@@ -39,14 +39,6 @@ select compress_chunk(show_chunks('null_dump'));
 --quote-all-identifiers --no-tablespaces --no-owner --no-privileges --exclude-schema=test
 --quote-all-identifiers --no-tablespaces --no-owner --no-privileges --exclude-schema=test
 pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump: detail: hypertable
-pg_dump: hint: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: hint: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump: detail: chunk
-pg_dump: hint: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: hint: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
 pg_dump: detail: continuous_agg
 pg_dump: hint: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
 pg_dump: hint: Consider using a full dump instead of a --data-only dump to avoid this problem.


### PR DESCRIPTION
pg_dump warns about these with `there are circular foreign-key
constraints on this table`. These put additional constraints on
dump/restore. The foreign key constraints do not enforce consistency
because internal catalog writes will skip verifying the constraint.
