### PR TITLE
Stabilize `cagg_refresh_cleanup_register` test

### DIFF
--- a/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
+++ b/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
@@ -405,9 +405,10 @@ step R3_refresh:
  <waiting ...>
 step L1_unlock: 
     COMMIT;
-
+ <waiting ...>
 step R2_refresh: <... completed>
 step R3_refresh: <... completed>
+step L1_unlock: <... completed>
 step check_jobs: 
     SELECT ca.user_view_name,
            _timescaledb_functions.to_timestamp(r.start_range) AS start_time,

--- a/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
+++ b/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
@@ -241,4 +241,4 @@ permutation "P1_add_policy" "WP_after_register_enable" "P1_run_policy" "check_jo
 # Stale registration cleanup by concurrent refreshes.
 # Kill a backend during refresh to end up with a pid left behind. Later two concurrent refreshes run, only one removes the stale pid.
 # backend R1 is killed, we can no longer use this for later permutations
-permutation "WP_before_txn2_commit_enable" "R1_refresh" "check_jobs" "K1_terminate"("check_jobs") "WP_before_txn2_commit_disable" "L1_lock" "R2_refresh"("L1_lock") "R3_refresh"("R2_refresh") "L1_unlock" "check_jobs"
+permutation "WP_before_txn2_commit_enable" "R1_refresh" "check_jobs" "K1_terminate"("check_jobs") "WP_before_txn2_commit_disable" "L1_lock" "R2_refresh"("L1_lock") "R3_refresh"("R2_refresh") "L1_unlock"(R2_refresh, R3_refresh) "check_jobs"


### PR DESCRIPTION
This fixes the race condition in the last permutation.

It's possible that the jobs table is checked before the blocked refreshes are finished. This stabilizes the test by forcing the unlock step to not be reported as completed until the previous refresh steps complete.

Disable-check: force-changelog-file