### PR TITLE
Remove dead post_parse_analyze_hook capture in loader

### DIFF
--- a/.unreleased/pr_9604
+++ b/.unreleased/pr_9604
@@ -1,0 +1,1 @@
+Fixes: #9604 Remove dead post_parse_analyze_hook capture in loader

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -51,15 +51,11 @@
  *   2. When a command is run with timescale not loaded, post_analyze_hook:
  *        a. Gets the extension version.
  *        b. Loads the versioned extension.
- *        c. Grabs the post_parse_analyze_hook from the versioned extension
- *           (src/init.c:post_analyze_hook) and stores it in
- *           extension_post_parse_analyze_hook.
- *        d. Sets the post_parse_analyze_hook back to what it was before we
+ *        c. Sets the post_parse_analyze_hook back to what it was before we
  *           loaded the versioned extension (this hook eventually called our
  *           post_analyze_hook, but may not be our function, for instance, if
  *           another extension is loaded).
- *        e. Calls extension_post_parse_analyze_hook.
- *        f. Calls the prev_post_parse_analyze_hook.
+ *        d. Calls the prev_post_parse_analyze_hook.
  *
  * Some notes on design:
  *
@@ -137,10 +133,6 @@ typedef struct TsExtension
 
 	/* Shared object library version loaded; empty if none. */
 	char soversion[MAX_VERSION_LEN];
-
-	/* TODO Remove.  Neither timescaledb nor OSM actually have this hook,
-	 * never have, and we don't plan to add them. */
-	post_parse_analyze_hook_type post_parse_analyze_hook;
 } TsExtension;
 
 TsExtension extensions[] = {
@@ -153,7 +145,6 @@ TsExtension extensions[] = {
 		.guc_disable_load_name = MAKE_EXTOPTION("disable_load"),
 		.guc_disable_load = false,
 		.soversion = "",
-		.post_parse_analyze_hook = NULL,
 	},
 	{
 		.name = "timescaledb_osm",
@@ -162,7 +153,6 @@ TsExtension extensions[] = {
 		.guc_disable_load_name = "timescaledb_osm.disable_load",
 		.guc_disable_load = false,
 		.soversion = "",
-		.post_parse_analyze_hook = NULL,
 	},
 	{
 		.name = "timescaledb_lake",
@@ -171,14 +161,10 @@ TsExtension extensions[] = {
 		.guc_disable_load_name = "timescaledb_lake.disable_load",
 		.guc_disable_load = false,
 		.soversion = "",
-		.post_parse_analyze_hook = NULL,
 	},
 };
 
 inline static void extension_check(TsExtension * /*ext*/);
-static void call_extension_post_parse_analyze_hook(ParseState *pstate, Query *query,
-												   TsExtension const * /*ext*/,
-												   JumbleState *jstate);
 
 static bool
 extension_is_loaded(TsExtension const *const ext)
@@ -590,16 +576,6 @@ post_analyze_hook(ParseState *pstate, Query *query, JumbleState *jstate)
 		{
 			extension_check(ext);
 		}
-
-		/*
-		 * Call the extension's hook. This is necessary since the extension is
-		 * installed during the hook. If we did not do this the extension's hook
-		 * would not be called during the first command because the extension
-		 * would not have yet been installed. Thus the loader captures the
-		 * extension hook and calls it explicitly after the check for installing
-		 * the extension.
-		 */
-		call_extension_post_parse_analyze_hook(pstate, query, ext, jstate);
 	}
 
 	if (prev_post_parse_analyze_hook != NULL)
@@ -754,18 +730,12 @@ do_load(TsExtension *const ext)
 	}
 
 	/*
-	 * we need to capture the loaded extension's post analyze hook, giving it
-	 * a NULL as previous
+	 * Save and restore post_parse_analyze_hook around the load so that
+	 * loading the versioned extension cannot modify our hook chain.
 	 */
 	old_hook = post_parse_analyze_hook;
 	post_parse_analyze_hook = NULL;
 
