### PR TITLE
Add firstlast sparse index type for compression

### DIFF
--- a/.unreleased/pr_9580
+++ b/.unreleased/pr_9580
@@ -1,0 +1,1 @@
+Implements: #9580 Add first/last sparse indexes to compression

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -20,7 +20,7 @@
 #include <common/md5.h>
 #include <utils/palloc.h>
 
-TSDLLEXPORT const char *ts_sparse_index_type_names[] = { "bloom", "minmax" };
+TSDLLEXPORT const char *ts_sparse_index_type_names[] = { "bloom", "minmax", "firstlast" };
 TSDLLEXPORT const char *ts_sparse_index_source_names[] = { "config", "default", "orderby" };
 TSDLLEXPORT const char *ts_sparse_index_common_keys[] = { "type", "column", "source", NULL };
 static ScanTupleResult compression_settings_tuple_update(TupleInfo *ti, void *data);
@@ -628,6 +628,14 @@ ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state, SparseInde
 							 ts_sparse_index_common_keys[SparseIndexKeyCol],
 							 minmax_config->col); /* column */
 			break;
+		case _SparseIndexTypeEnumFirstLast:
+		{
+			FirstLastIndexColumnConfig *firstlast_config = (FirstLastIndexColumnConfig *) config;
+			ts_jsonb_add_str(parse_state,
+							 ts_sparse_index_common_keys[SparseIndexKeyCol],
+							 firstlast_config->col); /* column */
+			break;
+		}
 		case _SparseIndexTypeEnumBloom:
 			bloom_config = (BloomFilterConfig *) config;
 
@@ -1403,6 +1411,7 @@ ts_get_per_column_compression_settings(const SparseIndexSettings *settings)
 					per_column_setting = palloc0(sizeof(PerColumnCompressionSettings));
 					per_column_setting->column_name = column_name;
 					per_column_setting->minmax_obj_id = -1;
+					per_column_setting->firstlast_obj_id = -1;
 					per_column_setting->single_bloom_obj_id = -1;
 					per_column_setting->composite_bloom_index_obj_ids = NULL;
 					result_settings = lappend(result_settings, per_column_setting);
@@ -1412,6 +1421,12 @@ ts_get_per_column_compression_settings(const SparseIndexSettings *settings)
 				{
 					Assert(num_columns == 1);
 					per_column_setting->minmax_obj_id = obj_id;
+				}
+				else if (strcmp(index_type,
+								ts_sparse_index_type_names[_SparseIndexTypeEnumFirstLast]) == 0)
+				{
+					Assert(num_columns == 1);
+					per_column_setting->firstlast_obj_id = obj_id;
 				}
 				else if (strcmp(index_type,
 								ts_sparse_index_type_names[_SparseIndexTypeEnumBloom]) == 0)

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -18,7 +18,7 @@
 #include <common/md5.h>
 #include <utils/palloc.h>
 
-TSDLLEXPORT const char *ts_sparse_index_type_names[] = { "bloom", "minmax" };
+TSDLLEXPORT const char *ts_sparse_index_type_names[] = { "bloom", "minmax", "firstlast" };
 TSDLLEXPORT const char *ts_sparse_index_source_names[] = { "config", "default", "orderby" };
 TSDLLEXPORT const char *ts_sparse_index_common_keys[] = { "type", "column", "source", NULL };
 static ScanTupleResult compression_settings_tuple_update(TupleInfo *ti, void *data);
@@ -560,6 +560,14 @@ ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state, SparseInde
 							 ts_sparse_index_common_keys[SparseIndexKeyCol],
 							 minmax_config->col); /* column */
 			break;
+		case _SparseIndexTypeEnumFirstLast:
+		{
+			FirstLastIndexColumnConfig *firstlast_config = (FirstLastIndexColumnConfig *) config;
+			ts_jsonb_add_str(parse_state,
+							 ts_sparse_index_common_keys[SparseIndexKeyCol],
+							 firstlast_config->col); /* column */
+			break;
+		}
 		case _SparseIndexTypeEnumBloom:
 			bloom_config = (BloomFilterConfig *) config;
 
@@ -1230,6 +1238,7 @@ ts_get_per_column_compression_settings(const SparseIndexSettings *settings)
 					per_column_setting = palloc0(sizeof(PerColumnCompressionSettings));
 					per_column_setting->column_name = column_name;
 					per_column_setting->minmax_obj_id = -1;
+					per_column_setting->firstlast_obj_id = -1;
 					per_column_setting->single_bloom_obj_id = -1;
 					per_column_setting->composite_bloom_index_obj_ids = NULL;
 					result_settings = lappend(result_settings, per_column_setting);
@@ -1239,6 +1248,12 @@ ts_get_per_column_compression_settings(const SparseIndexSettings *settings)
 				{
 					Assert(num_columns == 1);
 					per_column_setting->minmax_obj_id = obj_id;
+				}
+				else if (strcmp(index_type,
+								ts_sparse_index_type_names[_SparseIndexTypeEnumFirstLast]) == 0)
+				{
+					Assert(num_columns == 1);
+					per_column_setting->firstlast_obj_id = obj_id;
 				}
 				else if (strcmp(index_type,
 								ts_sparse_index_type_names[_SparseIndexTypeEnumBloom]) == 0)

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -20,6 +20,7 @@ typedef enum SparseIndexTypeEnum
 {
 	_SparseIndexTypeEnumBloom = 0,
 	_SparseIndexTypeEnumMinmax,
+	_SparseIndexTypeEnumFirstLast,
 	_SparseIndexTypeEnumMax
 } SparseIndexTypeEnum;
 
@@ -54,6 +55,12 @@ typedef struct MinmaxIndexColumnConfig
 	SparseIndexConfigBase base;
 	const char *col;
 } MinmaxIndexColumnConfig;
+
+typedef struct FirstLastIndexColumnConfig
+{
+	SparseIndexConfigBase base;
+	const char *col;
+} FirstLastIndexColumnConfig;
 
 typedef struct SparseIndexColumn
 {
@@ -115,6 +122,9 @@ typedef struct PerColumnCompressionSettings
 
 	/* the index of the minmax index object that the column participates in, -1 if not present */
 	int minmax_obj_id;
+
+	/* the index of the firstlast index object that the column participates in, -1 if not present */
+	int firstlast_obj_id;
 
 	/* the index of the single bloom index object that the column participates in, -1 if not present
 	 */

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -68,6 +68,10 @@ static const WithClauseDefinition sparse_index_with_clause_def[] = {
 		.arg_names = {"compress_minmax", "minmax", "compress_min_max", "min_max", NULL},
 		.type_id = TEXTOID,
 	},
+	[_SparseIndexTypeEnumFirstLast] = {
+		.arg_names = {"compress_firstlast", "firstlast", "first_last", NULL},
+		.type_id = TEXTOID,
+	},
 };
 
 WithClauseResult *
