### PR TITLE
Preserve chunk settings during recompress

### DIFF
--- a/.unreleased/pr_9632
+++ b/.unreleased/pr_9632
@@ -1,0 +1,1 @@
+Fixes: #9632 Preserve chunk settings during recompress

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -724,6 +724,16 @@ ts_accept_for_segmentby(CompressionSettings *settings, Form_pg_attribute attr)
 
 	return false;
 }
+/* Sparse indexes are only set by default when no user configuration exists */
+bool
+ts_can_set_default_sparse_index(CompressionSettings *settings)
+{
+	return (settings->fd.index == NULL) ||
+		   !ts_jsonb_has_key_value_str_field(settings->fd.index,
+											 ts_sparse_index_common_keys[SparseIndexKeySource],
+											 ts_sparse_index_source_names
+												 [_SparseIndexSourceEnumConfig]);
+}
 
 /* adds orderby sparse index settings into fd.index */
 Jsonb *

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -153,6 +153,7 @@ bool ts_contains_sparse_index_config(CompressionSettings *settings, const char *
 									 const char *sparse_index_type, bool skip_column_arrays);
 TSDLLEXPORT bool ts_column_has_sparse_index(CompressionSettings *settings, const char *attname);
 TSDLLEXPORT bool ts_accept_for_segmentby(CompressionSettings *settings, Form_pg_attribute attr);
+TSDLLEXPORT bool ts_can_set_default_sparse_index(CompressionSettings *settings);
 TSDLLEXPORT Jsonb *ts_add_orderby_sparse_index(CompressionSettings *settings);
 
 TSDLLEXPORT Jsonb *ts_remove_orderby_sparse_index(CompressionSettings *settings);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1610,17 +1610,6 @@ compression_setting_orderby_get_default(Hypertable *ht, ArrayType *segmentby)
 	return ts_compress_parse_order_collist(orderby, ht);
 }
 
-/* sparse indexes will only be set by default if there was no configuration */
-static bool
-can_set_default_sparse_index(CompressionSettings *settings)
-{
-	return (settings->fd.index == NULL) ||
-		   !ts_jsonb_has_key_value_str_field(settings->fd.index,
-											 ts_sparse_index_common_keys[SparseIndexKeySource],
-											 ts_sparse_index_source_names
-												 [_SparseIndexSourceEnumConfig]);
-}
-
 static void
 create_default_composite_bloom(IndexInfo *index_info, Hypertable *ht, CompressionSettings *settings,
 							   JsonbParseState *parse_state, TsBmsList *sparse_index_columns,
@@ -1736,7 +1725,7 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 	/*
 	 * Sparse indexes are only created automatically if they are not set in compression settings
 	 */
-	if (!ts_guc_auto_sparse_indexes || !can_set_default_sparse_index(settings))
+	if (!ts_guc_auto_sparse_indexes || !ts_can_set_default_sparse_index(settings))
 		return NULL;
 
 	/*
@@ -1870,7 +1859,7 @@ compression_settings_set_defaults(Hypertable *ht, CompressionSettings *settings,
 		add_orderby_sparse_index = true;
 	}
 
-	if (ts_guc_auto_sparse_indexes && can_set_default_sparse_index(settings))
+	if (ts_guc_auto_sparse_indexes && ts_can_set_default_sparse_index(settings))
 	{
 		settings->fd.index = compression_setting_sparse_index_get_default(ht, settings);
 		settings->fd.index = ts_add_orderby_sparse_index(settings);

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -826,6 +826,62 @@ perform_recompression(RecompressContext *recompress_ctx, Relation compressed_chu
 }
 
 /*
+ * Builds recompression settings for a chunk.
+ * Keeps the chunk's existing compression settings unless
+ * the user has explicitly configured settings at the hypertable level.
+ */
+static CompressionSettings *
+resolve_recompression_settings(Chunk *uncompressed_chunk)
+{
+	CompressionSettings *chunk_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	Ensure(chunk_settings != NULL,
+		   "compression settings not found for chunk \"%s\"",
+		   get_rel_name(uncompressed_chunk->table_id));
+
+	/* get hypertable level settings */
+	CompressionSettings *new_settings =
+		ts_compression_settings_get(uncompressed_chunk->hypertable_relid);
+	Ensure(new_settings != NULL,
+		   "compression settings not found for hypertable of chunk \"%s\"",
+		   get_rel_name(uncompressed_chunk->table_id));
+
+	new_settings->fd.relid = chunk_settings->fd.relid;
+	new_settings->fd.compress_relid = InvalidOid;
+
+	/* Set the chunk settings where hypertable settings are unset */
+	if (!new_settings->fd.orderby)
+	{
+		new_settings->fd.orderby = chunk_settings->fd.orderby;
+		new_settings->fd.orderby_desc = chunk_settings->fd.orderby_desc;
+		new_settings->fd.orderby_nullsfirst = chunk_settings->fd.orderby_nullsfirst;
+	}
+
+	if (!new_settings->fd.segmentby)
+	{
+		new_settings->fd.segmentby = chunk_settings->fd.segmentby;
+	}
+
+	if (ts_can_set_default_sparse_index(new_settings))
+	{
+		new_settings->fd.index = chunk_settings->fd.index;
+	}
+
+	/* Rebuild orderby sparse indexes for the final orderby columns */
+	if (new_settings->fd.orderby)
+	{
+		if (new_settings->fd.index)
+		{
+			new_settings->fd.index = ts_remove_orderby_sparse_index(new_settings);
+		}
+		new_settings->fd.index = ts_add_orderby_sparse_index(new_settings);
+	}
+
+	Ensure(new_settings->fd.orderby, "empty orderby after resolving recompression settings");
+
+	return new_settings;
+}
+
+/*
  * Perform per segment in-memory recompression of a compressed chunk.
  */
 bool
@@ -855,16 +911,10 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, lockmode);
 	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, lockmode);
 