-	/*
-	 * We want to call the post_parse_analyze_hook from the versioned
-	 * extension after we've loaded the versioned so. When the file is loaded
-	 * it sets post_parse_analyze_hook, which we capture and store in
-	 * extension_post_parse_analyze_hook to call at the end _PG_init
-	 */
 	PG_TRY();
 	{
 		PGFunction ts_post_load_init =
@@ -777,13 +747,14 @@ do_load(TsExtension *const ext)
 	}
 	PG_CATCH();
 	{
-		ext->post_parse_analyze_hook = post_parse_analyze_hook;
 		post_parse_analyze_hook = old_hook;
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
-	ext->post_parse_analyze_hook = post_parse_analyze_hook;
+	/* The versioned extension must not install a post_parse_analyze_hook:
+	 * the loader would silently drop it when restoring old_hook below. */
+	Assert(post_parse_analyze_hook == NULL);
 	post_parse_analyze_hook = old_hook;
 }
 
@@ -795,9 +766,8 @@ extension_check(TsExtension *const ext)
 		case EXTENSION_STATE_TRANSITIONING:
 			/*
 			 * Always load as soon as the extension is transitioning. This is
-			 * necessary so that the extension load before any CREATE FUNCTION
-			 * calls. Otherwise, the CREATE FUNCTION calls will load the .so
-			 * without capturing the post_parse_analyze_hook.
+			 * necessary so that the extension is loaded before any CREATE
+			 * FUNCTION calls trigger an uncontrolled load of the .so.
 			 */
 		case EXTENSION_STATE_CREATED:
 			do_load(ext);
@@ -814,15 +784,5 @@ ts_loader_extension_check(void)
 	for (size_t i = 0; i < sizeof(extensions) / sizeof(TsExtension); ++i)
 	{
 		extension_check(&extensions[i]);
-	}
-}
-
-static void
-call_extension_post_parse_analyze_hook(ParseState *pstate, Query *query,
-									   TsExtension const *const ext, JumbleState *jstate)
-{
-	if (extension_is_loaded(ext) && ext->post_parse_analyze_hook != NULL)
-	{
-		ext->post_parse_analyze_hook(pstate, query, jstate);
 	}
 }

--- a/test/expected/loader-tsl.out
+++ b/test/expected/loader-tsl.out
@@ -20,26 +20,21 @@ SELECT 1;
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-1"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
  timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-1';
-WARNING:  mock post_analyze_hook "mock-1"
 NOTICE:  extension "timescaledb" already exists, skipping
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-2';
-WARNING:  mock post_analyze_hook "mock-1"
 NOTICE:  extension "timescaledb" already exists, skipping
 DROP EXTENSION timescaledb;
-WARNING:  mock post_analyze_hook "mock-1"
 \set ON_ERROR_STOP 0
 --test that we cannot accidentally load another library version
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-2';
@@ -61,13 +56,11 @@ CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
 --same backend as create extension;
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-1"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -77,27 +70,23 @@ WARNING:  mock post_analyze_hook "mock-1"
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT 1;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
 
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
 
 --test fn call after load
 SELECT mock_function();
-WARNING:  mock post_analyze_hook "mock-1"
 WARNING:  mock function call "mock-1"
  mock_function 
 ---------------
  
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-1"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -107,7 +96,6 @@ WARNING:  mock post_analyze_hook "mock-1"
 --test fn call as first command
 SELECT mock_function();
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
 WARNING:  mock function call "mock-1"
  mock_function 
 ---------------
@@ -129,22 +117,18 @@ SELECT 1;
 SET timescaledb.disable_load = 'off';
 SELECT 1;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
 
 \set ON_ERROR_STOP 0
 SET timescaledb.disable_load = 'not bool';
-WARNING:  mock post_analyze_hook "mock-1"
 ERROR:  parameter "timescaledb.disable_load" requires a Boolean value
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 RESET ALL;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
@@ -153,7 +137,6 @@ WARNING:  mock post_analyze_hook "mock-1"
 SET timescaledb.disable_load TO DEFAULT;
 SELECT 1;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
@@ -162,7 +145,6 @@ WARNING:  mock post_analyze_hook "mock-1"
 RESET timescaledb.disable_load;
 SELECT 1;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
@@ -170,9 +152,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET timescaledb.other = 'on';
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
@@ -191,7 +171,6 @@ SELECT * FROM test.extension;
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-1"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -202,13 +181,11 @@ WARNING:  mock post_analyze_hook "mock-1"
 ALTER EXTENSION timescaledb UPDATE TO 'mock-2';
 WARNING:  mock init "mock-2"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-2"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-2"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -216,7 +193,6 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 --drop extension
 DROP EXTENSION timescaledb;
-WARNING:  mock post_analyze_hook "mock-2"
 SELECT 1;
  ?column? 
 ----------
