### PR TITLE
Fix use-after-free of PlaceHolderVar.phrels in cached ChunkAppend plans

### DIFF
--- a/.unreleased/pr_9607_followup
+++ b/.unreleased/pr_9607_followup
@@ -1,0 +1,1 @@
+Fixes: #9607 Fix use-after-free of PlaceHolderVar.phrels in cached ChunkAppend plans

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -180,7 +180,14 @@ ts_chunk_append_state_create(CustomScan *cscan)
 	state->csstate.methods = &chunk_append_state_methods;
 
 	state->initial_subplans = cscan->custom_plans;
-	state->initial_ri_clauses = list_nth(cscan->custom_private, CAP_ChunkRIClauses);
+	/*
+	 * Deep-copy the restrictinfo clauses out of custom_private. initialize_constraints
+	 * may rewrite them with ChangeVarNodes, which allocates new Bitmapsets in the
+	 * current (per-execution) memory context. Mutating the cached plan would leave
+	 * dangling pointers inside cached PlaceHolderVars on the next EXECUTE.
+	 */
+	state->initial_ri_clauses =
+		(List *) copyObject(list_nth(cscan->custom_private, CAP_ChunkRIClauses));
 	state->sort_options = list_nth(cscan->custom_private, CAP_SortOptions);
 	state->initial_parent_clauses = list_nth(cscan->custom_private, CAP_ParentClauses);
 

--- a/tsl/test/shared/expected/parameterized_chunkappend.out
+++ b/tsl/test/shared/expected/parameterized_chunkappend.out
@@ -49,6 +49,9 @@ RESET enable_material;
 -- #9607: PlaceHolderVar in runtime chunk exclusion clauses used to trip
 -- pull_var_clause with flag 0. GROUP BY ROLLUP on a view over a hypertable
 -- combined with a join and a generic plan can produce such PlaceHolderVars.
+-- The second EXECUTE additionally guards against a use-after-free where
+-- ChangeVarNodes mutated PlaceHolderVar.phrels in the cached plan with a
+-- Bitmapset allocated in the per-execution memory context.
 PREPARE p9607(int, timestamptz, timestamptz) AS
 SELECT h.device_name, COUNT(*)
 FROM hourly_device_metrics h
@@ -56,6 +59,12 @@ JOIN devices d ON h.device_name = d.name
 WHERE h.device_id = $1 AND h.hour >= $2 AND h.hour < $3
 GROUP BY ROLLUP(h.device_name);
 SET plan_cache_mode = force_generic_plan;
+EXECUTE p9607(1, '2000-01-01'::timestamptz, '2000-01-20'::timestamptz);
+ device_name | count 
+-------------+-------
+             |   448
+ Device 1    |   448
+
 EXECUTE p9607(1, '2000-01-01'::timestamptz, '2000-01-20'::timestamptz);
  device_name | count 
 -------------+-------

--- a/tsl/test/shared/sql/parameterized_chunkappend.sql
+++ b/tsl/test/shared/sql/parameterized_chunkappend.sql
@@ -35,6 +35,9 @@ RESET enable_material;
 -- #9607: PlaceHolderVar in runtime chunk exclusion clauses used to trip
 -- pull_var_clause with flag 0. GROUP BY ROLLUP on a view over a hypertable
 -- combined with a join and a generic plan can produce such PlaceHolderVars.
+-- The second EXECUTE additionally guards against a use-after-free where
+-- ChangeVarNodes mutated PlaceHolderVar.phrels in the cached plan with a
+-- Bitmapset allocated in the per-execution memory context.
 PREPARE p9607(int, timestamptz, timestamptz) AS
 SELECT h.device_name, COUNT(*)
 FROM hourly_device_metrics h
@@ -43,6 +46,7 @@ WHERE h.device_id = $1 AND h.hour >= $2 AND h.hour < $3
 GROUP BY ROLLUP(h.device_name);
 
 SET plan_cache_mode = force_generic_plan;
+EXECUTE p9607(1, '2000-01-01'::timestamptz, '2000-01-20'::timestamptz);
 EXECUTE p9607(1, '2000-01-01'::timestamptz, '2000-01-20'::timestamptz);
 RESET plan_cache_mode;
 DEALLOCATE p9607;


### PR DESCRIPTION
initialize_constraints calls ChangeVarNodes on the chunk restrictinfo
clauses stored in cscan->custom_private. When such a clause contains a
PlaceHolderVar (possible since 6ac9acc allowed PHV-bearing clauses to
flow into ChunkAppend's runtime exclusion), the walker writes a fresh
Bitmapset for phv->phrels allocated in the per-execution memory context
back into the cached plan node. After the executor context is reset,
the next EXECUTE of the generic plan reads the dangling pointer.

Deep-copy the clause list at exec-init so all rewrites happen on the
executor copy, leaving custom_private untouched across executions.

Fixes #9607