@@ -535,6 +539,7 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 {
 	TypeCacheEntry *type_cache;
 	MinmaxIndexColumnConfig minmax_config;
+	FirstLastIndexColumnConfig firstlast_config;
 	BloomFilterConfig bloom_config;
 	SparseIndexConfigBase config;
 	SparseIndexConfigBase *config_ptr = &config;
@@ -573,7 +578,7 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("minmax index can only have one column")));
+					 errmsg("only bloom indexes can have multiple columns")));
 		}
 	}
 
@@ -680,6 +685,22 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 			minmax_config.base = config;
 			config_ptr = (SparseIndexConfigBase *) &minmax_config;
 			minmax_config.col = first_column.name;
+			break;
+
+		case _SparseIndexTypeEnumFirstLast:
+			if (ts_bmslist_contains_set(*sparse_index_columns, attnums_bitmap))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate column name \"%s\"", first_column.name),
+						 errhint("The sparse index option must reference distinct "
+								 "column.")));
+			}
+			*sparse_index_columns = ts_bmslist_add_set(*sparse_index_columns, attnums_bitmap);
+
+			firstlast_config.base = config;
+			config_ptr = (SparseIndexConfigBase *) &firstlast_config;
+			firstlast_config.col = first_column.name;
 			break;
 
 		default:

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -68,6 +68,10 @@ static const WithClauseDefinition sparse_index_with_clause_def[] = {
 		.arg_names = {"compress_minmax", "minmax", "compress_min_max", "min_max", NULL},
 		.type_id = TEXTOID,
 	},
+	[_SparseIndexTypeEnumFirstLast] = {
+		.arg_names = {"compress_firstlast", "firstlast", "first_last", NULL},
+		.type_id = TEXTOID,
+	},
 };
 
 WithClauseResult *
@@ -477,6 +481,7 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 {
 	TypeCacheEntry *type_cache;
 	MinmaxIndexColumnConfig minmax_config;
+	FirstLastIndexColumnConfig firstlast_config;
 	BloomFilterConfig bloom_config;
 	SparseIndexConfigBase config;
 	SparseIndexConfigBase *config_ptr = &config;
@@ -511,7 +516,7 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("minmax index can only have one column")));
+					 errmsg("only bloom indexes can have multiple columns")));
 		}
 	}
 
@@ -612,6 +617,22 @@ parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_d
 			minmax_config.base = config;
 			config_ptr = (SparseIndexConfigBase *) &minmax_config;
 			minmax_config.col = first_column.name;
+			break;
+
+		case _SparseIndexTypeEnumFirstLast:
+			if (ts_bmslist_contains_set(*sparse_index_columns, attnums_bitmap))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_SYNTAX_ERROR),
+						 errmsg("duplicate column name \"%s\"", first_column.name),
+						 errhint("The sparse index option must reference distinct "
+								 "column.")));
+			}
+			*sparse_index_columns = ts_bmslist_add_set(*sparse_index_columns, attnums_bitmap);
+
+			firstlast_config.base = config;
+			config_ptr = (SparseIndexConfigBase *) &firstlast_config;
+			firstlast_config.col = first_column.name;
 			break;
 
 		default:

--- a/tsl/src/compression/CMakeLists.txt
+++ b/tsl/src/compression/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/api.c
     ${CMAKE_CURRENT_SOURCE_DIR}/batch_metadata_builder_bloom1.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/batch_metadata_builder_firstlast.c
     ${CMAKE_CURRENT_SOURCE_DIR}/batch_metadata_builder_minmax.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compression.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compression_dml.c

--- a/tsl/src/compression/batch_metadata_builder.h
+++ b/tsl/src/compression/batch_metadata_builder.h
@@ -14,6 +14,7 @@ enum BatchMetadataBuilderType
 {
 	METADATA_BUILDER_MINMAX,
 	METADATA_BUILDER_BLOOM1,
+	METADATA_BUILDER_FIRSTLAST,
 };
 
 typedef struct BatchMetadataBuilder
