### PR TITLE
Add metadata to ranges catalog table

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -460,6 +460,8 @@ CREATE TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges (
   start_range bigint NOT NULL,
   end_range bigint NOT NULL,
   pid integer NOT NULL,
+  job_id integer NOT NULL,
+  created_at timestamptz NOT NULL,
   -- table constraints
   CONSTRAINT continuous_aggs_jobs_refresh_ranges_materialization_id_fkey FOREIGN KEY (materialization_id) REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE
 );

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -71,6 +71,8 @@ CREATE TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges (
   start_range bigint NOT NULL,
   end_range bigint NOT NULL,
   pid integer NOT NULL,
+  job_id integer NOT NULL,
+  created_at timestamptz NOT NULL,
   CONSTRAINT continuous_aggs_jobs_refresh_ranges_materialization_id_fkey FOREIGN KEY (materialization_id) REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE
 );
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -6,5 +6,6 @@ ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_
 DROP FUNCTION IF EXISTS _timescaledb_functions.bloom1_contains_any_hashes(_timescaledb_internal.bloom1, bigint[]);
 DROP FUNCTION IF EXISTS _timescaledb_functions.bloom1_hash(anyelement);
 -- Drop continuous_aggs_jobs_refresh_ranges table
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 DROP TABLE IF EXISTS _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1118,6 +1118,8 @@ typedef enum Anum_continuous_aggs_jobs_refresh_ranges
 	Anum_continuous_aggs_jobs_refresh_ranges_start_range,
 	Anum_continuous_aggs_jobs_refresh_ranges_end_range,
 	Anum_continuous_aggs_jobs_refresh_ranges_pid,
+	Anum_continuous_aggs_jobs_refresh_ranges_job_id,
+	Anum_continuous_aggs_jobs_refresh_ranges_created_at,
 	_Anum_continuous_aggs_jobs_refresh_ranges_max,
 } Anum_continuous_aggs_jobs_refresh_ranges;
 
@@ -1130,6 +1132,8 @@ typedef struct FormData_continuous_aggs_jobs_refresh_ranges
 	int64 start_range;
 	int64 end_range;
 	int32 pid;
+	int32 job_id;
+	TimestampTz created_at;
 } FormData_continuous_aggs_jobs_refresh_ranges;
 
 typedef FormData_continuous_aggs_jobs_refresh_ranges *Form_continuous_aggs_jobs_refresh_ranges;

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
@@ -10,6 +10,7 @@
 #include <storage/lmgr.h>
 #include <storage/procarray.h>
 #include <utils/snapmgr.h>
+#include <utils/timestamp.h>
 
 #include "debug_point.h"
 #include "scan_iterator.h"
@@ -50,6 +51,10 @@ ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id, int64 start_range, 
 		Int64GetDatum(end_range);
 	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_jobs_refresh_ranges_pid)] =
 		Int32GetDatum(pid);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_jobs_refresh_ranges_job_id)] =
+		Int32GetDatum(0);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_jobs_refresh_ranges_created_at)] =
+		TimestampTzGetDatum(GetCurrentTimestamp());
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_insert_values(rel, desc, values, nulls);

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.c
@@ -33,7 +33,7 @@ init_scan_by_materialization_id(ScanIterator *iterator, const int32 materializat
 
 static void
 ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id, int64 start_range, int64 end_range,
-								   int32 pid)
+								   int32 pid, int32 job_id)
 {
 	Catalog *catalog = ts_catalog_get();
 	Relation rel = table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_JOBS_REFRESH_RANGES),
@@ -52,7 +52,7 @@ ts_cagg_jobs_refresh_ranges_insert(int32 materialization_id, int64 start_range, 
 	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_jobs_refresh_ranges_pid)] =
 		Int32GetDatum(pid);
 	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_jobs_refresh_ranges_job_id)] =
-		Int32GetDatum(0);
+		Int32GetDatum(job_id);
 	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_jobs_refresh_ranges_created_at)] =
 		TimestampTzGetDatum(GetCurrentTimestamp());
 
@@ -124,7 +124,7 @@ ts_cagg_jobs_refresh_ranges_delete_by_pid(int32 materialization_id, int32 pid)
  */
 TSDLLEXPORT bool
 ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id, int64 start_range,
