### PR TITLE
Drop existing sparse indexes when dropping columns

### DIFF
--- a/.unreleased/pr_9583
+++ b/.unreleased/pr_9583
@@ -1,0 +1,1 @@
+Implements: #9583 Drop existing sparse indexes when dropping columns

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -60,9 +60,9 @@
 
 #include "bgw_policy/compression_api.h"
 
-#ifdef USE_ASSERT_CHECKING
 static const char *sparse_index_types[] = { "min", "max" };
 
+#ifdef USE_ASSERT_CHECKING
 static bool
 is_sparse_index_type(const char *type)
 {
@@ -1078,6 +1078,21 @@ drop_column_from_compression_table(CompressionSettings *comp_settings, char *nam
 	cmd->missing_ok = true;
 	cmds = list_make1(cmd);
 
+	/* always try to drop sparse index metadata columns */
+	for (size_t i = 0; i < sizeof(sparse_index_types) / sizeof(sparse_index_types[0]); i++)
+	{
+		char *meta_name =
+			compressed_column_metadata_name_v2(sparse_index_types[i], (const char **) &name, 1);
+		if (get_attnum(relid, meta_name) != InvalidAttrNumber)
+		{
+			cmd = makeNode(AlterTableCmd);
+			cmd->subtype = AT_DropColumn;
+			cmd->name = meta_name;
+			cmd->missing_ok = true;
+			cmds = lappend(cmds, cmd);
+		}
+	}
+
 	if (jb)
 	{
 		SparseIndexSettings *parsed_settings = ts_convert_to_sparse_index_settings(jb);
@@ -1108,6 +1123,9 @@ drop_column_from_compression_table(CompressionSettings *comp_settings, char *nam
 								compressed_column_metadata_name_list_v2(bloom1_column_prefix,
 																		pair->values);
 							Assert(bloom_column_name != NULL);
+							/* No need to remove if its not there */
+							if (get_attnum(relid, bloom_column_name) == InvalidAttrNumber)
+								bloom_column_name = NULL;
 							break;
 						}
 					}

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -626,3 +626,170 @@ select * from settings;
 
 reset timescaledb.enable_sparse_index_bloom;
 drop table test_sparse_index;
+-- Test drop column with sparse indexes
+create table test_drop_sparse(x int, value text, u uuid, ts timestamp, extra text);
+select create_hypertable('test_drop_sparse', 'x');
+WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
+       create_hypertable       
+-------------------------------
+ (7,public,test_drop_sparse,t)
+
+insert into test_drop_sparse
+select x, md5(x::text),
+    '6c1d0998-05f3-452c-abd3-45afe72bbcab'::uuid,
+    '2021-01-01'::timestamp + (interval '1 hour') * x,
+    'extra'
+from generate_series(1, 1000) x;
+-- Configure with bloom on u, minmax on ts, composite bloom on (u, extra)
+alter table test_drop_sparse set (timescaledb.compress,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u"), minmax("ts"), bloom("u","extra")');
+select * from settings;
+      relid       | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                  index                                                                                                                  
+------------------+----------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ test_drop_sparse |                | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "minmax", "column": "ts", "source": "config"}, {"type": "bloom", "column": ["u", "extra"], "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+
+select count(compress_chunk(x)) from show_chunks('test_drop_sparse') x;
+ count 
+-------
+     1
+
+select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
+    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+        where hypertable_id = (select id from _timescaledb_catalog.hypertable
+            where table_name = 'test_drop_sparse') limit 1)
+\gset
+-- Show columns before drop
+select * from test.show_columns_ext(:'chunk'::regclass);
+           Column           |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count             | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1             | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1             | integer                               |           |          |         | plain    |         1000 | 
+ x                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ value                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_u       | _timescaledb_internal.bloom1          |           |          |         | external |         1000 | 
+ u                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ _ts_meta_v2_min_ts         | timestamp without time zone           |           |          |         | plain    |         1000 | 
+ _ts_meta_v2_max_ts         | timestamp without time zone           |           |          |         | plain    |         1000 | 
+ ts                         | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ extra                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_u_extra | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
+
+-- Drop column with minmax sparse index
+alter table test_drop_sparse drop column ts;
+select * from settings;
+                  relid                  |                 compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                      index                                                                                      
+-----------------------------------------+-------------------------------------------------+-----------+---------+--------------+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ test_drop_sparse                        |                                                 | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "bloom", "column": ["u", "extra"], "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+ _timescaledb_internal._hyper_7_11_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "bloom", "column": ["u", "extra"], "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+           Column           |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count             | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1             | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1             | integer                               |           |          |         | plain    |         1000 | 
+ x                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ value                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_u       | _timescaledb_internal.bloom1          |           |          |         | external |         1000 | 
+ u                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ extra                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_u_extra | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
+
+-- Verify data is still queryable
+select count(*) from test_drop_sparse;
+ count 
+-------
+  1000
+
+-- Drop column with bloom sparse index (also part of composite bloom)
+alter table test_drop_sparse drop column u;
+select * from settings;
+                  relid                  |                 compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                          index                           
+-----------------------------------------+-------------------------------------------------+-----------+---------+--------------+--------------------+----------------------------------------------------------
+ test_drop_sparse                        |                                                 | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
+ _timescaledb_internal._hyper_7_11_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+     Column     |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1 | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1 | integer                               |           |          |         | plain    |         1000 | 
+ x              | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ value          | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ extra          | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+
+-- Verify data is still queryable
+select count(*) from test_drop_sparse;
+ count 
+-------
+  1000
+
+-- Drop column with only composite bloom participation
+drop table test_drop_sparse;
+create table test_drop_sparse2(x int, a text, b text, c text);
+select create_hypertable('test_drop_sparse2', 'x');
+       create_hypertable        
+--------------------------------
+ (9,public,test_drop_sparse2,t)
+
+insert into test_drop_sparse2
+select x, 'a', 'b', 'c' from generate_series(1, 1000) x;
+alter table test_drop_sparse2 set (timescaledb.compress,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("a","b","c")');
+select * from settings;
+       relid       | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                           index                                                            
+-------------------+----------------+-----------+---------+--------------+--------------------+----------------------------------------------------------------------------------------------------------------------------
+ test_drop_sparse2 |                | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": ["a", "b", "c"], "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
+
+select count(compress_chunk(x)) from show_chunks('test_drop_sparse2') x;
+ count 
+-------
+     1
+
+select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
+    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+        where hypertable_id = (select id from _timescaledb_catalog.hypertable
+            where table_name = 'test_drop_sparse2') limit 1)
+\gset
+select * from test.show_columns_ext(:'chunk'::regclass);
+          Column          |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count           | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1           | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1           | integer                               |           |          |         | plain    |         1000 | 
+ x                        | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ a                        | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ b                        | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ c                        | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_a_b_c | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
+
+-- Drop one column from the composite bloom
+alter table test_drop_sparse2 drop column b;
+select * from settings;
+                  relid                  |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                          index                           
+-----------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+----------------------------------------------------------
+ test_drop_sparse2                       |                                                  | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
+ _timescaledb_internal._hyper_9_13_chunk | _timescaledb_internal.compress_hyper_10_14_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "minmax", "column": "x", "source": "orderby"}]
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+     Column     |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1 | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1 | integer                               |           |          |         | plain    |         1000 | 
+ x              | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ a              | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ c              | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+
+select count(*) from test_drop_sparse2;
+ count 
+-------
+  1000
+
+drop table test_drop_sparse2;

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -407,3 +407,85 @@ select * from test.show_columns_ext(:'chunk'::regclass);
 select * from settings;
 reset timescaledb.enable_sparse_index_bloom;
 drop table test_sparse_index;