@@ -31,6 +32,10 @@ BatchMetadataBuilder *batch_metadata_builder_minmax_create(Oid type, Oid collati
 BatchMetadataBuilder *batch_metadata_builder_bloom1_create(int num_columns, const Oid *type_oids,
 														   const AttrNumber *attnums,
 														   int bloom_attr_offset);
+
+BatchMetadataBuilder *batch_metadata_builder_firstlast_create(Oid type_oid, AttrNumber attnum,
+															  int first_attr_offset,
+															  int last_attr_offset);
 
 /* Hasher interface common to bloom filters, used to compute the hash without updating the bloom
  * filter */

--- a/tsl/src/compression/batch_metadata_builder_firstlast.c
+++ b/tsl/src/compression/batch_metadata_builder_firstlast.c
@@ -1,0 +1,164 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <utils/datum.h>
+#include <utils/typcache.h>
+
+#include "batch_metadata_builder_firstlast.h"
+
+#include "compression.h"
+
+static void firstlast_update_row(void *builder_, TupleTableSlot *slot);
+static void firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor);
+static void firstlast_reset(void *builder_, RowCompressor *compressor);
+
+BatchMetadataBuilder *
+batch_metadata_builder_firstlast_create(Oid type_oid, AttrNumber attnum, int first_attr_offset,
+										int last_attr_offset)
+{
+	BatchMetadataBuilderFirstLast *builder = palloc(sizeof(*builder));
+	TypeCacheEntry *type = lookup_type_cache(type_oid, 0);
+
+	*builder = (BatchMetadataBuilderFirstLast){
+		.functions =
+			(BatchMetadataBuilder){
+				.update_row = firstlast_update_row,
+				.insert_to_compressed_row = firstlast_insert_to_compressed_row,
+				.reset = firstlast_reset,
+				.builder_type = METADATA_BUILDER_FIRSTLAST,
+			},
+		.type_oid = type_oid,
+		.attnum = attnum,
+		.empty = true,
+		.type_by_val = type->typbyval,
+		.type_len = type->typlen,
+		.first_is_null = true,
+		.last_is_null = true,
+		.first_metadata_attr_offset = first_attr_offset,
+		.last_metadata_attr_offset = last_attr_offset,
+	};
+
+	return &builder->functions;
+}
+
+static void
+firstlast_update_row(void *builder_, TupleTableSlot *slot)
+{
+	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
+	Assert(builder->functions.builder_type == METADATA_BUILDER_FIRSTLAST);
+
+	bool is_null;
+	Datum val = slot_getattr(slot, builder->attnum, &is_null);
+
+	if (builder->empty)
+	{
+		if (is_null)
+		{
+			builder->first_is_null = true;
+			builder->first = (Datum) 0;
+		}
+		else
+		{
+			builder->first_is_null = false;
+			builder->first = datumCopy(val, builder->type_by_val, builder->type_len);
+		}
+		builder->empty = false;
+	}
+
+	/* Always update last to the current row */
+	if (!builder->last_is_null && !builder->type_by_val)
+		pfree(DatumGetPointer(builder->last));
+
+	if (is_null)
+	{
+		builder->last_is_null = true;
+		builder->last = (Datum) 0;
+	}
+	else
+	{
+		builder->last_is_null = false;
+		builder->last = datumCopy(val, builder->type_by_val, builder->type_len);
+	}
+}
+
+static void
+firstlast_reset(void *builder_, RowCompressor *compressor)
+{
+	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
+
+	if (!builder->empty)
+	{
+		if (!builder->first_is_null && !builder->type_by_val)
+			pfree(DatumGetPointer(builder->first));
+		if (!builder->last_is_null && !builder->type_by_val)
+			pfree(DatumGetPointer(builder->last));
+		builder->first = (Datum) 0;
+		builder->last = (Datum) 0;
+	}
+	builder->empty = true;
+	builder->first_is_null = true;
+	builder->last_is_null = true;
+
+	compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+	compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+	compressor->compressed_values[builder->first_metadata_attr_offset] = (Datum) 0;
+	compressor->compressed_values[builder->last_metadata_attr_offset] = (Datum) 0;
+}
+
+static void
+firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+{
+	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
+	Assert(builder->first_metadata_attr_offset >= 0);
+	Assert(builder->last_metadata_attr_offset >= 0);
+
+	if (builder->empty)
+	{
+		compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+		compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+		return;
+	}
+
+	/* First value */
+	if (builder->first_is_null)
+	{
+		compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+	}
+	else
+	{
+		Datum first = builder->first;
+		if (builder->type_len == -1)
+		{
+			Datum unpacked = PointerGetDatum(PG_DETOAST_DATUM_PACKED(first));
+			if (first != unpacked)
+				pfree(DatumGetPointer(first));
+			first = unpacked;
+			builder->first = first;
+		}
+		compressor->compressed_is_null[builder->first_metadata_attr_offset] = false;
+		compressor->compressed_values[builder->first_metadata_attr_offset] = first;
+	}
+
+	/* Last value */
+	if (builder->last_is_null)
+	{
+		compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+	}
+	else
+	{
+		Datum last = builder->last;
+		if (builder->type_len == -1)
+		{
+			Datum unpacked = PointerGetDatum(PG_DETOAST_DATUM_PACKED(last));
+			if (last != unpacked)
+				pfree(DatumGetPointer(last));
+			last = unpacked;
+			builder->last = last;
+		}
+		compressor->compressed_is_null[builder->last_metadata_attr_offset] = false;
+		compressor->compressed_values[builder->last_metadata_attr_offset] = last;
+	}
+}

--- a/tsl/src/compression/batch_metadata_builder_firstlast.c
+++ b/tsl/src/compression/batch_metadata_builder_firstlast.c
@@ -1,0 +1,174 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <utils/datum.h>
+#include <utils/typcache.h>
+
+#include "batch_metadata_builder_firstlast.h"
+
+#include "compression.h"
+
+static void firstlast_update_row(void *builder_, TupleTableSlot *slot);
+static void firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor);
+static void firstlast_reset(void *builder_, RowCompressor *compressor);
+
+BatchMetadataBuilder *
+batch_metadata_builder_firstlast_create(Oid type_oid, AttrNumber attnum, int first_attr_offset,
+										int last_attr_offset)
+{
+	BatchMetadataBuilderFirstLast *builder = palloc(sizeof(*builder));
+	TypeCacheEntry *type = lookup_type_cache(type_oid, 0);
+
+	*builder = (BatchMetadataBuilderFirstLast){
+		.functions =
+			(BatchMetadataBuilder){
+				.update_row = firstlast_update_row,
+				.insert_to_compressed_row = firstlast_insert_to_compressed_row,
+				.reset = firstlast_reset,
+				.builder_type = METADATA_BUILDER_FIRSTLAST,
+			},
+		.type_oid = type_oid,
+		.attnum = attnum,
+		.empty = true,
+		.type_by_val = type->typbyval,
+		.type_len = type->typlen,
+		.first_is_null = true,
+		.last_is_null = true,
+		.first_metadata_attr_offset = first_attr_offset,
+		.last_metadata_attr_offset = last_attr_offset,
+	};
+
+	return &builder->functions;
+}
+
+static void
+firstlast_update_row(void *builder_, TupleTableSlot *slot)
+{
+	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
+	Assert(builder->functions.builder_type == METADATA_BUILDER_FIRSTLAST);
+
+	bool is_null;
+	Datum val = slot_getattr(slot, builder->attnum, &is_null);
+
+	if (builder->empty)
+	{
+		if (is_null)
+		{
+			builder->first_is_null = true;
+			builder->first = (Datum) 0;
+		}
+		else
+		{
+			builder->first_is_null = false;
+			builder->first = datumCopy(val, builder->type_by_val, builder->type_len);
+		}
+		builder->empty = false;
+	}
+
+	/* Always update last to the current row */
+	if (!builder->last_is_null && !builder->type_by_val)
+	{
+		pfree(DatumGetPointer(builder->last));
+	}
+
+	if (is_null)
+	{
+		builder->last_is_null = true;
+		builder->last = (Datum) 0;
+	}
+	else
+	{
+		builder->last_is_null = false;
+		builder->last = datumCopy(val, builder->type_by_val, builder->type_len);
+	}
+}
+
+static void
+firstlast_reset(void *builder_, RowCompressor *compressor)
+{
+	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
+
+	if (!builder->empty)
+	{
+		if (!builder->first_is_null && !builder->type_by_val)
+		{
+			pfree(DatumGetPointer(builder->first));
+		}
+		if (!builder->last_is_null && !builder->type_by_val)
+		{
+			pfree(DatumGetPointer(builder->last));
+		}
+		builder->first = (Datum) 0;
+		builder->last = (Datum) 0;
+	}
+	builder->empty = true;
+	builder->first_is_null = true;
+	builder->last_is_null = true;
+
+	compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+	compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+	compressor->compressed_values[builder->first_metadata_attr_offset] = (Datum) 0;
+	compressor->compressed_values[builder->last_metadata_attr_offset] = (Datum) 0;
+}
+
+static void
+firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+{
+	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
+	Assert(builder->first_metadata_attr_offset >= 0);
+	Assert(builder->last_metadata_attr_offset >= 0);
+
+	if (builder->empty)
+	{
+		compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+		compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+		return;
+	}
+
+	/* First value */
+	if (builder->first_is_null)
+	{
+		compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+	}
+	else
+	{
+		Datum first = builder->first;
+		if (builder->type_len == -1)
+		{
+			Datum unpacked = PointerGetDatum(PG_DETOAST_DATUM_PACKED(first));
+			if (first != unpacked)
+			{
+				pfree(DatumGetPointer(first));
+			}
+			first = unpacked;
+			builder->first = first;
+		}
+		compressor->compressed_is_null[builder->first_metadata_attr_offset] = false;
+		compressor->compressed_values[builder->first_metadata_attr_offset] = first;
+	}
+
+	/* Last value */
+	if (builder->last_is_null)
+	{
+		compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+	}
+	else
+	{
+		Datum last = builder->last;
+		if (builder->type_len == -1)
+		{
+			Datum unpacked = PointerGetDatum(PG_DETOAST_DATUM_PACKED(last));
+			if (last != unpacked)
+			{
+				pfree(DatumGetPointer(last));
+			}
+			last = unpacked;
+			builder->last = last;
+		}
+		compressor->compressed_is_null[builder->last_metadata_attr_offset] = false;
+		compressor->compressed_values[builder->last_metadata_attr_offset] = last;
+	}
+}

