### PR TITLE
Limit apt install steps to 3 minutes

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -44,6 +44,7 @@ jobs:
 
     steps:
     - name: Add repositories
+      timeout-minutes: 3
       run: |
         apt-get update
         apt-get install -y wget lsb-release gnupg sudo postgresql-common git cmake jq
@@ -54,6 +55,7 @@ jobs:
         wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor -o /etc/apt/trusted.gpg.d/timescale_timescaledb.gpg
 
     - name: Install timescaledb
+      timeout-minutes: 3
       run: |
         apt-get update
         apt-get install -y --no-install-recommends \

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -42,6 +42,7 @@ jobs:
 
     steps:
     - name: Add repositories
+      timeout-minutes: 3
       run: |
         apt-get update
         apt-get install -y wget lsb-release gnupg apt-transport-https sudo postgresql-common jq
@@ -57,6 +58,7 @@ jobs:
 
 
     - name: Install timescaledb
+      timeout-minutes: 3
       run: |
         apt-get update
         apt-get install -y --no-install-recommends \
@@ -108,6 +110,7 @@ jobs:
         fi
 
     - name: Install toolkit
+      timeout-minutes: 3
       run: |
         apt-get install -y --no-install-recommends \
           timescaledb-toolkit-postgresql-${{ matrix.pg }}

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get -y install coccinelle

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -77,7 +77,8 @@ jobs:
     env:
       LLVM_VER: 17
     steps:
-    - name: Install dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
           gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
           gpg --batch --export --export-options export-minimal --armor 15CF4D18AF4F7421 | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -22,7 +22,8 @@ jobs:
         pg: [16, 17, 18]
         os: [ubuntu-22.04]
     steps:
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -100,7 +100,8 @@ jobs:
     runs-on: timescaledb-runner-arm64
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     steps:
-      - name: Install dependencies
+      - name: Install Linux Dependencies
+        timeout-minutes: 3
         run: |
           sudo apt-get update
           sudo apt-get install jq

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
         # If needed, install them before opening the core dump.

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -101,11 +101,13 @@ jobs:
 
     # /__e/node16/bin/node (used by actions/checkout@v4) needs 64-bit libraries
     - name: Install 64-bit libraries for GitHub actions
+      timeout-minutes: 3
       run: |
         apt-get update
         apt-get install -y lib64atomic1 lib64gcc-s1 lib64stdc++6 libc6-amd64 jq
 
     - name: Install build dependencies
+      timeout-minutes: 3
       run: |
         PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
         echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -78,6 +78,7 @@ jobs:
     steps:
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
+      timeout-minutes: 3
       run: |
         # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
         # If needed, install them before opening the core dump.

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -69,6 +69,7 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install cmake flex bison systemd-coredump gdb \

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common python3-psutil

--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -76,11 +76,12 @@ jobs:
       - name: Checkout TimescaleDB
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Dependencies
+      - name: Install Linux Dependencies
         # we want the right version of Postgres for handling any dump file
+        timeout-minutes: 3
         run: |
           sudo apt-get update
-          sudo apt-get install gnupg postgresql-common 
+          sudo apt-get install gnupg postgresql-common
           yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
           sudo apt-get update
           sudo apt-get install postgresql-17 

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -15,7 +15,8 @@ jobs:
 
     steps:
 
-    - name: Install dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get purge llvm-16 llvm-17 llvm-18 clang-16 clang-17 clang-18
@@ -44,6 +45,7 @@ jobs:
         clang-tidy --load /usr/local/lib/libPostgresCheck.so --checks='-*,postgres-*' --list-checks | grep postgres
 
     - name: Configure timescaledb
+      timeout-minutes: 3
       run: |
         # installing postgres headers pulls in llvm-17 which confuses pg_ladybug build process so we install this here instead of at beginning
         sudo apt-get install postgresql-server-dev-16

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -48,6 +48,7 @@ jobs:
 
     steps:
       - name: Install Linux Dependencies
+        timeout-minutes: 3
         run: |
           sudo apt-get update
           sudo apt-get install pip postgresql-common
@@ -57,6 +58,7 @@ jobs:
           pip install testgres
 
       - name: Install PostgreSQL ${{ matrix.pg_version_old}} and ${{ matrix.pg_version_new }}
+        timeout-minutes: 3
         run: |
           yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
           echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list

--- a/.github/workflows/release_feature_freeze_ceremony.yaml
+++ b/.github/workflows/release_feature_freeze_ceremony.yaml
@@ -82,7 +82,8 @@ jobs:
           git config user.name "timescale-automation"
           git config user.email "123763385+github-actions[bot]@users.noreply.github.com"
 
-      - name: Install Dependencies
+      - name: Install Linux Dependencies
+        timeout-minutes: 3
         run: |
           sudo apt-get update
           sudo apt-get install pip

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -82,6 +82,7 @@ jobs:
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
     steps:
     - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -28,7 +28,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install shellcheck

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -60,6 +60,7 @@ jobs:
     steps:
 
     - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
         # If needed, install them before opening the core dump.

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -30,7 +30,8 @@ jobs:
       JOB_NAME: SQLsmith PG${{ matrix.pg }}
 
     steps:
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common \

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -72,6 +72,7 @@ jobs:
 
     - name: Install Linux Dependencies
       if: steps.check.outputs.should_run == 'true'
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install flex bison cmake

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -39,7 +39,8 @@ jobs:
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
+      timeout-minutes: 3
       run: |
         sudo apt-get update
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev


### PR DESCRIPTION
The Azure Ubuntu mirror sometimes throttles heavily, and these jobs don't fail and take over an hour. Failing is preferrable to reduce the CI load.

The problem is described e.g. here https://github.com/actions/runner-images/issues/12949