@@ -231,13 +207,11 @@ SELECT * FROM test.extension;
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 WARNING:  mock init "mock-2"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-2"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-2"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -247,13 +221,11 @@ WARNING:  mock post_analyze_hook "mock-2"
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT 1;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-1"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -263,7 +235,6 @@ WARNING:  mock post_analyze_hook "mock-1"
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 SELECT * FROM test.extension;
 WARNING:  mock init "mock-2"
-WARNING:  mock post_analyze_hook "mock-2"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -275,13 +246,11 @@ ERROR:  extension "timescaledb" cannot be updated after the old version has alre
 \set ON_ERROR_STOP 1
 --should still be on mock-2
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-2"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-2"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -289,7 +258,6 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 --drop extension
 DROP EXTENSION timescaledb;
-WARNING:  mock post_analyze_hook "mock-2"
 SELECT 1;
  ?column? 
 ----------
@@ -305,20 +273,17 @@ SELECT * FROM test.extension;
 CREATE EXTENSION timescaledb VERSION 'mock-3';
 WARNING:  mock init "mock-3"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-3"
  ?column? 
 ----------
         1
 
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-3"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
  timescaledb | mock-3  | public     | Enables scalable inserts and complex queries for time-series data
 
 DROP EXTENSION timescaledb;
-WARNING:  mock post_analyze_hook "mock-3"
 SELECT 1;
  ?column? 
 ----------
@@ -341,43 +306,40 @@ SELECT * FROM test.extension;
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
---broken version and drop
 CREATE EXTENSION timescaledb VERSION 'mock-broken';
 WARNING:  mock init "mock-broken"
-\set ON_ERROR_STOP 0
---intentional broken version
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-broken"
-ERROR:  mock broken "mock-broken"
+    Name     |   Version   |   Schema   |                            Description                            
+-------------+-------------+------------+-------------------------------------------------------------------
+ plpgsql     | 1.0         | pg_catalog | PL/pgSQL procedural language
+ timescaledb | mock-broken | public     | Enables scalable inserts and complex queries for time-series data
+
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-broken"
-ERROR:  mock broken "mock-broken"
+ ?column? 
+----------
+        1
+
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-broken"
-ERROR:  mock broken "mock-broken"
---cannot drop extension; already loaded broken version
-DROP EXTENSION timescaledb;
-WARNING:  mock post_analyze_hook "mock-broken"
-ERROR:  mock broken "mock-broken"
-\set ON_ERROR_STOP 1
-\c :TEST_DBNAME_2 :ROLE_SUPERUSER
---can drop extension now. Since drop first command.
+ ?column? 
+----------
+        1
+
 DROP EXTENSION timescaledb;
 SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
  plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 
---broken version and update to fixed
+--cannot update extension; already loaded version
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-broken';
 WARNING:  mock init "mock-broken"
-\set ON_ERROR_STOP 0
---intentional broken version
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-broken"
-ERROR:  mock broken "mock-broken"
---cannot update extension; already loaded bad version
+ ?column? 
+----------
+        1
+
+\set ON_ERROR_STOP 0
 ALTER EXTENSION timescaledb UPDATE TO 'mock-5';
 ERROR:  extension "timescaledb" cannot be updated after the old version has already been loaded
 \set ON_ERROR_STOP 1
@@ -386,13 +348,11 @@ ERROR:  extension "timescaledb" cannot be updated after the old version has alre
 ALTER EXTENSION timescaledb UPDATE TO 'mock-5';
 WARNING:  mock init "mock-5"
 SELECT 1;
-WARNING:  mock post_analyze_hook "mock-5"
  ?column? 
 ----------
         1
 
 SELECT mock_function();
-WARNING:  mock post_analyze_hook "mock-5"
 WARNING:  mock function call "mock-5"
  mock_function 
 ---------------
@@ -406,17 +366,14 @@ WARNING:  mock init "mock-6"
 --Thus mock_function is defined incorrectly to point to the mock-5.so
 --This will now be a FATAL error.
 SELECT format($$\! utils/test_fatal_command.sh %1$s "SELECT mock_function()"$$, :'TEST_DBNAME_2') as command_to_run \gset
-WARNING:  mock post_analyze_hook "mock-6"
 :command_to_run
 WARNING:  mock init "mock-6"
