### PR TITLE
Fix use-after-free crash in cache_destroy during transaction abort

### DIFF
--- a/.unreleased/pr_9610
+++ b/.unreleased/pr_9610
@@ -1,0 +1,1 @@
+Fixes: #9610 Fix use-after-free crash in cache_destroy during transaction abort

--- a/src/cache.c
+++ b/src/cache.c
@@ -74,9 +74,14 @@ cache_destroy(Cache **cache_ptr)
 	if (cache->pre_destroy_hook != NULL)
 		cache->pre_destroy_hook(cache);
 
-	hash_destroy(cache->htab);
-	MemoryContextDelete(cache->hctl.hcxt);
+	/*
+	 * Save the memory context and NULL out the external pointer before
+	 * deleting. Deleting the parent context recursively frees the hash
+	 * table's child context and all cache allocations.
+	 */
+	MemoryContext hcxt = cache->hctl.hcxt;
 	*cache_ptr = NULL;
+	MemoryContextDelete(hcxt);
 }
 
 void


### PR DESCRIPTION
NULL out the external cache pointer before deleting the memory context
instead of after. Previously, if MemoryContextDelete triggered any
re-entrant code path (e.g. a relcache invalidation callback processed
during abort cleanup), the pointer still referenced the context being
freed, leading to a SIGSEGV in MemoryContextDelete.

Also remove the redundant hash_destroy() call since MemoryContextDelete
on the parent context recursively frees the hash table's child context.
