### PR TITLE
Change how we work with apt install timeouts again

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Add repositories
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         apt-get update
         apt-get install -y wget lsb-release gnupg sudo postgresql-common git cmake jq
@@ -55,7 +55,7 @@ jobs:
         wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor -o /etc/apt/trusted.gpg.d/timescale_timescaledb.gpg
 
     - name: Install timescaledb
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         apt-get update
         apt-get install -y --no-install-recommends \

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Add repositories
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         apt-get update
         apt-get install -y wget lsb-release gnupg apt-transport-https sudo postgresql-common jq
@@ -58,7 +58,7 @@ jobs:
 
 
     - name: Install timescaledb
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         apt-get update
         apt-get install -y --no-install-recommends \
@@ -110,7 +110,7 @@ jobs:
         fi
 
     - name: Install toolkit
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         apt-get install -y --no-install-recommends \
           timescaledb-toolkit-postgresql-${{ matrix.pg }}

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -15,13 +15,10 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get -y install coccinelle
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install coccinelle
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -78,19 +78,16 @@ jobs:
       LLVM_VER: 17
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-          gpg --batch --export --export-options export-minimal --armor 15CF4D18AF4F7421 | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+      timeout-minutes: 15
+      run: |
+        gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+        gpg --batch --export --export-options export-minimal --armor 15CF4D18AF4F7421 | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
 
-          . /etc/os-release
-          echo "deb https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${LLVM_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
-          sudo apt-get update
+        . /etc/os-release
+        echo "deb https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${LLVM_VER} main" | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+        sudo apt-get update
 
-          sudo apt-get install clang-format-${LLVM_VER}
+        sudo apt-get install clang-format-${LLVM_VER}
     - name: Checkout source
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Check trailing whitespace

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -23,16 +23,13 @@ jobs:
         os: [ubuntu-22.04]
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install gnupg systemd-coredump gdb postgresql-common
-          yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-          sudo apt-get update
-          sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get update
+        sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -101,13 +101,10 @@ jobs:
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     steps:
       - name: Install Linux Dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
-            sudo apt-get update
-            sudo apt-get install jq
+        timeout-minutes: 15
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
       - name: Get board column of issue
         id: extract_board_column
         continue-on-error: true

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -22,16 +22,13 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
-          # If needed, install them before opening the core dump.
-          sudo apt-get update
-          sudo apt-get install 7zip clang lld llvm flex bison libipc-run-perl \
-            libtest-most-perl tree jq
+      timeout-minutes: 15
+      run: |
+        # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
+        # If needed, install them before opening the core dump.
+        sudo apt-get update
+        sudo apt-get install 7zip clang lld llvm flex bison libipc-run-perl \
+          libtest-most-perl tree jq
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -148,13 +145,10 @@ jobs:
 
     steps:
     - name: Install Linux dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install 7zip systemd-coredump gdb
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install 7zip systemd-coredump gdb
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -101,23 +101,20 @@ jobs:
 
     # /__e/node16/bin/node (used by actions/checkout@v4) needs 64-bit libraries
     - name: Install 64-bit libraries for GitHub actions
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         apt-get update
         apt-get install -y lib64atomic1 lib64gcc-s1 lib64stdc++6 libc6-amd64 jq
 
     - name: Install build dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
-          echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
-          apt-get install -y gcc make cmake libssl-dev libipc-run-perl \
-            libtest-most-perl sudo gdb git wget gawk lbzip2 flex bison lcov base-files \
-            locales clang-14 llvm-14 llvm-14-dev llvm-14-tools postgresql-client pkgconf \
-            icu-devtools
+      timeout-minutes: 15
+      run: |
+        PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
+        echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
+        apt-get install -y gcc make cmake libssl-dev libipc-run-perl \
+          libtest-most-perl sudo gdb git wget gawk lbzip2 flex bison lcov base-files \
+          locales clang-14 llvm-14 llvm-14-dev llvm-14-tools postgresql-client pkgconf \
+          icu-devtools
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -78,16 +78,13 @@ jobs:
     steps:
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
-          # If needed, install them before opening the core dump.
-          sudo apt-get update
-          sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \
-            libtest-most-perl pkgconf icu-devtools faketime jq ${{ matrix.extra_packages }}
+      timeout-minutes: 15
+      run: |
+        # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
+        # If needed, install them before opening the core dump.
+        sudo apt-get update
+        sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \
+          libtest-most-perl pkgconf icu-devtools faketime jq ${{ matrix.extra_packages }}
 
     - name: Check macOS Build Dependencies
       if: runner.os == 'macOS'