--- a/tsl/src/compression/batch_metadata_builder_firstlast.h
+++ b/tsl/src/compression/batch_metadata_builder_firstlast.h
@@ -1,0 +1,33 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include "batch_metadata_builder.h"
+
+typedef struct BatchMetadataBuilderFirstLast
+{
+	BatchMetadataBuilder functions;
+
+	Oid type_oid;
+	AttrNumber attnum;
+	bool empty;
+
+	bool type_by_val;
+	int16 type_len;
+
+	Datum first;
+	bool first_is_null;
+
+	Datum last;
+	bool last_is_null;
+
+	int16 first_metadata_attr_offset;
+	int16 last_metadata_attr_offset;
+} BatchMetadataBuilderFirstLast;
+
+typedef struct RowCompressor RowCompressor;

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -960,6 +960,31 @@ build_column_map(const CompressionSettings *settings, const TupleDesc in_desc,
 																	 bloom_attr_offset));
 				}
 
+				const AttrNumber first_attr_number =
+					compressed_column_metadata_attno(settings,
+													 settings->fd.relid,
+													 attr->attnum,
+													 settings->fd.compress_relid,
+													 "first");
+				const AttrNumber last_attr_number =
+					compressed_column_metadata_attno(settings,
+													 settings->fd.relid,
+													 attr->attnum,
+													 settings->fd.compress_relid,
+													 "last");
+				if (AttributeNumberIsValid(first_attr_number) &&
+					AttributeNumberIsValid(last_attr_number))
+				{
+					const int16 first_attr_offset = AttrNumberGetAttrOffset(first_attr_number);
+					const int16 last_attr_offset = AttrNumberGetAttrOffset(last_attr_number);
+					metadata_builders =
+						lappend(metadata_builders,
+								batch_metadata_builder_firstlast_create(attr->atttypid,
+																		attr->attnum,
+																		first_attr_offset,
+																		last_attr_offset));
+				}
+
 				*column = (PerColumn){
 					.compressor = compressor_for_type(attr->atttypid),
 					.segmentby_column_index = -1,

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -906,6 +906,31 @@ build_column_map(const CompressionSettings *settings, const TupleDesc in_desc,
 																	 bloom_attr_offset));
 				}
 
+				const AttrNumber first_attr_number =
+					compressed_column_metadata_attno(settings,
+													 settings->fd.relid,
+													 attr->attnum,
+													 settings->fd.compress_relid,
+													 "first");
+				const AttrNumber last_attr_number =
+					compressed_column_metadata_attno(settings,
+													 settings->fd.relid,
+													 attr->attnum,
+													 settings->fd.compress_relid,
+													 "last");
+				if (AttributeNumberIsValid(first_attr_number) &&
+					AttributeNumberIsValid(last_attr_number))
+				{
+					const int16 first_attr_offset = AttrNumberGetAttrOffset(first_attr_number);
+					const int16 last_attr_offset = AttrNumberGetAttrOffset(last_attr_number);
+					metadata_builders =
+						lappend(metadata_builders,
+								batch_metadata_builder_firstlast_create(attr->atttypid,
+																		attr->attnum,
+																		first_attr_offset,
+																		last_attr_offset));
+				}
+
 				*column = (PerColumn){
 					.compressor = compressor_for_type(attr->atttypid),
 					.segmentby_column_index = -1,

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -60,7 +60,7 @@
 
 #include "bgw_policy/compression_api.h"
 
-static const char *sparse_index_types[] = { "min", "max" };
+static const char *sparse_index_types[] = { "min", "max", "first", "last" };
 
 #ifdef USE_ASSERT_CHECKING
 static bool
@@ -393,20 +393,26 @@ create_sparse_index_column_def(List *attributes, const char *metadata_type)
 			column_def->storage = TYPSTORAGE_MAIN;
 		}
 	}
