### PR TITLE
Drop refresh ranges when dropping CAgg

### DIFF
--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -43,6 +43,7 @@
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/compression_settings.h"
 #include "ts_catalog/continuous_agg.h"
+#include "ts_catalog/continuous_aggs_jobs_refresh_ranges.h"
 #include "ts_catalog/continuous_aggs_watermark.h"
 #include "utils.h"
 #include "with_clause/alter_table_with_clause.h"
@@ -887,6 +888,9 @@ drop_continuous_agg(FormData_continuous_agg *cadata, bool drop_user_view)
 
 		/* Delete watermark */
 		ts_cagg_watermark_delete_by_mat_hypertable_id(form.mat_hypertable_id);
+
+		/* Delete any refresh ranges registered for this CAgg */
+		ts_cagg_jobs_refresh_ranges_delete_by_mat_hypertable_id(form.mat_hypertable_id);
 	}
 
 	cagg_bucket_function_delete(cadata->mat_hypertable_id);

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
@@ -58,6 +58,28 @@ ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id, int64 start_range, 
 }
 
 TSDLLEXPORT void
+ts_cagg_jobs_refresh_ranges_delete_by_mat_hypertable_id(int32 materialization_id)
+{
+	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_JOBS_REFRESH_RANGES,
+													RowExclusiveLock,
+													CurrentMemoryContext);
+
+	init_scan_by_materialization_id(&iterator, materialization_id);
+
+	/*
+	 * We can have multiple entries for the same materialization_id. Find
+	 * them all and delete them.
+	 */
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+
+		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+	}
+	ts_scan_iterator_close(&iterator);
+}
+
+TSDLLEXPORT void
 ts_cagg_jobs_refresh_ranges_delete_by_pid(int32 materialization_id, int32 pid)
 {
 	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_JOBS_REFRESH_RANGES,

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.h
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.h
@@ -12,5 +12,7 @@
 extern TSDLLEXPORT bool ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id,
 																	  int64 start_range,
 																	  int64 end_range, int32 pid);
+extern TSDLLEXPORT void
+ts_cagg_jobs_refresh_ranges_delete_by_mat_hypertable_id(int32 materialization_id);
 extern TSDLLEXPORT void ts_cagg_jobs_refresh_ranges_delete_by_pid(int32 materialization_id,
 																  int32 pid);

--- a/tsl/test/expected/cagg_refresh_cleanup.out
+++ b/tsl/test/expected/cagg_refresh_cleanup.out
@@ -156,6 +156,37 @@ FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 -----------------------------
                            0
 
+-- Test 6: dropping a CAgg cleans up its refresh range entries
+CREATE MATERIALIZED VIEW cond_daily_drop_test
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, avg(value) AS avg_val
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+-- Insert dummy refresh range entries for the new CAgg
+INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+    (materialization_id, start_range, end_range, pid)
+SELECT mat_hypertable_id,
+       _timescaledb_functions.to_unix_microseconds(s),
+       _timescaledb_functions.to_unix_microseconds(s + interval '1 month'),
+       0
+FROM _timescaledb_catalog.continuous_agg,
+     generate_series('2026-01-01'::timestamptz, '2026-05-01'::timestamptz, interval '1 month') AS s
+WHERE user_view_name = 'cond_daily_drop_test';
+SELECT count(*) AS refresh_ranges_before_drop
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ refresh_ranges_before_drop 
+----------------------------
+                          5
+
+DROP MATERIALIZED VIEW cond_daily_drop_test;
+-- Refresh ranges for the dropped CAgg should be gone
+SELECT count(*) AS refresh_ranges_after_drop
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ refresh_ranges_after_drop 
+---------------------------
+                         0
+
 DROP TABLE conditions CASCADE;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to 2 other objects

--- a/tsl/test/sql/cagg_refresh_cleanup.sql
+++ b/tsl/test/sql/cagg_refresh_cleanup.sql
@@ -118,4 +118,32 @@ CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
 SELECT count(*) AS jobs_after_dead_pid_cleanup
 FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 
+-- Test 6: dropping a CAgg cleans up its refresh range entries
+CREATE MATERIALIZED VIEW cond_daily_drop_test
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 day', time) AS bucket, avg(value) AS avg_val
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+
+-- Insert dummy refresh range entries for the new CAgg
+INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
+    (materialization_id, start_range, end_range, pid)
+SELECT mat_hypertable_id,
+       _timescaledb_functions.to_unix_microseconds(s),
+       _timescaledb_functions.to_unix_microseconds(s + interval '1 month'),
+       0
+FROM _timescaledb_catalog.continuous_agg,
+     generate_series('2026-01-01'::timestamptz, '2026-05-01'::timestamptz, interval '1 month') AS s
+WHERE user_view_name = 'cond_daily_drop_test';
+
+SELECT count(*) AS refresh_ranges_before_drop
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+DROP MATERIALIZED VIEW cond_daily_drop_test;
+
+-- Refresh ranges for the dropped CAgg should be gone
+SELECT count(*) AS refresh_ranges_after_drop
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
 DROP TABLE conditions CASCADE;


### PR DESCRIPTION
Drop relevant entries in continuous_aggs_jobs_refresh_ranges when dropping a continuous aggregate.