### PR TITLE
Run the LLM Fuzzer on main only

### DIFF
--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -5,8 +5,12 @@
 # avoid false positives.
 name: LLM fuzzer
 "on":
-  pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths: .github/workflows/llm-fuzzer.yaml
 
 env:
   PG_SRC_DIR: "pgbuild"


### PR DESCRIPTION
It needs the API key which we don't have on the forks.