### PR TITLE
Fix out of memory when propagating ALTER TABLE to many chunks

### DIFF
--- a/.unreleased/pr_9550
+++ b/.unreleased/pr_9550
@@ -1,0 +1,2 @@
+Fixes: #9550 Fix out of memory when propagating ALTER TABLE to many chunks
+Thanks: @patstrom for reporting an out of memory error when dropping constraints

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -475,7 +475,12 @@ add_chunk_oid(Hypertable *ht, Oid chunk_relid, void *vargs)
 {
 	ProcessUtilityArgs *args = vargs;
 	GrantStmt *stmt = castNode(GrantStmt, args->parsetree);
-	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	Chunk *chunk;
+
+	/* Switch to the parent context for persistent allocations */
+	MemoryContext per_chunk_mcxt = MemoryContextSwitchTo(GetMemoryChunkContext(stmt));
+
+	chunk = ts_chunk_get_by_relid(chunk_relid, true);
 	/*
 	 * If chunk is in the same schema as the hypertable it could already be part of
 	 * the objects list in the case of "GRANT ALL IN SCHEMA" for example
@@ -486,6 +491,7 @@ add_chunk_oid(Hypertable *ht, Oid chunk_relid, void *vargs)
 			makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), -1);
 		stmt->objects = lappend(stmt->objects, rv);
 	}
+	MemoryContextSwitchTo(per_chunk_mcxt);
 }
 
 static DDLResult
@@ -906,17 +912,31 @@ foreach_chunk(Hypertable *ht, process_chunk_t process_chunk, void *arg)
 	List *chunks;
 	ListCell *lc;
 	int n = 0;
+	MemoryContext orig_mcxt = CurrentMemoryContext;
+	MemoryContext chunk_mcxt;
 
 	if (NULL == ht)
 		return -1;
 
 	chunks = find_inheritance_children(ht->main_table_relid, NoLock);
 
+	/*
+	 * Use a per-iteration temporary memory context to avoid accumulating
+	 * allocations when processing hypertables with many chunks. Callbacks
+	 * that need persistent allocations should switch to the parent context.
+	 */
+	chunk_mcxt = AllocSetContextCreate(orig_mcxt, "foreach_chunk", ALLOCSET_DEFAULT_SIZES);
 	foreach (lc, chunks)
 	{
+		MemoryContextSwitchTo(chunk_mcxt);
 		process_chunk(ht, lfirst_oid(lc), arg);
+		MemoryContextSwitchTo(orig_mcxt);
+		MemoryContextReset(chunk_mcxt);
 		n++;
 	}
+
+	MemoryContextDelete(chunk_mcxt);
+	list_free(chunks);
 
 	return n;
 }
@@ -933,18 +953,27 @@ foreach_compressed_chunk(Hypertable *ht, process_chunk_t process_chunk, void *ar
 	List *chunks;
 	ListCell *lc;
 	int n = 0;
+	MemoryContext orig_mcxt = CurrentMemoryContext;
+	MemoryContext chunk_mcxt;
 
 	if (!ht || !ht->fd.compressed_hypertable_id)
 		return -1;
 
 	chunks = ts_chunk_get_by_hypertable_id(ht->fd.compressed_hypertable_id);
 
+	chunk_mcxt = AllocSetContextCreate(orig_mcxt, "foreach_chunk", ALLOCSET_DEFAULT_SIZES);
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
+		MemoryContextSwitchTo(chunk_mcxt);
 		process_chunk(ht, chunk->table_id, arg);
+		MemoryContextReset(chunk_mcxt);
 		n++;
 	}
+
+	MemoryContextSwitchTo(orig_mcxt);
+	MemoryContextDelete(chunk_mcxt);
+	list_free(chunks);
 
 	return n;
 }
@@ -1056,9 +1085,14 @@ static void
 add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
 {
 	VacuumCtx *ctx = (VacuumCtx *) arg;
-	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	Chunk *chunk;
 	VacuumRelation *chunk_vacuum_rel;
 	RangeVar *chunk_range_var;
+
+	/* Switch to the parent context for persistent allocations */
+	MemoryContext per_chunk_mcxt = MemoryContextSwitchTo(GetMemoryChunkContext(ctx->ht_vacuum_rel));
+
+	chunk = ts_chunk_get_by_relid(chunk_relid, true);
 
 	chunk_range_var = copyObject(ctx->ht_vacuum_rel->relation);
 	chunk_range_var->relname = NameStr(chunk->fd.table_name);
@@ -1080,6 +1114,7 @@ add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
 	}
 
 	register_chunk_for_rebuild_if_needed(chunk_relid, ctx);
