### PR TITLE
Include database name in BGW launch logs and job worker names (#7430)

### DIFF
--- a/.unreleased/pr_7430
+++ b/.unreleased/pr_7430
@@ -1,0 +1,1 @@
+Implements: #7430 Include the database name in BGW launch logs and job worker bgw_name

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -23,6 +23,7 @@
 #include <storage/proc.h>
 #include <storage/shmem.h>
 #include <tcop/tcopprot.h>
+#include <commands/dbcommands.h>
 #include <utils/acl.h>
 #include <utils/inval.h>
 #include <utils/jsonb.h>
@@ -60,6 +61,17 @@ static bool jobs_list_needs_update;
 
 /* has to be global to shutdown jobs on exit */
 static List *scheduled_jobs = NIL;
+
+/*
+ * Cached name of the database this scheduler process is attached to.  Used in
+ * log messages and in the BGW name of job workers (#7430) so that centralised
+ * logs and ps output can distinguish which database a job belongs to.
+ *
+ * Populated once at scheduler startup from inside a transaction
+ * (ts_bgw_scheduler_process).  get_database_name() requires transaction
+ * context; the scheduler's inner loop runs outside one, so we cache here.
+ */
+static char scheduler_database_name[NAMEDATALEN] = { 0 };
 
 static MemoryContext scheduler_mctx;
 static MemoryContext scratch_mctx;
@@ -125,7 +137,21 @@ ts_bgw_start_worker(const char *name, const BgwParams *bgw_params)
 	};
 	BackgroundWorkerHandle *handle = NULL;
 
-	strlcpy(worker.bgw_name, name, BGW_MAXLEN);
+	/*
+	 * Include the database name in bgw_name so logs from the worker (and ps
+	 * output, and pg_stat_activity.backend_type) identify which database this
+	 * job belongs to (#7430).  snprintf's truncation preserves the
+	 * application_name prefix if the combined string overflows BGW_MAXLEN;
+	 * the database name suffix is lost first in that case, but the common
+	 * case (NAMEDATALEN is 64, BGW_MAXLEN is 96) fits comfortably.  The
+	 * database name is cached by ts_bgw_scheduler_process; fall back to the
+	 * old format if the cache has not been populated yet (e.g. the scheduler
+	 * process never entered the main loop).
+	 */
+	if (scheduler_database_name[0] != '\0')
+		snprintf(worker.bgw_name, BGW_MAXLEN, "%s [%s]", name, scheduler_database_name);
+	else
+		strlcpy(worker.bgw_name, name, BGW_MAXLEN);
 	strlcpy(worker.bgw_library_name, ts_extension_get_so_name(), BGW_MAXLEN);
 	strlcpy(worker.bgw_function_name, bgw_params->bgw_main, BGW_MAXLEN);
 
@@ -324,9 +350,10 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 			if (!sjob->reserved_worker)
 			{
 				elog(WARNING,
-					 "failed to launch job %d \"%s\": out of background workers",
+					 "failed to launch job %d \"%s\" in database \"%s\": out of background workers",
 					 sjob->job.fd.id,
-					 NameStr(sjob->job.fd.application_name));
+					 NameStr(sjob->job.fd.application_name),
+					 scheduler_database_name);
 				sjob->consecutive_failed_launches++;
 				scheduled_bgw_job_transition_state_to(sjob, JOB_STATE_SCHEDULED);
 				PopActiveSnapshot();
@@ -351,17 +378,19 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 			MemoryContextSwitchTo(scratch_mctx);
 
 			elog(DEBUG1,
-				 "launching job %d \"%s\"",
+				 "launching job %d \"%s\" in database \"%s\"",
 				 sjob->job.fd.id,
-				 NameStr(sjob->job.fd.application_name));
+				 NameStr(sjob->job.fd.application_name),
+				 scheduler_database_name);
 
 			sjob->handle = ts_bgw_job_start(&sjob->job, sjob->job.fd.owner);
 			if (sjob->handle == NULL)
 			{
 				elog(WARNING,
-					 "failed to launch job %d \"%s\": failed to start a background worker",
+					 "failed to launch job %d \"%s\" in database \"%s\": failed to start a background worker",
 					 sjob->job.fd.id,
-					 NameStr(sjob->job.fd.application_name));
+					 NameStr(sjob->job.fd.application_name),
+					 scheduler_database_name);
 				on_failure_to_start_job(sjob);
 				return;
 			}
