### PR TITLE
Fix policy skipping uncompressed chunks

### DIFF
--- a/.unreleased/pr_9590
+++ b/.unreleased/pr_9590
@@ -1,0 +1,1 @@
+Fixes: #9590 Fix policy skipping uncompressed chunks

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -65,8 +65,7 @@ DECLARE
   -- fully compressed chunk status
   status_fully_compressed int := 1;
   -- chunk status bits:
-  bit_compressed int := 1;
-  bit_compressed_unordered int := 2;
+  bit_uncompressed int := 0;
   bit_frozen int := 4;
   bit_compressed_partial int := 8;
   creation_lag INTERVAL := NULL;
@@ -113,7 +112,7 @@ BEGIN
     AND ch.status & bit_frozen = 0
   LOOP
     BEGIN
-      IF chunk_rec.status = bit_compressed OR recompress_enabled IS TRUE THEN
+      IF chunk_rec.status = bit_uncompressed OR recompress_enabled IS TRUE THEN
         PERFORM @extschema@.compress_chunk(chunk_rec.oid);
         numchunks_compressed := numchunks_compressed + 1;
       END IF;

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -949,6 +949,67 @@ SELECT _timescaledb_functions.restart_background_workers();
 ----------------------------
  t
 
+-- Test that uncompressed chunks (status=0) are compressed even when
+-- recompress is explicitly disabled.
+CREATE TABLE sensor_data_recompress
+(
+    time timestamptz not null,
+    sensor_id integer not null,
+    cpu double precision null,
+    temperature double precision null
+);
+SELECT FROM create_hypertable('sensor_data_recompress', 'time');
+--
+
+INSERT INTO sensor_data_recompress
+	SELECT
+		time,
+		sensor_id,
+		random() AS cpu,
+		random() * 100 AS temperature
+	FROM
+		generate_series('2022-08-01'::timestamptz, '2022-09-01'::timestamptz, INTERVAL '30 minute') AS g1(time),
+		generate_series(1, 10, 1) AS g2(sensor_id)
+	ORDER BY time;
+-- enable compression
+ALTER TABLE sensor_data_recompress SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+-- verify we have uncompressed chunks
+SELECT count(*) > 0 AS has_uncompressed_chunks
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_recompress' AND NOT is_compressed;
+ has_uncompressed_chunks 
+-------------------------
+ t
+
+-- add compression policy with recompress explicitly set to false
+SELECT add_compression_policy('sensor_data_recompress', INTERVAL '1 minute') AS compressjob_recompress_id \gset
+SELECT alter_job(id, config := jsonb_set(config, '{recompress}', 'false')) FROM _timescaledb_catalog.bgw_job WHERE id = :compressjob_recompress_id;
+                                                                                                      alter_job                                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1015,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""recompress"": false, ""hypertable_id"": 6, ""compress_after"": ""@ 1 min""}",-infinity,_timescaledb_functions.policy_compression_check,f,,,"Columnstore Policy [1015]")
+
+-- run the compression policy
+CALL run_job(:compressjob_recompress_id);
+-- all chunks should be compressed even with recompress=false
+SELECT count(*) = 0 AS all_chunks_compressed
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_recompress' AND NOT is_compressed;
+ all_chunks_compressed 
+-----------------------
+ t
+
+-- cleanup
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+
+DROP TABLE sensor_data_recompress;
+SELECT _timescaledb_functions.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+
 -- Github issue #5537
 -- Proc that waits until the given job enters the expected state
 CREATE OR REPLACE PROCEDURE wait_for_job_status(job_param_id INTEGER, expected_status TEXT, spins INTEGER=:TEST_SPINWAIT_ITERS)
@@ -999,9 +1060,9 @@ SELECT job_id, job_status, next_start,
   ORDER BY job_id;
  job_id | job_status | next_start | total_runs | total_successes | total_failures 
 --------+------------+------------+------------+-----------------+----------------
-   1015 | Running    | -infinity  |          1 |               0 |              0
    1016 | Running    | -infinity  |          1 |               0 |              0
    1017 | Running    | -infinity  |          1 |               0 |              0
+   1018 | Running    | -infinity  |          1 |               0 |              0
 
 SELECT job_id, err_message
   FROM timescaledb_information.job_errors
@@ -1044,12 +1105,12 @@ SELECT add_job('custom_proc', '1h') AS job_proc \gset
 SELECT ts_test_bgw_job_function_call_string(:job_func);
   ts_test_bgw_job_function_call_string   
 -----------------------------------------
