### PR TITLE
Fix sort_transform crash with hypertable on nullable side of outer join

### DIFF
--- a/.unreleased/pr_9654
+++ b/.unreleased/pr_9654
@@ -1,0 +1,1 @@
+Fixes: #9654 Fix backend crash in sort_transform with hypertable on nullable side of outer join

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -382,7 +382,16 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig, Relids child_relids
 			int i = -1;
 			while ((i = bms_next_member(em->em_relids, i)) >= 0)
 			{
+				/*
+				 * em_relids may include outer-join relids from varnullingrels
+				 * (PG16+); those don't correspond to a base RelOptInfo.
+				 */
+#if PG16_GE
+				if (bms_is_member(i, root->outer_join_rels))
+					continue;
+#endif
 				RelOptInfo *rel = root->simple_rel_array[i];
+				Assert(rel != NULL);
 
 				rel->eclass_indexes =
 					bms_add_member(rel->eclass_indexes, list_length(root->eq_classes));

--- a/test/expected/sort_optimization.out
+++ b/test/expected/sort_optimization.out
@@ -135,3 +135,18 @@ ORDER BY min(time);
 ------------------------------+------------+------------------
  Fri Jan 30 11:00:00 2026 CET |          1 |                2
 
+-- Crash in sort_transform_ec when a hypertable sits on the nullable side of an
+-- outer join and the pathkey expression references that nullable column.
+-- pull_varnos pulls outer-join nullingrels into em_relids on PG16+, and those
+-- relids have no entry in simple_rel_array.
+CREATE TABLE sort_oj_plain(v int);
+CREATE TABLE sort_oj_ht(time timestamptz NOT NULL, v int) WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+INSERT INTO sort_oj_ht VALUES ('2026-01-01', 1);
+SELECT DISTINCT time_bucket('1 day', b.time)
+FROM sort_oj_plain a LEFT JOIN sort_oj_ht b ON a.v = b.v;
+ time_bucket 
+-------------
+
+DROP TABLE sort_oj_ht;
+DROP TABLE sort_oj_plain;

--- a/test/sql/sort_optimization.sql
+++ b/test/sql/sort_optimization.sql
@@ -98,3 +98,15 @@ FROM row_numbered
 GROUP BY machine_id, (time - (seqnum * interval '1 minute'))
 ORDER BY min(time);
 
+-- Crash in sort_transform_ec when a hypertable sits on the nullable side of an
+-- outer join and the pathkey expression references that nullable column.
+-- pull_varnos pulls outer-join nullingrels into em_relids on PG16+, and those
+-- relids have no entry in simple_rel_array.
+CREATE TABLE sort_oj_plain(v int);
+CREATE TABLE sort_oj_ht(time timestamptz NOT NULL, v int) WITH (tsdb.hypertable);
+INSERT INTO sort_oj_ht VALUES ('2026-01-01', 1);
+SELECT DISTINCT time_bucket('1 day', b.time)
+FROM sort_oj_plain a LEFT JOIN sort_oj_ht b ON a.v = b.v;
+DROP TABLE sort_oj_ht;
+DROP TABLE sort_oj_plain;
+


### PR DESCRIPTION
sort_transform_ec() iterates the new EquivalenceMember's em_relids and indexes simple_rel_array[i] to update each rel's eclass_indexes. On PG16+, em_relids comes from pull_varnos() which includes outer-join relids tracked in Var.varnullingrels. Those outer-join relids have no RelOptInfo, so simple_rel_array[i] is NULL and the dereference crashes the backend.

Skip outer-join relids using root->outer_join_rels (PG16+); on PG15, varnullingrels does not exist so em_relids contains only base relids.

Found by sqlsmith: https://github.com/timescale/timescaledb/actions/runs/24974711869/job/73124246206