### PR TITLE
Check frozen chunks early in compress_chunk

### DIFF
--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -824,6 +824,17 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 {
 	Oid uncompressed_chunk_id = chunk->table_id;
 
+	if (ts_chunk_is_frozen(chunk))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("chunk \"%s.%s\" is frozen, skipping compression",
+						NameStr(chunk->fd.schema_name),
+						NameStr(chunk->fd.table_name)),
+				 errhint("Use _timescaledb_functions.unfreeze_chunk to unfreeze.")));
+		return uncompressed_chunk_id;
+	}
+
 	write_logical_replication_msg_compression_start();
 
 	if (ts_chunk_needs_compression(chunk))

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -329,7 +329,7 @@ SELECT  _timescaledb_functions.freeze_chunk( :'CHNAME');
 
 \set ON_ERROR_STOP 0
 SELECT  compress_chunk( :'CHNAME');
-ERROR:  compress_chunk not permitted on frozen chunk "_hyper_2_7_chunk" 
+ERROR:  chunk "_timescaledb_internal._hyper_2_7_chunk" is frozen, skipping compression
 \set ON_ERROR_STOP 1
 --TEST dropping a frozen chunk
 --DO NOT CHANGE this behavior ---
@@ -1867,3 +1867,26 @@ DROP TABLE ht_pub_test CASCADE;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- clean up databases created
 DROP DATABASE postgres_fdw_db WITH (FORCE);
+-- Test recompression for partial chunks blocked for frozen chunks
+\set ON_ERROR_STOP 0
+BEGIN;
+SET timescaledb.enable_direct_compress_insert = true;
+CREATE TABLE metrics (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz, 'd1', 0;
+WARNING:  disabling direct compress because of too small batch size
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz - (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+       chunk_status_text        
+--------------------------------
+ {COMPRESSED,UNORDERED,PARTIAL}
+
+SELECT _timescaledb_functions.freeze_chunk(chunk) FROM show_chunks('metrics') chunk;
+ freeze_chunk 
+--------------
+ t
+
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+ERROR:  chunk "_timescaledb_internal._hyper_30_49_chunk" is frozen, skipping compression
+ROLLBACK;
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -1010,3 +1010,16 @@ DROP TABLE ht_pub_test CASCADE;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- clean up databases created
 DROP DATABASE postgres_fdw_db WITH (FORCE);
+
+-- Test recompression for partial chunks blocked for frozen chunks
+\set ON_ERROR_STOP 0
+BEGIN;
+SET timescaledb.enable_direct_compress_insert = true;
+CREATE TABLE metrics (time TIMESTAMPTZ NOT NULL, device TEXT, value float) WITH (tsdb.hypertable, tsdb.orderby='time');
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz, 'd1', 0;
+INSERT INTO metrics SELECT '2025-01-01'::timestamptz - (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
+SELECT _timescaledb_functions.freeze_chunk(chunk) FROM show_chunks('metrics') chunk;
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+ROLLBACK;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Previously, frozen chunks were handled by individual code paths within compress_chunk_wrapper. This led to inconsistent behavior: segmentwise recompression only detected frozen chunks after all recompression work was already done, and error messages varied across paths.

Disable-check: force-changelog-file