### PR TITLE
Release 2.26.3

### DIFF
--- a/.unreleased/pr_9511
+++ b/.unreleased/pr_9511
@@ -1,2 +1,0 @@
-Fixes: #9511 Fix alter_job failing for retention policy with drop_created_before
-Thanks: @sebastian-ederer for reporting an issue with alter_job and drop_created_before

--- a/.unreleased/pr_9551
+++ b/.unreleased/pr_9551
@@ -1,1 +1,0 @@
-Fixes: #9551 Fix resource leaks on error paths for cagg refresh

--- a/.unreleased/pr_9557
+++ b/.unreleased/pr_9557
@@ -1,1 +1,0 @@
-Fixes: #9557 Clean up orphaned compression_chunk_size entries during upgrade

--- a/.unreleased/pr_9563
+++ b/.unreleased/pr_9563
@@ -1,2 +1,0 @@
-Fixes: #9563 Fix gapfill out-of-order bucket creation during DST shift
-Thanks: @petergledhillinclusive for reporting the DST shift issue with time_bucket_gapfill

--- a/.unreleased/pr_9571
+++ b/.unreleased/pr_9571
@@ -1,2 +1,0 @@
-Fixes: #9571 Fix concurrent refreshes of continuous aggregates
-Thanks: @GTan615 for reporting the data duplicate issues observed during overlapping cagg refreshes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ This page lists all the latest features and updates to TimescaleDB. When
 you use psql to update your database, use the -X flag and prevent any .psqlrc
 commands from accidentally triggering the load of a previous DB version.**
 
+## 2.26.3 (2026-04-13)
+
+This release contains performance improvements and bug fixes since the 2.26.2 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.26.3**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* [#9511](https://github.com/timescale/timescaledb/pull/9511) Fix alter_job failing for retention policy with drop_created_before
+* [#9557](https://github.com/timescale/timescaledb/pull/9557) Clean up orphaned compression_chunk_size entries during upgrade
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* @sebastian-ederer for reporting an issue with alter_job and drop_created_before
+
 ## 2.26.2 (2026-04-07)
 
 This release contains bug fixes since the 2.26.1 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ This page lists all the latest features and updates to TimescaleDB. When
 you use psql to update your database, use the -X flag and prevent any .psqlrc
 commands from accidentally triggering the load of a previous DB version.**
 
-## 2.26.3 (2026-04-13)
+## 2.26.3 (2026-04-14)
 
-This release contains performance improvements and bug fixes since the 2.26.2 release. We recommend that you upgrade at the next available opportunity.
+This release contains bug fixes since the 2.26.2 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
-* [#9511](https://github.com/timescale/timescaledb/pull/9511) Fix `alter_job` failing for retention policy with drop_created_before
-* [#9557](https://github.com/timescale/timescaledb/pull/9557) Clean up orphaned compression_chunk_size entries during upgrade
-* [#9551](https://github.com/timescale/timescaledb/pull/9551) Fix resource leaks on error paths for cagg refresh
+* [#9511](https://github.com/timescale/timescaledb/pull/9511) Fix `alter_job` failing for retention policy with `drop_created_before` argument
+* [#9557](https://github.com/timescale/timescaledb/pull/9557) Clean up orphaned `compression_chunk_size` entries during the extension upgrade
+* [#9551](https://github.com/timescale/timescaledb/pull/9551) Fix resource leaks on error paths for during a continuous aggregate refresh
 * [#9563](https://github.com/timescale/timescaledb/pull/9563) Fix gapfill out-of-order bucket creation during DST shift
 * [#9571](https://github.com/timescale/timescaledb/pull/9571) Fix concurrent refreshes of continuous aggregates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,17 @@ commands from accidentally triggering the load of a previous DB version.**
 
 This release contains performance improvements and bug fixes since the 2.26.2 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.26.3**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
-
 **Bugfixes**
-* [#9511](https://github.com/timescale/timescaledb/pull/9511) Fix alter_job failing for retention policy with drop_created_before
+* [#9511](https://github.com/timescale/timescaledb/pull/9511) Fix `alter_job` failing for retention policy with drop_created_before
 * [#9557](https://github.com/timescale/timescaledb/pull/9557) Clean up orphaned compression_chunk_size entries during upgrade
-
-**New Settings**
-
-**GUCs**
+* [#9551](https://github.com/timescale/timescaledb/pull/9551) Fix resource leaks on error paths for cagg refresh
+* [#9563](https://github.com/timescale/timescaledb/pull/9563) Fix gapfill out-of-order bucket creation during DST shift
+* [#9571](https://github.com/timescale/timescaledb/pull/9571) Fix concurrent refreshes of continuous aggregates
 
 **Thanks**
 * @sebastian-ederer for reporting an issue with alter_job and drop_created_before
+* @petergledhillinclusive for reporting the DST shift issue with time_bucket_gapfill
+* @GTan615 for reporting the data duplicate issues observed during overlapping cagg refreshes
 
 ## 2.26.2 (2026-04-07)
 


### PR DESCRIPTION
## 2.26.3 (2026-04-14)

This release contains bug fixes since the 2.26.2 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#9511](https://github.com/timescale/timescaledb/pull/9511) Fix `alter_job` failing for retention policy with `drop_created_before` argument
* [#9557](https://github.com/timescale/timescaledb/pull/9557) Clean up orphaned `compression_chunk_size` entries during the extension upgrade
* [#9551](https://github.com/timescale/timescaledb/pull/9551) Fix resource leaks on error paths for during a continuous aggregate refresh
* [#9563](https://github.com/timescale/timescaledb/pull/9563) Fix gapfill out-of-order bucket creation during DST shift
* [#9571](https://github.com/timescale/timescaledb/pull/9571) Fix concurrent refreshes of continuous aggregates

**Thanks**
* @sebastian-ederer for reporting an issue with alter_job and drop_created_before
* @petergledhillinclusive for reporting the DST shift issue with time_bucket_gapfill
* @GTan615 for reporting the data duplicate issues observed during overlapping cagg refreshes