### PR TITLE
Fix COPY path with transition tables after column drop

### DIFF
--- a/.unreleased/pr_9641
+++ b/.unreleased/pr_9641
@@ -1,0 +1,1 @@
+Fixes: #9641 Fix corrupted transition table tuples with COPY after column drop

--- a/src/copy.c
+++ b/src/copy.c
@@ -1086,6 +1086,16 @@ copyfrom(CopyChunkState *ccstate, ParseState *pstate, Hypertable *ht, MemoryCont
 		if (insertMethod != buffer->method)
 			TSCopyMultiInsertInfoFlush(&multiInsertInfo, cis);
 
+		/*
+		 * If we're capturing transition tuples, save the original tuple in
+		 * hypertable format before converting to chunk format. Chunks created
+		 * after a column drop have a different TupleDesc, and the transition
+		 * table must store tuples in the hypertable's format.
+		 * See PostgreSQL's CopyFrom in copyfrom.c.
+		 */
+		if (ccstate->cstate && ccstate->cstate->transition_capture != NULL)
+			ccstate->cstate->transition_capture->tcs_original_insert_tuple = myslot;
+
 		/* Convert the tuple to match the chunk's rowtype */
 		if (buffer->method == TS_CIM_SINGLE)
 		{

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -460,8 +460,12 @@ SELECT create_hypertable('transition_drop', 'time');
 ALTER TABLE transition_drop DROP COLUMN to_drop;
 CREATE OR REPLACE FUNCTION transition_drop_fn()
     RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+DECLARE
+    r record;
 BEGIN
-    PERFORM name FROM to_insert;
+    FOR r IN SELECT name, c1 FROM to_insert ORDER BY name LOOP
+        RAISE NOTICE 'transition: name=% c1=%', r.name, r.c1;
+    END LOOP;
     RETURN NULL;
 END $$;
 CREATE TRIGGER transition_drop_tg
@@ -469,5 +473,11 @@ CREATE TRIGGER transition_drop_tg
     REFERENCING NEW TABLE AS to_insert
     FOR EACH STATEMENT EXECUTE FUNCTION transition_drop_fn();
 INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxx', 1);
+NOTICE:  transition: name=xxxxx c1=1
 INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxxx', 1);
+NOTICE:  transition: name=xxxxxx c1=1
+-- Same issue also affects the COPY path.
+COPY transition_drop (time, name, c1) FROM STDIN;
+NOTICE:  transition: name=yyyyy c1=2
+NOTICE:  transition: name=yyyyyy c1=2
 DROP TABLE transition_drop;

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -346,8 +346,12 @@ ALTER TABLE transition_drop DROP COLUMN to_drop;
 
 CREATE OR REPLACE FUNCTION transition_drop_fn()
     RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+DECLARE
+    r record;
 BEGIN
-    PERFORM name FROM to_insert;
+    FOR r IN SELECT name, c1 FROM to_insert ORDER BY name LOOP
+        RAISE NOTICE 'transition: name=% c1=%', r.name, r.c1;
+    END LOOP;
     RETURN NULL;
 END $$;
 
@@ -358,5 +362,11 @@ CREATE TRIGGER transition_drop_tg
 
 INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxx', 1);
 INSERT INTO transition_drop (time, name, c1) VALUES ('2026-04-16 08:00:00+00', 'xxxxxx', 1);
+
+-- Same issue also affects the COPY path.
+COPY transition_drop (time, name, c1) FROM STDIN;
+2026-04-16 08:00:00+00	yyyyy	2
+2026-04-16 08:00:00+00	yyyyyy	2
+\.
 DROP TABLE transition_drop;
 


### PR DESCRIPTION
Commit 28667fc6 fixed this class of bug in the INSERT path but missed the COPY path, which has its own tuple routing in copy.c. When COPY inserts into a hypertable with a statement-level AFTER trigger that references a NEW TABLE, the transition table captured the chunk-format tuple instead of the hypertable-format one, and the trigger function read corrupted values from it (text fields truncated, integer fields read as NULL).

Fix by saving the original hypertable-format tuple in tcs_original_insert_tuple before converting to chunk format, matching PostgreSQL's CopyFrom in copyfrom.c.

Strengthen the existing #9613 regression test: the original trigger body "PERFORM name FROM to_insert" ran silently over corrupted transition tuples without detecting anything, so the test only caught the INSERT-path bug incidentally via a segfault in some builds. The updated trigger raises NOTICE with the actual column values so the expected-output file pins the correctness of captured tuples for both the INSERT and COPY paths.

Fixes #9613