### PR TITLE
Fix data corruption when merging chunks with different compression settings

### DIFF
--- a/.unreleased/pr_9655
+++ b/.unreleased/pr_9655
@@ -1,0 +1,1 @@
+Fixes: #9655 Reject merge_chunks across chunks with different compression settings to prevent data corruption

--- a/tsl/src/chunk_merge.c
+++ b/tsl/src/chunk_merge.c
@@ -42,6 +42,7 @@
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/chunk_rewrite.h"
 #include "ts_catalog/compression_chunk_size.h"
+#include "ts_catalog/compression_settings.h"
 
 typedef struct RelationMergeInfo
 {
@@ -1319,6 +1320,45 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 		 * resort */
 		if (relinfos[i].isresult)
 			mergeindex = i;
+	}
+
+	/*
+	 * All compressed chunks being merged must share the same compression
+	 * settings. Without this check, the heap copy in merge_relinfos rewrites
+	 * tuples positionally between chunks whose compressed layouts diverge,
+	 * silently corrupting the merged chunk and producing decompression errors
+	 * or crashes at read time.
+	 */
+	{
+		const CompressionSettings *result_settings = NULL;
+		const Chunk *result_chunk = relinfos[mergeindex].chunk;
+
+		if (result_chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+			result_settings = ts_compression_settings_get(result_chunk->table_id);
+
+		for (int i = 0; i < nrelids; i++)
+		{
+			const Chunk *chunk = relinfos[i].chunk;
+			const CompressionSettings *settings;
+
+			if (i == mergeindex || chunk->fd.compressed_chunk_id == INVALID_CHUNK_ID)
+				continue;
+
+			settings = ts_compression_settings_get(chunk->table_id);
+
+			if (result_settings == NULL ||
+				!ts_compression_settings_equal(result_settings, settings))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("cannot merge compressed chunks with different "
+								"compression settings"),
+						 errdetail("Chunk \"%s\" was compressed with different "
+								   "settings than chunk \"%s\".",
+								   get_rel_name(chunk->table_id),
+								   get_rel_name(result_chunk->table_id)),
+						 errhint("Decompress the affected chunks and recompress them "
+								 "with the current compression settings before merging.")));
+		}
 	}
 
 	DEBUG_WAITPOINT("merge_chunks_before_rewrite");

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -946,3 +946,73 @@ ORDER BY schemaname, tablename;
 -- Cleanup
 DROP PUBLICATION test_merge_pub CASCADE;
 DROP TABLE pub_merge_test CASCADE;
+-- Test merging chunks compressed with different compression settings.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE compress_settings_merge(
+    time   timestamptz NOT NULL,
+    device int,
+    name   text,
+    temp   float8,
+    val    int
+);
+SELECT create_hypertable('compress_settings_merge', 'time', chunk_time_interval => INTERVAL '1 day');
+          create_hypertable           
+--------------------------------------
+ (6,public,compress_settings_merge,t)
+
+INSERT INTO compress_settings_merge VALUES
+    ('2024-01-01 12:00', 1, 'one', 1.5, 100),
+    ('2024-01-02 12:00', 2, 'two', 2.5, 200);
+SELECT format('%I.%I', schema_name, table_name) AS first_chunk
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='compress_settings_merge')
+ORDER BY id LIMIT 1 \gset
+SELECT format('%I.%I', schema_name, table_name) AS second_chunk
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='compress_settings_merge')
+ORDER BY id OFFSET 1 LIMIT 1 \gset
+-- Variant 1: change compress_segmentby between compressions.
+BEGIN;
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+SELECT compress_chunk(:'first_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_6_22_chunk
+
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='name');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(:'second_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_6_23_chunk
+
+\set ON_ERROR_STOP 0
+CALL merge_chunks(ARRAY[:'first_chunk', :'second_chunk']::regclass[]);
+ERROR:  cannot merge compressed chunks with different compression settings
+SELECT * FROM compress_settings_merge ORDER BY time;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+\set ON_ERROR_STOP 1
+ROLLBACK;
+-- Variant 2: change compress_orderby between compressions.
+BEGIN;
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+SELECT compress_chunk(:'first_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_6_22_chunk
+
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='val DESC');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(:'second_chunk');
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_6_23_chunk
+
+\set ON_ERROR_STOP 0
+CALL merge_chunks(ARRAY[:'first_chunk', :'second_chunk']::regclass[]);
+ERROR:  cannot merge compressed chunks with different compression settings
+SELECT * FROM compress_settings_merge ORDER BY time;
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+\set ON_ERROR_STOP 1
+ROLLBACK;
+DROP TABLE compress_settings_merge;

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -502,3 +502,58 @@ ORDER BY schemaname, tablename;
 -- Cleanup
 DROP PUBLICATION test_merge_pub CASCADE;
 DROP TABLE pub_merge_test CASCADE;
+
+-- Test merging chunks compressed with different compression settings.
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE compress_settings_merge(
+    time   timestamptz NOT NULL,
+    device int,
+    name   text,
+    temp   float8,
+    val    int
+);
+SELECT create_hypertable('compress_settings_merge', 'time', chunk_time_interval => INTERVAL '1 day');
+
+INSERT INTO compress_settings_merge VALUES
+    ('2024-01-01 12:00', 1, 'one', 1.5, 100),
+    ('2024-01-02 12:00', 2, 'two', 2.5, 200);
+
+SELECT format('%I.%I', schema_name, table_name) AS first_chunk
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='compress_settings_merge')
+ORDER BY id LIMIT 1 \gset
+SELECT format('%I.%I', schema_name, table_name) AS second_chunk
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='compress_settings_merge')
+ORDER BY id OFFSET 1 LIMIT 1 \gset
+
+-- Variant 1: change compress_segmentby between compressions.
+BEGIN;
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+SELECT compress_chunk(:'first_chunk');
+
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='name');
+SELECT compress_chunk(:'second_chunk');
+
+\set ON_ERROR_STOP 0
+CALL merge_chunks(ARRAY[:'first_chunk', :'second_chunk']::regclass[]);
+SELECT * FROM compress_settings_merge ORDER BY time;
+\set ON_ERROR_STOP 1
+ROLLBACK;
+
+-- Variant 2: change compress_orderby between compressions.
+BEGIN;
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+SELECT compress_chunk(:'first_chunk');
+
+ALTER TABLE compress_settings_merge SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='val DESC');
+SELECT compress_chunk(:'second_chunk');
+
+\set ON_ERROR_STOP 0
+CALL merge_chunks(ARRAY[:'first_chunk', :'second_chunk']::regclass[]);
+SELECT * FROM compress_settings_merge ORDER BY time;
+\set ON_ERROR_STOP 1
+ROLLBACK;
+
+DROP TABLE compress_settings_merge;


### PR DESCRIPTION
merge_chunks copies tuples positionally from each source chunk into the destination via heapam_relation_copy_for_cluster, which deforms with the source TupleDesc and re-forms with the destination's. When chunks were compressed under different compress_segmentby or compress_orderby settings the layouts diverge and column values get rewritten into the wrong attno. Depending on the swapped types, this either silently corrupts the merged chunk or crashes the backend during the merge or at decompression time.

Reject the merge with a clear error before any heap copy when the source chunks' compression settings differ from the destination chunk's.