### PR TITLE
Fix DST shift when generating gapfill buckets

### DIFF
--- a/.unreleased/pr_9563
+++ b/.unreleased/pr_9563
@@ -1,0 +1,2 @@
+Fixes: #9563 Fix gapfill out-of-order bucket creation during DST shift
+Thanks: @petergledhillinclusive for reporting the DST shift issue with time_bucket_gapfill

--- a/tsl/src/nodes/gapfill/gapfill_exec.c
+++ b/tsl/src/nodes/gapfill/gapfill_exec.c
@@ -654,11 +654,9 @@ gapfill_advance_timestamp(GapFillState *state)
 		case TIMESTAMPTZOID:
 			/*
 			 * To be consistent with time_bucket we do UTC bucketing unless
-			 * a different timezone got explicitly passed to the function
-			 * and we are bucketing by non-fixed intervals.
+			 * a different timezone got explicitly passed to the function.
 			 */
-			if (state->have_timezone &&
-				(state->next_offset->day != 0 || state->next_offset->month != 0))
+			if (state->have_timezone)
 			{
 				bool isnull;
 				/* TODO: optimize by constifying and caching the datum if possible */
@@ -666,18 +664,62 @@ gapfill_advance_timestamp(GapFillState *state)
 					gapfill_exec_expr(state, state->scanslot, get_timezone_arg(state), &isnull);
 				Assert(!isnull);
 
-				/* Convert to local timestamp */
-				next = DirectFunctionCall2(timestamptz_zone,
-										   tzname,
-										   TimestampTzGetDatum(state->gapfill_start));
+				if (state->next_offset->day != 0 || state->next_offset->month != 0)
+				{
+					/*
+					 * For variable-length intervals (day/month components),
+					 * convert to local time, add interval, convert back.
+					 */
+					next = DirectFunctionCall2(timestamptz_zone,
+											   tzname,
+											   TimestampTzGetDatum(state->gapfill_start));
+					next = DirectFunctionCall2(timestamp_pl_interval,
+											   next,
+											   IntervalPGetDatum(state->next_offset));
+					next = DirectFunctionCall2(timestamp_zone, tzname, next);
+				}
+				else
+				{
+					/*
+					 * For fixed-size intervals with timezone, we must compute
+					 * bucket boundaries using the same logic as time_bucket
+					 * with timezone (convert to local, bucket, convert back,
+					 * DST fix-up). Plain UTC arithmetic produces boundaries
+					 * that don't match time_bucket during DST transitions,
+					 * causing out-of-order output (issue #8844).
+					 */
+					Datum period = IntervalPGetDatum(state->gapfill_interval);
+					int64 period_us = state->gapfill_interval->time;
+					TimestampTz candidate = state->next_timestamp;
+					next = TimestampGetDatum(candidate);
+					Datum local_ts;
+					Datum local_bucket;
 
-				/* Add interval */
-				next = DirectFunctionCall2(timestamp_pl_interval,
-										   next,
-										   IntervalPGetDatum(state->next_offset));
+					/*
+					 * During DST transitions the aligned bucket may equal or
+					 * precede the current position. Advance the candidate
+					 * until we find the next distinct bucket boundary.
+					 */
+					while (DatumGetTimestampTz(next) <= state->next_timestamp)
+					{
+						candidate += period_us;
+						local_ts = DirectFunctionCall2(timestamptz_zone,
+													   tzname,
+													   TimestampTzGetDatum(candidate));
+						local_bucket = DirectFunctionCall2(ts_timestamp_bucket, period, local_ts);
+						next = DirectFunctionCall2(timestamp_zone, tzname, local_bucket);
 
-				/* Convert back to specified timezone */
-				next = DirectFunctionCall2(timestamp_zone, tzname, next);
+						/*
+						 * DST fix-up: during fall-back, timestamp_zone may pick
+						 * the standard-time interpretation, placing the bucket
+						 * start after the candidate. Subtract periods until the
+						 * bucket is at or before the candidate (same fix-up as
+						 * ts_timestamptz_timezone_bucket, issue #9136).
+						 */
+						while (DatumGetTimestampTz(next) > candidate)
+							next = DirectFunctionCall2(timestamptz_mi_interval, next, period);
+					}
+				}
 			}
 			else
 			{

--- a/tsl/test/shared/expected/gapfill_bug.out
+++ b/tsl/test/shared/expected/gapfill_bug.out
@@ -423,3 +423,69 @@ ORDER BY id, mins;
 
 DROP TABLE i4693;
 DROP TYPE i4693_type;
+-- check gapfill bucket boundaries match time_bucket with timezone across DST
+-- fall-back transitions for fixed-size intervals #8844
+SET timezone TO 'Europe/London';
+-- 3-hour gapfill across fall-back DST (Europe/London, Oct 2025)
+-- Clocks go back at 02:00 BST -> 01:00 GMT on Oct 26.
+SELECT time_bucket_gapfill('3 hours', time, 'Europe/London', '2025-10-25 23:00+00', '2025-10-26 08:00+00')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+     time_bucket_gapfill      
+------------------------------
+ Sun Oct 26 00:00:00 2025 BST
+ Sun Oct 26 03:00:00 2025 GMT
+ Sun Oct 26 06:00:00 2025 GMT
+
+-- 2-hour gapfill across fall-back DST
+SELECT time_bucket_gapfill('2 hours', time, 'Europe/London', '2025-10-25 23:00+00', '2025-10-26 08:00+00')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+     time_bucket_gapfill      
+------------------------------
+ Sun Oct 26 00:00:00 2025 BST
+ Sun Oct 26 02:00:00 2025 GMT
+ Sun Oct 26 04:00:00 2025 GMT
+ Sun Oct 26 06:00:00 2025 GMT
+
+-- 1-hour gapfill across fall-back DST (regression check)
+SELECT time_bucket_gapfill('1 hour', time, 'Europe/London', '2025-10-25 23:00+00', '2025-10-26 04:00+00')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+     time_bucket_gapfill      
+------------------------------
+ Sun Oct 26 00:00:00 2025 BST
+ Sun Oct 26 01:00:00 2025 BST
+ Sun Oct 26 01:00:00 2025 GMT
+ Sun Oct 26 02:00:00 2025 GMT
+ Sun Oct 26 03:00:00 2025 GMT
+
+-- Join of two gapfilled CTEs across DST should not produce
+-- "mergejoin input data is out of order" error #8844
+CREATE TABLE gf8844_table1 (device_id int, ts timestamptz, flow int);
+INSERT INTO gf8844_table1 VALUES (1234, '2025-10-26 03:20:00+00', 10);
+CREATE TABLE gf8844_table2 (device_id int, ts timestamptz, volume_delta bigint);
+INSERT INTO gf8844_table2 VALUES (1234, '2025-10-26 03:20:00+00', 5);
+WITH
+	STATS AS (
+		SELECT time_bucket_gapfill('3 hours', ts, 'Europe/London') AS bucket,
+			avg(flow) AS "flowAvg"
+		FROM gf8844_table1
+		WHERE ts > '2025-10-25 23:00:00' AND ts < '2025-10-26 08:00:00+00'
+		GROUP BY bucket ORDER BY bucket ASC
+	),
+	VOLUME AS (
+		SELECT time_bucket_gapfill('3 hours', ts, 'Europe/London') AS bucket,
+			sum(volume_delta) AS "volumeSum"
+		FROM gf8844_table2
+		WHERE ts > '2025-10-25 23:00:00' AND ts < '2025-10-26 08:00:00+00'
+		GROUP BY bucket ORDER BY bucket ASC
+	)
+SELECT * FROM STATS LEFT JOIN VOLUME USING (bucket);
+            bucket            |       flowAvg       | volumeSum 
+------------------------------+---------------------+-----------
+ Sat Oct 25 21:00:00 2025 BST |                     |          
+ Sun Oct 26 00:00:00 2025 BST |                     |          
+ Sun Oct 26 03:00:00 2025 GMT | 10.0000000000000000 |         5
+ Sun Oct 26 06:00:00 2025 GMT |                     |          
+
+DROP TABLE gf8844_table1;
+DROP TABLE gf8844_table2;
+RESET timezone;

--- a/tsl/test/shared/sql/gapfill_bug.sql
+++ b/tsl/test/shared/sql/gapfill_bug.sql
@@ -232,3 +232,50 @@ ORDER BY id, mins;
 
 DROP TABLE i4693;
 DROP TYPE i4693_type;
+
+-- check gapfill bucket boundaries match time_bucket with timezone across DST
+-- fall-back transitions for fixed-size intervals #8844
+SET timezone TO 'Europe/London';
+
+-- 3-hour gapfill across fall-back DST (Europe/London, Oct 2025)
+-- Clocks go back at 02:00 BST -> 01:00 GMT on Oct 26.
+SELECT time_bucket_gapfill('3 hours', time, 'Europe/London', '2025-10-25 23:00+00', '2025-10-26 08:00+00')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+
+-- 2-hour gapfill across fall-back DST
+SELECT time_bucket_gapfill('2 hours', time, 'Europe/London', '2025-10-25 23:00+00', '2025-10-26 08:00+00')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+
+-- 1-hour gapfill across fall-back DST (regression check)
+SELECT time_bucket_gapfill('1 hour', time, 'Europe/London', '2025-10-25 23:00+00', '2025-10-26 04:00+00')
+FROM (SELECT NULL::timestamptz AS time LIMIT 0) s GROUP BY 1;
+
+-- Join of two gapfilled CTEs across DST should not produce
+-- "mergejoin input data is out of order" error #8844
+CREATE TABLE gf8844_table1 (device_id int, ts timestamptz, flow int);
+INSERT INTO gf8844_table1 VALUES (1234, '2025-10-26 03:20:00+00', 10);
+
+CREATE TABLE gf8844_table2 (device_id int, ts timestamptz, volume_delta bigint);
+INSERT INTO gf8844_table2 VALUES (1234, '2025-10-26 03:20:00+00', 5);
+
+WITH
+	STATS AS (
+		SELECT time_bucket_gapfill('3 hours', ts, 'Europe/London') AS bucket,
+			avg(flow) AS "flowAvg"
+		FROM gf8844_table1
+		WHERE ts > '2025-10-25 23:00:00' AND ts < '2025-10-26 08:00:00+00'
+		GROUP BY bucket ORDER BY bucket ASC
+	),
+	VOLUME AS (
+		SELECT time_bucket_gapfill('3 hours', ts, 'Europe/London') AS bucket,
+			sum(volume_delta) AS "volumeSum"
+		FROM gf8844_table2
+		WHERE ts > '2025-10-25 23:00:00' AND ts < '2025-10-26 08:00:00+00'
+		GROUP BY bucket ORDER BY bucket ASC
+	)
+SELECT * FROM STATS LEFT JOIN VOLUME USING (bucket);
+
+DROP TABLE gf8844_table1;
+DROP TABLE gf8844_table2;
+
+RESET timezone;


### PR DESCRIPTION
Gapfill was generating out of order buckets when DST shift occurs. This change accounts for the DST shift and bring gapfill function in line with time_bucket.

Fixes #8844 