### PR TITLE
Add support for reporting index creation progress

### DIFF
--- a/.unreleased/pr_9521
+++ b/.unreleased/pr_9521
@@ -1,0 +1,2 @@
+Implements: #9521 Add support for reporting index creation progress
+Thanks: @maltalex for reporting an issue with index creation progress reporting

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -23,6 +23,7 @@
 #include <commands/defrem.h>
 #include <commands/event_trigger.h>
 #include <commands/prepare.h>
+#include <commands/progress.h>
 #include <commands/tablecmds.h>
 #include <commands/tablespace.h>
 #include <commands/trigger.h>
@@ -43,6 +44,7 @@
 #include <storage/lockdefs.h>
 #include <tcop/utility.h>
 #include <utils/acl.h>
+#include <utils/backend_progress.h>
 #include <utils/builtins.h>
 #include <utils/elog.h>
 #include <utils/guc.h>
@@ -977,6 +979,7 @@ foreach_chunk_multitransaction(Oid relid, MemoryContext mctx, mt_process_chunk_t
 	CommitTransactionCommand();
 
 	num_chunks = list_length(chunks);
+	pgstat_progress_update_param(PROGRESS_CREATEIDX_PARTITIONS_TOTAL, num_chunks);
 	foreach (lc, chunks)
 	{
 		process_chunk(hypertable_id, lfirst_oid(lc), arg);
@@ -3203,6 +3206,7 @@ typedef struct CreateIndexInfo
 	Oid main_table_relid;
 	HypertableIndexOptions extended_options;
 	MemoryContext mctx;
+	int64 partitions_done; /* for tracking chunk progress on PG15 */
 } CreateIndexInfo;
 
 /*
@@ -3244,6 +3248,14 @@ process_index_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 
 	index_close(hypertable_index_rel, NoLock);
 	table_close(chunk_rel, NoLock);
+
+#if PG16_GE
+	pgstat_progress_incr_param(PROGRESS_CREATEIDX_PARTITIONS_DONE, 1);
+#else
+	/* pgstat_progress_incr_param is not available before PG16 */
+	pgstat_progress_update_param(PROGRESS_CREATEIDX_PARTITIONS_DONE, ++info->partitions_done);
+#endif
+	DEBUG_WAITPOINT("process_index_chunk_done");
 }
 
 static void
@@ -3343,6 +3355,14 @@ process_index_chunk_multitransaction(int32 hypertable_id, Oid chunk_relid, void 
 	table_close(chunk_rel, NoLock);
 
 	ts_catalog_restore_user(&sec_ctx);
+
+#if PG16_GE
+	pgstat_progress_incr_param(PROGRESS_CREATEIDX_PARTITIONS_DONE, 1);
+#else
+	/* pgstat_progress_incr_param is not available before PG16 */
+	pgstat_progress_update_param(PROGRESS_CREATEIDX_PARTITIONS_DONE, ++info->partitions_done);
+#endif
+	DEBUG_WAITPOINT("process_index_chunk_multitransaction_done");
 
 	PopActiveSnapshot();
 	CommitTransactionCommand();
@@ -3535,22 +3555,38 @@ process_index_start(ProcessUtilityArgs *args)
 	index_close(main_table_index_relation, NoLock);
 	table_close(main_table_relation, NoLock);
 
+	/*
+	 * Start progress reporting for chunk index creation. The root table's
+	 * DefineIndex already started and ended its own progress command, so we
+	 * start a new one to track progress across chunks.
+	 */
+	pgstat_progress_start_command(PROGRESS_COMMAND_CREATE_INDEX, ht->main_table_relid);
+	pgstat_progress_update_param(PROGRESS_CREATEIDX_COMMAND, PROGRESS_CREATEIDX_COMMAND_CREATE);
+	pgstat_progress_update_param(PROGRESS_CREATEIDX_INDEX_OID, info.obj.objectId);
+
 	/* create chunk indexes using the same transaction for all the chunks */
 	if (!info.extended_options.multitransaction)
 	{
 		CatalogSecurityContext sec_ctx;
+		List *chunks;
 		/*
 		 * Change user since chunk's are typically located in an internal
 		 * schema and chunk indexes require metadata changes. In the
 		 * multi-transaction case, we do this once per chunk.
 		 */
 		ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+
+		chunks = find_inheritance_children(ht->main_table_relid, NoLock);
+		pgstat_progress_update_param(PROGRESS_CREATEIDX_PARTITIONS_TOTAL, list_length(chunks));
+		list_free(chunks);
+
 		/* Recurse to each chunk and create a corresponding index. */
 		foreach_chunk(ht, process_index_chunk, &info);
 
 		ts_catalog_restore_user(&sec_ctx);
 		ts_cache_release(&hcache);
 
+		pgstat_progress_end_command();
 		return DDL_DONE;
 	}
 
@@ -3589,6 +3625,8 @@ process_index_start(ProcessUtilityArgs *args)
 								   info.mctx,
 								   process_index_chunk_multitransaction,
 								   &info);
+
+	pgstat_progress_end_command();
 
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());

