### PR TITLE
Clean up orphaned compression_chunk_size in update script

### DIFF
--- a/.unreleased/pr_9557
+++ b/.unreleased/pr_9557
@@ -1,0 +1,1 @@
+Fixes: #9557 Clean up orphaned compression_chunk_size entries during upgrade

--- a/sql/updates/2.25.2--2.26.0.sql
+++ b/sql/updates/2.25.2--2.26.0.sql
@@ -65,6 +65,11 @@ ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_hypertable_id_fkey F
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
 
+-- clean orphaned entries
+DELETE FROM _timescaledb_catalog.compression_chunk_size ccs WHERE
+  NOT EXISTS (SELECT FROM _timescaledb_catalog.chunk c WHERE c.id = ccs.chunk_id)
+  OR NOT EXISTS (SELECT FROM _timescaledb_catalog.chunk c WHERE c.id = ccs.compressed_chunk_id);
+
 --add the foreign key constraints
 ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);
 ALTER TABLE _timescaledb_catalog.chunk_column_stats ADD CONSTRAINT chunk_column_stats_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id);


### PR DESCRIPTION
Since 2.25.2 to 2.26.0 upgrade readds foreign key constraints
any orphaned entries will cause the update script to fail. This
change removes orphaned entries before readding foreign key
constraints.