@@ -97,17 +94,14 @@ jobs:
 
     - name: Install macOS Test Dependencies
       if: runner.os == 'macOS' && matrix.installcheck
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          # Disable the automatic dependency upgrade executed by `brew install`
-          # https://docs.brew.sh/Manpage#install-options-formulacask-
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gawk
-          # Install perl modules after last Homebew call, since Homebrew can change the perl version
-          sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
-          sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
+      timeout-minutes: 15
+      run: |
+        # Disable the automatic dependency upgrade executed by `brew install`
+        # https://docs.brew.sh/Manpage#install-options-formulacask-
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install gawk
+        # Install perl modules after last Homebew call, since Homebrew can change the perl version
+        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
+        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 
     - name: Setup macOS coredump directory
       if: runner.os == 'macOS'

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -73,14 +73,11 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install cmake flex bison systemd-coredump gdb \
-            jq ${{ env.extra_packages }}
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install cmake flex bison systemd-coredump gdb \
+          jq ${{ env.extra_packages }}
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -19,16 +19,13 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install gnupg systemd-coredump gdb postgresql-common python3-psutil
-          yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-          sudo apt-get update
-          sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common python3-psutil
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get update
+        sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -78,16 +78,13 @@ jobs:
 
       - name: Install Linux Dependencies
         # we want the right version of Postgres for handling any dump file
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
-            sudo apt-get update
-            sudo apt-get install gnupg postgresql-common
-            yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-            sudo apt-get update
-            sudo apt-get install postgresql-17
+        timeout-minutes: 15
+        run: |
+          sudo apt-get update
+          sudo apt-get install gnupg postgresql-common
+          yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+          sudo apt-get update
+          sudo apt-get install postgresql-17
     
       - name: "Run update smoke test with v${{ matrix.version }} to ${{needs.get-next-version.outputs.next_version}}"
         # Now run the test.  Currently the cloud instance is always up.

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -16,15 +16,12 @@ jobs:
     steps:
 
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get purge llvm-16 llvm-17 llvm-18 clang-16 clang-17 clang-18
-          sudo apt-get install llvm-19 llvm-19-dev clang-19 libclang-19-dev clang-tidy-19 libcurl4-openssl-dev
-          sudo ln -sf /usr/bin/clang-tidy-19 /usr/bin/clang-tidy
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get purge llvm-16 llvm-17 llvm-18 clang-16 clang-17 clang-18
+        sudo apt-get install llvm-19 llvm-19-dev clang-19 libclang-19-dev clang-tidy-19 libcurl4-openssl-dev
+        sudo ln -sf /usr/bin/clang-tidy-19 /usr/bin/clang-tidy
 
     - name: Checkout timescaledb
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -48,7 +45,7 @@ jobs:
         clang-tidy --load /usr/local/lib/libPostgresCheck.so --checks='-*,postgres-*' --list-checks | grep postgres
 
     - name: Configure timescaledb
-      timeout-minutes: 3
+      timeout-minutes: 15
       run: |
         # installing postgres headers pulls in llvm-17 which confuses pg_ladybug build process so we install this here instead of at beginning
         sudo apt-get install postgresql-server-dev-16

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -48,34 +48,28 @@ jobs:
 
     steps:
       - name: Install Linux Dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
