### PR TITLE
Fix NULL datumCopy crash in segmentby analysis

### DIFF
--- a/.unreleased/pr_9640
+++ b/.unreleased/pr_9640
@@ -1,0 +1,1 @@
+Fixes: #9640 Fix NULL datumCopy crash in segmentby analysis

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2989,7 +2989,8 @@ process_segmentby_candidate_value(ColumnAnalysis *ca, Datum val, bool is_null)
 	if (ca->n_distinct < MAX_SEGMENTBY_DISTINCT)
 	{
 		DistinctEntry *entry = &ca->entries[ca->n_distinct];
-		entry->value = datumCopy(val, ca->seg_info->typ_by_val, ca->seg_info->typlen);
+		entry->value =
+			is_null ? (Datum) 0 : datumCopy(val, ca->seg_info->typ_by_val, ca->seg_info->typlen);
 		entry->is_null = is_null;
 		entry->count = 1;
 		ca->n_distinct++;

--- a/tsl/test/expected/direct_compress_analyze_segmentby.out
+++ b/tsl/test/expected/direct_compress_analyze_segmentby.out
@@ -411,3 +411,24 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  _timescaledb_internal._hyper_29_43_chunk | _timescaledb_internal.compress_hyper_30_45_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 ROLLBACK;
+-- Test NULL values in pass-by-reference column during auto segmentby analysis
+BEGIN;
+CREATE TABLE test_null_text(time timestamptz NOT NULL, tag text, val float);
+SELECT create_hypertable('test_null_text', 'time', chunk_time_interval => '7 days'::interval);
+      create_hypertable       
+------------------------------
+ (31,public,test_null_text,t)
+
+ALTER TABLE test_null_text SET (timescaledb.compress, timescaledb.compress_orderby = 'time');
+SET timescaledb.direct_compress_insert_tuple_sort_limit = 500;
+SET timescaledb.direct_compress_segmentby_min_rows = 100;
+SET timescaledb.direct_compress_segmentby_batch_size_limit = 10;
+-- tag is text (pass-by-reference); mix of non-NULL and NULL values
+-- exercises the datumCopy guard for NULL distinct entries
+INSERT INTO test_null_text
+SELECT
+    '2020-01-01'::timestamptz + (i || ' seconds')::interval,
+    CASE WHEN i <= 200 THEN 'a' WHEN i <= 400 THEN 'b' ELSE NULL END,
+    i
+FROM generate_series(1, 600) i;
+ROLLBACK;

--- a/tsl/test/sql/direct_compress_analyze_segmentby.sql
+++ b/tsl/test/sql/direct_compress_analyze_segmentby.sql
@@ -336,3 +336,23 @@ ANALYZE test_copy_segmentby;
 -- should have default segmentby set for the new direct compressed chunk
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ROLLBACK;
+
+-- Test NULL values in pass-by-reference column during auto segmentby analysis
+BEGIN;
+CREATE TABLE test_null_text(time timestamptz NOT NULL, tag text, val float);
+SELECT create_hypertable('test_null_text', 'time', chunk_time_interval => '7 days'::interval);
+ALTER TABLE test_null_text SET (timescaledb.compress, timescaledb.compress_orderby = 'time');
+
+SET timescaledb.direct_compress_insert_tuple_sort_limit = 500;
+SET timescaledb.direct_compress_segmentby_min_rows = 100;
+SET timescaledb.direct_compress_segmentby_batch_size_limit = 10;
+
+-- tag is text (pass-by-reference); mix of non-NULL and NULL values
+-- exercises the datumCopy guard for NULL distinct entries
+INSERT INTO test_null_text
+SELECT
+    '2020-01-01'::timestamptz + (i || ' seconds')::interval,
+    CASE WHEN i <= 200 THEN 'a' WHEN i <= 400 THEN 'b' ELSE NULL END,
+    i
+FROM generate_series(1, 600) i;
+ROLLBACK;


### PR DESCRIPTION
When auto segmentby analysis encountered a NULL value in a pass-by-reference column like text, it called datumCopy on an undefined datum pointer, causing a crash.