### PR TITLE
Fix segfault with transition tables after column drop

### DIFF
--- a/.unreleased/pr_9615
+++ b/.unreleased/pr_9615
@@ -1,0 +1,2 @@
+Fixes: #9615 Fix segfault with transition tables after column drop
+Thanks: @patstrom for reporting a segfault with transition table triggers after dropping a column

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -619,6 +619,17 @@ ExecPrepareTupleRouting(ModifyTableState *mtstate,
 						ResultRelInfo **partRelInfo)
 {
 	ChunkInsertState *cis = ctr->cis;
+
+	/*
+	 * If we're capturing transition tuples, save the original tuple in
+	 * hypertable format before converting to chunk format. This is needed
+	 * because chunks created after a column drop have a different TupleDesc,
+	 * and the transition table must store tuples in the hypertable's format.
+	 * See PostgreSQL's ExecPrepareTupleRouting in nodeModifyTable.c.
+	 */
+	if (mtstate->mt_transition_capture != NULL)
+		mtstate->mt_transition_capture->tcs_original_insert_tuple = slot;
+
 	/* Convert the tuple to the chunk's rowtype, if necessary */
 	if (cis->hyper_to_chunk_map != NULL && ctr->has_dropped_attrs == false)
 		slot = execute_attr_map_slot(cis->hyper_to_chunk_map->attrMap, slot, cis->slot);

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -450,3 +450,24 @@ ERROR:  ROW triggers with transition tables are not supported on hypertables
 CREATE TRIGGER t7 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 ERROR:  ROW triggers with transition tables are not supported on hypertables
 \set ON_ERROR_STOP 1
+-- #9613: segfault when referencing transition table after column drop
+CREATE TABLE transition_drop(time timestamptz NOT NULL, to_drop int NOT NULL, name text NOT NULL, c1 bigint NOT NULL);
+SELECT create_hypertable('transition_drop', 'time');
+      create_hypertable       
+------------------------------
+ (5,public,transition_drop,t)
+
+ALTER TABLE transition_drop DROP COLUMN to_drop;
+CREATE OR REPLACE FUNCTION transition_drop_fn()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+    PERFORM name FROM to_insert;
+    RETURN NULL;
+END $$;
+CREATE TRIGGER transition_drop_tg
+    AFTER INSERT ON transition_drop
+    REFERENCING NEW TABLE AS to_insert
+    FOR EACH STATEMENT EXECUTE FUNCTION transition_drop_fn();
+INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxx', 1);
+INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxxx', 1);
+DROP TABLE transition_drop;

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -339,3 +339,24 @@ CREATE TRIGGER t6 AFTER UPDATE ON transition_test REFERENCING NEW TABLE AS new_t
 CREATE TRIGGER t7 AFTER DELETE ON transition_test REFERENCING OLD TABLE AS old_trans FOR EACH ROW EXECUTE FUNCTION test_trigger();
 \set ON_ERROR_STOP 1
 
+-- #9613: segfault when referencing transition table after column drop
+CREATE TABLE transition_drop(time timestamptz NOT NULL, to_drop int NOT NULL, name text NOT NULL, c1 bigint NOT NULL);
+SELECT create_hypertable('transition_drop', 'time');
+ALTER TABLE transition_drop DROP COLUMN to_drop;
+
+CREATE OR REPLACE FUNCTION transition_drop_fn()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+    PERFORM name FROM to_insert;
+    RETURN NULL;
+END $$;
+
+CREATE TRIGGER transition_drop_tg
+    AFTER INSERT ON transition_drop
+    REFERENCING NEW TABLE AS to_insert
+    FOR EACH STATEMENT EXECUTE FUNCTION transition_drop_fn();
+
+INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxx', 1);
+INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxxx', 1);
+DROP TABLE transition_drop;
+


### PR DESCRIPTION
When a hypertable had a dropped column and a statement-level AFTER trigger with REFERENCING NEW TABLE, inserting data could cause a segfault. The crash happened because ExecPrepareTupleRouting converted the tuple from hypertable format to chunk format but did not save the original tuple for the transition table capture. When the chunk was created after the column drop, its TupleDesc differed from the hypertable's, and the transition table received the chunk-format tuple while the trigger function expected hypertable-format tuples.

Fix by saving the original hypertable-format tuple in tcs_original_insert_tuple before converting, matching what PostgreSQL's native ExecPrepareTupleRouting does for partitioned tables.

Fixes #9613