### PR TITLE
Support ENABLE/DISABLE TRIGGER on hypertables

### DIFF
--- a/.unreleased/pr_9648
+++ b/.unreleased/pr_9648
@@ -1,0 +1,1 @@
+Implements: #9648 Support ENABLE/DISABLE TRIGGER on hypertables

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4825,11 +4825,7 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_DisableTrigAll:
 		case AT_EnableTrigUser:
 		case AT_DisableTrigUser:
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("hypertables do not support  "
-							"enabling or disabling triggers.")));
-			/* Break here to silence compiler */
+			foreach_chunk(ht, process_altertable_chunk, cmd);
 			break;
 		case AT_ClusterOn:
 			process_altertable_clusteron_end(ht, cmd);

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -391,11 +391,72 @@ SELECT * FROM color;
 
 -- switch back to default user to run some dropping tests
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER;
-\set ON_ERROR_STOP 0
--- test that disable trigger is disallowed
+-- test that ENABLE/DISABLE TRIGGER is propagated to chunks
+SELECT tgenabled FROM pg_trigger WHERE tgname = 'create_vehicle_trigger'
+  AND tgrelid = 'location'::regclass;
+ tgenabled 
+-----------
+ O
+
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+ tgenabled 
+-----------
+ O
+
 ALTER TABLE location DISABLE TRIGGER create_vehicle_trigger;
-ERROR:  hypertables do not support  enabling or disabling triggers.
-\set ON_ERROR_STOP 1
+SELECT tgenabled FROM pg_trigger WHERE tgname = 'create_vehicle_trigger'
+  AND tgrelid = 'location'::regclass;
+ tgenabled 
+-----------
+ D
+
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+ tgenabled 
+-----------
+ D
+
+ALTER TABLE location ENABLE TRIGGER create_vehicle_trigger;
+SELECT tgenabled FROM pg_trigger WHERE tgname = 'create_vehicle_trigger'
+  AND tgrelid = 'location'::regclass;
+ tgenabled 
+-----------
+ O
+
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+ tgenabled 
+-----------
+ O
+
+ALTER TABLE location ENABLE ALWAYS TRIGGER create_vehicle_trigger;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+ tgenabled 
+-----------
+ A
+
+ALTER TABLE location DISABLE TRIGGER USER;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+ tgenabled 
+-----------
+ D
+
+ALTER TABLE location ENABLE TRIGGER USER;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+ tgenabled 
+-----------
+ O
+
 -- test that drop trigger works
 DROP TRIGGER create_color_trigger ON location;
 DROP TRIGGER create_vehicle_trigger ON location;

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -289,10 +289,41 @@ SELECT * FROM color;
 -- switch back to default user to run some dropping tests
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER;
 
-\set ON_ERROR_STOP 0
--- test that disable trigger is disallowed
+-- test that ENABLE/DISABLE TRIGGER is propagated to chunks
+SELECT tgenabled FROM pg_trigger WHERE tgname = 'create_vehicle_trigger'
+  AND tgrelid = 'location'::regclass;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+
 ALTER TABLE location DISABLE TRIGGER create_vehicle_trigger;
-\set ON_ERROR_STOP 1
+SELECT tgenabled FROM pg_trigger WHERE tgname = 'create_vehicle_trigger'
+  AND tgrelid = 'location'::regclass;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+
+ALTER TABLE location ENABLE TRIGGER create_vehicle_trigger;
+SELECT tgenabled FROM pg_trigger WHERE tgname = 'create_vehicle_trigger'
+  AND tgrelid = 'location'::regclass;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+
+ALTER TABLE location ENABLE ALWAYS TRIGGER create_vehicle_trigger;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+
+ALTER TABLE location DISABLE TRIGGER USER;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
+
+ALTER TABLE location ENABLE TRIGGER USER;
+SELECT DISTINCT tgenabled FROM pg_trigger t
+  JOIN show_chunks('location') c(oid) ON t.tgrelid = c.oid
+  WHERE tgname = 'create_vehicle_trigger';
 
 -- test that drop trigger works
 DROP TRIGGER create_color_trigger ON location;


### PR DESCRIPTION
Replace the hard rejection with propagation to all chunks via
foreach_chunk(). Since chunk triggers share the hypertable trigger's
name, AT_EnableTrig/AT_DisableTrig and their ALL/USER/ALWAYS/REPLICA
variants apply directly to each chunk without translation.

Fixes: #4757
