### PR TITLE
Recover bgw jobs stuck at next_start = -infinity after failover

### DIFF
--- a/.unreleased/pr_9360
+++ b/.unreleased/pr_9360
@@ -1,0 +1,1 @@
+Fixes: #9360 Sanitize DT_NOBEGIN next_start to recover jobs stuck after primary failover

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -518,12 +518,15 @@ bgw_job_stat_tuple_mark_end(TupleInfo *ti, void *const data)
 
 		/*
 		 * Mark the next start at the end if the job itself hasn't (this may
-		 * have happened before failure) and the failure was not in starting.
-		 * If the failure was in starting, then next_start should have been
-		 * restored in `on_failure_to_start_job` and thus we don't change it here.
-		 * Even if it wasn't restored, then keep it as DT_NOBEGIN to mark it as highest priority.
+		 * have happened before failure). For JOB_FAILURE_TO_START the
+		 * next_start should already have been restored to its previous value
+		 * in `on_failure_to_start_job` so we don't need to recalculate.
+		 * However when the previous next_start was DT_NOBEGIN (the sentinel
+		 * mark_start writes) the restore is skipped and the row would be
+		 * left pinned at -infinity. Calculate a real next_start in that case
+		 * to avoid the job getting permanently stuck.
 		 */
-		if (!bgw_job_stat_next_start_was_set(fd) && result_ctx->result != JOB_FAILURE_TO_START)
+		if (!bgw_job_stat_next_start_was_set(fd))
 			fd->next_start = calculate_next_start_on_failure(fd->last_finish,
 															 fd->consecutive_failures,
 															 result_ctx->job,
@@ -814,6 +817,19 @@ ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job, int32 consecutive_f
 
 		return calculate_next_start_on_crash(jobstat->fd.consecutive_crashes, job);
 	}
+
+	/*
+	 * A persisted next_start of DT_NOBEGIN is a sentinel mark_start writes
+	 * while a job is running. After a primary failover it can be inherited
+	 * by the new primary, and on_failure_to_start_job's `next_start !=
+	 * DT_NOBEGIN` guard can also leave it in this state. Returning
+	 * DT_NOBEGIN here would propagate the sentinel into sjob->next_start
+	 * and the row would never be cleared, leaving the job permanently
+	 * stuck. Sanitize to "now" so the scheduler runs the job and a real
+	 * next_start gets persisted on completion.
+	 */
+	if (jobstat->fd.next_start == DT_NOBEGIN)
+		return ts_timer_get_current_timestamp();
 
 	return jobstat->fd.next_start;
 }

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -1531,6 +1531,49 @@ SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_i
 ------------------------------+------------------------+------------------
  Fri Dec 31 16:00:00 1999 PST | -infinity              | f
 
+--
+-- Test recovery from a failover-inherited job_stat row pinned at
+-- next_start = -infinity. mark_start writes -infinity while a job is
+-- running, and a primary crash before mark_end leaves the replica with
+-- this sentinel. The scheduler must replace it with a real next_start
+-- rather than propagate -infinity (issue #9360).
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_catalog.bgw_job;
+SELECT ts_bgw_params_reset_time();
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+
+SELECT insert_job('test_failover_recovery', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS failover_job_id \gset
+-- Inherited from a primary that crashed mid-execution.
+INSERT INTO _timescaledb_internal.bgw_job_stat
+(job_id, last_start, last_finish, next_start, last_successful_finish,
+ last_run_success, total_runs, total_duration, total_duration_failures,
+ total_successes, total_failures, total_crashes, consecutive_failures,
+ consecutive_crashes, flags)
+VALUES (:failover_job_id, '2020-01-01'::timestamptz, '-infinity', '-infinity',
+        '-infinity', false, 1, '0'::interval, '0'::interval, 0, 0, 1, 0, 1, 0);
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Run long enough mock-time to clear the post-crash 5 minute wait.
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(400000);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+
+-- The scheduler must have run the job and replaced -infinity with a real
+-- next_start so subsequent scheduler ticks can pick up the job again.
+SELECT total_successes > 0 AS job_ran,
+       next_start <> '-infinity'::timestamptz AS next_start_recovered,
+       last_finish <> '-infinity'::timestamptz AS last_finish_recovered,
+       consecutive_crashes = 0 AS crash_counter_cleared
+FROM _timescaledb_internal.bgw_job_stat WHERE job_id = :failover_job_id;
+ job_ran | next_start_recovered | last_finish_recovered | crash_counter_cleared 
+---------+----------------------+-----------------------+-----------------------
+ t       | t                    | t                     | t
+
 -- clean up jobs
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_functions.stop_background_workers();

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -698,6 +698,41 @@ SELECT job_id, last_run_success, total_runs, total_successes, total_failures, to
 SELECT * FROM sorted_bgw_log WHERE msg NOT LIKE '[TESTING] Wait until%';
 SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_internal.bgw_job_stat;
 
+--
+-- Test recovery from a failover-inherited job_stat row pinned at
+-- next_start = -infinity. mark_start writes -infinity while a job is
+-- running, and a primary crash before mark_end leaves the replica with
+-- this sentinel. The scheduler must replace it with a real next_start
+-- rather than propagate -infinity (issue #9360).
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_catalog.bgw_job;
+SELECT ts_bgw_params_reset_time();
+SELECT insert_job('test_failover_recovery', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', INTERVAL '1s') AS failover_job_id \gset
+
+-- Inherited from a primary that crashed mid-execution.
+INSERT INTO _timescaledb_internal.bgw_job_stat
+(job_id, last_start, last_finish, next_start, last_successful_finish,
+ last_run_success, total_runs, total_duration, total_duration_failures,
+ total_successes, total_failures, total_crashes, consecutive_failures,
+ consecutive_crashes, flags)
+VALUES (:failover_job_id, '2020-01-01'::timestamptz, '-infinity', '-infinity',
+        '-infinity', false, 1, '0'::interval, '0'::interval, 0, 0, 1, 0, 1, 0);
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Run long enough mock-time to clear the post-crash 5 minute wait.
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(400000);
+
+-- The scheduler must have run the job and replaced -infinity with a real
+-- next_start so subsequent scheduler ticks can pick up the job again.
+SELECT total_successes > 0 AS job_ran,
+       next_start <> '-infinity'::timestamptz AS next_start_recovered,
+       last_finish <> '-infinity'::timestamptz AS last_finish_recovered,
+       consecutive_crashes = 0 AS crash_counter_cleared
+FROM _timescaledb_internal.bgw_job_stat WHERE job_id = :failover_job_id;
+
 -- clean up jobs
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_functions.stop_background_workers();


### PR DESCRIPTION
mark_start writes next_start = DT_NOBEGIN as a sentinel while a job
runs. If the primary crashes before mark_end, the replica inherits the
sentinel and the job can never be scheduled again: on_failure_to_start_job
guards set_next_start with `next_start != DT_NOBEGIN` so the row stays
pinned at -infinity, and ts_bgw_job_stat_next_start propagates that
sentinel back into the in-memory sjob->next_start.

Replace the sentinel with a real timestamp on both ends:
ts_bgw_job_stat_next_start returns the current time when the persisted
row is DT_NOBEGIN, and bgw_job_stat_tuple_mark_end recalculates
next_start whenever the field is still DT_NOBEGIN at end-of-job (also
for JOB_FAILURE_TO_START, which previously skipped the recalculation).

Fixes #9360