+	MemoryContextSwitchTo(per_chunk_mcxt);
 }
 
 /*

--- a/test/expected/alter_table_memory.out
+++ b/test/expected/alter_table_memory.out
@@ -1,0 +1,49 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test that ALTER TABLE propagation to chunks doesn't leak memory.
+-- We use an event trigger to capture PortalContext memory after each
+-- ALTER TABLE completes.
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+-- Returns the amount of memory currently allocated in a given
+-- memory context.
+CREATE OR REPLACE FUNCTION ts_debug_allocated_bytes(text = 'PortalContext') RETURNS bigint
+AS :MODULE_PATHNAME, 'ts_debug_allocated_bytes' LANGUAGE C STRICT VOLATILE;
+CREATE TABLE memory_log(id serial, bytes bigint);
+-- Log current memory usage into the log table.
+CREATE OR REPLACE FUNCTION log_memory() RETURNS event_trigger as $$
+BEGIN
+  INSERT INTO memory_log(bytes) SELECT ts_debug_allocated_bytes();
+END;
+$$ LANGUAGE PLPGSQL;
+-- Create hypertables with increasing chunk counts using 1-day chunk intervals.
+DO $$
+BEGIN
+  FOR i IN 1..5 LOOP
+    EXECUTE format('CREATE TABLE alter_mem_%s(time timestamptz NOT NULL, value float) WITH (tsdb.hypertable,tsdb.partition_column=''time'',tsdb.chunk_interval=''1day'')', i);
+    EXECUTE format($sql$INSERT INTO alter_mem_%s SELECT t, 1.0
+      FROM generate_series('2020-01-01'::timestamptz, '2020-01-01'::timestamptz + make_interval(days => %s - 1), interval '1 day') t$sql$, i, i * 100);
+  END LOOP;
+END $$;
+-- Add the event trigger after setup to avoid capturing setup DDL.
+CREATE EVENT TRIGGER alter_memory_trigger ON ddl_command_end WHEN TAG IN ('ALTER TABLE') EXECUTE FUNCTION log_memory();
+-- Run ALTER TABLE on hypertables with 100, 200, 300, 400, 500 chunks.
+ALTER TABLE alter_mem_1 SET (fillfactor = 50);
+ALTER TABLE alter_mem_2 SET (fillfactor = 50);
+ALTER TABLE alter_mem_3 SET (fillfactor = 50);
+ALTER TABLE alter_mem_4 SET (fillfactor = 50);
+ALTER TABLE alter_mem_5 SET (fillfactor = 50);
+DROP EVENT TRIGGER alter_memory_trigger;
+select count(*) from memory_log;
+ count 
+-------
+     5
+
+-- Check that the memory doesn't increase with number of chunks by using
+-- linear regression.
+select * from memory_log where (
+  select regr_slope(bytes, id - 1) / regr_intercept(bytes, id - 1)::float > 0.05 from memory_log
+);
+ id | bytes 
+----+-------
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -109,6 +109,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(
     APPEND
     TEST_FILES
+    alter_table_memory.sql
     bgw_launcher.sql
     c_unit_tests.sql
     copy_memory_usage.sql

--- a/test/sql/alter_table_memory.sql
+++ b/test/sql/alter_table_memory.sql
@@ -1,0 +1,53 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Test that ALTER TABLE propagation to chunks doesn't leak memory.
+-- We use an event trigger to capture PortalContext memory after each
+-- ALTER TABLE completes.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+
+-- Returns the amount of memory currently allocated in a given
+-- memory context.
+CREATE OR REPLACE FUNCTION ts_debug_allocated_bytes(text = 'PortalContext') RETURNS bigint
+AS :MODULE_PATHNAME, 'ts_debug_allocated_bytes' LANGUAGE C STRICT VOLATILE;
+
+CREATE TABLE memory_log(id serial, bytes bigint);
+
+-- Log current memory usage into the log table.
+CREATE OR REPLACE FUNCTION log_memory() RETURNS event_trigger as $$
+BEGIN
+  INSERT INTO memory_log(bytes) SELECT ts_debug_allocated_bytes();
+END;
+$$ LANGUAGE PLPGSQL;
+
+-- Create hypertables with increasing chunk counts using 1-day chunk intervals.
+DO $$
+BEGIN
+  FOR i IN 1..5 LOOP
+    EXECUTE format('CREATE TABLE alter_mem_%s(time timestamptz NOT NULL, value float) WITH (tsdb.hypertable,tsdb.partition_column=''time'',tsdb.chunk_interval=''1day'')', i);
+    EXECUTE format($sql$INSERT INTO alter_mem_%s SELECT t, 1.0
+      FROM generate_series('2020-01-01'::timestamptz, '2020-01-01'::timestamptz + make_interval(days => %s - 1), interval '1 day') t$sql$, i, i * 100);
+  END LOOP;
+END $$;
+
+-- Add the event trigger after setup to avoid capturing setup DDL.
+CREATE EVENT TRIGGER alter_memory_trigger ON ddl_command_end WHEN TAG IN ('ALTER TABLE') EXECUTE FUNCTION log_memory();
+
+-- Run ALTER TABLE on hypertables with 100, 200, 300, 400, 500 chunks.
+ALTER TABLE alter_mem_1 SET (fillfactor = 50);
+ALTER TABLE alter_mem_2 SET (fillfactor = 50);
+ALTER TABLE alter_mem_3 SET (fillfactor = 50);
+ALTER TABLE alter_mem_4 SET (fillfactor = 50);
+ALTER TABLE alter_mem_5 SET (fillfactor = 50);
+
+DROP EVENT TRIGGER alter_memory_trigger;
+
+select count(*) from memory_log;
+
+-- Check that the memory doesn't increase with number of chunks by using
+-- linear regression.
+select * from memory_log where (
+  select regr_slope(bytes, id - 1) / regr_intercept(bytes, id - 1)::float > 0.05 from memory_log
+);


### PR DESCRIPTION
Add per-iteration temporary memory context in foreach_chunk() and
foreach_compressed_chunk() to prevent unbounded memory accumulation
when processing hypertables with many chunks. Previously, each
iteration's allocations (e.g. from AlterTableInternal) accumulated
in the caller's memory context, causing OOM for hypertables with
thousands of chunks.

Fixes #9547