@@ -841,6 +870,22 @@ ts_bgw_scheduler_process(int32 run_for_interval_ms,
 	/* txn to read the list of jobs from the DB */
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
+
+	/*
+	 * Cache the database name once, while we have transaction context.  Used
+	 * by log lines and job worker bgw_name downstream, where we are no longer
+	 * in a transaction (get_database_name calls SearchSysCache, which needs
+	 * one).  Safe to call only on first entry; on subsequent calls into
+	 * ts_bgw_scheduler_process we already have the value.
+	 */
+	if (scheduler_database_name[0] == '\0')
+	{
+		const char *dbname = get_database_name(MyDatabaseId);
+		strlcpy(scheduler_database_name,
+				dbname != NULL ? dbname : "unknown",
+				sizeof(scheduler_database_name));
+	}
+
 	scheduled_jobs = ts_update_scheduled_jobs_list(scheduled_jobs, scheduler_mctx);
 	PopActiveSnapshot();
 	CommitTransactionCommand();

--- a/tsl/test/expected/bgw_scheduler_control.out
+++ b/tsl/test/expected/bgw_scheduler_control.out
@@ -31,7 +31,16 @@ CREATE TABLE public.bgw_log(
 );
 CREATE VIEW cleaned_bgw_log AS
     SELECT msg_no, application_name,
-    	   regexp_replace(regexp_replace(msg, '(Wait until|started at|execution time|database) [0-9]+(\.[0-9]+)?', '\1 (RANDOM)', 'g'), 'background worker "[^"]+"','connection') AS msg
+    	   regexp_replace(
+    	     regexp_replace(
+    	       regexp_replace(msg,
+    	                      '(Wait until|started at|execution time|database) [0-9]+(\.[0-9]+)?',
+    	                      '\1 (RANDOM)',
+    	                      'g'),
+    	       'background worker "[^"]+"',
+    	       'connection'),
+    	     'in database "[^"]+"',
+    	     'in database "(RANDOM)"') AS msg
       FROM bgw_log ORDER BY mock_time, application_name COLLATE "C", msg_no;
 -- Remove all default jobs
 DELETE FROM _timescaledb_catalog.bgw_job WHERE TRUE;
@@ -89,7 +98,7 @@ SELECT * FROM cleaned_bgw_log;
 --------+------------------+-------------------------------------------------------------------------
       0 | DB Scheduler     | extension state changed: unknown to created
       1 | DB Scheduler     | database scheduler for database (RANDOM) starting
-      2 | DB Scheduler     | launching job 1000 "test_job_1b"
+      2 | DB Scheduler     | launching job 1000 "test_job_1b" in database "(RANDOM)"
       3 | DB Scheduler     | [TESTING] Registered new background worker
       4 | DB Scheduler     | [TESTING] Wait until (RANDOM), started at (RANDOM)
       0 | test_job_1b      | Execute job 1

--- a/tsl/test/sql/bgw_scheduler_control.sql
+++ b/tsl/test/sql/bgw_scheduler_control.sql
@@ -35,7 +35,16 @@ CREATE TABLE public.bgw_log(
 
 CREATE VIEW cleaned_bgw_log AS
     SELECT msg_no, application_name,
-    	   regexp_replace(regexp_replace(msg, '(Wait until|started at|execution time|database) [0-9]+(\.[0-9]+)?', '\1 (RANDOM)', 'g'), 'background worker "[^"]+"','connection') AS msg
+    	   regexp_replace(
+    	     regexp_replace(
+    	       regexp_replace(msg,
+    	                      '(Wait until|started at|execution time|database) [0-9]+(\.[0-9]+)?',
+    	                      '\1 (RANDOM)',
+    	                      'g'),
+    	       'background worker "[^"]+"',
+    	       'connection'),
+    	     'in database "[^"]+"',
+    	     'in database "(RANDOM)"') AS msg
       FROM bgw_log ORDER BY mock_time, application_name COLLATE "C", msg_no;
 
 -- Remove all default jobs


### PR DESCRIPTION
Implements #7430.

## Problem

In multi-database deployments with centralised logging, operators rely on `log_line_prefix`'s `%d` to route lines by tenant database. Postgres background workers do not populate `%d`, so every TimescaleDB job-launch line arrives in the central feed with no DB context:

    DEBUG:  launching job 1000 "Compression Policy [1000]"

Two users have asked for this in the last ~6 months; @akuzm suggested the direction in [his 2024-11-08 comment](https://github.com/timescale/timescaledb/issues/7430#issuecomment-2463729751) on the issue.

## Changes

**Scheduler-side log lines** (`src/bgw/scheduler.c`) now include the database name:

- `DEBUG1` `"launching job %d \"%s\" in database \"%s\""`
- `WARNING` `"failed to launch job %d \"%s\" in database \"%s\": out of background workers"`
- `WARNING` `"failed to launch job %d \"%s\" in database \"%s\": failed to start a background worker"`

**Job worker `bgw_name`** (`ts_bgw_start_worker` in the same file) now reads `"<application_name> [<dbname>]"` — visible in `ps`, `pg_stat_activity.backend_type`, and any log line `%a` prefix.

**Implementation note:** the database name is cached once at scheduler startup from inside the existing read-scheduled-jobs transaction (`ts_bgw_scheduler_process`). `get_database_name()` requires transaction context; the scheduler's per-job launch path runs outside one, so naively calling it per log line crashes the scheduler with a segfault (confirmed locally). Caching sidesteps that.

## What was explicitly out of scope

- The launcher-side scheduler BGW name (`bgw_launcher.c:312`) still uses the numeric `db_id`. I attempted to convert that to the DB name too; the launcher is not in a transaction when it registers the scheduler, and `get_database_name` segfaulted. Fixing that would need a separate mechanism (e.g., read `pg_database` directly via heapam, as the launcher already does earlier in `scan_for_existing_databases`). Leaving it for a follow-up — it's a minor cosmetic issue in the per-launcher log line, not in the per-job logs the issue is about.
- No changes to `application_name` — users may grep it in monitoring scripts.

## Test plan

- [x] Extended `cleaned_bgw_log` view in `tsl/test/sql/bgw_scheduler_control.sql` to regex-replace the dynamic database name with `(RANDOM)` so the expected file stays stable.
- [x] Updated `tsl/test/expected/bgw_scheduler_control.out` to match the new log format.
- [x] Built and verified locally against PG18: server starts cleanly, scheduler caches the DB name at startup, no runtime crash.
- [ ] `Verify tests fail on old code` — the updated expected should fail on unpatched main (new " in database ..." suffix).

Opened as **draft** to give the team a chance to steer on whether to also fix the launcher-side scheduler name before this merges, and whether `[<dbname>]` is the right format vs `on database "<dbname>"`.