### PR TITLE
Error when querying compressed chunks under Apache license

### DIFF
--- a/.unreleased/pr_9623
+++ b/.unreleased/pr_9623
@@ -1,0 +1,2 @@
+Fixes: #9623 Error when querying compressed chunks under Apache license
+Thanks: @igor2x for reporting a problem when trying to query compressed data with apache license

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1448,6 +1448,34 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 			ts_create_private_reloptinfo(rel);
 
 			/*
+			 * Querying a compressed chunk requires Community Edition that
+			 * lives in the TSL module. Under the Apache license the TSL
+			 * module is not available, so without this check the planner
+			 * would only return the contents of the uncompressed chunk
+			 * relation. Raise an error instead.
+			 *
+			 * Skip the chunk fetch when the hypertable has no compression at
+			 * all: no chunk under it can be compressed, and opening the chunk
+			 * relation here has observable side effects (schema USAGE checks
+			 * fire before the parent's table-level ACL check).
+			 */
+			if (ts_license_is_apache() && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
+			{
+				const Chunk *chunk = ts_planner_chunk_fetch(root, rel);
+
+				if (chunk != NULL && ts_chunk_is_compressed(chunk))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("querying compressed data is not supported under the "
+									"current \"timescaledb.license\""),
+							 errdetail("Chunk \"%s\" is compressed and requires "
+									   "the TimescaleDB Community Edition to query.",
+									   get_rel_name(chunk->table_id)),
+							 errhint("Set timescaledb.license to 'timescale' and install the "
+									 "TimescaleDB Community Edition to query compressed data.")));
+			}
+
+			/*
 			 * We don't want to plan index scans on empty uncompressed tables of
 			 * fully compressed chunks. It takes a lot of time, and these tables
 			 * are empty anyway. Just reset the indexlist in this case. For

--- a/test/t/002_compressed_chunk_apache.pl
+++ b/test/t/002_compressed_chunk_apache.pl
@@ -1,0 +1,51 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and
+# LICENSE-APACHE for a copy of the license.
+
+# Regression test for issue #7787: if a user has compressed chunks
+# produced by the Community/TSL edition and then switches the
+# "timescaledb.license" GUC to "apache", a plain SELECT against the
+# hypertable must NOT silently return the near-empty contents of the
+# uncompressed chunk relation. It must raise a clear error pointing
+# at the license as the cause.
+
+use strict;
+use warnings;
+use TimescaleNode;
+use Test::More tests => 3;
+
+my $node = TimescaleNode->create('compressed_apache');
+
+# Override the default apache license from the shared postgresql.conf
+# template so we can actually create and compress a hypertable.
+$node->append_conf('postgresql.conf', "timescaledb.license='timescale'");
+$node->restart;
+
+$node->safe_psql(
+	'postgres', q[
+	CREATE TABLE metrics(time timestamptz NOT NULL, value float) WITH (tsdb.hypertable);
+	INSERT INTO metrics
+	SELECT generate_series('2023-01-01'::timestamptz,
+	                       '2023-01-03'::timestamptz,
+	                       '1 hour'::interval), random();
+	SELECT count(compress_chunk(c)) FROM show_chunks('metrics') c;
+]);
+
+my $row_count = $node->safe_psql('postgres', 'SELECT count(*) FROM metrics');
+is($row_count, '49', 'all rows visible under timescale license');
+
+# Switch to apache license and restart.
+$node->append_conf('postgresql.conf', "timescaledb.license='apache'");
+$node->restart;
+
+my ($rc, $stdout, $stderr) =
+  $node->psql('postgres', 'SELECT count(*) FROM metrics');
+isnt($rc, 0, 'querying compressed hypertable under apache license errors');
+like(
+	$stderr,
+	qr/querying compressed data is not supported/,
+	'error message points at the license');
+
+done_testing();
+
+1;

--- a/test/t/CMakeLists.txt
+++ b/test/t/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  list(APPEND PROVE_TEST_FILES 001_replication_telemetry.pl)
+  list(APPEND PROVE_TEST_FILES 001_replication_telemetry.pl
+       002_compressed_chunk_apache.pl)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 foreach(P_FILE ${PROVE_TEST_FILES})


### PR DESCRIPTION
Under the Apache license the TSL module is not loaded, so the
planner's decompression path is missing. A SELECT against a
compressed hypertable would only scan the uncompressed data
of partial chunks and never read data from the compressed
part of the chunk.

Raise a clear error in the planner when a compressed chunk is
queried without the TSL module available, pointing the user at
the license as the cause.

Fixes: #7787