-WARNING:  mock post_analyze_hook "mock-6"
 FATAL:  extension "timescaledb" version mismatch: shared library version mock-5; SQL version mock-6
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 connection to server was lost
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-6"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -426,14 +383,12 @@ WARNING:  mock post_analyze_hook "mock-6"
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT * FROM test.extension;
 WARNING:  mock init "mock-1"
-WARNING:  mock post_analyze_hook "mock-1"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
  timescaledb | mock-1  | public     | Enables scalable inserts and complex queries for time-series data
 
 DROP EXTENSION timescaledb;
-WARNING:  mock post_analyze_hook "mock-1"
 SELECT * FROM test.extension;
   Name   | Version |   Schema   |         Description          
 ---------+---------+------------+------------------------------
@@ -453,7 +408,6 @@ SELECT * FROM test.extension;
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 WARNING:  mock init "mock-2"
 SELECT * FROM test.extension;
-WARNING:  mock post_analyze_hook "mock-2"
     Name     | Version |   Schema   |                            Description                            
 -------------+---------+------------+-------------------------------------------------------------------
  plpgsql     | 1.0     | pg_catalog | PL/pgSQL procedural language
@@ -461,39 +415,27 @@ WARNING:  mock post_analyze_hook "mock-2"
 
 --make sure parallel workers started after a 'DISCARD ALL' work
 CREATE TABLE test (i int, j double precision);
-WARNING:  mock post_analyze_hook "mock-2"
 INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
-WARNING:  mock post_analyze_hook "mock-2"
 DISCARD ALL;
-WARNING:  mock post_analyze_hook "mock-2"
 SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
-WARNING:  mock post_analyze_hook "mock-2"
  set_config 
 ------------
  on
 
 SET max_parallel_workers_per_gather = 1;
-WARNING:  mock post_analyze_hook "mock-2"
 SELECT count(*) FROM test;
-WARNING:  mock post_analyze_hook "mock-2"
 WARNING:  mock init "mock-2"
  count 
 -------
    100
 
 CREATE EXTENSION timescaledb_osm VERSION 'mock-1';
-WARNING:  mock post_analyze_hook "mock-2"
-WARNING:  mock post_analyze_hook "mock-2"
 WARNING:  OSM-mock-1 _PG_init
 WARNING:  got lwlock osm lock
-WARNING:  mock post_analyze_hook "mock-2"
-WARNING:  mock post_analyze_hook "mock-2"
 -- Test that OSM process utility hook works:  it should see this DROP TABLE.
 DROP TABLE test;
-WARNING:  mock post_analyze_hook "mock-2"
 NOTICE:  OSM-mock-1 got DROP TABLE 'test'
 -- clean up additional database
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE :"TEST_DBNAME_2" WITH (FORCE);
 WARNING:  mock init "mock-2"
-WARNING:  mock post_analyze_hook "mock-2"