-            sudo apt-get update
-            sudo apt-get install pip postgresql-common
+        timeout-minutes: 15
+        run: |
+          sudo apt-get update
+          sudo apt-get install pip postgresql-common
 
       - name: Install testgres
         run: |
           pip install testgres
 
       - name: Install PostgreSQL ${{ matrix.pg_version_old}} and ${{ matrix.pg_version_new }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
-            yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-            echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
-            wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
-            sudo apt-get update
-            sudo apt-get install -y \
-              postgresql-${{ matrix.pg_version_old }} postgresql-server-dev-${{ matrix.pg_version_old }} \
-              postgresql-${{ matrix.pg_version_new }} postgresql-server-dev-${{ matrix.pg_version_new }}
-            sudo apt-get install -y --no-install-recommends \
-              timescaledb-2-postgresql-${{ matrix.pg_version_old }} \
-              timescaledb-2-postgresql-${{ matrix.pg_version_new }}
+        timeout-minutes: 15
+        run: |
+          yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+          echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
+          wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y \
+            postgresql-${{ matrix.pg_version_old }} postgresql-server-dev-${{ matrix.pg_version_old }} \
+            postgresql-${{ matrix.pg_version_new }} postgresql-server-dev-${{ matrix.pg_version_new }}
+          sudo apt-get install -y --no-install-recommends \
+            timescaledb-2-postgresql-${{ matrix.pg_version_old }} \
+            timescaledb-2-postgresql-${{ matrix.pg_version_new }}
 
       - name: Checkout TimescaleDB
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release_feature_freeze_ceremony.yaml
+++ b/.github/workflows/release_feature_freeze_ceremony.yaml
@@ -83,14 +83,11 @@ jobs:
           git config user.email "123763385+github-actions[bot]@users.noreply.github.com"
 
       - name: Install Linux Dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
-            sudo apt-get update
-            sudo apt-get install pip
-            pip install PyGithub requests
+        timeout-minutes: 15
+        run: |
+          sudo apt-get update
+          sudo apt-get install pip
+          pip install PyGithub requests
 
       # Read the next version and build the next versions
       - name: Set version configuration

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -82,14 +82,11 @@ jobs:
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \
-            libtest-most-perl jq ${{ env.extra_packages }}
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \
+          libtest-most-perl jq ${{ env.extra_packages }}
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -29,13 +29,10 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install shellcheck
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install shellcheck
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -60,16 +60,13 @@ jobs:
     steps:
 
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
-          # If needed, install them before opening the core dump.
-          sudo apt-get update
-          sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \
-            libtest-most-perl pkgconf icu-devtools clang-14 llvm-14 llvm-14-dev llvm-14-tools cmake
+      timeout-minutes: 15
+      run: |
+        # Don't add ddebs here because the ddebs mirror is always 503 Service Unavailable.
+        # If needed, install them before opening the core dump.
+        sudo apt-get update
+        sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl \
+          libtest-most-perl pkgconf icu-devtools clang-14 llvm-14 llvm-14-dev llvm-14-tools cmake
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -144,8 +141,8 @@ jobs:
     - name: make regresscheck
       id: regresscheck
       run: |
-          set -o pipefail
-          make -k -C build_snapshot installcheck IGNORES="${{ matrix.ignores }}" | tee installcheck.log
+        set -o pipefail
+        make -k -C build_snapshot installcheck IGNORES="${{ matrix.ignores }}" | tee installcheck.log
 
     - name: Show regression diffs
       if: always()

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -31,24 +31,21 @@ jobs:
 
     steps:
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install gnupg systemd-coredump gdb postgresql-common \
-              build-essential autoconf autoconf-archive \
-              libboost-regex-dev libsqlite3-dev jq
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common \
+            build-essential autoconf autoconf-archive \
+            libboost-regex-dev libsqlite3-dev jq
 
-          yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-          sudo apt-get purge postgresql*
-          sudo apt-get install libpqxx-dev postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get purge postgresql*
+        sudo apt-get install libpqxx-dev postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
-          # Make sure the system postgres service is not running.
-          sudo systemctl mask postgresql
-          sudo systemctl stop postgresql
-          { psql -c "select 1" && exit 1 ; } || :
+        # Make sure the system postgres service is not running.
+        sudo systemctl mask postgresql
+        sudo systemctl stop postgresql
+        { psql -c "select 1" && exit 1 ; } || :
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -80,13 +80,10 @@ jobs:
 
     - name: Install Linux Dependencies
       if: steps.check.outputs.should_run == 'true'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install flex bison cmake
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install flex bison cmake
 
     # We are going to rebuild Postgres daily, so that it doesn't suddenly break
     # ages after the original problem.

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -40,20 +40,17 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install Linux Dependencies
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-      with:
-        timeout_minutes: 3
-        max_attempts: 3
-        command: |
-          sudo apt-get update
-          sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev
-          yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-          echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
-          wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
-          sudo apt-get install -y --no-install-recommends timescaledb-2-postgresql-${{ matrix.pg }}
-          git fetch --tags
+      timeout-minutes: 15
+      run: |
+        sudo apt-get update
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
+        wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
+        sudo apt-get install -y --no-install-recommends timescaledb-2-postgresql-${{ matrix.pg }}
+        git fetch --tags
 
     - name: Update tests PG${{ matrix.pg }}
       run: |


### PR DESCRIPTION
The nick-fields/retry action doesn't work.
1) Can't kill processes running under sudo: https://github.com/nick-fields/retry/issues/114
2) Leaves stdin dangling so the interactive mode detection doesn't work: https://github.com/nick-fields/retry/issues/98

Increase timeout to 15 minutes instead.