### PR TITLE
Fix GROUP BY ROLLUP on compressed continuous aggregates

### DIFF
--- a/.unreleased/pr_9522
+++ b/.unreleased/pr_9522
@@ -1,0 +1,2 @@
+Fixes: #9522 Fix GROUP BY ROLLUP on compressed continuous aggregates
+Thanks: @pcayen for reporting an issue with GROUP BY ROLLUP

--- a/tsl/src/nodes/columnar_scan/planner.c
+++ b/tsl/src/nodes/columnar_scan/planner.c
@@ -561,6 +561,9 @@ replace_compressed_vars(Node *node, const CompressionInfo *info)
 						  var->vartypmod,
 						  var->varcollid,
 						  var->varlevelsup);
+#if PG16_GE
+		new_var->varnullingrels = var->varnullingrels;
+#endif
 
 		if (!AttributeNumberIsValid(new_var->varattno))
 			elog(ERROR, "cannot find column %s on decompressed chunk", colname);
@@ -568,9 +571,6 @@ replace_compressed_vars(Node *node, const CompressionInfo *info)
 		/* And return the replacement var */
 		return (Node *) new_var;
 	}
-	if (IsA(node, PlaceHolderVar))
-		elog(ERROR, "ignoring placeholders");
-
 	return expression_tree_mutator(node, replace_compressed_vars, (void *) info);
 }
 

--- a/tsl/test/expected/cagg_direct_compress.out
+++ b/tsl/test/expected/cagg_direct_compress.out
@@ -154,4 +154,17 @@ SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks
 -------------------
  {COMPRESSED}
 
+-- Test GROUP BY ROLLUP on compressed continuous aggregate (issue #9520)
+SELECT bucket, MAX(max)
+FROM conditions_hourly
+WHERE bucket >= '2025-12-14 00:00:00+00'::timestamptz AND bucket < '2025-12-14 03:00:00+00'::timestamptz
+GROUP BY ROLLUP(bucket)
+ORDER BY bucket ASC NULLS FIRST;
+            bucket            | max 
+------------------------------+-----
+                              |   1
+ Sat Dec 13 16:00:00 2025 PST |   1
+ Sat Dec 13 17:00:00 2025 PST |   1
+ Sat Dec 13 18:00:00 2025 PST |   1
+
 RESET timescaledb.enable_direct_compress_on_cagg_refresh;

--- a/tsl/test/sql/cagg_direct_compress.sql
+++ b/tsl/test/sql/cagg_direct_compress.sql
@@ -129,4 +129,11 @@ ALTER MATERIALIZED VIEW conditions_weekly SET (timescaledb.compress_segmentby = 
 CALL refresh_continuous_aggregate('conditions_weekly', NULL, NULL);
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('conditions_weekly') chunk;
 
+-- Test GROUP BY ROLLUP on compressed continuous aggregate (issue #9520)
+SELECT bucket, MAX(max)
+FROM conditions_hourly
+WHERE bucket >= '2025-12-14 00:00:00+00'::timestamptz AND bucket < '2025-12-14 03:00:00+00'::timestamptz
+GROUP BY ROLLUP(bucket)
+ORDER BY bucket ASC NULLS FIRST;
+
 RESET timescaledb.enable_direct_compress_on_cagg_refresh;


### PR DESCRIPTION
The replace_compressed_vars expression tree mutator errored on
PlaceHolderVar nodes which are introduced by PostgreSQL's planner
for GROUP BY ROLLUP, CUBE, and GROUPING SETS queries. Remove the
error and let expression_tree_mutator handle PlaceHolderVar by
recursing into its expression, replacing any compressed vars within.

Fixes #9520
