### PR TITLE
Use DROP CASCADE for trigger removal

### DIFF
--- a/.unreleased/pr_9616
+++ b/.unreleased/pr_9616
@@ -1,0 +1,1 @@
+Fixes: #9616 Use DROP CASCADE for trigger removal

--- a/sql/updates/2.22.1--2.23.0.sql
+++ b/sql/updates/2.22.1--2.23.0.sql
@@ -31,8 +31,8 @@ BEGIN
 END
 $$;
 
-DROP FUNCTION IF EXISTS _timescaledb_internal.continuous_agg_invalidation_trigger();
-DROP FUNCTION IF EXISTS _timescaledb_functions.continuous_agg_invalidation_trigger();
+DROP FUNCTION IF EXISTS _timescaledb_internal.continuous_agg_invalidation_trigger() CASCADE;
+DROP FUNCTION IF EXISTS _timescaledb_functions.continuous_agg_invalidation_trigger() CASCADE;
 DROP FUNCTION IF EXISTS _timescaledb_functions.has_invalidation_trigger(regclass);
 
 -- remove ts_insert_blocker trigger from all hypertables
@@ -48,5 +48,5 @@ BEGIN
 END
 $$;
 
-DROP FUNCTION IF EXISTS _timescaledb_internal.insert_blocker();
-DROP FUNCTION IF EXISTS _timescaledb_functions.insert_blocker();
+DROP FUNCTION IF EXISTS _timescaledb_internal.insert_blocker() CASCADE;
+DROP FUNCTION IF EXISTS _timescaledb_functions.insert_blocker() CASCADE;


### PR DESCRIPTION
When the insert_blocker trigger is still present on orphaned
relations that are not managed by timescaledb an update can fail.
DROP CASCADE will remove the timescaledb triggers from all objects
even those not managed by timescaledb.

Disable-check: approval-count