-	/* Check new chunk will have the same compression settings */
-	Hypertable *ht = ts_hypertable_get_by_id(uncompressed_chunk->fd.hypertable_id);
-	CompressionSettings *check_new_settings =
-		ts_compression_settings_get(uncompressed_chunk->hypertable_relid);
-	compression_settings_set_defaults(ht,
-									  check_new_settings,
-									  ts_alter_table_with_clause_parse(NIL),
-									  false);
+	CompressionSettings *new_settings = resolve_recompression_settings(uncompressed_chunk);
 
-	if (!ts_array_equal(settings->fd.segmentby, check_new_settings->fd.segmentby))
+	/* if segmentby settings have changed, we need to fallback to full recompression */
+	if (!ts_array_equal(settings->fd.segmentby, new_settings->fd.segmentby))
 	{
 		table_close(uncompressed_chunk_rel, lockmode);
 		table_close(compressed_chunk_rel, lockmode);
@@ -891,19 +941,11 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 											   index_rel,
 											   false);
 
-	/* Delete old compression settings before creating new compressed chunk to avoid conflict */
-	ts_compression_settings_delete(uncompressed_chunk->table_id);
+	Hypertable *ht = ts_hypertable_get_by_id(uncompressed_chunk->fd.hypertable_id);
 	Hypertable *compressed_ht = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
 	Chunk *new_compressed_chunk =
-		create_compress_chunk(compressed_ht, uncompressed_chunk, InvalidOid, false, NULL);
-	/* The old compression settings were deleted above to avoid catalog conflicts. */
-	CompressionSettings *new_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+		create_compress_chunk(compressed_ht, uncompressed_chunk, InvalidOid, false, new_settings);
 	Relation new_compressed_chunk_rel = table_open(new_compressed_chunk->table_id, lockmode);