--- a/test/isolation/expected/create_index_progress.out
+++ b/test/isolation/expected/create_index_progress.out
@@ -1,0 +1,65 @@
+Parsed test spec with 3 sessions
+
+starting permutation: WPE CI check WPR
+step WPE: SELECT debug_waitpoint_enable('process_index_chunk_done');
+debug_waitpoint_enable
+----------------------
+                      
+
+step CI: CREATE INDEX progress_test_idx ON progress_test(location); <waiting ...>
+step check: 
+    SELECT
+        relid::regclass AS relation,
+        CASE WHEN index_relid::text = index_relid::regclass::text
+             THEN 'not yet visible'
+             ELSE index_relid::regclass::text
+        END AS index,
+        command,
+        phase,
+        partitions_total,
+        partitions_done
+    FROM pg_stat_progress_create_index
+    WHERE relid = 'progress_test'::regclass;
+
+relation     |index          |command     |phase         |partitions_total|partitions_done
+-------------+---------------+------------+--------------+----------------+---------------
+progress_test|not yet visible|CREATE INDEX|building index|               3|              1
+
+step WPR: SELECT debug_waitpoint_release('process_index_chunk_done');
+debug_waitpoint_release
+-----------------------
+                       
+
+step CI: <... completed>
+
+starting permutation: WPE_MT CI_MT check WPR_MT
+step WPE_MT: SELECT debug_waitpoint_enable('process_index_chunk_multitransaction_done');
+debug_waitpoint_enable
+----------------------
+                      
+
+step CI_MT: CREATE INDEX progress_test_mt_idx ON progress_test(location) WITH (timescaledb.transaction_per_chunk); <waiting ...>
+step check: 
+    SELECT
+        relid::regclass AS relation,
+        CASE WHEN index_relid::text = index_relid::regclass::text
+             THEN 'not yet visible'
+             ELSE index_relid::regclass::text
+        END AS index,
+        command,
+        phase,
+        partitions_total,
+        partitions_done
+    FROM pg_stat_progress_create_index
+    WHERE relid = 'progress_test'::regclass;
+
+relation     |index               |command     |phase         |partitions_total|partitions_done
+-------------+--------------------+------------+--------------+----------------+---------------
+progress_test|progress_test_mt_idx|CREATE INDEX|building index|               3|              1
+
+step WPR_MT: SELECT debug_waitpoint_release('process_index_chunk_multitransaction_done');
+debug_waitpoint_release
+-----------------------
+                       
+
+step CI_MT: <... completed>

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -13,9 +13,14 @@ file(REMOVE ${ISOLATION_TEST_SCHEDULE})
 set(TEST_TEMPLATES)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  list(APPEND TEST_FILES concurrent_add_dimension.spec
-       concurrent_query_and_drop_chunks.spec dropchunks_race.spec
-       multi_transaction_indexing.spec)
+  list(
+    APPEND
+    TEST_FILES
+    concurrent_add_dimension.spec
+    concurrent_query_and_drop_chunks.spec
+    create_index_progress.spec
+    dropchunks_race.spec
+    multi_transaction_indexing.spec)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 foreach(TEST_FILE ${TEST_FILES})

--- a/test/isolation/specs/create_index_progress.spec
+++ b/test/isolation/specs/create_index_progress.spec
@@ -1,0 +1,49 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and
+# LICENSE-APACHE for a copy of the license.
+
+# Test that pg_stat_progress_create_index reports progress during
+# hypertable index creation (GitHub issue #3157).
+
+setup {
+    CREATE TABLE progress_test(time int, temp float, location int);
+    SELECT create_hypertable('progress_test', 'time', chunk_time_interval => 10, create_default_indexes => false);
+    INSERT INTO progress_test VALUES (1, 23.4, 1),
+        (11, 21.3, 2),
+        (21, 19.5, 3);
+}
+
+teardown {
+    DROP TABLE progress_test;
+}
+
+session "Waitpoints"
+step "WPE"     { SELECT debug_waitpoint_enable('process_index_chunk_done'); }
+step "WPR"     { SELECT debug_waitpoint_release('process_index_chunk_done'); }
+step "WPE_MT"  { SELECT debug_waitpoint_enable('process_index_chunk_multitransaction_done'); }
+step "WPR_MT"  { SELECT debug_waitpoint_release('process_index_chunk_multitransaction_done'); }
+
+session "CREATE_INDEX"
+step "CI"    { CREATE INDEX progress_test_idx ON progress_test(location); }
+step "CI_MT" { CREATE INDEX progress_test_mt_idx ON progress_test(location) WITH (timescaledb.transaction_per_chunk); }
+
+session "CHECK_PROGRESS"
+step "check" {
+    SELECT
+        relid::regclass AS relation,
+        CASE WHEN index_relid::text = index_relid::regclass::text
+             THEN 'not yet visible'
+             ELSE index_relid::regclass::text
+        END AS index,
+        command,
+        phase,
+        partitions_total,
+        partitions_done
+    FROM pg_stat_progress_create_index
+    WHERE relid = 'progress_test'::regclass;
+}
+
+# Single-transaction index creation
+permutation "WPE" "CI" "check" "WPR"
+# Multi-transaction index creation
+permutation "WPE_MT" "CI_MT" "check" "WPR_MT"


### PR DESCRIPTION
Report progress of index creation on hypertables in
pg_stat_progress_create_index.

Fixes: #3157