-	else /* either min or max */
+	else /* min, max, first, or last */
 	{
 		Form_pg_attribute attr = (Form_pg_attribute) lfirst(list_head(attributes));
-		TypeCacheEntry *type = lookup_type_cache(attr->atttypid, TYPECACHE_LT_OPR);
+		const bool is_minmax =
+			strcmp(metadata_type, "min") == 0 || strcmp(metadata_type, "max") == 0;
 
-		/*
-		 * a comparison operator if required for min max operations
-		 */
-		if (!OidIsValid(type->lt_opr))
+		if (is_minmax)
 		{
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-					 errmsg("invalid minmax column type %s", format_type_be(attr->atttypid)),
-					 errdetail("Could not identify a less-than operator for the type.")));
+			TypeCacheEntry *type = lookup_type_cache(attr->atttypid, TYPECACHE_LT_OPR);
+
+			/*
+			 * a comparison operator is required for min max operations
+			 */
+			if (!OidIsValid(type->lt_opr))
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_FUNCTION),
+						 errmsg("invalid minmax column type %s", format_type_be(attr->atttypid)),
+						 errdetail("Could not identify a less-than operator for the type.")));
+			}
 		}
 
 		column_def =
@@ -505,6 +511,16 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 					lappend(composite_attr_lists[per_column_setting->minmax_obj_id], attr);
 			}
 
+			if (per_column_setting->firstlast_obj_id != -1 &&
+				per_column_setting->firstlast_obj_id < num_sparse_index_objects)
+			{
+				/* Firstlast index configuration objects will have a single element list */
+				Assert(list_length(composite_attr_lists[per_column_setting->firstlast_obj_id]) ==
+					   0);
+				composite_attr_lists[per_column_setting->firstlast_obj_id] =
+					lappend(composite_attr_lists[per_column_setting->firstlast_obj_id], attr);
+			}
+
 			if (per_column_setting->single_bloom_obj_id != -1 &&
 				per_column_setting->single_bloom_obj_id < num_sparse_index_objects)
 			{
@@ -577,6 +593,7 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 			/* check sparse index columndefs is applicable */
 			bool is_bloom = per_column_setting->single_bloom_obj_id != -1;
 			bool is_minmax = per_column_setting->minmax_obj_id != -1;
+			bool is_firstlast = per_column_setting->firstlast_obj_id != -1;
 
 			/*
 			 * We allow only one sparse index per column. Columns used in the ORDER BY
@@ -626,6 +643,24 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 				def = create_sparse_index_column_def(composite_attr_lists[per_column_setting
 																			  ->minmax_obj_id],
 													 "max");
+				compressed_column_defs = lappend(compressed_column_defs, def);
+			}
+
+			if (is_firstlast)
+			{
+				/*
+				 * Add firstlast sparse index for this column.
+				 * Uses the source column's type, like minmax.
+				 */
+				ColumnDef *def =
+					create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			->firstlast_obj_id],
+												   "first");
+				compressed_column_defs = lappend(compressed_column_defs, def);
+
+				def = create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			  ->firstlast_obj_id],
+													 "last");
 				compressed_column_defs = lappend(compressed_column_defs, def);
 			}
 		}

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -61,7 +61,7 @@
 #include "bgw_policy/compression_api.h"
 
 #ifdef USE_ASSERT_CHECKING
-static const char *sparse_index_types[] = { "min", "max" };
+static const char *sparse_index_types[] = { "min", "max", "first", "last" };
 
 static bool
 is_sparse_index_type(const char *type)
@@ -387,19 +387,25 @@ create_sparse_index_column_def(List *attributes, const char *metadata_type)
 			column_def->storage = TYPSTORAGE_MAIN;
 		}
 	}
-	else /* either min or max */
+	else /* min, max, first, or last */
 	{
 		Form_pg_attribute attr = (Form_pg_attribute) lfirst(list_head(attributes));
-		TypeCacheEntry *type = lookup_type_cache(attr->atttypid, TYPECACHE_LT_OPR);
+		const bool is_minmax =
+			strcmp(metadata_type, "min") == 0 || strcmp(metadata_type, "max") == 0;
 
-		/*
-		 * a comparison operator if required for min max operations
-		 */
-		if (!OidIsValid(type->lt_opr))
-			ereport(ERROR,
-					(errcode(ERRCODE_UNDEFINED_FUNCTION),
-					 errmsg("invalid minmax column type %s", format_type_be(attr->atttypid)),
-					 errdetail("Could not identify a less-than operator for the type.")));
+		if (is_minmax)
+		{
+			TypeCacheEntry *type = lookup_type_cache(attr->atttypid, TYPECACHE_LT_OPR);
+
+			/*
+			 * a comparison operator is required for min max operations
+			 */
+			if (!OidIsValid(type->lt_opr))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_FUNCTION),
+						 errmsg("invalid minmax column type %s", format_type_be(attr->atttypid)),
+						 errdetail("Could not identify a less-than operator for the type.")));
+		}
 
 		column_def =
 			makeColumnDef(compressed_column_metadata_name_list_v2(metadata_type, column_names),
@@ -493,6 +499,16 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 					lappend(composite_attr_lists[per_column_setting->minmax_obj_id], attr);
 			}
 
+			if (per_column_setting->firstlast_obj_id != -1 &&
+				per_column_setting->firstlast_obj_id < num_sparse_index_objects)
+			{
+				/* Firstlast index configuration objects will have a single element list */
+				Assert(list_length(composite_attr_lists[per_column_setting->firstlast_obj_id]) ==
+					   0);
+				composite_attr_lists[per_column_setting->firstlast_obj_id] =
+					lappend(composite_attr_lists[per_column_setting->firstlast_obj_id], attr);
+			}
+
 			if (per_column_setting->single_bloom_obj_id != -1 &&
 				per_column_setting->single_bloom_obj_id < num_sparse_index_objects)
 			{
@@ -563,6 +579,7 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 			/* check sparse index columndefs is applicable */
 			bool is_bloom = per_column_setting->single_bloom_obj_id != -1;
 			bool is_minmax = per_column_setting->minmax_obj_id != -1;
+			bool is_firstlast = per_column_setting->firstlast_obj_id != -1;
 
 			/*
 			 * We allow only one sparse index per column. Columns used in the ORDER BY
@@ -612,6 +629,24 @@ build_columndefs(CompressionSettings *settings, Oid src_reloid)
 				def = create_sparse_index_column_def(composite_attr_lists[per_column_setting
 																			  ->minmax_obj_id],
 													 "max");
+				compressed_column_defs = lappend(compressed_column_defs, def);
+			}
+
+			if (is_firstlast)
+			{
+				/*
+				 * Add firstlast sparse index for this column.
+				 * Uses the source column's type, like minmax.
+				 */
+				ColumnDef *def =
+					create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			->firstlast_obj_id],
+												   "first");
+				compressed_column_defs = lappend(compressed_column_defs, def);
+
+				def = create_sparse_index_column_def(composite_attr_lists[per_column_setting
+																			  ->firstlast_obj_id],
+													 "last");
 				compressed_column_defs = lappend(compressed_column_defs, def);
 			}
 		}