-
-	Ensure(ts_compression_settings_equal(new_settings, check_new_settings),
-		   "compression settings mismatch during recompression of \"%s.%s\"",
-		   NameStr(uncompressed_chunk->fd.schema_name),
-		   NameStr(uncompressed_chunk->fd.table_name));
 
 	perform_recompression(recompress_ctx,
 						  compressed_chunk_rel,

--- a/tsl/test/expected/compress_auto_sparse_index.out
+++ b/tsl/test/expected/compress_auto_sparse_index.out
@@ -27,7 +27,7 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 
 -- Should be disabled with the GUC
 set timescaledb.auto_sparse_indexes to off;
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
  count 
 -------
      1
@@ -40,7 +40,7 @@ explain (buffers off, costs off) select * from sparse where value = 1;
    ->  Seq Scan on compress_hyper_2_3_chunk
 
 reset timescaledb.auto_sparse_indexes;
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
  count 
 -------
      1
@@ -73,7 +73,7 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 -- Not for expression indexes.
 drop index ii;
 create index ii on sparse((value + 1));
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
  count 
 -------
      1
@@ -88,7 +88,7 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 -- Not for other index types.
 drop index ii;
 create index ii on sparse using hash(value);
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
  count 
 -------
      1
@@ -103,7 +103,7 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 
 -- When the chunk is recompressed without index, no sparse index is created.
 drop index ii;
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
  count 
 -------
      1

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -529,7 +529,7 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x');
 NOTICE:  updated compression settings will only apply to future compressions
-select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
  count 
 -------
      1
@@ -596,7 +596,7 @@ set timescaledb.enable_sparse_index_bloom to false;
 alter table test_sparse_index reset (timescaledb.compress_segmentby,
     timescaledb.compress_orderby,
     timescaledb.compress_index);
-select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
  count 
 -------
      1

--- a/tsl/test/expected/direct_compress_analyze_segmentby.out
+++ b/tsl/test/expected/direct_compress_analyze_segmentby.out
@@ -371,6 +371,85 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  _timescaledb_internal._hyper_27_39_chunk | _timescaledb_internal.compress_hyper_28_40_chunk |           | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 ROLLBACK;
+-- Test recompress preserves auto-discovered segmentby
+BEGIN;
+CREATE TABLE test_recompress_segmentby (
+    time TIMESTAMPTZ NOT NULL,
+    time2 TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    value FLOAT
+) WITH (tsdb.hypertable, tsdb.partition_column='time');
+-- Large insert triggers direct compress and auto-segmentby analysis
+INSERT INTO test_recompress_segmentby
+SELECT t, t, (i % 5), random()
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-02'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+-- device_id should be auto-selected as segmentby
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
+ test_recompress_segmentby                |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_29_41_chunk | _timescaledb_internal.compress_hyper_30_43_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+-- Small insert into the same chunk range makes it partial
+INSERT INTO test_recompress_segmentby VALUES
+    ('2024-01-01 12:00:00', '2024-01-01 12:00:00', 1, 99.9),
+    ('2024-01-01 12:01:00', '2024-01-01 12:01:00', 2, 88.8),
+    ('2024-01-01 12:02:00', '2024-01-01 12:02:00', 3, 77.7);
+WARNING:  disabling direct compress because of too small batch size
+-- Recompress should preserve the auto-discovered segmentby
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_recompress_segmentby') chunk; -- unordered, partial
+       chunk_status_text        
+--------------------------------
+ {COMPRESSED,UNORDERED,PARTIAL}
+
+SELECT compress_chunk(ch, recompress := true) FROM show_chunks('test_recompress_segmentby') ch;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_41_chunk
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
+ test_recompress_segmentby                |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_29_41_chunk | _timescaledb_internal.compress_hyper_30_43_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_recompress_segmentby') chunk; -- unordered
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
+SELECT compress_chunk(ch, recompress := true) FROM show_chunks('test_recompress_segmentby') ch;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_41_chunk
+
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_recompress_segmentby') chunk; -- compressed
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
+------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
+ test_recompress_segmentby                |                                                  |             |         |              |                    | 
+ _timescaledb_internal._hyper_29_41_chunk | _timescaledb_internal.compress_hyper_30_44_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+
+-- Recompress should overwrite settings
+ALTER TABLE test_recompress_segmentby SET (tsdb.segment_by = '', tsdb.order_by = 'time2');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(ch, recompress := true) FROM show_chunks('test_recompress_segmentby') ch;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_41_chunk
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+                  relid                   |                  compress_relid                  | segmentby |   orderby    | orderby_desc | orderby_nullsfirst |                                                          index                                                          
+------------------------------------------+--------------------------------------------------+-----------+--------------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------
+ test_recompress_segmentby                |                                                  | {}        | {time2,time} | {f,t}        | {f,t}              | [{"type": "minmax", "column": "time2", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_29_41_chunk | _timescaledb_internal.compress_hyper_30_45_chunk | {}        | {time2,time} | {f,t}        | {f,t}              | [{"type": "minmax", "column": "time2", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]
+
+ROLLBACK;
 -- Test default segmentby gets set via COPY path
 BEGIN;
 SET timescaledb.enable_direct_compress_insert = false;
@@ -389,14 +468,14 @@ ANALYZE test_copy_segmentby;
 SELECT compress_chunk(c) FROM show_chunks('test_copy_segmentby') c;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_29_41_chunk
+ _timescaledb_internal._hyper_31_46_chunk
 
 -- should have device_id as default segmentby
 SELECT * FROM _timescaledb_catalog.compression_settings;
                   relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
 ------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
  test_copy_segmentby                      |                                                  |             |         |              |                    | 
- _timescaledb_internal._hyper_29_41_chunk | _timescaledb_internal.compress_hyper_30_42_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_31_46_chunk | _timescaledb_internal.compress_hyper_32_47_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 SET timescaledb.enable_direct_compress_copy = true;
 -- 7205 rows with 5 device_ids into a new chunk range via COPY
@@ -407,8 +486,8 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
                   relid                   |                  compress_relid                  |  segmentby  | orderby | orderby_desc | orderby_nullsfirst |                            index                            
 ------------------------------------------+--------------------------------------------------+-------------+---------+--------------+--------------------+-------------------------------------------------------------
  test_copy_segmentby                      |                                                  |             |         |              |                    | 
- _timescaledb_internal._hyper_29_41_chunk | _timescaledb_internal.compress_hyper_30_42_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
- _timescaledb_internal._hyper_29_43_chunk | _timescaledb_internal.compress_hyper_30_45_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_31_46_chunk | _timescaledb_internal.compress_hyper_32_47_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ _timescaledb_internal._hyper_31_48_chunk | _timescaledb_internal.compress_hyper_32_50_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 ROLLBACK;
 -- Test NULL values in pass-by-reference column during auto segmentby analysis
@@ -417,7 +496,7 @@ CREATE TABLE test_null_text(time timestamptz NOT NULL, tag text, val float);
 SELECT create_hypertable('test_null_text', 'time', chunk_time_interval => '7 days'::interval);
       create_hypertable       
 ------------------------------
- (31,public,test_null_text,t)
+ (33,public,test_null_text,t)
 
 ALTER TABLE test_null_text SET (timescaledb.compress, timescaledb.compress_orderby = 'time');
 SET timescaledb.direct_compress_insert_tuple_sort_limit = 500;

--- a/tsl/test/sql/compress_auto_sparse_index.sql
+++ b/tsl/test/sql/compress_auto_sparse_index.sql
@@ -17,12 +17,12 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 
 -- Should be disabled with the GUC
 set timescaledb.auto_sparse_indexes to off;
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
 vacuum analyze sparse;
 explain (buffers off, costs off) select * from sparse where value = 1;
 
 reset timescaledb.auto_sparse_indexes;
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
 vacuum analyze sparse;
 explain (buffers off, costs off) select * from sparse where value = 1;
 
@@ -37,7 +37,7 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 -- Not for expression indexes.
 drop index ii;
 create index ii on sparse((value + 1));
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
 vacuum analyze sparse;
 explain (buffers off, costs off) select * from sparse where value = 1;
 
@@ -45,14 +45,14 @@ explain (buffers off, costs off) select * from sparse where value = 1;
 -- Not for other index types.
 drop index ii;
 create index ii on sparse using hash(value);
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
 vacuum analyze sparse;
 explain (buffers off, costs off) select * from sparse where value = 1;
 
 
 -- When the chunk is recompressed without index, no sparse index is created.
 drop index ii;
-select count(compress_chunk(x, recompress:=true)) from show_chunks('sparse') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('sparse') x;
 vacuum analyze sparse;
 explain (buffers off, costs off) select * from sparse where value = 1;
 

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -360,7 +360,7 @@ alter table test_sparse_index set (timescaledb.compress,
     timescaledb.compress_segmentby = '',
     timescaledb.compress_orderby = 'x');
 
-select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
 
 select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
     where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
@@ -394,7 +394,7 @@ set timescaledb.enable_sparse_index_bloom to false;
 alter table test_sparse_index reset (timescaledb.compress_segmentby,
     timescaledb.compress_orderby,
     timescaledb.compress_index);
-select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
+select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
 vacuum full analyze test_sparse_index;
 
 select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk

--- a/tsl/test/sql/direct_compress_analyze_segmentby.sql
+++ b/tsl/test/sql/direct_compress_analyze_segmentby.sql
@@ -307,6 +307,47 @@ FROM generate_series('2024-01-01'::timestamptz, '2024-01-02'::timestamptz, '1 mi
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ROLLBACK;
 
+-- Test recompress preserves auto-discovered segmentby
+BEGIN;
+CREATE TABLE test_recompress_segmentby (
+    time TIMESTAMPTZ NOT NULL,
+    time2 TIMESTAMPTZ NOT NULL,
+    device_id INT NOT NULL,
+    value FLOAT
+) WITH (tsdb.hypertable, tsdb.partition_column='time');
+
+-- Large insert triggers direct compress and auto-segmentby analysis
+INSERT INTO test_recompress_segmentby
+SELECT t, t, (i % 5), random()
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-02'::timestamptz, '1 minute') t,
+     generate_series(1, 5) i;
+
+-- device_id should be auto-selected as segmentby
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- Small insert into the same chunk range makes it partial
+INSERT INTO test_recompress_segmentby VALUES
+    ('2024-01-01 12:00:00', '2024-01-01 12:00:00', 1, 99.9),
+    ('2024-01-01 12:01:00', '2024-01-01 12:01:00', 2, 88.8),
+    ('2024-01-01 12:02:00', '2024-01-01 12:02:00', 3, 77.7);
+
+-- Recompress should preserve the auto-discovered segmentby
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_recompress_segmentby') chunk; -- unordered, partial
+SELECT compress_chunk(ch, recompress := true) FROM show_chunks('test_recompress_segmentby') ch;
+SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_recompress_segmentby') chunk; -- unordered
+SELECT compress_chunk(ch, recompress := true) FROM show_chunks('test_recompress_segmentby') ch;
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_recompress_segmentby') chunk; -- compressed
+SELECT * FROM _timescaledb_catalog.compression_settings;
+
+-- Recompress should overwrite settings
+ALTER TABLE test_recompress_segmentby SET (tsdb.segment_by = '', tsdb.order_by = 'time2');
+SELECT compress_chunk(ch, recompress := true) FROM show_chunks('test_recompress_segmentby') ch;
+
+
+SELECT * FROM _timescaledb_catalog.compression_settings;
+ROLLBACK;
+
 -- Test default segmentby gets set via COPY path
 BEGIN;
 SET timescaledb.enable_direct_compress_insert = false;


### PR DESCRIPTION
Recompress was recomputing settings from the hypertable, which lost auto-discovered segmentby. Instead, inherit missing fields from the existing chunk settings and pass them directly to create_compress_chunk. User configured settings will take precedence and will be maintained.