- SELECT public.custom_func('1018', NULL)
+ SELECT public.custom_func('1019', NULL)
 
 SELECT ts_test_bgw_job_function_call_string(:job_proc);
  ts_test_bgw_job_function_call_string  
 ---------------------------------------
- CALL public.custom_proc('1019', NULL)
+ CALL public.custom_proc('1020', NULL)
 
 SELECT delete_job(:job_func);
  delete_job 
@@ -1066,19 +1127,19 @@ SELECT add_job('custom_proc', '1h', config => '{"type":"procedure"}'::jsonb) AS 
 SELECT ts_test_bgw_job_function_call_string(:job_func);
            ts_test_bgw_job_function_call_string            
 -----------------------------------------------------------
- SELECT public.custom_func('1020', '{"type": "function"}')
+ SELECT public.custom_func('1021', '{"type": "function"}')
 
 SELECT ts_test_bgw_job_function_call_string(:job_proc);
            ts_test_bgw_job_function_call_string           
 ----------------------------------------------------------
- CALL public.custom_proc('1021', '{"type": "procedure"}')
+ CALL public.custom_proc('1022', '{"type": "procedure"}')
 
 -- Remove the procedure and let's check it fallingback to PROKIND_FUNCTION
 DROP PROCEDURE custom_proc(jobid int, args jsonb);
 SELECT ts_test_bgw_job_function_call_string(:job_proc);
             ts_test_bgw_job_function_call_string            
 ------------------------------------------------------------
- SELECT public.custom_proc('1021', '{"type": "procedure"}')
+ SELECT public.custom_proc('1022', '{"type": "procedure"}')
 
 \set ON_ERROR_STOP 0
 -- Mess with pg catalog to don't identify the PROKIND
@@ -1114,7 +1175,7 @@ CALL run_job(:job_work_mem);
 SELECT * FROM work_mem_log;
  job_id | work_mem_value 
 --------+----------------
-   1022 | 123MB
+   1023 | 123MB
 
 -- Cleanup
 SELECT delete_job(:job_work_mem);

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -828,7 +828,7 @@ SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
 ERROR:  columnstore policy failure
 DETAIL:  Failed to convert '31' chunks to columnstore. Successfully converted '0' chunks.
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 120 at RAISE
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 119 at RAISE
 SQL statement "CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time)"
 PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 62 at CALL
 \set VERBOSITY terse

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -629,6 +629,56 @@ SELECT count(*) = 0
 -- cleanup
 SELECT _timescaledb_functions.stop_background_workers();
 DROP TABLE sensor_data;
+
+SELECT _timescaledb_functions.restart_background_workers();
+
+-- Test that uncompressed chunks (status=0) are compressed even when
+-- recompress is explicitly disabled.
+CREATE TABLE sensor_data_recompress
+(
+    time timestamptz not null,
+    sensor_id integer not null,
+    cpu double precision null,
+    temperature double precision null
+);
+
+SELECT FROM create_hypertable('sensor_data_recompress', 'time');
+
+INSERT INTO sensor_data_recompress
+	SELECT
+		time,
+		sensor_id,
+		random() AS cpu,
+		random() * 100 AS temperature
+	FROM
+		generate_series('2022-08-01'::timestamptz, '2022-09-01'::timestamptz, INTERVAL '30 minute') AS g1(time),
+		generate_series(1, 10, 1) AS g2(sensor_id)
+	ORDER BY time;
+
+-- enable compression
+ALTER TABLE sensor_data_recompress SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+
+-- verify we have uncompressed chunks
+SELECT count(*) > 0 AS has_uncompressed_chunks
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_recompress' AND NOT is_compressed;
+
+-- add compression policy with recompress explicitly set to false
+SELECT add_compression_policy('sensor_data_recompress', INTERVAL '1 minute') AS compressjob_recompress_id \gset
+SELECT alter_job(id, config := jsonb_set(config, '{recompress}', 'false')) FROM _timescaledb_catalog.bgw_job WHERE id = :compressjob_recompress_id;
+
+-- run the compression policy
+CALL run_job(:compressjob_recompress_id);
+
+-- all chunks should be compressed even with recompress=false
+SELECT count(*) = 0 AS all_chunks_compressed
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'sensor_data_recompress' AND NOT is_compressed;
+
+-- cleanup
+SELECT _timescaledb_functions.stop_background_workers();
+DROP TABLE sensor_data_recompress;
+
 SELECT _timescaledb_functions.restart_background_workers();
 
 -- Github issue #5537


### PR DESCRIPTION
The compression policy compared chunk status against bit_compressed (1) instead of 0. Since the WHERE
clause already excludes status=1, this was always
false. Uncompressed chunks were only compressed when recompress_enabled was true (the default), masking the bug.\