### PR TITLE
Fix HAVING clause with time_bucket_gapfill returning wrong rows

### DIFF
--- a/.unreleased/pr_9624
+++ b/.unreleased/pr_9624
@@ -1,0 +1,2 @@
+Fixes: #9624 Fix HAVING clause with time_bucket_gapfill
+Thanks: @fr3aker for reporting an issue with time_bucket_gapfill and HAVING

--- a/tsl/src/nodes/gapfill/gapfill.h
+++ b/tsl/src/nodes/gapfill/gapfill.h
@@ -32,5 +32,7 @@ void gapfill_adjust_window_targetlist(PlannerInfo *root, RelOptInfo *input_rel,
 typedef struct GapFillPath
 {
 	CustomPath cpath;
-	FuncExpr *func; /* time_bucket_gapfill function call */
+	FuncExpr *func;		/* time_bucket_gapfill function call */
+	List *having_quals; /* HAVING quals lifted from the aggregate subpath so they are evaluated
+						   after gaps are generated (fixes #5202) */
 } GapFillPath;

--- a/tsl/src/nodes/gapfill/gapfill_exec.c
+++ b/tsl/src/nodes/gapfill/gapfill_exec.c
@@ -857,14 +857,13 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 }
 
 /*
- * This is the main loop of the node it is called whenever the upper node
- * wants to consume a new tuple. Returning NULL signals that the tuples
- * are exhausted. All gapfill state transitions happen in this function.
+ * Produce the next candidate tuple from the gapfill state machine without
+ * applying the HAVING qual. Returning NULL signals that the tuples are
+ * exhausted. All gapfill state transitions happen in this function.
  */
 static TupleTableSlot *
-gapfill_exec(CustomScanState *node)
+gapfill_next_candidate(GapFillState *state)
 {
-	GapFillState *state = (GapFillState *) node;
 	TupleTableSlot *slot = NULL;
 
 	while (true)
@@ -941,6 +940,32 @@ gapfill_exec(CustomScanState *node)
 		}
 
 		return NULL;
+	}
+}
+
+/*
+ * Return the next tuple that passes the HAVING qual (if any). The qual is
+ * evaluated on top of the GapFill node so that it does not prevent gap rows
+ * from being generated.
+ */
+static TupleTableSlot *
+gapfill_exec(CustomScanState *node)
+{
+	GapFillState *state = (GapFillState *) node;
+	ExprState *qual = node->ss.ps.qual;
+	ExprContext *econtext = node->ss.ps.ps_ExprContext;
+
+	while (true)
+	{
+		ResetExprContext(econtext);
+		TupleTableSlot *slot = gapfill_next_candidate(state);
+
+		if (TupIsNull(slot) || qual == NULL)
+			return slot;
+
+		econtext->ecxt_scantuple = slot;
+		if (ExecQual(qual, econtext))
+			return slot;
 	}
 }
 

--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -275,6 +275,8 @@ gapfill_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path, List *
 	cscan->flags = path->flags;
 	cscan->methods = &gapfill_plan_methods;
 
+	cscan->scan.plan.qual = gfpath->having_quals;
+
 	cscan->custom_private = ts_new_list(T_List, GFP_Count);
 	lfirst(list_nth_cell(cscan->custom_private, GFP_GapfillFunc)) = gfpath->func;
 	lfirst(list_nth_cell(cscan->custom_private, GFP_GroupClause)) = root->parse->groupClause;
