### PR TITLE
Allow to specify the git tag for "label released PRs"

### DIFF
--- a/.github/workflows/label-released-prs.yaml
+++ b/.github/workflows/label-released-prs.yaml
@@ -6,6 +6,12 @@ on:
     types: [published]
   push:
     branches: [trigger/label-released-prs]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to label PRs for (e.g. 2.19.0). Defaults to the latest release."
+        required: false
+        type: string
 
 jobs:
   label-release:
@@ -21,9 +27,13 @@ jobs:
         run: |
           pip install PyGithub requests
 
-      - name: Get latest release tag
+      - name: Get release tag
         run: |
-          echo "LATEST_TAG=$(gh release view --json tagName --jq '.tagName')" >> $GITHUB_ENV
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "LATEST_TAG=${{ inputs.tag }}" >> $GITHUB_ENV
+          else
+            echo "LATEST_TAG=$(gh release view --json tagName --jq '.tagName')" >> $GITHUB_ENV
+          fi
 
       - name: Run label-released script
         run: |


### PR DESCRIPTION
Looks like we messed up the tagging somehow temporarily, and the workflow that was triggered for 2.26.0 considered the latest release to be 2.25.2. I need to run it manually for the 2.26.0 to fix the labels for 2.26.0