### PR TITLE
Fix build by preventing clobbering

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -761,12 +761,13 @@ static void continuous_agg_refresh_spi_setup_and_connect(CaggRefreshSpiContext *
 }
 
 void
-continuous_agg_refresh_internal(const ContinuousAgg *cagg,
+continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg,
 								const InternalTimeRange *refresh_window_arg,
 								const ContinuousAggRefreshContext context, const bool start_isnull,
 								const bool end_isnull, bool bucketing_refresh_window, bool force,
 								bool process_hypertable_invalidations, bool extend_last_bucket)
 {
+	const ContinuousAgg *volatile cagg = cagg_arg;
 	int32 mat_id = cagg->data.mat_hypertable_id;
 	InternalTimeRange refresh_window = *refresh_window_arg;
 	int64 invalidation_threshold;

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -14,7 +14,7 @@
 
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void
-continuous_agg_refresh_internal(const ContinuousAgg *cagg, const InternalTimeRange *refresh_window,
+continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg, const InternalTimeRange *refresh_window,
 								const ContinuousAggRefreshContext context, const bool start_isnull,
 								const bool end_isnull, bool bucketing_refresh_window, bool force,
 								bool process_hypertable_invalidations, bool extend_last_bucket);


### PR DESCRIPTION
Build was failing with 
```
error: argument ‘cagg’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Werror=clobbered]
  764 | continuous_agg_refresh_internal(const ContinuousAgg *cagg,
```

Assigning the argument to a volatile field, then using it could fix it. 