### PR TITLE
Fix diff in "tests fail on old code" workflow

### DIFF
--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -41,8 +41,14 @@ jobs:
 
         echo "Looking at PR event ref $(git rev-parse @) vs base $(git rev-parse base)"
 
+        # Use merge-base to only see changes introduced by the PR.
+        # Main can advance after the PR merge ref was created, so
+        # diffing against the fetched main directly would pick up
+        # unrelated changes.
+        MERGE_BASE=$(git merge-base base HEAD)
+
         # Code changes: anything under src/ directories
-        readarray -t CODE_CHANGES < <(git diff --name-only base HEAD -- $CODE_PATHS)
+        readarray -t CODE_CHANGES < <(git diff --name-only "$MERGE_BASE" HEAD -- $CODE_PATHS)
 
         if ! ((${#CODE_CHANGES[@]}))
         then
@@ -55,7 +61,7 @@ jobs:
         # For versioned test outputs, we should only check the version that
         # matches the Postgers version we build.
         readarray -t CHANGED_TESTS < <( \
-            git diff --name-only base HEAD -- test/expected test/isolation/expected \
+            git diff --name-only "$MERGE_BASE" HEAD -- test/expected test/isolation/expected \
                 tsl/test/expected tsl/test/isolation/expected tsl/test/shared/expected \
             | sed -n 's!^.*expected/\([^/ -]\+\(-${{ steps.pg.outputs.major }}\)\?\)\.out$!\1!gp')
 

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -37,15 +37,17 @@ jobs:
     - name: Check for code and test changes
       id: check
       run: |
-        git fetch origin ${{ github.base_ref }}:base
+        set -euo pipefail
 
-        echo "Looking at PR event ref $(git rev-parse @) vs base $(git rev-parse base)"
+        git fetch origin ${{ github.base_ref }}:base
 
         # Use merge-base to only see changes introduced by the PR.
         # Main can advance after the PR merge ref was created, so
         # diffing against the fetched main directly would pick up
         # unrelated changes.
         MERGE_BASE=$(git merge-base base HEAD)
+
+        echo "Looking at PR event ref $(git rev-parse @), base $(git rev-parse base), merge base ${MERGE_BASE}"
 
         # Code changes: anything under src/ directories
         readarray -t CODE_CHANGES < <(git diff --name-only "$MERGE_BASE" HEAD -- $CODE_PATHS)


### PR DESCRIPTION
It was picking up unrelated changes when the main branch goes forward against the PR merge reference. This is uncommon but can happen because there's no interlock.

Example failure: https://github.com/timescale/timescaledb/actions/runs/24391348361/job/71237904479?pr=9582