### PR TITLE
Keep original error code of CAgg refresh errors

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -777,7 +777,7 @@ rollback_and_error(const ContinuousAgg *cagg, CaggRefreshSpiContext *cagg_spi_ct
 	/* Commit the cleanup transaction, then throw the original error. */
 	cleanup_before_cagg_refresh_exit(cagg, cagg_spi_ctx);
 	SPI_commit();
-	elog(ERROR, "%s", edata->message);
+	ThrowErrorData(edata);
 }
 
 void


### PR DESCRIPTION
When an error occurs during refresh transactions, throw it with proper error code. Using `elog()` for these errors previously had changed error code to internal error (XX000).

Disable-check: force-changelog-file