--- a/tsl/test/expected/compress_firstlast_sparse.out
+++ b/tsl/test/expected/compress_firstlast_sparse.out
@@ -1,0 +1,302 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+-- basic configuration
+create table test_firstlast(ts timestamptz, value int, tag text);
+select create_hypertable('test_firstlast', 'ts');
+      create_hypertable      
+-----------------------------
+ (1,public,test_firstlast,t)
+
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select * from settings;
+     relid      | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                          index                                                          
+----------------+----------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------
+ test_firstlast |                |           | {ts}    | {f}          | {f}                | [{"type": "firstlast", "column": "value", "source": "config"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("tag")');
+select * from settings;
+     relid      | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+----------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ test_firstlast |                |           | {ts}    | {f}          | {f}                | [{"type": "firstlast", "column": "tag", "source": "config"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+-- firstlast alongside bloom
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value"), bloom("tag")');
+select * from settings;
+     relid      | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                      index                                                                                      
+----------------+----------------+-----------+---------+--------------+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ test_firstlast |                |           | {ts}    | {f}          | {f}                | [{"type": "firstlast", "column": "value", "source": "config"}, {"type": "bloom", "column": "tag", "source": "config"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+drop table test_firstlast;
+-- metadata column values
+create table fl_basic(ts int, value int);
+select create_hypertable('fl_basic', 'ts', chunk_time_interval => 10000);
+   create_hypertable   
+-----------------------
+ (3,public,fl_basic,t)
+
+insert into fl_basic select x, x * 10 from generate_series(1, 5) x;
+alter table fl_basic set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_basic') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
+\gset
+-- sorted by ts ASC: values are [10,20,30,40,50]
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      10 |                     50
+
+drop table fl_basic;
+-- all NULLs
+create table fl_nulls(ts int, value int);
+select create_hypertable('fl_nulls', 'ts', chunk_time_interval => 10000);
+   create_hypertable   
+-----------------------
+ (5,public,fl_nulls,t)
+
+insert into fl_nulls select x, null from generate_series(1, 5) x;
+alter table fl_nulls set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_first_value is null as first_is_null,
+       _ts_meta_v2_last_value is null as last_is_null
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value | first_is_null | last_is_null 
+-------------------------+------------------------+---------------+--------------
+                         |                        | t             | t
+
+drop table fl_nulls;
+-- mixed NULLs
+create table fl_mixed(ts int, value int);
+select create_hypertable('fl_mixed', 'ts', chunk_time_interval => 10000);
+   create_hypertable   
+-----------------------
+ (7,public,fl_mixed,t)
+
+insert into fl_mixed values (1, 10), (2, null), (3, 30), (4, null), (5, 50);
+alter table fl_mixed set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
+\gset
+-- first row (1,10), last row (5,50)
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      10 |                     50
+
+drop table fl_mixed;
+-- first row is NULL
+create table fl_firstnull(ts int, value int);
+select create_hypertable('fl_firstnull', 'ts', chunk_time_interval => 10000);
+     create_hypertable     
+---------------------------
+ (9,public,fl_firstnull,t)
+
+insert into fl_firstnull values (1, null), (2, 20), (3, 30);
+alter table fl_firstnull set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_first_value is null as first_is_null
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value | first_is_null 
+-------------------------+------------------------+---------------
+                         |                     30 | t
+
+drop table fl_firstnull;
+-- last row is NULL
+create table fl_lastnull(ts int, value int);
+select create_hypertable('fl_lastnull', 'ts', chunk_time_interval => 10000);
+     create_hypertable     
+---------------------------
+ (11,public,fl_lastnull,t)
+
+insert into fl_lastnull values (1, 10), (2, 20), (3, null);
+alter table fl_lastnull set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_last_value is null as last_is_null
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value | last_is_null 
+-------------------------+------------------------+--------------
+                      10 |                        | t
+
+drop table fl_lastnull;
+-- single row batch
+create table fl_single(ts int, value int);
+select create_hypertable('fl_single', 'ts', chunk_time_interval => 10000);
+    create_hypertable    
+-------------------------
+ (13,public,fl_single,t)
+
+insert into fl_single values (1, 42);
+alter table fl_single set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_single') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      42 |                     42
+
+drop table fl_single;
+-- multiple orderby columns
+create table fl_multi(a int, b int, value text);
+select create_hypertable('fl_multi', 'a', chunk_time_interval => 10000);
+   create_hypertable    
+------------------------
+ (15,public,fl_multi,t)
+
+insert into fl_multi values (1, 5, 'x'), (2, 3, 'w'), (1, 8, 'y'), (3, 2, 'v'), (2, 1, 'z');
+alter table fl_multi set (timescaledb.compress,
+    timescaledb.compress_orderby = 'a, b',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_multi') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
+\gset
+-- sorted: (1,5,x),(1,8,y),(2,1,z),(2,3,w),(3,2,v)
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+ x                       | v
+
+drop table fl_multi;
+-- recompression after insert
+create table fl_recompress(ts int, value int);
+select create_hypertable('fl_recompress', 'ts', chunk_time_interval => 10000);
+      create_hypertable      
+-----------------------------
+ (17,public,fl_recompress,t)
+
+insert into fl_recompress select x, x * 10 from generate_series(1, 5) x;
+alter table fl_recompress set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_recompress') x;
+ count 
+-------
+     1
+
+insert into fl_recompress values (6, 600);
+select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompress') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      10 |                     50
+                     600 |                    600
+
+drop table fl_recompress;
+-- error cases
+\set ON_ERROR_STOP 0
+create table fl_errors(ts int, value int, tag text);
+select create_hypertable('fl_errors', 'ts', chunk_time_interval => 10000);
+    create_hypertable    
+-------------------------
+ (19,public,fl_errors,t)
+
+-- duplicate column
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value"), firstlast("value")');
+ERROR:  duplicate column name "value"
+-- invalid column
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("nonexistent")');
+ERROR:  column "nonexistent" does not exist
+-- multi-column not supported
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value", "tag")');
+ERROR:  only bloom indexes can have multiple columns
+\set ON_ERROR_STOP 1
+drop table fl_errors;
+drop view settings;

--- a/tsl/test/expected/compress_firstlast_sparse.out
+++ b/tsl/test/expected/compress_firstlast_sparse.out
@@ -1,0 +1,304 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+-- basic configuration
+create table test_firstlast(ts timestamptz, value int, tag text);
+select create_hypertable('test_firstlast', 'ts');
+      create_hypertable      
+-----------------------------
+ (1,public,test_firstlast,t)
+
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select * from settings;
+     relid      | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                          index                                                          
+----------------+----------------+-----------+---------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------
+ test_firstlast |                |           | {ts}    | {f}          | {f}                | [{"type": "firstlast", "column": "value", "source": "config"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("tag")');
+NOTICE:  updated compression settings will only apply to future compressions
+select * from settings;
+     relid      | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+----------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ test_firstlast |                |           | {ts}    | {f}          | {f}                | [{"type": "firstlast", "column": "tag", "source": "config"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+-- firstlast alongside bloom
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value"), bloom("tag")');
+NOTICE:  updated compression settings will only apply to future compressions
+select * from settings;
+     relid      | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                      index                                                                                      
+----------------+----------------+-----------+---------+--------------+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ test_firstlast |                |           | {ts}    | {f}          | {f}                | [{"type": "firstlast", "column": "value", "source": "config"}, {"type": "bloom", "column": "tag", "source": "config"}, {"type": "minmax", "column": "ts", "source": "orderby"}]
+
+drop table test_firstlast;
+-- metadata column values
+create table fl_basic(ts int, value int);
+select create_hypertable('fl_basic', 'ts', chunk_time_interval => 10000);
+   create_hypertable   
+-----------------------
+ (3,public,fl_basic,t)
+
+insert into fl_basic select x, x * 10 from generate_series(1, 5) x;
+alter table fl_basic set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_basic') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
+\gset
+-- sorted by ts ASC: values are [10,20,30,40,50]
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      10 |                     50
+
+drop table fl_basic;
+-- all NULLs
+create table fl_nulls(ts int, value int);
+select create_hypertable('fl_nulls', 'ts', chunk_time_interval => 10000);
+   create_hypertable   
+-----------------------
+ (5,public,fl_nulls,t)
+
+insert into fl_nulls select x, null from generate_series(1, 5) x;
+alter table fl_nulls set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_first_value is null as first_is_null,
+       _ts_meta_v2_last_value is null as last_is_null
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value | first_is_null | last_is_null 
+-------------------------+------------------------+---------------+--------------
+                         |                        | t             | t
+
+drop table fl_nulls;
+-- mixed NULLs
+create table fl_mixed(ts int, value int);
+select create_hypertable('fl_mixed', 'ts', chunk_time_interval => 10000);
+   create_hypertable   
+-----------------------
+ (7,public,fl_mixed,t)
+
+insert into fl_mixed values (1, 10), (2, null), (3, 30), (4, null), (5, 50);
+alter table fl_mixed set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
+\gset
+-- first row (1,10), last row (5,50)
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      10 |                     50
+
+drop table fl_mixed;
+-- first row is NULL
+create table fl_firstnull(ts int, value int);
+select create_hypertable('fl_firstnull', 'ts', chunk_time_interval => 10000);
+     create_hypertable     
+---------------------------
+ (9,public,fl_firstnull,t)
+
+insert into fl_firstnull values (1, null), (2, 20), (3, 30);
+alter table fl_firstnull set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_first_value is null as first_is_null
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value | first_is_null 
+-------------------------+------------------------+---------------
+                         |                     30 | t
+
+drop table fl_firstnull;
+-- last row is NULL
+create table fl_lastnull(ts int, value int);
+select create_hypertable('fl_lastnull', 'ts', chunk_time_interval => 10000);
+     create_hypertable     
+---------------------------
+ (11,public,fl_lastnull,t)
+
+insert into fl_lastnull values (1, 10), (2, 20), (3, null);
+alter table fl_lastnull set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_last_value is null as last_is_null
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value | last_is_null 
+-------------------------+------------------------+--------------
+                      10 |                        | t
+
+drop table fl_lastnull;
+-- single row batch
+create table fl_single(ts int, value int);
+select create_hypertable('fl_single', 'ts', chunk_time_interval => 10000);
+    create_hypertable    
+-------------------------
+ (13,public,fl_single,t)
+
+insert into fl_single values (1, 42);
+alter table fl_single set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_single') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      42 |                     42
+
+drop table fl_single;
+-- multiple orderby columns
+create table fl_multi(a int, b int, value text);
+select create_hypertable('fl_multi', 'a', chunk_time_interval => 10000);
+   create_hypertable    
+------------------------
+ (15,public,fl_multi,t)
+
+insert into fl_multi values (1, 5, 'x'), (2, 3, 'w'), (1, 8, 'y'), (3, 2, 'v'), (2, 1, 'z');
+alter table fl_multi set (timescaledb.compress,
+    timescaledb.compress_orderby = 'a, b',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_multi') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
+\gset
+-- sorted: (1,5,x),(1,8,y),(2,1,z),(2,3,w),(3,2,v)
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+ x                       | v
+
+drop table fl_multi;
+-- recompression after insert
+create table fl_recompress(ts int, value int);
+select create_hypertable('fl_recompress', 'ts', chunk_time_interval => 10000);
+      create_hypertable      
+-----------------------------
+ (17,public,fl_recompress,t)
+
+insert into fl_recompress select x, x * 10 from generate_series(1, 5) x;
+alter table fl_recompress set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_recompress') x;
+ count 
+-------
+     1
+
+insert into fl_recompress values (6, 600);
+select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompress') x;
+ count 
+-------
+     1
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
+\gset
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+ _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------------------------+------------------------
+                      10 |                     50
+                     600 |                    600
+
+drop table fl_recompress;
+-- error cases
+\set ON_ERROR_STOP 0
+create table fl_errors(ts int, value int, tag text);
+select create_hypertable('fl_errors', 'ts', chunk_time_interval => 10000);
+    create_hypertable    
+-------------------------
+ (19,public,fl_errors,t)
+
+-- duplicate column
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value"), firstlast("value")');
+ERROR:  duplicate column name "value"
+-- invalid column
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("nonexistent")');
+ERROR:  column "nonexistent" does not exist
+-- multi-column not supported
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value", "tag")');
+ERROR:  only bloom indexes can have multiple columns
+\set ON_ERROR_STOP 1
+drop table fl_errors;
+drop view settings;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_FILES
     compress_compbloom_manual_config.sql
     compress_compbloom_upsert.sql
     compress_sparse_config.sql
+    compress_firstlast_sparse.sql
     compress_default.sql
     compress_dml_copy.sql
     compress_explain.sql

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_FILES
     compress_compbloom_index_drop.sql
     compress_compbloom_manual_config.sql
     compress_compbloom_upsert.sql
+    compress_firstlast_sparse.sql
     compress_default.sql
     compress_dml_copy.sql
     compress_explain.sql

--- a/tsl/test/sql/compress_firstlast_sparse.sql
+++ b/tsl/test/sql/compress_firstlast_sparse.sql
@@ -1,0 +1,234 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE VIEW settings AS SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY upper(relid::text) COLLATE "C";
+
+-- basic configuration
+create table test_firstlast(ts timestamptz, value int, tag text);
+select create_hypertable('test_firstlast', 'ts');
+
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select * from settings;
+
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("tag")');
+select * from settings;
+
+-- firstlast alongside bloom
+alter table test_firstlast set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value"), bloom("tag")');
+select * from settings;
+
+drop table test_firstlast;
+
+-- metadata column values
+create table fl_basic(ts int, value int);
+select create_hypertable('fl_basic', 'ts', chunk_time_interval => 10000);
+insert into fl_basic select x, x * 10 from generate_series(1, 5) x;
+
+alter table fl_basic set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_basic') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
+\gset
+
+-- sorted by ts ASC: values are [10,20,30,40,50]
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+
+drop table fl_basic;
+
+-- all NULLs
+create table fl_nulls(ts int, value int);
+select create_hypertable('fl_nulls', 'ts', chunk_time_interval => 10000);
+insert into fl_nulls select x, null from generate_series(1, 5) x;
+
+alter table fl_nulls set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
+\gset
+
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_first_value is null as first_is_null,
+       _ts_meta_v2_last_value is null as last_is_null
+from :compressed_chunk;
+
+drop table fl_nulls;
+
+-- mixed NULLs
+create table fl_mixed(ts int, value int);
+select create_hypertable('fl_mixed', 'ts', chunk_time_interval => 10000);
+insert into fl_mixed values (1, 10), (2, null), (3, 30), (4, null), (5, 50);
+
+alter table fl_mixed set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
+\gset
+
+-- first row (1,10), last row (5,50)
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+
+drop table fl_mixed;
+
+-- first row is NULL
+create table fl_firstnull(ts int, value int);
+select create_hypertable('fl_firstnull', 'ts', chunk_time_interval => 10000);
+insert into fl_firstnull values (1, null), (2, 20), (3, 30);
+
+alter table fl_firstnull set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
+\gset
+
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_first_value is null as first_is_null
+from :compressed_chunk;
+
+drop table fl_firstnull;
+
+-- last row is NULL
+create table fl_lastnull(ts int, value int);
+select create_hypertable('fl_lastnull', 'ts', chunk_time_interval => 10000);
+insert into fl_lastnull values (1, 10), (2, 20), (3, null);
+
+alter table fl_lastnull set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
+\gset
+
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
+       _ts_meta_v2_last_value is null as last_is_null
+from :compressed_chunk;
+
+drop table fl_lastnull;
+
+-- single row batch
+create table fl_single(ts int, value int);
+select create_hypertable('fl_single', 'ts', chunk_time_interval => 10000);
+insert into fl_single values (1, 42);
+
+alter table fl_single set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_single') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
+\gset
+
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+
+drop table fl_single;
+
+-- multiple orderby columns
+create table fl_multi(a int, b int, value text);
+select create_hypertable('fl_multi', 'a', chunk_time_interval => 10000);
+insert into fl_multi values (1, 5, 'x'), (2, 3, 'w'), (1, 8, 'y'), (3, 2, 'v'), (2, 1, 'z');
+
+alter table fl_multi set (timescaledb.compress,
+    timescaledb.compress_orderby = 'a, b',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_multi') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
+\gset
+
+-- sorted: (1,5,x),(1,8,y),(2,1,z),(2,3,w),(3,2,v)
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+
+drop table fl_multi;
+
+-- recompression after insert
+create table fl_recompress(ts int, value int);
+select create_hypertable('fl_recompress', 'ts', chunk_time_interval => 10000);
+insert into fl_recompress select x, x * 10 from generate_series(1, 5) x;
+
+alter table fl_recompress set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value")');
+select count(compress_chunk(x)) from show_chunks('fl_recompress') x;
+
+insert into fl_recompress values (6, 600);
+select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompress') x;
+
+select ch.schema_name || '.' || ch.table_name as compressed_chunk
+from _timescaledb_catalog.chunk ch
+inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
+\gset
+
+select _ts_meta_v2_first_value, _ts_meta_v2_last_value
+from :compressed_chunk;
+
+drop table fl_recompress;
+
+-- error cases
+\set ON_ERROR_STOP 0
+
+create table fl_errors(ts int, value int, tag text);
+select create_hypertable('fl_errors', 'ts', chunk_time_interval => 10000);
+
+-- duplicate column
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value"), firstlast("value")');
+
+-- invalid column
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("nonexistent")');
+
+-- multi-column not supported
+alter table fl_errors set (timescaledb.compress,
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'firstlast("value", "tag")');
+
+\set ON_ERROR_STOP 1
+
+drop table fl_errors;
+
+drop view settings;


### PR DESCRIPTION
Add a new sparse index type that stores the actual first and last values of each compressed batch in sort order, including NULLs. Unlike minmax, which skips NULLs and tracks statistical extremes, firstlast tracks positional boundary values. This enables tracking batch ordering and NULL presence at batch boundaries.