-											  int64 end_range, int32 pid)
+											  int64 end_range, int32 pid, int32 job_id)
 {
 	Catalog *catalog = ts_catalog_get();
 	Oid relid = catalog_get_table_id(catalog, CONTINUOUS_AGGS_JOBS_REFRESH_RANGES);
@@ -204,7 +204,7 @@ ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id, int64 st
 	if (overlap_found)
 		return false;
 
-	ts_cagg_jobs_refresh_ranges_insert(materialization_id, start_range, end_range, pid);
+	ts_cagg_jobs_refresh_ranges_insert(materialization_id, start_range, end_range, pid, job_id);
         DEBUG_ERROR_INJECTION("cagg_refresh_fail_in_registration");
 	return true;
 }

--- a/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.h
+++ b/src/ts_catalog/continuous_aggs_jobs_refresh_ranges.h
@@ -11,7 +11,8 @@
 
 extern TSDLLEXPORT bool ts_cagg_jobs_refresh_ranges_lock_and_register(int32 materialization_id,
 																	  int64 start_range,
-																	  int64 end_range, int32 pid);
+																	  int64 end_range, int32 pid,
+																	  int32 job_id);
 extern TSDLLEXPORT void
 ts_cagg_jobs_refresh_ranges_delete_by_mat_hypertable_id(int32 materialization_id);
 extern TSDLLEXPORT void ts_cagg_jobs_refresh_ranges_delete_by_pid(int32 materialization_id,

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -420,7 +420,7 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 						PGC_S_SESSION);
 	}
 
-	ContinuousAggRefreshContext context = { .callctx = CAGG_REFRESH_POLICY };
+	ContinuousAggRefreshContext context = { .callctx = CAGG_REFRESH_POLICY, .job_id = job_id };
 
 	/* Try to split window range into a list of ranges */
 	List *refresh_window_list =

