### PR TITLE
Nullify the hypertable cache pointer on invalidation

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -93,10 +93,10 @@ ts_cache_invalidate(Cache **cache_ptr)
 	cache->refcount--;
 	cache_destroy(cache_ptr);
 	/*
-     * Even if the cache stays alive due to pins, clear the caller
-     * pointer so that it cannot be reused. The cache itself will be
-     * freed with the last pin release (see remove_pin).
-     */
+	 * Even if the cache stays alive due to pins, clear the caller
+	 * pointer so that it cannot be reused. The cache itself will be
+	 * freed with the last pin release (see remove_pin).
+	 */
 	*cache_ptr = NULL;
 }
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -92,6 +92,12 @@ ts_cache_invalidate(Cache **cache_ptr)
 		return;
 	cache->refcount--;
 	cache_destroy(cache_ptr);
+	/*
+     * Even if the cache stays alive due to pins, clear the caller
+     * pointer so that it cannot be reused. The cache itself will be
+     * freed with the last pin release (see remove_pin).
+     */
+	*cache_ptr = NULL;
 }
 
 /*


### PR DESCRIPTION
Failure to do this results in the possible use after free if hypertable_cache_create fails due to out of memory.

Observed a segfault  on the running instance under low memory condition (schema obfuscated):
```
[1034109]: [69d02db8.fc77d-15] [XX000] ERROR:  cache "(null)" is not initialized

[1034109]: [69d02db8.fc77d-16]  [XX000] STATEMENT:  INSERT INTO sample_table (a_id, timestamp, metric, b_text, c_text, d_text, created, updated, e_bool) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), false) ON CONFLICT (a_id, timestamp, metric, b_text) DO NOTHING
[891]: [69c81ac3.37b-1174] 0 @,app= [00000] LOG:  server process (PID 1034109) was terminated by signal 11: Segmentation fault
[891]: [69c81ac3.37b-1175] 0 @,app= [00000] DETAIL:  Failed process was running: INSERT INTO sample_table (a_id, timestamp, metric, b_text, c_text, d_text, created, updated, e_bool) VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), false) ON CONFLICT (a_id, timestamp, metric, b_text) DO NOTHING
```

Disable-check: force-changelog-file