### PR TITLE
Notice on compression settings change

### DIFF
--- a/.unreleased/pr_9559
+++ b/.unreleased/pr_9559
@@ -1,0 +1,1 @@
+Implements: #9559 Notice on compression settings change

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1274,6 +1274,20 @@ tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options
 
 	compression_settings_set_manually_for_alter(ht, settings, with_clause_options);
 
+	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
+	{
+		bool settings_changed = !with_clause_options[AlterTableFlagSegmentBy].is_default ||
+								!with_clause_options[AlterTableFlagOrderBy].is_default ||
+								!with_clause_options[AlterTableFlagIndex].is_default;
+		if (settings_changed)
+		{
+			ereport(NOTICE,
+					(errmsg("updated compression settings will only apply to future compressions"),
+					 errdetail("Existing compressed chunks will not be recompressed."),
+					 errhint("Use compress_chunk(chunk, recompress => true) to recompress.")));
+		}
+	}
+
 	if (!TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		/* take explicit locks on catalog tables and keep them till end of txn */

--- a/tsl/test/expected/cagg_ddl-15.out
+++ b/tsl/test/expected/cagg_ddl-15.out
@@ -1510,6 +1510,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'false', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1586,6 +1587,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'true', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';

--- a/tsl/test/expected/cagg_ddl-16.out
+++ b/tsl/test/expected/cagg_ddl-16.out
@@ -1510,6 +1510,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'false', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1586,6 +1587,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'true', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';

--- a/tsl/test/expected/cagg_ddl-17.out
+++ b/tsl/test/expected/cagg_ddl-17.out
@@ -1510,6 +1510,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'false', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1586,6 +1587,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'true', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';

--- a/tsl/test/expected/cagg_ddl-18.out
+++ b/tsl/test/expected/cagg_ddl-18.out
@@ -1510,6 +1510,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'false', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';
@@ -1586,6 +1587,7 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 --now set it back to false --
 ALTER MATERIALIZED VIEW test_setting_cagg SET (timescaledb.materialized_only = 'true', timescaledb.compress='true');
 NOTICE:  defaulting compress_orderby to time_bucket
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT view_name, compression_enabled, materialized_only
 FROM timescaledb_information.continuous_aggregates
 where view_name = 'test_setting_cagg';

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -516,6 +516,7 @@ timescaledb.compress_orderby = 'bucket');
 --enable compression and test re-enabling compression
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress);
 NOTICE:  defaulting compress_orderby to bucket
+NOTICE:  updated compression settings will only apply to future compressions
 insert into i2980 select now();
 call refresh_continuous_aggregate('i2980_cagg2', NULL, NULL);
 SELECT compress_chunk(ch) FROM show_chunks('i2980_cagg2') ch;
@@ -527,6 +528,7 @@ ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress = 'false');
 ERROR:  cannot disable columnstore on hypertable with columnstore chunks
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress = 'true');
 NOTICE:  defaulting compress_orderby to bucket
+NOTICE:  updated compression settings will only apply to future compressions
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, timescaledb.compress_segmentby = 'bucket');
 NOTICE:  defaulting compress_orderby to bucket
 ERROR:  cannot use column "bucket" for both ordering and segmenting

--- a/tsl/test/expected/compress_batch_size.out
+++ b/tsl/test/expected/compress_batch_size.out
@@ -14,6 +14,7 @@ from generate_series(1, 99999) x
 ;
 alter table batch_size set (tsdb.compress, tsdb.compress_segmentby = 'sb',
     tsdb.compress_orderby = 'ts');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x)) from show_chunks('batch_size') x;
  count 
 -------
@@ -59,6 +60,7 @@ alter table batch_size set (tsdb.compress,
     tsdb.compress_segmentby = 'sb, i2, i4, i8, f4, f8, n, u, t, b',
     tsdb.compress_orderby = 'ts')
 ;
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x)) from show_chunks('batch_size') x;
 NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
 NOTICE:  chunk "_hyper_1_3_chunk" is already converted to columnstore
@@ -212,6 +214,7 @@ CREATE TABLE recompress_batch_test(segment int, ts int, value int)
 INSERT INTO recompress_batch_test SELECT 1, x, x FROM generate_series(1, 99999) x;
 ALTER TABLE recompress_batch_test SET (
     tsdb.compress, tsdb.compress_segmentby = 'segment', tsdb.compress_orderby = 'ts');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT count(compress_chunk(x)) FROM show_chunks('recompress_batch_test') x;
  count 
 -------

--- a/tsl/test/expected/compress_compbloom_basics.out
+++ b/tsl/test/expected/compress_compbloom_basics.out
@@ -483,5 +483,6 @@ alter table sparse set (
     timescaledb.order_by='o',
     timescaledb.segment_by='sby',
     timescaledb.compress_index = 'bloom(big1),bloom(value),bloom(boo,big1),bloom(o,boo)');
+NOTICE:  updated compression settings will only apply to future compressions
 DROP TABLE IF EXISTS sparse CASCADE;
 DROP TABLE IF EXISTS sparse_sister CASCADE;

--- a/tsl/test/expected/compress_compbloom_config.out
+++ b/tsl/test/expected/compress_compbloom_config.out
@@ -27,6 +27,7 @@ ERROR:  bloom index has too many columns: 9 > max 8
 \set ON_ERROR_STOP 1
 -- The ordering of bloom columns in the composite bloom index should be determined by the order of the columns in the CREATE TABLE statement
 ALTER TABLE t SET (timescaledb.compress, timescaledb.compress_orderby = 'b', timescaledb.compress_index = 'bloom("h","g","f","e","d","c","b")');
+NOTICE:  updated compression settings will only apply to future compressions
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings
 where relid = 't'::regclass and index is not null order by 1,2;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                 index                                                                                                  
@@ -92,6 +93,7 @@ select relname,attname from compressedcols order by 1,2;
  compress_hyper_4_2_chunk | xmin
 
 ALTER TABLE u SET (timescaledb.compress_index = 'bloom("a","b","c")');
+NOTICE:  updated compression settings will only apply to future compressions
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                   index                                                                                                                    
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -100,6 +102,7 @@ select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,in
 
 -- Also in a different order
 ALTER TABLE u SET (timescaledb.compress_index = 'bloom("c","b","a")');
+NOTICE:  updated compression settings will only apply to future compressions
 select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,index from settings where index is not null order by 1,2;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                   index                                                                                                                    
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/tsl/test/expected/compress_compbloom_manual_config.out
+++ b/tsl/test/expected/compress_compbloom_manual_config.out
@@ -126,6 +126,7 @@ ORDER BY 1,2,3,4;
 ALTER TABLE mixed_avail_manual SET (
     timescaledb.compress_index = 'bloom(a,c)'
 );
