### PR TITLE
Use ShareLock to check if error injection is enabled

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -879,3 +879,20 @@ ItemPointerGetDatum(const ItemPointerData *X)
 	return PointerGetDatum(X);
 }
 #endif
+
+#if PG17_LT
+/*
+ * PG17 added the 'orstronger' parameter to LockHeldByMe.  On older versions
+ * we use LockOrStrongerHeldByMe when orstronger is true.
+ */
+static inline bool
+LockHeldByMeCompat(const LOCKTAG *locktag, LOCKMODE lockmode, bool orstronger)
+{
+	if (orstronger)
+		return LockOrStrongerHeldByMe(locktag, lockmode);
+	return LockHeldByMe(locktag, lockmode);
+}
+#else
+#define LockHeldByMeCompat(locktag, lockmode, orstronger)                                          \
+	LockHeldByMe(locktag, lockmode, orstronger)
+#endif

--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -20,6 +20,8 @@
 #include "annotations.h"
 #include "export.h"
 
+#include "compat/compat.h"
+
 TS_FUNCTION_INFO_V1(ts_debug_point_enable);
 TS_FUNCTION_INFO_V1(ts_debug_point_release);
 TS_FUNCTION_INFO_V1(ts_debug_point_id);
@@ -270,7 +272,8 @@ ts_debug_point_raise_error_if_enabled(const char *name)
 			 * But we still need to check whether this session itself enabled
 			 * the injection. */
 			LockRelease(&point.tag, ShareLock, true);
-			if (LockHeldByMe(&point.tag, ExclusiveLock, false)) {
+			if (LockHeldByMeCompat(&point.tag, ExclusiveLock, false))
+			{
 				break;
 			}
 			return;

--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -243,9 +243,16 @@ ts_debug_point_wait(const char *name, bool blocking)
  * Produce an error in case if the debug point is enabled.
  *
  * The idea is to enable the debug point separately first which
- * acquires a ShareLock on this tag. With the debug point enabled, this function
- * when invoked will not get the exclusive lock and will be able to raise
+ * acquires an ExclusiveLock on this tag. With the debug point enabled, this function
+ * when invoked will not get the ShareLock and will be able to raise
  * the error as desired.
+ *
+ * ShareLock is used instead of an ExclusiveLock to prevent concurrent sessions reaching
+ * the same injection point from raising false conflicts.
+ *
+ * A ShareLock request from the same session that holds an ExclusiveLock
+ * always succeeds since a session never conflicts with itself, so we
+ * additionally check with LockHeldByMe to detect same-session injection.
  */
 void
 ts_debug_point_raise_error_if_enabled(const char *name)
@@ -255,17 +262,22 @@ ts_debug_point_raise_error_if_enabled(const char *name)
 
 	debug_point_init(&point, name);
 
-	lock_acquire_result = LockAcquire(&point.tag, ExclusiveLock, true, true);
+	lock_acquire_result = LockAcquire(&point.tag, ShareLock, true, true);
 	switch (lock_acquire_result)
 	{
 		case LOCKACQUIRE_OK:
+			/* ShareLock granted means no other session holds ExclusiveLock.
+			 * But we still need to check whether this session itself enabled
+			 * the injection. */
+			LockRelease(&point.tag, ShareLock, true);
+			if (LockHeldByMe(&point.tag, ExclusiveLock, false)) {
+				break;
+			}
+			return;
 		case LOCKACQUIRE_ALREADY_HELD:
 		case LOCKACQUIRE_ALREADY_CLEAR:
-			/* Release/decrement lock count */
-			LockRelease(&point.tag, ExclusiveLock, true);
-			if (lock_acquire_result == LOCKACQUIRE_OK)
-				return;
-			break;
+			LockRelease(&point.tag, ShareLock, true);
+			return;
 		case LOCKACQUIRE_NOT_AVAIL:
 			break;
 	}


### PR DESCRIPTION
Currently an ExclusiveLock is held briefly when checking if DEBUG_ERROR_INJECTION is enabled. This can lead to false conflicts when two sessions perform this check concurrently in our isolation tests. Using a ShareLock instead ensures that concurrent sessions do not conflict with each other, but still correctly error out if the injection point is actually enabled.

Disable-check: force-changelog-file