### PR TITLE
Fix timescaledb_post_restore() needing two calls to start workers

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -413,19 +413,23 @@ elif len(sys.argv) > 2:
 
     if tests:
         to_run = [t for t in list(tests) if t not in flaky_exclude_tests] * 20
-        random.shuffle(to_run)
-        installcheck_args = f'TESTS="{" ".join(to_run)}"'
-        m["include"].append(
-            build_debug_config(
-                {
-                    "coverage": False,
-                    "installcheck_args": installcheck_args,
-                    "name": "Flaky Check Debug",
-                    "pg": PG18_LATEST,
-                    "pginstallcheck": False,
-                }
+        # Skip the Flaky job when every changed test is excluded. Otherwise
+        # TESTS="" makes `make installcheck` run the full suite, which exposes
+        # pre-existing XX000s the per-test loop would never have touched.
+        if to_run:
+            random.shuffle(to_run)
+            installcheck_args = f'TESTS="{" ".join(to_run)}"'
+            m["include"].append(
+                build_debug_config(
+                    {
+                        "coverage": False,
+                        "installcheck_args": installcheck_args,
+                        "name": "Flaky Check Debug",
+                        "pg": PG18_LATEST,
+                        "pginstallcheck": False,
+                    }
+                )
             )
-        )
 
 # generate command to set github action variable
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /sql/timescaledb--*.sql
 /sql/pre_install/*.gen
 /sql/updates/*.gen
+/sql/updates/header.sql
 /data/
 /src/*.o
 /src/*.so

--- a/.unreleased/pr_9625
+++ b/.unreleased/pr_9625
@@ -1,0 +1,1 @@
+Fixes: #9625 Make timescaledb_post_restore() reliably restart background workers in a single call

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -42,6 +42,7 @@
 
 /* for getting settings correct before loading the versioned scheduler */
 #include "catalog/pg_db_role_setting.h"
+#include "utils/guc.h"
 
 #include "../compat/compat.h"
 #include "../extension_constants.h"
@@ -963,6 +964,16 @@ process_settings(Oid databaseid)
 
 	if (!IsUnderPostmaster)
 		return;
+
+	/*
+	 * Force the restoring placeholder's reset_val to "off". The worker may
+	 * have read pg_db_role_settings before post_restore's RESET committed and
+	 * stored the old 'on' value as reset_val. ApplySetting below only applies
+	 * rows that exist, so the stale reset_val would be inherited by the real
+	 * GUC once DefineCustomBoolVariable runs and the scheduler would exit.
+	 * NULL would only restore that stale value, so pass "off" explicitly.
+	 */
+	SetConfigOption(MAKE_EXTOPTION("restoring"), "off", PGC_SUSET, PGC_S_DATABASE);
 
 	relsetting = table_open(DbRoleSettingRelationId, AccessShareLock);
 

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -385,6 +385,51 @@ SELECT wait_worker_counts(1,0,1,0);
 --------------------
  t
 
+-- A single timescaledb_post_restore() should keep the scheduler running
+-- even if a new worker reads pg_db_role_settings before post_restore's
+-- RESET commits and stores restoring='on' as the placeholder's reset_val.
+-- Without the loader fix the versioned .so picks up that stale value via
+-- DefineCustomBoolVariable and the scheduler exits silently.
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+
+SELECT wait_worker_counts(1,0,0,0);
+ wait_worker_counts 
+--------------------
+ t
+
+BEGIN;
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+
+-- Wait for the worker to read pg_db_role_settings (which still shows
+-- restoring='on' because the RESET has not committed yet).
+SELECT wait_worker_counts(1,0,1,0);
+ wait_worker_counts 
+--------------------
+ t
+
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+
+COMMIT;
+-- Give the scheduler time to exit (bug) or keep running (fix).
+SELECT pg_sleep(2);
+ pg_sleep 
+----------
+ 
+
+SELECT wait_worker_counts(1,0,1,0);
+ wait_worker_counts 
+--------------------
+ t
+
 -- Make sure dropping the extension means that the scheduler is stopped
 BEGIN;
 DROP EXTENSION timescaledb;

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -171,6 +171,24 @@ COMMIT;
 -- And they stay started
 SELECT wait_worker_counts(1,0,1,0);
 
+-- A single timescaledb_post_restore() should keep the scheduler running
+-- even if a new worker reads pg_db_role_settings before post_restore's
+-- RESET commits and stores restoring='on' as the placeholder's reset_val.
+-- Without the loader fix the versioned .so picks up that stale value via
+-- DefineCustomBoolVariable and the scheduler exits silently.
+SELECT timescaledb_pre_restore();
+SELECT wait_worker_counts(1,0,0,0);
+BEGIN;
+SELECT timescaledb_post_restore();
+-- Wait for the worker to read pg_db_role_settings (which still shows
+-- restoring='on' because the RESET has not committed yet).
+SELECT wait_worker_counts(1,0,1,0);
+SELECT pg_sleep(1);
+COMMIT;
+-- Give the scheduler time to exit (bug) or keep running (fix).
+SELECT pg_sleep(2);
+SELECT wait_worker_counts(1,0,1,0);
+
 -- Make sure dropping the extension means that the scheduler is stopped
 BEGIN;
 DROP EXTENSION timescaledb;


### PR DESCRIPTION
A single timescaledb_post_restore() could leave the bgw scheduler
exiting silently when the freshly spawned worker had read its session
settings (BackgroundWorkerInitializeConnectionByOid) before the
post_restore txn committed. The worker saw the still-uncommitted
ALTER DATABASE … SET timescaledb.restoring='on' and recorded it as the
placeholder's reset_val. The subsequent process_settings re-read iterates
only over rows present in pg_db_role_settings, so the removed row left
the placeholder's reset_val intact at 'on'. When the versioned .so
defined the real GUC via DefineCustomBoolVariable, that 'on' was
inherited and the scheduler exited because it thought the database was
still being restored.

Force the placeholder's database-level value back to 'off' before
re-reading pg_db_role_settings. A subsequent ApplySetting call (if a
row reappears) overrides this value.

Fixes #5842 

Disable-check: commit-count
Disable-check: loader-change

