### PR TITLE
Fix resource leaks on error paths during CAgg refresh

### DIFF
--- a/.unreleased/pr_9551
+++ b/.unreleased/pr_9551
@@ -1,0 +1,1 @@
+Fixes: #9551 Fix resource leaks on error paths for cagg refresh

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2339,29 +2339,40 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 	if (SPI_connect() != SPI_OK_CONNECT)
 		elog(ERROR, "could not connect to SPI");
 
-	res = SPI_execute(command.data, true /* read_only */, 0 /*count*/);
+	int64 max_value;
 
-	if (res < 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 (errmsg("could not find the maximum time value for hypertable \"%s\"",
-						 get_rel_name(ht->main_table_relid)))));
+	PG_TRY();
+	{
+		res = SPI_execute(command.data, true /* read_only */, 0 /*count*/);
 
-	/* In most cases the result type is the same as the time type. However, with UUIDs we first
-	 * extract the timestamptz so the result type is timestamptz instead. */
-	Oid result_type = timetype == UUIDOID ? TIMESTAMPTZOID : timetype;
+		if (res < 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 (errmsg("could not find the maximum time value for hypertable \"%s\"",
+							 get_rel_name(ht->main_table_relid)))));
 
-	Ensure(SPI_gettypeid(SPI_tuptable->tupdesc, 1) == result_type,
-		   "partition types for result (%d) and dimension (%d) do not match",
-		   SPI_gettypeid(SPI_tuptable->tupdesc, 1),
-		   ts_dimension_get_partition_type(dim));
-	maxdat = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &max_isnull);
+		/* In most cases the result type is the same as the time type. However, with UUIDs we
+		 * first extract the timestamptz so the result type is timestamptz instead. */
+		Oid result_type = timetype == UUIDOID ? TIMESTAMPTZOID : timetype;
 
-	if (isnull)
-		*isnull = max_isnull;
+		Ensure(SPI_gettypeid(SPI_tuptable->tupdesc, 1) == result_type,
+			   "partition types for result (%d) and dimension (%d) do not match",
+			   SPI_gettypeid(SPI_tuptable->tupdesc, 1),
+			   ts_dimension_get_partition_type(dim));
+		maxdat = SPI_getbinval(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &max_isnull);
 
-	int64 max_value =
-		max_isnull ? ts_time_get_min(result_type) : ts_time_value_to_internal(maxdat, result_type);
+		if (isnull)
+			*isnull = max_isnull;
+
+		max_value = max_isnull ? ts_time_get_min(result_type) :
+								 ts_time_value_to_internal(maxdat, result_type);
+	}
+	PG_CATCH();
+	{
+		SPI_finish();
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	res = SPI_finish();
 	if (res != SPI_OK_FINISH)

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -281,10 +281,19 @@ invalidation_threshold_set_or_get(const ContinuousAgg *cagg,
 				F_INT4EQ,
 				Int32GetDatum(cagg->data.raw_hypertable_id));
 
-	found = ts_scanner_scan_one(&scanctx, false, CAGG_INVALIDATION_THRESHOLD_NAME);
-	Ensure(found,
-		   "invalidation threshold for hypertable %d not found",
-		   cagg->data.raw_hypertable_id);
+	PG_TRY();
+	{
+		found = ts_scanner_scan_one(&scanctx, false, CAGG_INVALIDATION_THRESHOLD_NAME);
+		Ensure(found,
+			   "invalidation threshold for hypertable %d not found",
+			   cagg->data.raw_hypertable_id);
+	}
+	PG_CATCH();
+	{
+		PopActiveSnapshot();
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 	PopActiveSnapshot();
 
 	return updatectx.computed_invalidation_threshold;


### PR DESCRIPTION
Wrap SPI query execution in ts_hypertable_get_open_dim_max_value() and the invalidation threshold scanner in invalidation_threshold_set_or_get() with PG_TRY/PG_CATCH blocks to ensure proper cleanup on error:

- SPI_finish() is now called before re-throwing preventing "invalid transaction termination" errors (when attempting to rollback transaction in SPI non-atomic context connection)
- PopActiveSnapshot() is now called before re-throwing  preventing active snapshot leaks.