### PR TITLE
timescaledb hypertable expansion for non-target tables of DML queries

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -432,11 +432,15 @@ preprocess_query(Node *node, PreprocessQueryContext *context)
 
 					if (ht)
 					{
-						/* Mark hypertable RTEs we'd like to expand ourselves */
+						/* Mark hypertable RTEs we'd like to expand ourselves.
+						 * We skip the DML target relation (resultRelation != 0
+						 * in the current query) but allow non-target hypertables
+						 * in subqueries of UPDATE/DELETE to use TSDB expansion. */
 						if (ts_guc_enable_optimizations && ts_guc_enable_constraint_exclusion &&
-							!IS_UPDL_CMD(context->rootquery) && query->resultRelation == 0 &&
-							rte->inh)
+							query->resultRelation == 0 && rte->inh)
+						{
 							rte_mark_for_expansion(rte);
+						}
 
 						if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 						{
@@ -1420,38 +1424,18 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 	Query *query = root->parse;
 	Hypertable *ht;
 	const TsRelType type = ts_classify_relation(root, rel, &ht);
-	AclMode requiredPerms = 0;
-
-#if PG16_LT
-	requiredPerms = rte->requiredPerms;
-#else
-	if (rte->perminfoindex > 0)
-	{
-		RTEPermissionInfo *perminfo = getRTEPermissionInfo(query->rteperminfos, rte);
-		requiredPerms = perminfo->requiredPerms;
-	}
-#endif
 
 	switch (type)
 	{
 		case TS_REL_HYPERTABLE:
 		{
 			/* Mark hypertable RTEs we'd like to expand ourselves.
-			 * Hypertables inside inlineable functions don't get marked during the query
-			 * preprocessing step. Therefore we do an extra try here. However, we need to
-			 * be careful for UPDATE/DELETE as Postgres (in at least version 12) plans them
-			 * in a complicated way (see planner.c:inheritance_planner). First, it runs the
-			 * UPDATE/DELETE through the planner as a simulated SELECT. It uses the results
-			 * of this fake planning to adapt its own UPDATE/DELETE plan. Then it's planned
-			 * a second time as a real UPDATE/DELETE, but with requiredPerms set to 0, as it
-			 * assumes permission checking has been done already during the first planner call.
-			 * We don't want to touch the UPDATE/DELETEs, so we need to check all the regular
-			 * conditions here that are checked during preprocess_query, as well as the
-			 * condition that requiredPerms is not requiring UPDATE/DELETE on this rel.
+			 * Hypertables inside inlineable functions don't get marked during
+			 * the query preprocessing step. Therefore we do an extra try here.
+			 * We skip the DML target relation identified by resultRelation.
 			 */
 			if (ts_guc_enable_optimizations && ts_guc_enable_constraint_exclusion && inhparent &&
-				rte->ctename == NULL && !IS_UPDL_CMD(query) && query->resultRelation == 0 &&
-				(requiredPerms & (ACL_UPDATE | ACL_DELETE)) == 0)
+				rte->ctename == NULL && rel->relid != (Index) query->resultRelation)
 			{
 				rte_mark_for_expansion(rte);
 			}

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -125,13 +125,13 @@ WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series
                      ->  HashAggregate
                            Group Key: "two_Partitions_1".series_1
                            ->  Append
-                                 ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_1_chunk "two_Partitions_6"
+                                 ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_1_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
-                                 ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_2_chunk "two_Partitions_7"
+                                 ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_2_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
-                                 ->  Index Scan using "_hyper_1_3_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_3_chunk "two_Partitions_8"
+                                 ->  Index Scan using "_hyper_1_3_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_3_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
-                                 ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_4_chunk "two_Partitions_9"
+                                 ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_4_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/plan_hypertable_inline.out
+++ b/test/expected/plan_hypertable_inline.out
@@ -40,17 +40,13 @@ RETURNS SETOF test LANGUAGE SQL STABLE
 as $f$
    SELECT * FROM test WHERE b >= _ts AND b <= _ts + 2 FOR UPDATE
 $f$;
--- pruning should not be done by TimescaleDb in this case
--- specifically, the parent hypertable must exist in the output plan
+-- pruning can be done by TimescaleDb in this case since it now properly supports row marks
 :PREFIX SELECT * FROM test_f(5);
 --- QUERY PLAN ---
  Subquery Scan on test_f
    ->  LockRows
-         ->  Append
-               ->  Seq Scan on test test_1
-                     Filter: ((b >= '5'::bigint) AND (b <= '7'::bigint))
-               ->  Index Scan using _hyper_1_1_chunk_test_b_idx on _hyper_1_1_chunk test_2
-                     Index Cond: ((b >= '5'::bigint) AND (b <= '7'::bigint))
+         ->  Index Scan using _hyper_1_1_chunk_test_b_idx on _hyper_1_1_chunk
+               Index Cond: ((b >= '5'::bigint) AND (b <= '7'::bigint))
 
 :PREFIX SELECT * FROM test WHERE b >= 5 AND b <= 5 + 2 FOR UPDATE;
 --- QUERY PLAN ---

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -95,11 +95,11 @@ WHERE series_1 IN (SELECT series_1 FROM "one_Partition" WHERE series_1 > series_
                      ->  HashAggregate
                            Group Key: "one_Partition_1".series_1
                            ->  Append
-                                 ->  Index Scan using "_hyper_1_1_chunk_one_Partition_timeCustom_series_1_idx" on _hyper_1_1_chunk "one_Partition_5"
+                                 ->  Index Scan using "_hyper_1_1_chunk_one_Partition_timeCustom_series_1_idx" on _hyper_1_1_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
-                                 ->  Index Scan using "_hyper_1_2_chunk_one_Partition_timeCustom_series_1_idx" on _hyper_1_2_chunk "one_Partition_6"
+                                 ->  Index Scan using "_hyper_1_2_chunk_one_Partition_timeCustom_series_1_idx" on _hyper_1_2_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
-                                 ->  Index Scan using "_hyper_1_3_chunk_one_Partition_timeCustom_series_1_idx" on _hyper_1_3_chunk "one_Partition_7"
+                                 ->  Index Scan using "_hyper_1_3_chunk_one_Partition_timeCustom_series_1_idx" on _hyper_1_3_chunk
                                        Index Cond: (series_1 > (series_val())::double precision)
 
 SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id, series_0, series_1, series_2;

--- a/test/sql/plan_hypertable_inline.sql
+++ b/test/sql/plan_hypertable_inline.sql
@@ -32,8 +32,7 @@ as $f$
 $f$;
 
 
--- pruning should not be done by TimescaleDb in this case
--- specifically, the parent hypertable must exist in the output plan
+-- pruning can be done by TimescaleDb in this case since it now properly supports row marks
 :PREFIX SELECT * FROM test_f(5);
 
 :PREFIX SELECT * FROM test WHERE b >= 5 AND b <= 5 + 2 FOR UPDATE;

--- a/tsl/test/expected/modify_exclusion-15.out
+++ b/tsl/test/expected/modify_exclusion-15.out
@@ -1028,14 +1028,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1066,18 +1066,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1112,18 +1112,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1158,14 +1158,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1196,18 +1196,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1242,18 +1242,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 -- join

--- a/tsl/test/expected/modify_exclusion-16.out
+++ b/tsl/test/expected/modify_exclusion-16.out
@@ -1028,14 +1028,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1066,18 +1066,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1112,18 +1112,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1158,14 +1158,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1196,18 +1196,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1242,18 +1242,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 -- join

--- a/tsl/test/expected/modify_exclusion-17.out
+++ b/tsl/test/expected/modify_exclusion-17.out
@@ -1028,14 +1028,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1066,18 +1066,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1112,18 +1112,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1158,14 +1158,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1196,18 +1196,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1242,18 +1242,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 -- join

--- a/tsl/test/expected/modify_exclusion-18.out
+++ b/tsl/test/expected/modify_exclusion-18.out
@@ -1028,14 +1028,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1066,18 +1066,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1112,18 +1112,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1158,14 +1158,14 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
 
 ROLLBACK;
 BEGIN;
@@ -1196,18 +1196,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 BEGIN;
@@ -1242,18 +1242,18 @@ BEGIN;
                            Output: metrics_int2.ctid, metrics_int2."time", metrics_int2.tableoid
                            Group Key: metrics_int2."time"
                            ->  Append (actual rows=4.00 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk metrics_int2_1 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_1.ctid, metrics_int2_1."time", metrics_int2_1.tableoid
-                                       Index Cond: (metrics_int2_1."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk metrics_int2_2 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_2.ctid, metrics_int2_2."time", metrics_int2_2.tableoid
-                                       Index Cond: (metrics_int2_2."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk metrics_int2_3 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_3.ctid, metrics_int2_3."time", metrics_int2_3.tableoid
-                                       Index Cond: (metrics_int2_3."time" < length(version()))
-                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk metrics_int2_4 (actual rows=1.00 loops=1)
-                                       Output: metrics_int2_4.ctid, metrics_int2_4."time", metrics_int2_4.tableoid
-                                       Index Cond: (metrics_int2_4."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_1_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_1_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_1_chunk.ctid, _hyper_1_1_chunk."time", _hyper_1_1_chunk.tableoid
+                                       Index Cond: (_hyper_1_1_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_9_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_9_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_9_chunk.ctid, _hyper_1_9_chunk."time", _hyper_1_9_chunk.tableoid
+                                       Index Cond: (_hyper_1_9_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_17_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_17_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_17_chunk.ctid, _hyper_1_17_chunk."time", _hyper_1_17_chunk.tableoid
+                                       Index Cond: (_hyper_1_17_chunk."time" < length(version()))
+                                 ->  Index Scan Backward using _hyper_1_25_chunk_metrics_int2_time_idx on _timescaledb_internal._hyper_1_25_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_1_25_chunk.ctid, _hyper_1_25_chunk."time", _hyper_1_25_chunk.tableoid
+                                       Index Cond: (_hyper_1_25_chunk."time" < length(version()))
 
 ROLLBACK;
 -- join


### PR DESCRIPTION
Currently we disable the hypertable expansion for any table at any level in a DML query, but it should already work properly for the tables that are not the target relation.

Part of https://github.com/timescale/timescaledb/pull/9315

Disable-check: force-changelog-file