@@ -414,6 +416,34 @@ gapfill_build_pathtarget(PathTarget *pt_upper, PathTarget *pt_path, PathTarget *
 }
 
 /*
+ * Lifting a qual onto the CustomScan plan only works when every Aggref it
+ * references is also a top-level expression of the pathtarget, because
+ * set_customscan_references resolves quals against custom_scan_tlist and
+ * cannot match a bare Aggref against a wrapped expression like locf(agg).
+ */
+static bool
+gapfill_quals_reference_only_pathtarget_aggs(List *quals, PathTarget *pt)
+{
+	List *aggs = pull_var_clause((Node *) quals, PVC_INCLUDE_AGGREGATES | PVC_RECURSE_PLACEHOLDERS);
+	ListCell *lc;
+	bool ok = true;
+
+	foreach (lc, aggs)
+	{
+		Node *agg = lfirst(lc);
+
+		if (IsA(agg, Aggref) && !list_member(pt->exprs, agg))
+		{
+			ok = false;
+			break;
+		}
+	}
+
+	list_free(aggs);
+	return ok;
+}
+
+/*
  * Create a Gapfill Path node.
  *
  * The gap fill node needs rows to be sorted by time ASC
@@ -445,6 +475,37 @@ gapfill_path_create(PlannerInfo *root, Path *subpath, FuncExpr *func)
 	gapfill_build_pathtarget(root->upper_targets[UPPERREL_FINAL],
 							 path->cpath.path.pathtarget,
 							 subpath->pathtarget);
+
+	/*
+	 * Move HAVING quals from the aggregate subpath onto the GapFill node so
+	 * they run after gap rows are generated; otherwise filtered-out groups
+	 * disappear before gapfill can extend them (#5202). Skipped when an
+	 * Aggref is not a top-level pathtarget expression (locf/interpolate
+	 * wraps it), since setrefs cannot resolve it then.
+	 */
+	List **subpath_qual_slot = NULL;
+	switch (nodeTag(subpath))
+	{
+		case T_AggPath:
+			subpath_qual_slot = &((AggPath *) subpath)->qual;
+			break;
+		case T_GroupPath:
+			subpath_qual_slot = &((GroupPath *) subpath)->qual;
+			break;
+		case T_GroupingSetsPath:
+			subpath_qual_slot = &((GroupingSetsPath *) subpath)->qual;
+			break;
+		default:
+			break;
+	}
+
+	if (subpath_qual_slot != NULL && *subpath_qual_slot != NIL &&
+		gapfill_quals_reference_only_pathtarget_aggs(*subpath_qual_slot,
+													 path->cpath.path.pathtarget))
+	{
+		path->having_quals = *subpath_qual_slot;
+		*subpath_qual_slot = NIL;
+	}
 
 	if (!gapfill_correct_order(root, subpath, func))
 	{

--- a/tsl/test/shared/expected/gapfill_bug.out
+++ b/tsl/test/shared/expected/gapfill_bug.out
@@ -489,3 +489,305 @@ SELECT * FROM STATS LEFT JOIN VOLUME USING (bucket);
 DROP TABLE gf8844_table1;
 DROP TABLE gf8844_table2;
 RESET timezone;
+-- Fix for #5202: time_bucket_gapfill with HAVING clause returning incorrect rows
+-- HAVING quals must be evaluated on top of the GapFill node so they do not
+-- remove groups before gap rows have been generated.
+SET timezone TO 'UTC';
+CREATE TABLE gf5202(time timestamptz, device_id int, value float);
+INSERT INTO gf5202 VALUES
+    ('2023-01-03T00:00:00Z', 1, 4),
+    ('2023-01-03T01:00:00Z', 1, 4),
+    ('2023-01-03T02:00:00Z', 1, 4),
+    ('2023-01-05T00:00:00Z', 1, 6);
+-- Filter should appear on the Custom Scan (GapFill) node, not on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) < 2;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   Filter: ((count(*)) < 2)
+   ->  Sort
+         Sort Key: device_id, (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  GroupAggregate
+               Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone)), device_id
+               ->  Sort
+                     Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone)), device_id
+                     ->  Seq Scan on gf5202
+                           Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+-- HAVING count(*) < 2: real group with count=3 (2023-01-03) is dropped.
+-- Real group with count=1 (2023-01-05) is kept. Gap rows (NULL count) are
+-- rejected by <2 (NULL<2 is UNKNOWN -> false) under SQL semantics.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) < 2
+ORDER BY day, device_id;
+             day              | device_id | count 
+------------------------------+-----------+-------
+ Thu Jan 05 00:00:00 2023 UTC |         1 |     1
+
+-- HAVING count(*) IS NULL keeps only the gap rows.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) IS NULL
+ORDER BY day, device_id;
+             day              | device_id | count 
+------------------------------+-----------+-------
+ Sun Jan 01 00:00:00 2023 UTC |         1 |      
+ Mon Jan 02 00:00:00 2023 UTC |         1 |      
+ Wed Jan 04 00:00:00 2023 UTC |         1 |      
+ Fri Jan 06 00:00:00 2023 UTC |         1 |      
+ Sat Jan 07 00:00:00 2023 UTC |         1 |      
+
+-- HAVING predicate combining agg and group column.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) IS NULL OR count(*) < 2
+ORDER BY day, device_id;
+             day              | device_id | count 
+------------------------------+-----------+-------
+ Sun Jan 01 00:00:00 2023 UTC |         1 |      
+ Mon Jan 02 00:00:00 2023 UTC |         1 |      
+ Wed Jan 04 00:00:00 2023 UTC |         1 |      
+ Thu Jan 05 00:00:00 2023 UTC |         1 |     1
+ Fri Jan 06 00:00:00 2023 UTC |         1 |      
+ Sat Jan 07 00:00:00 2023 UTC |         1 |      
+
+-- HAVING that rejects every real group must still produce the gap rows when
+-- the predicate leaves room for them via IS NULL. Before the fix this
+-- returned zero rows because HAVING ran below the gapfill node.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) > 1000 OR count(*) IS NULL
+ORDER BY day, device_id;
+             day              | device_id | count 
+------------------------------+-----------+-------
+ Sun Jan 01 00:00:00 2023 UTC |         1 |      
+ Mon Jan 02 00:00:00 2023 UTC |         1 |      
+ Wed Jan 04 00:00:00 2023 UTC |         1 |      
+ Fri Jan 06 00:00:00 2023 UTC |         1 |      
+ Sat Jan 07 00:00:00 2023 UTC |         1 |      
+
+-- Fallback: aggregate wrapped in locf is not a top-level pathtarget
+-- expression, so set_customscan_references cannot resolve a bare Aggref
+-- against it. Filter must remain on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, locf(count(*))
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         Filter: (count(*) > 1)
+         ->  Sort
+               Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Seq Scan on gf5202
+                     Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+-- Fallback: aggregate referenced only in HAVING is not in the GapFill
+-- pathtarget either, so filter again stays on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) > 1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   ->  Sort
+         Sort Key: device_id, (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  GroupAggregate
+               Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone)), device_id
+               Filter: (count(*) > 1)
+               ->  Sort
+                     Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone)), device_id
+                     ->  Seq Scan on gf5202
+                           Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+-- By-reference HAVING aggregate (string_agg returns text). Exercises that
+-- pass-by-reference values in the projected slot stay valid through the
+-- HAVING qual: the per-tuple memory must not be reset between projection
+-- and ExecQual.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, string_agg(value::text, ',' ORDER BY value)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING string_agg(value::text, ',' ORDER BY value) = '4,4,4';
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   Filter: ((string_agg((value)::text, ','::text ORDER BY value)) = '4,4,4'::text)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Sort
+               Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone)), value
+               ->  Seq Scan on gf5202
+                     Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+SELECT time_bucket_gapfill('1 day', time) AS day, string_agg(value::text, ',' ORDER BY value)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING string_agg(value::text, ',' ORDER BY value) = '4,4,4'
+ORDER BY day;
+             day              | string_agg 
+------------------------------+------------
+ Tue Jan 03 00:00:00 2023 UTC | 4,4,4
+
+-- COALESCE-wrapped aggregate in the SELECT list, bare aggregate in HAVING.
+-- The bare aggregate is not a top-level pathtarget expression (only the
+-- COALESCE wrapper is), so HAVING stays on the GroupAggregate. Gap rows are
+-- produced after HAVING runs and show COALESCE(NULL, 0) = 0.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         Filter: (count(*) > 1)
+         ->  Sort
+               Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Seq Scan on gf5202
+                     Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1
+ORDER BY day;
+             day              | c 
+------------------------------+---
+ Sun Jan 01 00:00:00 2023 UTC | 0
+ Mon Jan 02 00:00:00 2023 UTC | 0
+ Tue Jan 03 00:00:00 2023 UTC | 3
+ Wed Jan 04 00:00:00 2023 UTC | 0
+ Thu Jan 05 00:00:00 2023 UTC | 0
+ Fri Jan 06 00:00:00 2023 UTC | 0
+ Sat Jan 07 00:00:00 2023 UTC | 0
+
+-- SELECT contains both a bare and a COALESCE-wrapped aggregate. The bare
+-- count(*) is a top-level pathtarget expression, so HAVING is lifted onto
+-- GapFill. Gap rows have NULL for count and 0 for the COALESCE projection.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(count(*), 0) AS c0
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) IS NULL OR count(*) > 1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   Filter: (((count(*)) IS NULL) OR ((count(*)) > 1))
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Sort
+               Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Seq Scan on gf5202
+                     Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(count(*), 0) AS c0
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) IS NULL OR count(*) > 1
+ORDER BY day;
+             day              | c | c0 
+------------------------------+---+----
+ Sun Jan 01 00:00:00 2023 UTC |   |  0
+ Mon Jan 02 00:00:00 2023 UTC |   |  0
+ Tue Jan 03 00:00:00 2023 UTC | 3 |  3
+ Wed Jan 04 00:00:00 2023 UTC |   |  0
+ Fri Jan 06 00:00:00 2023 UTC |   |  0
+ Sat Jan 07 00:00:00 2023 UTC |   |  0
+
+-- COALESCE wraps the aggregate in both SELECT and HAVING. The Aggref inside
+-- HAVING is the bare count(*) but only the wrapper is top-level, so HAVING
+-- stays on the GroupAggregate. Every real group has count(*) > 0, so they
+-- all pass; gap rows are added afterwards with COALESCE = 0.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING COALESCE(count(*), 0) > 0;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         Filter: (COALESCE(count(*), '0'::bigint) > 0)
+         ->  Sort
+               Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Seq Scan on gf5202
+                     Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING COALESCE(count(*), 0) > 0
+ORDER BY day;
+             day              | c 
+------------------------------+---
+ Sun Jan 01 00:00:00 2023 UTC | 0
+ Mon Jan 02 00:00:00 2023 UTC | 0
+ Tue Jan 03 00:00:00 2023 UTC | 3
+ Wed Jan 04 00:00:00 2023 UTC | 0
+ Thu Jan 05 00:00:00 2023 UTC | 1
+ Fri Jan 06 00:00:00 2023 UTC | 0
+ Sat Jan 07 00:00:00 2023 UTC | 0
+
+-- HAVING references one bare top-level aggregate and one aggregate that is
+-- only present wrapped in COALESCE. The wrapped aggregate is not top-level
+-- so HAVING remains on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(sum(value), 0) AS s
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1 OR COALESCE(sum(value), 0) > 5;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         Filter: ((count(*) > 1) OR (COALESCE(sum(value), '0'::double precision) > '5'::double precision))
+         ->  Sort
+               Sort Key: (time_bucket_gapfill('@ 1 day'::interval, "time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Seq Scan on gf5202
+                     Filter: (("time" >= 'Sun Jan 01 00:00:00 2023 UTC'::timestamp with time zone) AND ("time" < 'Sun Jan 08 00:00:00 2023 UTC'::timestamp with time zone))
+
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(sum(value), 0) AS s
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1 OR COALESCE(sum(value), 0) > 5
+ORDER BY day;
+             day              | c | s  
+------------------------------+---+----
+ Sun Jan 01 00:00:00 2023 UTC |   |  0
+ Mon Jan 02 00:00:00 2023 UTC |   |  0
+ Tue Jan 03 00:00:00 2023 UTC | 3 | 12
+ Wed Jan 04 00:00:00 2023 UTC |   |  0
+ Thu Jan 05 00:00:00 2023 UTC | 1 |  6
+ Fri Jan 06 00:00:00 2023 UTC |   |  0
+ Sat Jan 07 00:00:00 2023 UTC |   |  0
+
+DROP TABLE gf5202;
+RESET timezone;

--- a/tsl/test/shared/sql/gapfill_bug.sql
+++ b/tsl/test/shared/sql/gapfill_bug.sql
@@ -279,3 +279,169 @@ DROP TABLE gf8844_table1;
 DROP TABLE gf8844_table2;
 
 RESET timezone;
+
+-- Fix for #5202: time_bucket_gapfill with HAVING clause returning incorrect rows
+-- HAVING quals must be evaluated on top of the GapFill node so they do not
+-- remove groups before gap rows have been generated.
+SET timezone TO 'UTC';
+
+CREATE TABLE gf5202(time timestamptz, device_id int, value float);
+INSERT INTO gf5202 VALUES
+    ('2023-01-03T00:00:00Z', 1, 4),
+    ('2023-01-03T01:00:00Z', 1, 4),
+    ('2023-01-03T02:00:00Z', 1, 4),
+    ('2023-01-05T00:00:00Z', 1, 6);
+
+-- Filter should appear on the Custom Scan (GapFill) node, not on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) < 2;
+
+-- HAVING count(*) < 2: real group with count=3 (2023-01-03) is dropped.
+-- Real group with count=1 (2023-01-05) is kept. Gap rows (NULL count) are
+-- rejected by <2 (NULL<2 is UNKNOWN -> false) under SQL semantics.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) < 2
+ORDER BY day, device_id;
+
+-- HAVING count(*) IS NULL keeps only the gap rows.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) IS NULL
+ORDER BY day, device_id;
+
+-- HAVING predicate combining agg and group column.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) IS NULL OR count(*) < 2
+ORDER BY day, device_id;
+
+-- HAVING that rejects every real group must still produce the gap rows when
+-- the predicate leaves room for them via IS NULL. Before the fix this
+-- returned zero rows because HAVING ran below the gapfill node.
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id, count(*)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) > 1000 OR count(*) IS NULL
+ORDER BY day, device_id;
+
+-- Fallback: aggregate wrapped in locf is not a top-level pathtarget
+-- expression, so set_customscan_references cannot resolve a bare Aggref
+-- against it. Filter must remain on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, locf(count(*))
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1;
+
+-- Fallback: aggregate referenced only in HAVING is not in the GapFill
+-- pathtarget either, so filter again stays on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, device_id
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day, device_id
+HAVING count(*) > 1;
+
+-- By-reference HAVING aggregate (string_agg returns text). Exercises that
+-- pass-by-reference values in the projected slot stay valid through the
+-- HAVING qual: the per-tuple memory must not be reset between projection
+-- and ExecQual.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, string_agg(value::text, ',' ORDER BY value)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING string_agg(value::text, ',' ORDER BY value) = '4,4,4';
+
+SELECT time_bucket_gapfill('1 day', time) AS day, string_agg(value::text, ',' ORDER BY value)
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING string_agg(value::text, ',' ORDER BY value) = '4,4,4'
+ORDER BY day;
+
+-- COALESCE-wrapped aggregate in the SELECT list, bare aggregate in HAVING.
+-- The bare aggregate is not a top-level pathtarget expression (only the
+-- COALESCE wrapper is), so HAVING stays on the GroupAggregate. Gap rows are
+-- produced after HAVING runs and show COALESCE(NULL, 0) = 0.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1;
+
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1
+ORDER BY day;
+
+-- SELECT contains both a bare and a COALESCE-wrapped aggregate. The bare
+-- count(*) is a top-level pathtarget expression, so HAVING is lifted onto
+-- GapFill. Gap rows have NULL for count and 0 for the COALESCE projection.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(count(*), 0) AS c0
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) IS NULL OR count(*) > 1;
+
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(count(*), 0) AS c0
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) IS NULL OR count(*) > 1
+ORDER BY day;
+
+-- COALESCE wraps the aggregate in both SELECT and HAVING. The Aggref inside
+-- HAVING is the bare count(*) but only the wrapper is top-level, so HAVING
+-- stays on the GroupAggregate. Every real group has count(*) > 0, so they
+-- all pass; gap rows are added afterwards with COALESCE = 0.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING COALESCE(count(*), 0) > 0;
+
+SELECT time_bucket_gapfill('1 day', time) AS day, COALESCE(count(*), 0) AS c
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING COALESCE(count(*), 0) > 0
+ORDER BY day;
+
+-- HAVING references one bare top-level aggregate and one aggregate that is
+-- only present wrapped in COALESCE. The wrapped aggregate is not top-level
+-- so HAVING remains on the GroupAggregate.
+EXPLAIN (COSTS OFF)
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(sum(value), 0) AS s
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1 OR COALESCE(sum(value), 0) > 5;
+
+SELECT time_bucket_gapfill('1 day', time) AS day, count(*) AS c, COALESCE(sum(value), 0) AS s
+FROM gf5202
+WHERE time >= '2023-01-01T00:00:00Z' AND time < '2023-01-08T00:00:00Z'
+GROUP BY day
+HAVING count(*) > 1 OR COALESCE(sum(value), 0) > 5
+ORDER BY day;
+
+DROP TABLE gf5202;
+RESET timezone;


### PR DESCRIPTION
HAVING quals were attached to the GroupAggregate below the GapFill
node, so filtered-out groups disappeared before gap rows could be
generated. When HAVING eliminated every group the query returned zero
rows; when it eliminated some, GapFill still synthesized NULL rows for
the filtered buckets.

Lift the quals off the aggregate subpath and attach them to the
CustomScan plan's scan.plan.qual, then evaluate them on every tuple
(real and gap-filled) returned from gapfill_exec. Gap rows have NULL
aggregates, so standard SQL HAVING semantics apply: count(*) > N drops
them, count(*) IS NULL keeps them.

Fall back to the old behaviour for queries where HAVING references an
Aggref that is not a top-level expression of the GapFill pathtarget
(e.g. HAVING sum(x) > 4 with locf(sum(x)) in the target list), since
set_customscan_references cannot resolve the bare Aggref against
custom_scan_tlist in that case.

Fixes #5202