+
+-- Test drop column with sparse indexes
+create table test_drop_sparse(x int, value text, u uuid, ts timestamp, extra text);
+select create_hypertable('test_drop_sparse', 'x');
+
+insert into test_drop_sparse
+select x, md5(x::text),
+    '6c1d0998-05f3-452c-abd3-45afe72bbcab'::uuid,
+    '2021-01-01'::timestamp + (interval '1 hour') * x,
+    'extra'
+from generate_series(1, 1000) x;
+
+-- Configure with bloom on u, minmax on ts, composite bloom on (u, extra)
+alter table test_drop_sparse set (timescaledb.compress,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("u"), minmax("ts"), bloom("u","extra")');
+select * from settings;
+
+select count(compress_chunk(x)) from show_chunks('test_drop_sparse') x;
+
+select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
+    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+        where hypertable_id = (select id from _timescaledb_catalog.hypertable
+            where table_name = 'test_drop_sparse') limit 1)
+\gset
+
+-- Show columns before drop
+select * from test.show_columns_ext(:'chunk'::regclass);
+
+-- Drop column with minmax sparse index
+alter table test_drop_sparse drop column ts;
+select * from settings;
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+
+-- Verify data is still queryable
+select count(*) from test_drop_sparse;
+
+-- Drop column with bloom sparse index (also part of composite bloom)
+alter table test_drop_sparse drop column u;
+select * from settings;
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+
+-- Verify data is still queryable
+select count(*) from test_drop_sparse;
+
+-- Drop column with only composite bloom participation
+drop table test_drop_sparse;
+
+create table test_drop_sparse2(x int, a text, b text, c text);
+select create_hypertable('test_drop_sparse2', 'x');
+
+insert into test_drop_sparse2
+select x, 'a', 'b', 'c' from generate_series(1, 1000) x;
+
+alter table test_drop_sparse2 set (timescaledb.compress,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'x',
+    timescaledb.compress_index = 'bloom("a","b","c")');
+select * from settings;
+
+select count(compress_chunk(x)) from show_chunks('test_drop_sparse2') x;
+
+select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
+    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+        where hypertable_id = (select id from _timescaledb_catalog.hypertable
+            where table_name = 'test_drop_sparse2') limit 1)
+\gset
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+
+-- Drop one column from the composite bloom
+alter table test_drop_sparse2 drop column b;
+select * from settings;
+
+select * from test.show_columns_ext(:'chunk'::regclass);
+
+select count(*) from test_drop_sparse2;
+
+drop table test_drop_sparse2;


### PR DESCRIPTION
When dropping a column on a hypertable which has compression enabled and sparse indexes configured on that columns, we should also drop the sparse index columns associated with that column. This change adds that for minmax sparse index. Bloom indexes are already covered.