+NOTICE:  updated compression settings will only apply to future compressions
 -- Compress second chunk with bloom(a,c)
 SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c OFFSET 1 LIMIT 1;
 NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
@@ -137,6 +138,7 @@ NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore
 ALTER TABLE mixed_avail_manual SET (
     timescaledb.compress_index = 'bloom(b,c)'
 );
+NOTICE:  updated compression settings will only apply to future compressions
 -- Compress third chunk with bloom(b,c)
 SELECT compress_chunk(c) FROM show_chunks('mixed_avail_manual') c OFFSET 2;
 NOTICE:  chunk "_hyper_1_1_chunk" is already converted to columnstore

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -23,6 +23,7 @@ select * from settings;
 -- no custom sparse indexes
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
 ---------------+----------------+-----------+---------+--------------+--------------------+-------
@@ -32,6 +33,7 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u")');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                     index                                                      
 ---------------+----------------+-----------+---------+--------------+--------------------+----------------------------------------------------------------------------------------------------------------
@@ -40,6 +42,7 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'minmax("ts")');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                      index                                                       
 ---------------+----------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------
@@ -49,6 +52,7 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"), bloom("ts")');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                 index                                                                                 
 ---------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -57,6 +61,7 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u), bloom(ts)');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                 index                                                                                 
 ---------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -130,42 +135,54 @@ reset timescaledb.enable_sparse_index_bloom;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts)');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u","ts")');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u",ts)');
+NOTICE:  updated compression settings will only apply to future compressions
 -- three columns
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,value)');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u","ts","value")');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u",ts,"value")');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(long1_01234567890123456789,long2_01234567890123456789,long3_01234567890123456789)');
+NOTICE:  updated compression settings will only apply to future compressions
 -- more than 3 columns
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,value,d)');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,ts,value,d,b)');
+NOTICE:  updated compression settings will only apply to future compressions
 -- partial overlaps
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,value),bloom(u,ts)');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u),bloom(u,ts)');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom(u,value),bloom(u,ts,value)');
+NOTICE:  updated compression settings will only apply to future compressions
 -- invalid composite bloom filter cases:
 \set ON_ERROR_STOP 0
 -- nine column composite bloom is not supported
@@ -202,6 +219,7 @@ ERROR:  duplicate sparse index configuration ('x','u','ts')
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'ts',
     timescaledb.compress_index = '');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                  index                                                                  
 ---------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------
@@ -210,6 +228,7 @@ select * from settings;
 -- change orderby setting (sparse index changes)
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'u');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                 index                                                                  
 ---------------+----------------+-----------+---------+--------------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------
@@ -219,6 +238,7 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'ts',
     timescaledb.compress_index = 'bloom("value"), minmax("ts")');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                   index                                                                                    
 ---------------+----------------+-----------+---------+--------------+--------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -227,6 +247,7 @@ select * from settings;
 -- change orderby setting (sparse index doesn't change)
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'u');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                               index                                                                                                                
 ---------------+----------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -235,8 +256,10 @@ select * from settings;
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'minmax("x")');
+NOTICE:  updated compression settings will only apply to future compressions
 alter table test_settings set (timescaledb.compress,
     timescaledb.compress_orderby = 'u');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                      index                                                      
 ---------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------
@@ -278,6 +301,7 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'bloom("u"),minmax("ts")');
+NOTICE:  updated compression settings will only apply to future compressions
 select * from settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                 index                                                                                  
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -470,6 +494,7 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = 'minmax("x")');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
  count 
 -------
@@ -503,6 +528,7 @@ alter table test_sparse_index reset (timescaledb.compress_index);
 alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
  count 
 -------
@@ -536,6 +562,7 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x',
     timescaledb.compress_index = '');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
  count 
 -------

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1040,6 +1040,7 @@ SELECT create_hypertable('table1','col1', chunk_time_interval => 10);
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1');
 -- Listing all fields of the compound key should succeed:
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1,col2');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings ORDER BY hypertable_name;
  hypertable_schema | hypertable_name |   attname   | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+-------------+------------------------+----------------------+-------------+--------------------
@@ -2439,6 +2440,7 @@ SELECT compress_chunk(:'CHUNK', false);
 ERROR:  chunk "_hyper_47_102_chunk" is already converted to columnstore
 \set ON_ERROR_STOP 1
 ALTER TABLE compress_chunk_test SET (timescaledb.compress_segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
  compressed_chunk_id 
 ---------------------
@@ -2483,6 +2485,7 @@ SELECT * FROM ONLY :CHUNK;
 ------+--------+-------
 
 ALTER TABLE compress_chunk_test SET (timescaledb.compress_segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
 -- create another chunk
 INSERT INTO compress_chunk_test SELECT '2021-01-01', 'c3po', 3.14;
 SELECT show_chunks('compress_chunk_test') AS "CHUNK2" LIMIT 1 OFFSET 1 \gset

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1254,6 +1254,7 @@ ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress_segmentby = '"iDeA"'
 );
 NOTICE:  defaulting compress_orderby to t
+NOTICE:  updated compression settings will only apply to future compressions
 \set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW test1_cont_view2 SET (
   timescaledb.compress = true,
@@ -2347,6 +2348,7 @@ FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-03 23:55:00+0'
 SELECT compress_chunk(ch, true) AS "CHUNK_NAME" FROM show_chunks('compression_drop') ch ORDER BY ch DESC \gset
 -- change segmentby column
 ALTER TABLE compression_drop SET (timescaledb.compress_segmentby='v1');
+NOTICE:  updated compression settings will only apply to future compressions
 -- insert more data and compress next chunk
 INSERT INTO compression_drop(time, v0, v1)
 SELECT time, v0, v0+1

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -32,6 +32,9 @@ ERROR:  cannot use column "c" for both ordering and segmenting
 HINT:  Use separate columns for the timescaledb.compress_orderby and timescaledb.compress_segmentby options.
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'd DESC');
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'd');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 -- this is acceptable: having previously set the default value for orderby
 -- and skipping orderby on a subsequent alter command
 create table default_skipped (a integer not null, b integer, c integer, d integer);
@@ -42,6 +45,9 @@ select create_hypertable('default_skipped', 'a', chunk_time_interval=> 10);
 
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 create table with_rls (a integer, b integer);
 ALTER TABLE with_rls ENABLE ROW LEVEL SECURITY;
 select table_name from create_hypertable('with_rls', 'a', chunk_time_interval=> 10);