--- a/test/sql/loader.sql.in
+++ b/test/sql/loader.sql.in
@@ -140,30 +140,19 @@ SELECT format($$\! utils/test_fatal_command.sh %1$s "CREATE EXTENSION timescaled
 SELECT * FROM test.extension;
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
---broken version and drop
 CREATE EXTENSION timescaledb VERSION 'mock-broken';
 
-\set ON_ERROR_STOP 0
---intentional broken version
 SELECT * FROM test.extension;
 SELECT 1;
 SELECT 1;
---cannot drop extension; already loaded broken version
-DROP EXTENSION timescaledb;
-\set ON_ERROR_STOP 1
-
-\c :TEST_DBNAME_2 :ROLE_SUPERUSER
---can drop extension now. Since drop first command.
 DROP EXTENSION timescaledb;
 SELECT * FROM test.extension;
 
---broken version and update to fixed
+--cannot update extension; already loaded version
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-broken';
-\set ON_ERROR_STOP 0
---intentional broken version
 SELECT 1;
---cannot update extension; already loaded bad version
+\set ON_ERROR_STOP 0
 ALTER EXTENSION timescaledb UPDATE TO 'mock-5';
 \set ON_ERROR_STOP 1
 

--- a/test/src/loader/CMakeLists.txt
+++ b/test/src/loader/CMakeLists.txt
@@ -14,22 +14,20 @@ add_library(${PROJECT_NAME}-mock-broken MODULE ${SOURCES} config.h)
 add_library(${PROJECT_NAME}-mock-6 MODULE ${SOURCES} config.h)
 
 target_compile_definitions(${PROJECT_NAME}-mock-1
-                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-1" BROKEN=0)
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-1")
 target_compile_definitions(${PROJECT_NAME}-mock-2
-                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-2" BROKEN=0)
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-2")
 target_compile_definitions(${PROJECT_NAME}-mock-3
-                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-3" BROKEN=0)
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-3")
 # mock 4 is intentionally incorrect version mod
-target_compile_definitions(
-  ${PROJECT_NAME}-mock-4 PRIVATE TIMESCALEDB_VERSION_MOD="mock-4-mismatch"
-                                 BROKEN=0)
+target_compile_definitions(${PROJECT_NAME}-mock-4
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-4-mismatch")
 target_compile_definitions(${PROJECT_NAME}-mock-5
-                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-5" BROKEN=0)
-target_compile_definitions(
-  ${PROJECT_NAME}-mock-broken PRIVATE TIMESCALEDB_VERSION_MOD="mock-broken"
-                                      BROKEN=1)
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-5")
+target_compile_definitions(${PROJECT_NAME}-mock-broken
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-broken")
 target_compile_definitions(${PROJECT_NAME}-mock-6
-                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-6" BROKEN=0)
+                           PRIVATE TIMESCALEDB_VERSION_MOD="mock-6")
 
 foreach(
   MOCK_VERSION

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -30,8 +30,6 @@ PG_MODULE_MAGIC;
 extern void PGDLLEXPORT _PG_init(void);
 #endif
 
-static post_parse_analyze_hook_type prev_post_parse_analyze_hook;
-
 bool ts_license_guc_check_hook(char **newval, void **extra, GucSource source);
 void ts_license_guc_assign_hook(const char *newval, void *extra);
 
@@ -44,26 +42,6 @@ cache_invalidate_callback(Datum arg, Oid relid)
 		ts_extension_invalidate();
 }
 
-static void
-post_analyze_hook(ParseState *pstate, Query *query, JumbleState *jstate)
-{
-	if (ts_extension_is_loaded_and_not_upgrading())
-		elog(WARNING, "mock post_analyze_hook " STR(TIMESCALEDB_VERSION_MOD));
-
-		/*
-		 * a symbol needed by IsParallelWorker is not exported on windows so we do
-		 * not perform this check
-		 */
-#ifndef WIN32
-	if (prev_post_parse_analyze_hook != NULL && !IsParallelWorker())
-		elog(ERROR, "the extension called with a loader should always have a NULL prev hook");
-#endif
-	if (BROKEN && !creating_extension)
-		ereport(ERROR,
-				(errcode(ERRCODE_TRIGGERED_ACTION_EXCEPTION),
-				 errmsg("mock broken " STR(TIMESCALEDB_VERSION_MOD))));
-}
-
 void
 _PG_init(void)
 {
@@ -73,17 +51,20 @@ _PG_init(void)
 	 */
 	ts_extension_check_version(TIMESCALEDB_VERSION_MOD);
 	elog(WARNING, "mock init " STR(TIMESCALEDB_VERSION_MOD));
-	prev_post_parse_analyze_hook = post_parse_analyze_hook;
 
 	/*
-	 * a symbol needed by IsParallelWorker is not exported on windows so we do
-	 * not perform this check
+	 * The loader sets post_parse_analyze_hook to NULL before calling
+	 * ts_post_load_init so that a versioned extension cannot splice its own
+	 * hook into the chain. A non-NULL value here would indicate the loader
+	 * contract has changed.
+	 *
+	 * A symbol needed by IsParallelWorker is not exported on windows so we
+	 * do not perform this check there.
 	 */
 #ifndef WIN32
-	if (prev_post_parse_analyze_hook != NULL && !IsParallelWorker())
+	if (post_parse_analyze_hook != NULL && !IsParallelWorker())
 		elog(ERROR, "the extension called with a loader should always have a NULL prev hook");
 #endif
-	post_parse_analyze_hook = post_analyze_hook;
 	CacheRegisterRelcacheCallback(cache_invalidate_callback, PointerGetDatum(NULL));
 }
 


### PR DESCRIPTION
The post_parse_analyze_hook field in TsExtension was always NULL
because neither timescaledb nor OSM set this hook during load, and
we don't plan to add it. Remove the field, its initializers, the
now-unused call_extension_post_parse_analyze_hook function, and the
related capture logic in do_load. The defensive save/restore of the
global hook around the .so load is kept.

Disable-check: loader-change