--- a/tsl/src/continuous_aggs/common.h
+++ b/tsl/src/continuous_aggs/common.h
@@ -86,6 +86,7 @@ typedef enum ContinuousAggRefreshCallContext
 typedef struct ContinuousAggRefreshContext
 {
 	ContinuousAggRefreshCallContext callctx;
+	int32 job_id;
 	int32 processing_batch;
 	int32 number_of_batches;
 } ContinuousAggRefreshContext;

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -894,7 +894,8 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg,
 	if (!ts_cagg_jobs_refresh_ranges_lock_and_register(mat_id,
 													   refresh_window.start,
 													   refresh_window.end,
-													   MyProcPid))
+													   MyProcPid,
+													   context.job_id))
 		ereport(ERROR,
 				(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
 				 errmsg("could not refresh continuous aggregate \"%s\" due to a concurrent refresh",

--- a/tsl/test/expected/cagg_refresh_cleanup.out
+++ b/tsl/test/expected/cagg_refresh_cleanup.out
@@ -134,11 +134,11 @@ SELECT debug_waitpoint_release('cagg_refresh_fail_in_registration');
 -- Test 5: stale entry with a dead PID is cleaned up by the next refresh.
 -- Inserting a row with PID 0 as a dummy job.
 INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    (materialization_id, start_range, end_range, pid)
+    (materialization_id, start_range, end_range, pid, job_id, created_at)
 SELECT mat_hypertable_id,
        _timescaledb_functions.to_unix_microseconds('2026-01-05'::timestamptz),
        _timescaledb_functions.to_unix_microseconds('2026-03-15'::timestamptz),
-       0
+       0, 0, now()
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_daily';
 SELECT count(*) AS stale_jobs_before_refresh

--- a/tsl/test/expected/cagg_refresh_cleanup.out
+++ b/tsl/test/expected/cagg_refresh_cleanup.out
@@ -165,11 +165,11 @@ GROUP BY 1
 WITH NO DATA;
 -- Insert dummy refresh range entries for the new CAgg
 INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    (materialization_id, start_range, end_range, pid)
+    (materialization_id, start_range, end_range, pid, job_id, created_at)
 SELECT mat_hypertable_id,
        _timescaledb_functions.to_unix_microseconds(s),
        _timescaledb_functions.to_unix_microseconds(s + interval '1 month'),
-       0
+       0, 0, now()
 FROM _timescaledb_catalog.continuous_agg,
      generate_series('2026-01-01'::timestamptz, '2026-05-01'::timestamptz, interval '1 month') AS s
 WHERE user_view_name = 'cond_daily_drop_test';

--- a/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
+++ b/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
@@ -1,4 +1,4 @@
-Parsed test spec with 8 sessions
+Parsed test spec with 9 sessions
 
 starting permutation: WP_mat_enable R2_refresh L1_lock WP_mat_disable R3_refresh R4_refresh check_locks check_jobs L1_unlock check_locks check_jobs
 step WP_mat_enable: SELECT debug_waitpoint_enable('after_process_cagg_materializations');
@@ -263,6 +263,85 @@ step check_jobs:
 user_view_name|start_time|end_time
 --------------+----------+--------
 
+
+starting permutation: WP_after_register_enable R2_refresh check_jobs_metadata WP_after_register_disable
+step WP_after_register_enable: SELECT debug_waitpoint_enable('cagg_refresh_after_register');
+debug_waitpoint_enable
+----------------------
+                      
+
+step R2_refresh: 
+    CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-02-15');
+ <waiting ...>
+step check_jobs_metadata: 
+    SELECT ca.user_view_name,
+           r.job_id,
+           r.created_at IS NOT NULL AS has_created_at
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|job_id|has_created_at
+--------------+------+--------------
+cond_daily    |     0|t             
+
+step WP_after_register_disable: SELECT debug_waitpoint_release('cagg_refresh_after_register');
+debug_waitpoint_release
+-----------------------
+                       
+
+step R2_refresh: <... completed>
+
+starting permutation: P1_add_policy WP_after_register_enable P1_run_policy check_jobs_metadata WP_after_register_disable
+step P1_add_policy: 
+    SELECT add_continuous_aggregate_policy(
+        'cond_daily',
+        start_offset => NULL,
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h'
+    );
+
+add_continuous_aggregate_policy
+-------------------------------
+                           1000
+
+step WP_after_register_enable: SELECT debug_waitpoint_enable('cagg_refresh_after_register');
+debug_waitpoint_enable
+----------------------
+                      
+
+step P1_run_policy: 
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'cond_daily'
+        AND proc_name = 'policy_refresh_continuous_aggregate';
+        CALL run_job(jid);
+    END;
+    $$;
+ <waiting ...>
+step check_jobs_metadata: 
+    SELECT ca.user_view_name,
+           r.job_id,
+           r.created_at IS NOT NULL AS has_created_at
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+
+user_view_name|job_id|has_created_at
+--------------+------+--------------
+cond_daily    |  1000|t             
+
+step WP_after_register_disable: SELECT debug_waitpoint_release('cagg_refresh_after_register');
+debug_waitpoint_release
+-----------------------
+                       
+
+step P1_run_policy: <... completed>
 
 starting permutation: WP_before_txn2_commit_enable R1_refresh check_jobs K1_terminate WP_before_txn2_commit_disable L1_lock R2_refresh R3_refresh L1_unlock check_jobs
 step WP_before_txn2_commit_enable: SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');

--- a/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
+++ b/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
@@ -264,7 +264,7 @@ user_view_name|start_time|end_time
 --------------+----------+--------
 
 
-starting permutation: WP_after_register_enable R2_refresh check_jobs_metadata WP_after_register_disable
+starting permutation: WP_after_register_enable R2_refresh check_jobs_metadata_manual WP_after_register_disable
 step WP_after_register_enable: SELECT debug_waitpoint_enable('cagg_refresh_after_register');
 debug_waitpoint_enable
 ----------------------
@@ -273,18 +273,18 @@ debug_waitpoint_enable
 step R2_refresh: 
     CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-02-15');
  <waiting ...>
-step check_jobs_metadata: 
+step check_jobs_metadata_manual: 
     SELECT ca.user_view_name,
-           r.job_id,
+           r.job_id = 0 AS has_zero_job_id,
            r.created_at IS NOT NULL AS has_created_at
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
     JOIN _timescaledb_catalog.continuous_agg ca
         ON r.materialization_id = ca.mat_hypertable_id
     ORDER BY ca.user_view_name, r.start_range;
 
-user_view_name|job_id|has_created_at
---------------+------+--------------
-cond_daily    |     0|t             
+user_view_name|has_zero_job_id|has_created_at
+--------------+---------------+--------------
+cond_daily    |t              |t             
 
 step WP_after_register_disable: SELECT debug_waitpoint_release('cagg_refresh_after_register');
 debug_waitpoint_release
@@ -293,18 +293,18 @@ debug_waitpoint_release
 
 step R2_refresh: <... completed>
 
-starting permutation: P1_add_policy WP_after_register_enable P1_run_policy check_jobs_metadata WP_after_register_disable
+starting permutation: P1_add_policy WP_after_register_enable P1_run_policy check_jobs_metadata_policy WP_after_register_disable
 step P1_add_policy: 
-    SELECT add_continuous_aggregate_policy(
+    SELECT 1 AS policy_created FROM add_continuous_aggregate_policy(
         'cond_daily',
         start_offset => NULL,
         end_offset => NULL,
         schedule_interval => INTERVAL '1 h'
     );
 
-add_continuous_aggregate_policy
--------------------------------
-                           1000
+policy_created
+--------------
+             1
 
 step WP_after_register_enable: SELECT debug_waitpoint_enable('cagg_refresh_after_register');
 debug_waitpoint_enable
@@ -323,18 +323,18 @@ step P1_run_policy:
     END;
     $$;
  <waiting ...>
-step check_jobs_metadata: 
+step check_jobs_metadata_policy: 
     SELECT ca.user_view_name,
-           r.job_id,
+           r.job_id != 0 AS has_non_zero_job_id,
            r.created_at IS NOT NULL AS has_created_at
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
     JOIN _timescaledb_catalog.continuous_agg ca
         ON r.materialization_id = ca.mat_hypertable_id
     ORDER BY ca.user_view_name, r.start_range;
 
-user_view_name|job_id|has_created_at
---------------+------+--------------
-cond_daily    |  1000|t             
+user_view_name|has_non_zero_job_id|has_created_at
+--------------+-------------------+--------------
+cond_daily    |t                  |t             
 
 step WP_after_register_disable: SELECT debug_waitpoint_release('cagg_refresh_after_register');
 debug_waitpoint_release

--- a/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
+++ b/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
@@ -194,7 +194,7 @@ step "check_jobs_metadata_policy" {
 # Session P1: runs a policy refresh via run_job
 session "P1"
 setup {
-    SET SESSION lock_timeout = '500ms';
+    SET SESSION lock_timeout = '2s'
     SET SESSION deadlock_timeout = '500ms';
 }
 step "P1_add_policy" {

--- a/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
+++ b/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
@@ -171,9 +171,19 @@ step "L1_lock" {
 step "L1_unlock" {
     COMMIT;
 }
-step "check_jobs_metadata" {
+step "check_jobs_metadata_manual" {
     SELECT ca.user_view_name,
-           r.job_id,
+           r.job_id = 0 AS has_zero_job_id,
+           r.created_at IS NOT NULL AS has_created_at
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+}
+
+step "check_jobs_metadata_policy" {
+    SELECT ca.user_view_name,
+           r.job_id != 0 AS has_non_zero_job_id,
            r.created_at IS NOT NULL AS has_created_at
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
     JOIN _timescaledb_catalog.continuous_agg ca
@@ -188,7 +198,7 @@ setup {
     SET SESSION deadlock_timeout = '500ms';
 }
 step "P1_add_policy" {
-    SELECT add_continuous_aggregate_policy(
+    SELECT 1 AS policy_created FROM add_continuous_aggregate_policy(
         'cond_daily',
         start_offset => NULL,
         end_offset => NULL,
@@ -223,10 +233,10 @@ permutation "WP_before_txn2_start_enable" "R3_refresh" "check_jobs" "A1_revoke_p
 permutation "WP_before_txn3_start_enable" "R3_refresh" "check_jobs" "A1_revoke_mat_perm" "WP_before_txn3_start_disable"("A1_revoke_mat_perm") "check_jobs"
 
 # Manual refresh registers with job_id=0 and a non-null created_at.
-permutation "WP_after_register_enable" "R2_refresh" "check_jobs_metadata" "WP_after_register_disable"
+permutation "WP_after_register_enable" "R2_refresh" "check_jobs_metadata_manual" "WP_after_register_disable"
 
 # Policy refresh registers with the correct job_id and a non-null created_at.
-permutation "P1_add_policy" "WP_after_register_enable" "P1_run_policy" "check_jobs_metadata" "WP_after_register_disable"
+permutation "P1_add_policy" "WP_after_register_enable" "P1_run_policy" "check_jobs_metadata_policy" "WP_after_register_disable"
 
 # Stale registration cleanup by concurrent refreshes.
 # Kill a backend during refresh to end up with a pid left behind. Later two concurrent refreshes run, only one removes the stale pid.

--- a/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
+++ b/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
@@ -72,6 +72,8 @@ step "WP_before_txn3_start_enable"  { SELECT debug_waitpoint_enable('after_proce
 step "WP_before_txn3_start_disable"  { SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock'); }
 step "WP_before_txn2_start_enable"  { SELECT debug_waitpoint_enable('cagg_refresh_after_register'); }
 step "WP_before_txn2_start_disable"  { SELECT debug_waitpoint_release('cagg_refresh_after_register'); }
+step "WP_after_register_enable"  { SELECT debug_waitpoint_enable('cagg_refresh_after_register'); }
+step "WP_after_register_disable"  { SELECT debug_waitpoint_release('cagg_refresh_after_register'); }
 
 # Session K1: terminate R1's backend so its PID becomes dead in the
 # registration table, then wait until the process is gone.
@@ -169,7 +171,42 @@ step "L1_lock" {
 step "L1_unlock" {
     COMMIT;
 }
+step "check_jobs_metadata" {
+    SELECT ca.user_view_name,
+           r.job_id,
+           r.created_at IS NOT NULL AS has_created_at
+    FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
+    JOIN _timescaledb_catalog.continuous_agg ca
+        ON r.materialization_id = ca.mat_hypertable_id
+    ORDER BY ca.user_view_name, r.start_range;
+}
 
+# Session P1: runs a policy refresh via run_job
+session "P1"
+setup {
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+}
+step "P1_add_policy" {
+    SELECT add_continuous_aggregate_policy(
+        'cond_daily',
+        start_offset => NULL,
+        end_offset => NULL,
+        schedule_interval => INTERVAL '1 h'
+    );
+}
+step "P1_run_policy" {
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'cond_daily'
+        AND proc_name = 'policy_refresh_continuous_aggregate';
+        CALL run_job(jid);
+    END;
+    $$;
+}
 
 # Two refreshes wait for registration, one waits for cleanup before exiting. All blocked on an AccessExclusiveLock on continuous_aggs_jobs_refresh_ranges.
 # None of those refreshes overlaps, so all should succeed.
@@ -185,6 +222,11 @@ permutation "WP_before_txn2_start_enable" "R3_refresh" "check_jobs" "A1_revoke_p
 ## Refresh registers . But fails in txn3. Gets into catch block. Cleanup should succeed
 permutation "WP_before_txn3_start_enable" "R3_refresh" "check_jobs" "A1_revoke_mat_perm" "WP_before_txn3_start_disable"("A1_revoke_mat_perm") "check_jobs"
 
+# Manual refresh registers with job_id=0 and a non-null created_at.
+permutation "WP_after_register_enable" "R2_refresh" "check_jobs_metadata" "WP_after_register_disable"
+
+# Policy refresh registers with the correct job_id and a non-null created_at.
+permutation "P1_add_policy" "WP_after_register_enable" "P1_run_policy" "check_jobs_metadata" "WP_after_register_disable"
 
 # Stale registration cleanup by concurrent refreshes.
 # Kill a backend during refresh to end up with a pid left behind. Later two concurrent refreshes run, only one removes the stale pid.

--- a/tsl/test/sql/cagg_refresh_cleanup.sql
+++ b/tsl/test/sql/cagg_refresh_cleanup.sql
@@ -100,11 +100,11 @@ SELECT debug_waitpoint_release('cagg_refresh_fail_in_registration');
 -- Test 5: stale entry with a dead PID is cleaned up by the next refresh.
 -- Inserting a row with PID 0 as a dummy job.
 INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    (materialization_id, start_range, end_range, pid)
+    (materialization_id, start_range, end_range, pid, job_id, created_at)
 SELECT mat_hypertable_id,
        _timescaledb_functions.to_unix_microseconds('2026-01-05'::timestamptz),
        _timescaledb_functions.to_unix_microseconds('2026-03-15'::timestamptz),
-       0
+       0, 0, now()
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_daily';
 

--- a/tsl/test/sql/cagg_refresh_cleanup.sql
+++ b/tsl/test/sql/cagg_refresh_cleanup.sql
@@ -128,11 +128,11 @@ WITH NO DATA;
 
 -- Insert dummy refresh range entries for the new CAgg
 INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
-    (materialization_id, start_range, end_range, pid)
+    (materialization_id, start_range, end_range, pid, job_id, created_at)
 SELECT mat_hypertable_id,
        _timescaledb_functions.to_unix_microseconds(s),
        _timescaledb_functions.to_unix_microseconds(s + interval '1 month'),
-       0
+       0, 0, now()
 FROM _timescaledb_catalog.continuous_agg,
      generate_series('2026-01-01'::timestamptz, '2026-05-01'::timestamptz, interval '1 month') AS s
 WHERE user_view_name = 'cond_daily_drop_test';


### PR DESCRIPTION
Add `job_id` and `created_at` metadata to the `jobs_refresh_ranges` catalog table.