@@ -61,12 +67,27 @@ SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text;
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d DeSc NullS lAsT');
 --shold allow alter since segment by was empty
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d Asc NullS lAsT');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 --this is ok too
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c', timescaledb.compress_orderby = 'd DeSc NullS lAsT');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_orderby = 'a asc', timescaledb.compress_segmentby = 'c');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 alter table default_skipped set (timescaledb.compress, timescaledb.compress_segmentby = 'c');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
        table_name       
@@ -183,7 +204,13 @@ HINT:  The timescaledb.compress_orderby option must reference distinct column.
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b');
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='c');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 -- test alter reset
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
@@ -203,6 +230,9 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
  foo   |                |           |         |              |                    | 
 
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_index = 'bloom(c)');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                 index                                                                                  
 -------+----------------+-----------+---------+--------------+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -230,6 +260,9 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::reg
  foo   |                |           |         |              |                    | 
 
 ALTER TABLE foo SET (timescaledb.compress, timescaledb.compress_orderby = 'a, b', timescaledb.compress_segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 create table foo_fake (a integer, b integer, c integer, t text, p point);
 ALTER TABLE foo_fake RESET (timescaledb.compress_segmentby);
 ERROR:  timescaledb table options can only be specified for hypertables
@@ -269,6 +302,9 @@ SELECT decompress_chunk(ch, false) FROM show_chunks('foo') ch limit 1;
 ERROR:  chunk "_hyper_10_2_chunk" is not converted to columnstore
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT format('%I.%I',chunk_schema,chunk_name) AS "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'foo'
@@ -300,6 +336,9 @@ ERROR:  columnstore not enabled on "non_compressed"
 DETAIL:  It is not possible to convert chunks to columnstore on a hypertable or continuous aggregate that does not have columnstore enabled.
 HINT:  Enable columnstore using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.enable_columnstore option.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 ALTER TABLE foo set (timescaledb.compress='f');
 ERROR:  cannot disable columnstore on hypertable with columnstore chunks
 ALTER TABLE foo reset (timescaledb.compress);
@@ -320,6 +359,9 @@ NOTICE:  chunk "_hyper_10_5_chunk" is not converted to columnstore
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'foo'::regclass;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
 -------+----------------+-----------+---------+--------------+--------------------+-------
@@ -438,6 +480,9 @@ INSERT INTO fortable VALUES( 99 );
 INSERT INTO table_constr2 VALUES( 1000, 10, 5, 99);
 ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
  ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, d');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 --compress a chunk and try to disable compression, it should fail --
 SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht

--- a/tsl/test/expected/compression_indexcreate.out
+++ b/tsl/test/expected/compression_indexcreate.out
@@ -62,6 +62,7 @@ select decompress_chunk(show_chunks('segind'));
 
 -- change compression settings to use segmentby column
 alter table segind set (timescaledb.compress, timescaledb.compress_segmentby='a', timescaledb.compress_orderby='time, b');
+NOTICE:  updated compression settings will only apply to future compressions
 -- compress chunk
 -- this should create an index using segmentby and orderby columns
 select compress_chunk(show_chunks('segind'));

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -69,6 +69,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 1.2 [Index(ASC, Null_First), Compression(ASC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -98,6 +99,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 1.3 [Index(ASC, Null_First), Compression(DESC,Null_First)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -128,6 +130,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 --DROP INDEX idx_asc_null_last
 --Test Set 1.4 [Index(ASC, Null_First), Compression(DESC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -159,6 +162,7 @@ DROP INDEX idx_asc_null_first;
 --Test Set 2.1 [Index(ASC, Null_Last), Compression(ASC,Null_First)]
 CREATE INDEX idx_asc_null_last ON tab1(id, time);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -188,6 +192,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 2.2 [Index(ASC, Null_Last), Compression(ASC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -217,6 +222,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 2.3 [Index(ASC, Null_Last), Compression(DESC,Null_First)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -247,6 +253,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 --DROP INDEX idx_asc_null_last
 --Test Set 2.4 [Index(ASC, Null_Last), Compression(DESC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -278,6 +285,7 @@ DROP INDEX idx_asc_null_last;
 --Test Set 3.1 [Index(DESC, Null_First), Compression(ASC,Null_First)]
 CREATE INDEX idx_desc_null_first ON tab1(id, time DESC NULLS FIRST);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -307,6 +315,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 3.2 [Index(DESC, Null_First), Compression(ASC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -336,6 +345,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 3.3 [Index(DESC, Null_First), Compression(DESC,Null_First)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -366,6 +376,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 --DROP INDEX idx_asc_null_last
 --Test Set 3.4 [Index(DESC, Null_First), Compression(DESC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -397,6 +408,7 @@ DROP INDEX idx_desc_null_first;
 --Test Set 4.1 [Index(DESC, Null_Last), Compression(ASC,Null_First)]
 CREATE INDEX idx_desc_null_last ON tab1(id, time DESC);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -426,6 +438,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 4.2 [Index(DESC, Null_Last), Compression(ASC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -455,6 +468,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 4.3 [Index(DESC, Null_Last), Compression(DESC,Null_First)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -484,6 +498,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 
 --Test Set 4.4 [Index(DESC, Null_Last), Compression(DESC,Null_Last)]
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM timescaledb_information.compression_settings;
  hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
@@ -511,6 +526,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
  _timescaledb_internal._hyper_1_4_chunk
 
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'time');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(show_chunks('tab1'));
 INFO:  using index "_hyper_1_1_chunk_tab1_time_idx" to scan rows for converting to columnstore
 INFO:  using index "_hyper_1_2_chunk_tab1_time_idx" to scan rows for converting to columnstore
@@ -588,6 +604,7 @@ INSERT into tab2 SELECT * from tab1;
 CREATE INDEX idx_asc_null_first ON tab1(id, time ASC NULLS FIRST);
 CREATE INDEX idx2_asc_null_first ON tab2(id, time ASC NULLS FIRST);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 ALTER TABLE tab2 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
 RESET timescaledb.enable_compression_indexscan;
 SELECT compress_chunk(show_chunks('tab1'));
@@ -704,6 +721,7 @@ DROP INDEX idxcol_asc_null_first;
 --Test Set 7.1 with Collation segment_by
 CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "ucs_basic", time ASC NULLS FIRST);
 ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = 'name', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(show_chunks('tab3'));
 INFO:  using tuplesort to scan rows from "_hyper_5_93_chunk" for converting to columnstore
 INFO:  using tuplesort to scan rows from "_hyper_5_94_chunk" for converting to columnstore
@@ -750,6 +768,7 @@ DROP INDEX idxcol_asc_null_first;
 --Test Set 8 with multiple segment_by
 CREATE INDEX idx_asc_null_first ON tab1(id, c1, time ASC NULLS FIRST);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(show_chunks('tab1'));
 INFO:  using index "_hyper_1_1_chunk_idx_asc_null_first" to scan rows for converting to columnstore
 INFO:  using index "_hyper_1_2_chunk_idx_asc_null_first" to scan rows for converting to columnstore
@@ -773,6 +792,7 @@ SELECT decompress_chunk(show_chunks('tab1'));
 DROP INDEX idx_asc_null_first;
 CREATE INDEX idx_asc_null_first ON tab1(id, c1 DESC, time ASC NULLS FIRST);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(show_chunks('tab1'));
 INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for converting to columnstore
 INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for converting to columnstore
@@ -798,6 +818,7 @@ DROP INDEX idx_asc_null_first;
 --Last Column mismatch
 CREATE INDEX idx_asc_null_first ON tab1(id, c1, c2);
 ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(show_chunks('tab1'));
 INFO:  using tuplesort to scan rows from "_hyper_1_1_chunk" for converting to columnstore
 INFO:  using tuplesort to scan rows from "_hyper_1_2_chunk" for converting to columnstore

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1424,6 +1424,9 @@ ALTER TABLE gen_column SET (
 	timescaledb.compress_segmentby = '',
 	timescaledb.compress_orderby='"timestamp"'
 );
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT compress_chunk(show_chunks('gen_column'));
               compress_chunk              
 ------------------------------------------

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -126,6 +126,9 @@ ROLLBACK;
 -- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
 \set VERBOSITY default
 ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 WARNING:  compress_chunk_time_interval configured and primary dimension not first column in compress_orderby
 HINT:  consider setting "Time" as first compress_orderby column
 \set VERBOSITY terse
@@ -693,6 +696,7 @@ SELECT hypertable_name, range_start, range_end FROM timescaledb_information.chun
  test9           | Wed Jan 01 02:00:00 2020 PST | Wed Jan 01 03:00:00 2020 PST
 
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = '');
+NOTICE:  updated compression settings will only apply to future compressions
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
 NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore
@@ -710,6 +714,7 @@ NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore
 
 ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time DESC');
+NOTICE:  updated compression settings will only apply to future compressions
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
 NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore
@@ -727,6 +732,7 @@ NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore
 
 ROLLBACK;
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
 NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore
@@ -745,6 +751,7 @@ NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore
 ROLLBACK;
 -- reset back to original settings
 ALTER TABLE test9 SET (timescaledb.compress_segmentby = 'series_id', timescaledb.compress_orderby = 'time');
+NOTICE:  updated compression settings will only apply to future compressions
 BEGIN;
   SELECT compress_chunk(show_chunks('test9'), true);
 NOTICE:  chunk "_hyper_17_347_chunk" is already converted to columnstore

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -352,6 +352,7 @@ ALTER TABLE hyper SET (
     timescaledb.compress,
     timescaledb.compress_orderby = 'time',
     timescaledb.compress_segmentby = '');
+NOTICE:  updated compression settings will only apply to future compressions
 INSERT INTO hyper VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 5, 2), (21, 2, 3), (22, 3, 3), (23, 4, 3), (30, 1, 4), (31, 3, 4), (31, 5, 4);
 SELECT compress_chunk(show_chunks('hyper'));
              compress_chunk              
@@ -499,6 +500,7 @@ ALTER TABLE hyper SET (
     timescaledb.compress,
     timescaledb.compress_orderby = 'time',
     timescaledb.compress_segmentby = 'device_id');
+NOTICE:  updated compression settings will only apply to future compressions
 INSERT INTO hyper VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 5, 2), (21, 2, 3), (22, 3, 3), (23, 4, 3), (30, 1, 4), (31, 3, 4), (31, 5, 4);
 SELECT compress_chunk(show_chunks('hyper'));
              compress_chunk              

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -152,6 +152,7 @@ SELECT * FROM ht_settings;
 -- create chunk
 INSERT INTO metrics VALUES ('2000-01-01');
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='d1');
+NOTICE:  updated compression settings will only apply to future compressions
 -- settings should be updated
 SELECT * FROM settings;
   relid  | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst | index 
@@ -182,6 +183,7 @@ SELECT * FROM chunk_settings;
 
 -- changing settings should update settings for hypertable but not existing compressed chunks
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='d2');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
@@ -200,6 +202,7 @@ SELECT * FROM chunk_settings;
 
 -- changing settings should update settings for hypertable but not existing compressed chunks
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM settings;
                  relid                  |                 compress_relid                 | segmentby | orderby | orderby_desc | orderby_nullsfirst |                            index                            
 ----------------------------------------+------------------------------------------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------
@@ -244,6 +247,7 @@ SELECT * FROM chunk_settings;
  metrics    | _timescaledb_internal._hyper_3_8_chunk |           | "time" DESC | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='bloom(value)');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
 -- recompressing chunks should apply current hypertable settings
 SELECT compress_chunk(:'CHUNK', recompress:=true);
@@ -271,6 +275,7 @@ SELECT * FROM settings;
  _timescaledb_internal._hyper_3_8_chunk | _timescaledb_internal.compress_hyper_4_11_chunk | {d2}      | {time}  | {t}          | {t}                | [{"type": "bloom", "column": "value", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}]
 
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
 SELECT compress_chunk(:'CHUNK', recompress:=true);
              compress_chunk             
@@ -316,6 +321,7 @@ SELECT * FROM ht_settings;
  metrics2   |           | d1 NULLS FIRST,d2,"time",value |                          | 
 
 ALTER TABLE metrics2 SET (timescaledb.compress_orderby='d1 DESC NULLS LAST, d2 ASC NULLS FIRST, value DESC, time ASC NULLS FIRST');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM ht_settings;
  hypertable | segmentby |                             orderby                             | compress_interval_length |                                       index                                       
 ------------+-----------+-----------------------------------------------------------------+--------------------------+-----------------------------------------------------------------------------------
@@ -324,6 +330,7 @@ SELECT * FROM ht_settings;
 
 -- test decompression uses the correct settings
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(show_chunks('metrics'), recompress:=true);
              compress_chunk             
 ----------------------------------------
@@ -331,6 +338,7 @@ SELECT compress_chunk(show_chunks('metrics'), recompress:=true);
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE metrics SET (timescaledb.compress_segmentby='d1,d2');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT * FROM chunk_settings;
  hypertable |                 chunk                  | segmentby |   orderby   |                                       index                                       
 ------------+----------------------------------------+-----------+-------------+-----------------------------------------------------------------------------------
@@ -453,3 +461,31 @@ ERROR:  too many segmentby and orderby columns
 DETAIL:  Combined segmentby keys (1) and orderby keys (32) cannot exceed 32
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+-- Test NOTICE when changing compression settings on a table that already has compression enabled
+SET timescaledb.enable_direct_compress_insert = true;
+CREATE TABLE notice_test(time timestamptz not null, device text, temp float, created_at timestamptz not null default now()) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+ALTER TABLE notice_test SET (timescaledb.compress_segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-01-01'::timestamptz, '2000-01-02', '1 minute') t;
+ALTER TABLE notice_test SET (timescaledb.compress_segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-02-01'::timestamptz, '2000-02-02', '1 minute') t;
+ALTER TABLE notice_test SET (timescaledb.compress_orderby='created_at');
+NOTICE:  updated compression settings will only apply to future compressions
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-02-10'::timestamptz, '2000-02-11', '1 minute') t;
+ALTER TABLE notice_test SET (timescaledb.index='bloom(temp)');
+NOTICE:  updated compression settings will only apply to future compressions
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-04-01'::timestamptz, '2000-04-02', '1 minute') t;
+SELECT * FROM settings;
+                  relid                  |                  compress_relid                  | segmentby |      orderby       | orderby_desc | orderby_nullsfirst |                                                                                         index                                                                                         
+-----------------------------------------+--------------------------------------------------+-----------+--------------------+--------------+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ metrics2                                |                                                  |           | {d1,d2,value,time} | {t,f,t,f}    | {f,t,t,t}          | 
+ notice_test                             |                                                  | {}        | {created_at,time}  | {f,t}        | {f,t}              | [{"type": "bloom", "column": "temp", "source": "config"}, {"type": "minmax", "column": "created_at", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_19_chunk | _timescaledb_internal.compress_hyper_10_20_chunk | {device}  | {time}             | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_21_chunk | _timescaledb_internal.compress_hyper_10_22_chunk | {}        | {time}             | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_23_chunk | _timescaledb_internal.compress_hyper_10_24_chunk | {}        | {created_at,time}  | {f,t}        | {f,t}              | [{"type": "minmax", "column": "created_at", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_25_chunk | _timescaledb_internal.compress_hyper_10_26_chunk | {}        | {created_at,time}  | {f,t}        | {f,t}              | [{"type": "bloom", "column": "temp", "source": "config"}, {"type": "minmax", "column": "created_at", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+
+RESET timescaledb.enable_direct_compress_insert;
+DROP TABLE notice_test;

--- a/tsl/test/expected/compression_sorted_merge_columns.out
+++ b/tsl/test/expected/compression_sorted_merge_columns.out
@@ -58,6 +58,7 @@ select time + interval '1 second' from t order by time + interval '1 second';
 
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='timetz,time');
+NOTICE:  updated compression settings will only apply to future compressions
 select compress_chunk(show_chunks('t')) \gset
 select * from t order by timetz, time;
  x |           time           |            timetz            | int32 | int64 | s 
@@ -91,6 +92,7 @@ select timetz + interval '1 second' from t order by timetz + interval '1 second'
 
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='int32,timetz,time');
+NOTICE:  updated compression settings will only apply to future compressions
 select compress_chunk(show_chunks('t')) \gset
 select * from t order by int32, timetz, time;
  x |           time           |            timetz            | int32 | int64 | s 
@@ -119,6 +121,7 @@ ERROR:  debug: batch sorted merge is required but not possible at planning time
 \set ON_ERROR_STOP 1
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='int64,int32,timetz,time');
+NOTICE:  updated compression settings will only apply to future compressions
 select compress_chunk(show_chunks('t')) \gset
 select * from t order by int64, int32, timetz, time;
  x |           time           |            timetz            | int32 | int64 | s 
@@ -148,6 +151,7 @@ ERROR:  debug: batch sorted merge is required but not possible at planning time
 \set ON_ERROR_STOP 1
 select decompress_chunk(show_chunks('t')) \gset
 alter table t set (timescaledb.compress, timescaledb.compress_segmentby='x', timescaledb.compress_orderby='s,int32,time desc');
+NOTICE:  updated compression settings will only apply to future compressions
 select compress_chunk(show_chunks('t')) \gset
 select * from t order by s, int32, time desc;
  x |           time           |            timetz            | int32 | int64 | s 

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -3130,6 +3130,9 @@ SELECT decompress_chunk(show_chunks('update_trigger_test'));
  _timescaledb_internal._hyper_41_78_chunk
 
 ALTER TABLE update_trigger_test SET (timescaledb.compress, timescaledb.compress_segmentby='entity_id');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT compress_chunk(show_chunks('update_trigger_test'));
               compress_chunk              
 ------------------------------------------
@@ -3145,6 +3148,9 @@ INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'a' from generate_s
 INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'b' from generate_series(1,123);
 INSERT INTO delete_counter SELECT '2020-02-01'::timestamptz, 'c' from generate_series(1,123);
 ALTER TABLE delete_counter SET (timescaledb.compress_segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT count(compress_chunk(ch)) FROM show_chunks('delete_counter') ch;
  count 
 -------

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -3130,6 +3130,9 @@ SELECT decompress_chunk(show_chunks('update_trigger_test'));
  _timescaledb_internal._hyper_41_78_chunk
 
 ALTER TABLE update_trigger_test SET (timescaledb.compress, timescaledb.compress_segmentby='entity_id');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT compress_chunk(show_chunks('update_trigger_test'));
               compress_chunk              
 ------------------------------------------
@@ -3145,6 +3148,9 @@ INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'a' from generate_s
 INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'b' from generate_series(1,123);
 INSERT INTO delete_counter SELECT '2020-02-01'::timestamptz, 'c' from generate_series(1,123);
 ALTER TABLE delete_counter SET (timescaledb.compress_segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT count(compress_chunk(ch)) FROM show_chunks('delete_counter') ch;
  count 
 -------

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -3136,6 +3136,9 @@ SELECT decompress_chunk(show_chunks('update_trigger_test'));
  _timescaledb_internal._hyper_41_78_chunk
 
 ALTER TABLE update_trigger_test SET (timescaledb.compress, timescaledb.compress_segmentby='entity_id');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT compress_chunk(show_chunks('update_trigger_test'));
               compress_chunk              
 ------------------------------------------
@@ -3151,6 +3154,9 @@ INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'a' from generate_s
 INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'b' from generate_series(1,123);
 INSERT INTO delete_counter SELECT '2020-02-01'::timestamptz, 'c' from generate_series(1,123);
 ALTER TABLE delete_counter SET (timescaledb.compress_segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT count(compress_chunk(ch)) FROM show_chunks('delete_counter') ch;
  count 
 -------

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -3136,6 +3136,9 @@ SELECT decompress_chunk(show_chunks('update_trigger_test'));
  _timescaledb_internal._hyper_41_78_chunk
 
 ALTER TABLE update_trigger_test SET (timescaledb.compress, timescaledb.compress_segmentby='entity_id');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT compress_chunk(show_chunks('update_trigger_test'));
               compress_chunk              
 ------------------------------------------
@@ -3151,6 +3154,9 @@ INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'a' from generate_s
 INSERT INTO delete_counter SELECT '2020-01-01'::timestamptz, 'b' from generate_series(1,123);
 INSERT INTO delete_counter SELECT '2020-02-01'::timestamptz, 'c' from generate_series(1,123);
 ALTER TABLE delete_counter SET (timescaledb.compress_segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 SELECT count(compress_chunk(ch)) FROM show_chunks('delete_counter') ch;
  count 
 -------

--- a/tsl/test/expected/create_table_with.out
+++ b/tsl/test/expected/create_table_with.out
@@ -250,6 +250,7 @@ SELECT hypertable_name, compression_enabled FROM timescaledb_information.hyperta
  t13             | t
 
 ALTER TABLE t13 SET (tsdb.compress_segmentby='device',tsdb.compress_orderby='time DESC');
+NOTICE:  updated compression settings will only apply to future compressions
 INSERT INTO t13 SELECT '2025-01-01','d1',0.1;
 SELECT compress_chunk(show_chunks('t13'));
              compress_chunk              

--- a/tsl/test/expected/decompress_memory.out
+++ b/tsl/test/expected/decompress_memory.out
@@ -69,6 +69,7 @@ select count(decompress_chunk(c, true)) from show_chunks('ht_metrics_compressed'
 
 alter table ht_metrics_compressed set (timescaledb.compress,
     timescaledb.compress_segmentby='time', timescaledb.compress_orderby='value');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(c, true)) from show_chunks('ht_metrics_compressed') c;
  count 
 -------

--- a/tsl/test/expected/direct_compress_copy.out
+++ b/tsl/test/expected/direct_compress_copy.out
@@ -142,6 +142,7 @@ ROLLBACK;
 -- test with segmentby
 BEGIN;
 ALTER TABLE metrics SET (tsdb.segmentby = 'device');
+NOTICE:  updated compression settings will only apply to future compressions
 SET timescaledb.enable_direct_compress_copy = true;
 SET timescaledb.enable_direct_compress_copy_client_sorted = true;
 COPY metrics FROM PROGRAM 'seq 0 0.2 9.8 | sed -e ''s!.[0-9]$!!'' | xargs -II date -d "2025-01-01 - I minute" +"%Y-%m-%d %H:%M:%S,dI,0.I"' WITH (FORMAT CSV);

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -296,6 +296,7 @@ ROLLBACK;
 -- test with segmentby
 BEGIN;
 ALTER TABLE metrics SET (tsdb.segmentby = 'device');
+NOTICE:  updated compression settings will only apply to future compressions
 SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_client_sorted = true;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz - (i || ' minute')::interval, floor(i), i::float FROM generate_series(0.0,9.8,0.2) i;
@@ -321,6 +322,7 @@ ROLLBACK;
 -- segmentby with overlapping batches
 BEGIN;
 ALTER TABLE metrics SET (tsdb.segmentby = 'device');
+NOTICE:  updated compression settings will only apply to future compressions
 SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_client_sorted = false;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd'||i%2, i::float FROM generate_series(0,3000) i;
@@ -357,6 +359,7 @@ ROLLBACK;
 -- multikey orderby
 BEGIN;
 ALTER TABLE metrics SET (tsdb.orderby = 'device desc,time');
+NOTICE:  updated compression settings will only apply to future compressions
 SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_client_sorted = false;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd'||i%3, i::float FROM generate_series(0,3000) i;

--- a/tsl/test/expected/feature_flags.out
+++ b/tsl/test/expected/feature_flags.out
@@ -53,6 +53,7 @@ ALTER TABLE test
 SET (timescaledb.compress,
      timescaledb.compress_orderby = 'time',
      timescaledb.compress_segmentby = 'device');
+NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan-15.out
+++ b/tsl/test/expected/plan_skip_scan-15.out
@@ -3745,6 +3745,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4046,6 +4047,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_comp_query.sql:51: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4233,6 +4235,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:71: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4845,6 +4848,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_comp_query.sql:132: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5267,6 +5271,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:168: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5997,6 +6002,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_comp_query.sql:249: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -3741,6 +3741,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4042,6 +4043,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_comp_query.sql:51: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4229,6 +4231,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:71: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4841,6 +4844,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_comp_query.sql:132: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5263,6 +5267,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:168: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5989,6 +5994,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_comp_query.sql:249: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -3739,6 +3739,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4040,6 +4041,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_comp_query.sql:51: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4227,6 +4229,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:71: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4839,6 +4842,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_comp_query.sql:132: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5261,6 +5265,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:168: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5987,6 +5992,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_comp_query.sql:249: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan-18.out
+++ b/tsl/test/expected/plan_skip_scan-18.out
@@ -3736,6 +3736,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4037,6 +4038,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_comp_query.sql:51: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4224,6 +4226,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:71: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4836,6 +4839,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_comp_query.sql:132: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5258,6 +5262,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:168: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -5984,6 +5989,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_comp_query.sql:249: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan_dagg-16.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-16.out
@@ -2985,6 +2985,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3135,6 +3136,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:30: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3302,6 +3304,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:54: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3830,6 +3833,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:110: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4190,6 +4194,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:147: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4872,6 +4877,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_dagg_comp_query.sql:228: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan_dagg-17.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-17.out
@@ -2985,6 +2985,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3135,6 +3136,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:30: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3302,6 +3304,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:54: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3830,6 +3833,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:110: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4190,6 +4194,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:147: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4872,6 +4877,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_dagg_comp_query.sql:228: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan_dagg-18.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-18.out
@@ -2983,6 +2983,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3133,6 +3134,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:30: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3300,6 +3302,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:54: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -3828,6 +3831,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:110: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4188,6 +4192,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:147: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------
@@ -4870,6 +4875,7 @@ SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
  _timescaledb_internal._hyper_3_8_chunk
 
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_dagg_comp_query.sql:228: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/plan_skip_scan_notnull.out
+++ b/tsl/test/expected/plan_skip_scan_notnull.out
@@ -130,6 +130,7 @@ CREATE INDEX skip_scan_dev_devname_idx ON skip_scan(dev,dev_name);
 CREATE INDEX skip_scan_ht_dev_devname_idx ON skip_scan_ht(dev,dev_name);
 -- skip_scan_htc table
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_notnull_setup.sql:15: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/rebuild_columnstore_tests.out
+++ b/tsl/test/expected/rebuild_columnstore_tests.out
@@ -186,6 +186,7 @@ SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :COMPRESSED_C
 ALTER TABLE rebuild_settings SET (
     timescaledb.compress_segmentby = ''
 );
+NOTICE:  updated compression settings will only apply to future compressions
 -- settings changed, decompress/compress fallback
 SELECT * FROM chunk_status_view WHERE hypertable_name = 'rebuild_settings';
  hypertable_name  |                  chunk                  |                 compressed_chunk                 |             status             

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -639,6 +639,7 @@ SELECT create_hypertable('exclusive_test', by_range('time', INTERVAL '1 day'));
  (24,t)
 
 ALTER TABLE guc_test set (timescaledb.compress, timescaledb.compress_segmentby = 'a, b');
+NOTICE:  updated compression settings will only apply to future compressions
 INSERT INTO guc_test VALUES ('2024-10-30 14:04:00.501519-06'::timestamptz, 1, 1, 1);
 SELECT show_chunks as chunk_to_compress FROM show_chunks('guc_test') LIMIT 1 \gset
 SELECT compress_chunk(:'chunk_to_compress');

--- a/tsl/test/expected/recompression_integrity_unordered.out
+++ b/tsl/test/expected/recompression_integrity_unordered.out
@@ -506,6 +506,7 @@ INSERT INTO recomp_comp_settings SELECT '2025-01-01'::timestamptz + (i || ' minu
 INSERT INTO recomp_comp_settings SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, '2025-02-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float FROM generate_series(0,700) i;
 -- change orderby setting
 ALTER TABLE recomp_comp_settings SET (tsdb.orderby='time2', tsdb.segmentby='device');
+NOTICE:  updated compression settings will only apply to future compressions
 \set TEST_TABLE_NAME 'recomp_comp_settings'
 \set ORDER_BY_CLAUSE ' ORDER BY device, time, time2'
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
@@ -593,6 +594,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
 
 -- change sparse index setting
 ALTER TABLE recomp_comp_settings SET (tsdb.orderby='time', tsdb.index='bloom("time2")');
+NOTICE:  updated compression settings will only apply to future compressions
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -677,6 +679,7 @@ SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
 
 -- change segmentby setting, will fallback to decompress/compress
 ALTER TABLE recomp_comp_settings SET (tsdb.segmentby='');
+NOTICE:  updated compression settings will only apply to future compressions
 \ir :RECOMPRESSION_INTEGRITY_CHECK_RELPATH
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -1182,6 +1182,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
@@ -1212,6 +1213,7 @@ RESET enable_seqscan;
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_comp_query.sql:51: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- dev is leading column
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
@@ -1229,6 +1231,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -----------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:71: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho basic DISTINCT queries on :TABLE
 :PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
@@ -1278,6 +1281,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ------------------------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_comp_query.sql:132: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
 \qecho stable expression in targetlist on :TABLE
@@ -1309,6 +1313,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:168: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho SUBSELECTS on :TABLE
 :PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
@@ -1378,6 +1383,7 @@ DEALLOCATE prep;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_comp_query.sql:249: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
     (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
@@ -1422,6 +1428,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
@@ -1452,6 +1459,7 @@ RESET enable_seqscan;
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_comp_query.sql:51: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- dev is leading column
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
@@ -1469,6 +1477,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -----------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:71: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho basic DISTINCT queries on :TABLE
 :PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
@@ -1518,6 +1527,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ------------------------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_comp_query.sql:132: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
 \qecho stable expression in targetlist on :TABLE
@@ -1549,6 +1559,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_comp_query.sql:168: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho SUBSELECTS on :TABLE
 :PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
@@ -1618,6 +1629,7 @@ DEALLOCATE prep;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_comp_query.sql:249: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
     (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,

--- a/tsl/test/expected/skip_scan_dagg.out
+++ b/tsl/test/expected/skip_scan_dagg.out
@@ -936,6 +936,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -949,6 +950,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:30: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn compressed index with dev as leading column
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -968,6 +970,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -----------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:54: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho basic DISTINCT queries on :TABLE
 -- Various distint aggs over same column is OK
@@ -1014,6 +1017,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ------------------------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:110: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- Various distint aggs over same column is OK
 :PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
@@ -1044,6 +1048,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:147: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho SUBSELECTS on :TABLE
 :PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
@@ -1110,6 +1115,7 @@ DEALLOCATE prep;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_dagg_comp_query.sql:228: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT val) FROM :TABLE WHERE dev = 1;
 :PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT val) ct FROM :TABLE WHERE dev = a.dev) b;
@@ -1140,6 +1146,7 @@ SET max_parallel_workers_per_gather = 0;
 -- test different compression configurations
 -- compressed index on "segmentby='dev'" has default "dev ASC, NULLS LAST" sort order
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:14: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- SkipScan used when sort order on distinct column "dev" matches "segmentby" sort order
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -1153,6 +1160,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn "segmentby = 'dev, dev_name'"
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev,dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:30: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- multicolumn compressed index with dev as leading column
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
@@ -1172,6 +1180,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -----------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:54: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho basic DISTINCT queries on :TABLE
 -- Various distint aggs over same column is OK
@@ -1218,6 +1227,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ------------------------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev_name');
+psql:include/skip_scan_dagg_comp_query.sql:110: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- Various distint aggs over same column is OK
 :PREFIX SELECT count(DISTINCT dev_name), max(DISTINCT dev_name), 'q1_2' FROM :TABLE;
@@ -1248,6 +1258,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev');
+psql:include/skip_scan_dagg_comp_query.sql:147: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 \qecho SUBSELECTS on :TABLE
 :PREFIX SELECT c1, c2, 'q4_1' FROM (SELECT count(DISTINCT dev) as c1, sum(DISTINCT dev) as c2 FROM :TABLE) a;
@@ -1314,6 +1325,7 @@ DEALLOCATE prep;
 ---------------------------------------
 SELECT decompress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 ALTER TABLE skip_scan_htc SET (timescaledb.compress, timescaledb.compress_orderby='time', timescaledb.compress_segmentby='dev, val');
+psql:include/skip_scan_dagg_comp_query.sql:228: NOTICE:  updated compression settings will only apply to future compressions
 SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE UNION ALL SELECT count(DISTINCT val) FROM :TABLE WHERE dev = 1;
 :PREFIX SELECT *, 'q9_2' FROM (SELECT count(DISTINCT dev) cd, dev FROM :TABLE GROUP BY dev) a, LATERAL (SELECT count(DISTINCT val) ct FROM :TABLE WHERE dev = a.dev) b;

--- a/tsl/test/expected/vacuum.out
+++ b/tsl/test/expected/vacuum.out
@@ -162,6 +162,7 @@ SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd2', i::float
 FROM generate_series(101,105) i;
 WARNING:  disabling direct compress because of too small batch size
 ALTER TABLE vacuum_settings_test SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+NOTICE:  updated compression settings will only apply to future compressions
 ALTER TABLE vacuum_settings_test ADD COLUMN c2 int DEFAULT 20;
 SELECT chunk FROM show_chunks('vacuum_settings_test') AS chunk LIMIT 1 \gset
 SELECT _timescaledb_functions.chunk_status_text(:'chunk'::regclass) AS status_before;

--- a/tsl/test/expected/vector_agg_byte.out
+++ b/tsl/test/expected/vector_agg_byte.out
@@ -18,6 +18,7 @@ select count(compress_chunk(x)) from show_chunks('groupbyte') x;
      1
 
 alter table groupbyte set (tsdb.compress_segmentby = '');
+NOTICE:  updated compression settings will only apply to future compressions
 insert into groupbyte select 11,
     case when x % 11 = 0 then null else x % 3 = 0 end,
     case when x % 13 = 0 then null else 'tag' || (x % 7) end,

--- a/tsl/test/expected/vector_agg_expr.out
+++ b/tsl/test/expected/vector_agg_expr.out
@@ -23,6 +23,7 @@ select count(compress_chunk(x)) from show_chunks('aggexpr') x;
      1
 
 alter table aggexpr set (tsdb.compress_segmentby = '');
+NOTICE:  updated compression settings will only apply to future compressions
 insert into aggexpr select 11, null, null, null, generate_series(1, 1489);
 insert into aggexpr select 12, 12, '12', false, generate_series(1, 1487);
 insert into aggexpr select 13, case when x % 2 = 0 then 13 else null end,

--- a/tsl/test/expected/vector_agg_filter.out
+++ b/tsl/test/expected/vector_agg_filter.out
@@ -2763,6 +2763,7 @@ select count(compress_chunk(x)) from show_chunks('uuid_default') x;
 
 alter table uuid_default add column id uuid default '842ab294-923a-4f50-be7d-af6c51903a5f';
 alter table uuid_default set (tsdb.compress_segmentby = 'id');
+NOTICE:  updated compression settings will only apply to future compressions
 insert into uuid_default select generate_series(1000, 1999), 2, '5dd0565f-1ddf-4a6c-9e96-9b2b8c8c3993';
 select count(compress_chunk(x)) from show_chunks('uuid_default') x;
 NOTICE:  chunk "_hyper_3_5_chunk" is already converted to columnstore

--- a/tsl/test/expected/vector_agg_groupagg.out
+++ b/tsl/test/expected/vector_agg_groupagg.out
@@ -71,6 +71,7 @@ select count(decompress_chunk(x)) from show_chunks('groupagg') x;
 
 alter table groupagg set (timescaledb.compress, timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 's nulls first');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x)) from show_chunks('groupagg') x;
  count 
 -------
@@ -114,6 +115,7 @@ insert into text_table select 4, case when x % 2 = 0 then null else 'samewithnul
 insert into text_table select 5, case when x % 2 = 0 then null else 'differentwithnulls' || x end from generate_series(1, 1000) x;
 alter table text_table set (timescaledb.compress,
     timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x)) from show_chunks('text_table') x;
 NOTICE:  chunk "_hyper_3_7_chunk" is already converted to columnstore
  count 
@@ -163,6 +165,7 @@ select count(decompress_chunk(x)) from show_chunks('text_table') x;
 
 alter table text_table set (timescaledb.compress,
     timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'a nulls first');
+NOTICE:  updated compression settings will only apply to future compressions
 select count(compress_chunk(x)) from show_chunks('text_table') x;
  count 
 -------

--- a/tsl/test/isolation/expected/compression_dml_iso.out
+++ b/tsl/test/isolation/expected/compression_dml_iso.out
@@ -138,6 +138,9 @@ time|device|location|value
 
 
 starting permutation: NOS CA1 CAc SH I1 Ic SH UPD1 UPDc SH DEL1 DELc SH UPD1 UPDc SH
+CompressAll: NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 step NOS: 
     ALTER TABLE ts_device_table set(timescaledb.compress, timescaledb.compress_orderby='time');
 
@@ -190,6 +193,9 @@ total_chunks|number_compressed_chunks
 
 
 starting permutation: NOS IN1 INc CA1 CAc SH SS DEL1 UPD1 DELc UPDc SH SS
+CompressAll: NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 step NOS: 
     ALTER TABLE ts_device_table set(timescaledb.compress, timescaledb.compress_orderby='time');
 
@@ -235,6 +241,9 @@ time|device|location|value
 
 
 starting permutation: NOS IN1 INc CA1 CAc SH SS UPD1 DEL1 UPDc DELc SH SS
+CompressAll: NOTICE:  updated compression settings will only apply to future compressions
+DETAIL:  Existing compressed chunks will not be recompressed.
+HINT:  Use compress_chunk(chunk, recompress => true) to recompress.
 step NOS: 
     ALTER TABLE ts_device_table set(timescaledb.compress, timescaledb.compress_orderby='time');
 

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -211,3 +211,19 @@ ALTER TABLE test_column_limit_alter SET (
 
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+
+
+-- Test NOTICE when changing compression settings on a table that already has compression enabled
+SET timescaledb.enable_direct_compress_insert = true;
+CREATE TABLE notice_test(time timestamptz not null, device text, temp float, created_at timestamptz not null default now()) WITH (tsdb.hypertable);
+ALTER TABLE notice_test SET (timescaledb.compress_segmentby='device');
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-01-01'::timestamptz, '2000-01-02', '1 minute') t;
+ALTER TABLE notice_test SET (timescaledb.compress_segmentby='');
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-02-01'::timestamptz, '2000-02-02', '1 minute') t;
+ALTER TABLE notice_test SET (timescaledb.compress_orderby='created_at');
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-02-10'::timestamptz, '2000-02-11', '1 minute') t;
+ALTER TABLE notice_test SET (timescaledb.index='bloom(temp)');
+INSERT INTO notice_test SELECT t, 'dev1', 1.0, t + interval '1 hour' FROM generate_series('2000-04-01'::timestamptz, '2000-04-02', '1 minute') t;
+SELECT * FROM settings;
+RESET timescaledb.enable_direct_compress_insert;
+DROP TABLE notice_test;


### PR DESCRIPTION
  When compression settings (segmentby, orderby, index) are changed on
  a hypertable that already has compression enabled, emit a NOTICE
  informing the user that existing compressed chunks will not be
  recompressed with the new settings.