### PR TITLE
Fix PlaceHolderVar error in runtime chunk exclusion

### DIFF
--- a/.unreleased/pr_9612
+++ b/.unreleased/pr_9612
@@ -1,0 +1,2 @@
+Fixes: #9612 Fix PlaceHolderVar error in runtime chunk exclusion
+Thanks: @pcayen for reporting an issue with GROUP BY ROLLUP on views over hypertables

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -190,7 +190,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 			 *
 			 */
 			path->runtime_exclusion_parent = true;
-			foreach (lc_var, pull_var_clause((Node *) rinfo->clause, 0))
+			foreach (lc_var, pull_var_clause((Node *) rinfo->clause, PVC_RECURSE_PLACEHOLDERS))
 			{
 				Var *var = lfirst(lc_var);
 				/*
@@ -225,7 +225,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 			RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
 			ListCell *lc_var;
 
-			foreach (lc_var, pull_var_clause((Node *) rinfo->clause, 0))
+			foreach (lc_var, pull_var_clause((Node *) rinfo->clause, PVC_RECURSE_PLACEHOLDERS))
 			{
 				Var *var = lfirst(lc_var);
 				if ((Index) var->varno == rel->relid && var->varattno > 0 &&

--- a/tsl/test/shared/expected/parameterized_chunkappend.out
+++ b/tsl/test/shared/expected/parameterized_chunkappend.out
@@ -46,3 +46,21 @@ ORDER BY devices.device_id, win.id
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_material;
+-- #9607: PlaceHolderVar in runtime chunk exclusion clauses used to trip
+-- pull_var_clause with flag 0. GROUP BY ROLLUP on a view over a hypertable
+-- combined with a join and a generic plan can produce such PlaceHolderVars.
+PREPARE p9607(int, timestamptz, timestamptz) AS
+SELECT h.device_name, COUNT(*)
+FROM hourly_device_metrics h
+JOIN devices d ON h.device_name = d.name
+WHERE h.device_id = $1 AND h.hour >= $2 AND h.hour < $3
+GROUP BY ROLLUP(h.device_name);
+SET plan_cache_mode = force_generic_plan;
+EXECUTE p9607(1, '2000-01-01'::timestamptz, '2000-01-20'::timestamptz);
+ device_name | count 
+-------------+-------
+             |   448
+ Device 1    |   448
+
+RESET plan_cache_mode;
+DEALLOCATE p9607;

--- a/tsl/test/shared/sql/parameterized_chunkappend.sql
+++ b/tsl/test/shared/sql/parameterized_chunkappend.sql
@@ -31,3 +31,18 @@ ORDER BY devices.device_id, win.id
 RESET enable_hashjoin;
 RESET enable_mergejoin;
 RESET enable_material;
+
+-- #9607: PlaceHolderVar in runtime chunk exclusion clauses used to trip
+-- pull_var_clause with flag 0. GROUP BY ROLLUP on a view over a hypertable
+-- combined with a join and a generic plan can produce such PlaceHolderVars.
+PREPARE p9607(int, timestamptz, timestamptz) AS
+SELECT h.device_name, COUNT(*)
+FROM hourly_device_metrics h
+JOIN devices d ON h.device_name = d.name
+WHERE h.device_id = $1 AND h.hour >= $2 AND h.hour < $3
+GROUP BY ROLLUP(h.device_name);
+
+SET plan_cache_mode = force_generic_plan;
+EXECUTE p9607(1, '2000-01-01'::timestamptz, '2000-01-20'::timestamptz);
+RESET plan_cache_mode;
+DEALLOCATE p9607;


### PR DESCRIPTION
The runtime chunk exclusion code in ChunkAppend calls pull_var_clause
on rinfo->clause with flag 0, which raises "PlaceHolderVar found where
not expected" when the clause contains a PlaceHolderVar. This could be
triggered by queries that combined a view over a hypertable with a join
and GROUP BY ROLLUP, planned as a generic plan.

Pass PVC_RECURSE_PLACEHOLDERS so the walker recurses into PlaceHolderVar
contents and yields the underlying Vars, which is what the partitioning
column check needs. This matches the pattern already used in
columnar_scan.c.

Fixes #9607
