### PR TITLE
Fix concurrent merge of compressed chunks dropping the new heap

### DIFF
--- a/.unreleased/pr_9656
+++ b/.unreleased/pr_9656
@@ -1,0 +1,1 @@
+Fixes: #9656 Fix concurrent merge of compressed chunks failing with cache lookup error

--- a/tsl/src/chunk_merge.c
+++ b/tsl/src/chunk_merge.c
@@ -1457,6 +1457,34 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 	 */
 	DEBUG_WAITPOINT("merge_chunks_before_heap_swap");
 
+	/*
+	 * Delete chunk_rewrite catalog rows for all non-result chunks (both
+	 * uncompressed and compressed) before running merge_chunks_finish.
+	 *
+	 * The cleanup loop in merge_chunks_finish drops the non-result chunks,
+	 * which cascades through chunk_tuple_delete -> ts_chunk_rewrite_delete.
+	 * That helper interprets a still-alive new_relid as an "orphaned heap"
+	 * and drops it -- but mid-merge the new compressed heap (new_crelid) is
+	 * still actively in use as the destination for the second
+	 * merge_chunks_finish call. Dropping it here would cascade-remove its
+	 * indexes and the second swap would fail with a cache-lookup error.
+	 *
+	 * Preemptively delete only the catalog rows so the cascade has nothing
+	 * to act on. The result-chunk row is still cleaned up inside
+	 * merge_chunks_finish.
+	 */
+	if (concurrently)
+	{
+		for (int i = 0; i < nrelids; i++)
+		{
+			if (!relinfos[i].isresult && ItemPointerIsValid(&relinfos[i].chunk_rewrite_tid))
+				ts_chunk_rewrite_delete_by_tid(&relinfos[i].chunk_rewrite_tid);
+
+			if (!crelinfos[i].isresult && ItemPointerIsValid(&crelinfos[i].chunk_rewrite_tid))
+				ts_chunk_rewrite_delete_by_tid(&crelinfos[i].chunk_rewrite_tid);
+		}
+	}
+
 	merge_chunks_finish(new_relid, relinfos, nrelids, &merge_stats);
 
 	if (OidIsValid(new_crelid))

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -1016,3 +1016,43 @@ ERROR:  current transaction is aborted, commands ignored until end of transactio
 \set ON_ERROR_STOP 1
 ROLLBACK;
 DROP TABLE compress_settings_merge;
+-- Concurrent merge of compressed chunks: chunk_rewrite cleanup must not drop
+-- the new compressed transient heap when cascading through non-result chunks.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE concurrent_compressed_merge(
+    time timestamptz NOT NULL, device int, temp float8
+);
+SELECT create_hypertable('concurrent_compressed_merge', 'time',
+                         chunk_time_interval => INTERVAL '1 day');
+            create_hypertable             
+------------------------------------------
+ (9,public,concurrent_compressed_merge,t)
+
+ALTER TABLE concurrent_compressed_merge
+    SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO concurrent_compressed_merge VALUES
+    ('2024-01-01 12:00', 1, 1.5),
+    ('2024-01-02 12:00', 2, 2.5);
+SELECT compress_chunk(ch) FROM show_chunks('concurrent_compressed_merge') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_9_28_chunk
+ _timescaledb_internal._hyper_9_29_chunk
+
+SELECT format('%I.%I', schema_name, table_name) AS ccm_c1
+  FROM _timescaledb_catalog.chunk
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='concurrent_compressed_merge')
+ ORDER BY id LIMIT 1 \gset
+SELECT format('%I.%I', schema_name, table_name) AS ccm_c2
+  FROM _timescaledb_catalog.chunk
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='concurrent_compressed_merge')
+ ORDER BY id OFFSET 1 LIMIT 1 \gset
+CALL merge_chunks(:'ccm_c1'::regclass, :'ccm_c2'::regclass, concurrently => true);
+SELECT count(*) AS rows_after, count(DISTINCT show_chunks) AS chunks_after
+FROM concurrent_compressed_merge,
+     show_chunks('concurrent_compressed_merge');
+ rows_after | chunks_after 
+------------+--------------
+          2 |            1
+
+DROP TABLE concurrent_compressed_merge;

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -557,3 +557,35 @@ SELECT * FROM compress_settings_merge ORDER BY time;
 ROLLBACK;
 
 DROP TABLE compress_settings_merge;
+
+-- Concurrent merge of compressed chunks: chunk_rewrite cleanup must not drop
+-- the new compressed transient heap when cascading through non-result chunks.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE concurrent_compressed_merge(
+    time timestamptz NOT NULL, device int, temp float8
+);
+SELECT create_hypertable('concurrent_compressed_merge', 'time',
+                         chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE concurrent_compressed_merge
+    SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO concurrent_compressed_merge VALUES
+    ('2024-01-01 12:00', 1, 1.5),
+    ('2024-01-02 12:00', 2, 2.5);
+SELECT compress_chunk(ch) FROM show_chunks('concurrent_compressed_merge') ch;
+
+SELECT format('%I.%I', schema_name, table_name) AS ccm_c1
+  FROM _timescaledb_catalog.chunk
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='concurrent_compressed_merge')
+ ORDER BY id LIMIT 1 \gset
+SELECT format('%I.%I', schema_name, table_name) AS ccm_c2
+  FROM _timescaledb_catalog.chunk
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name='concurrent_compressed_merge')
+ ORDER BY id OFFSET 1 LIMIT 1 \gset
+
+CALL merge_chunks(:'ccm_c1'::regclass, :'ccm_c2'::regclass, concurrently => true);
+
+SELECT count(*) AS rows_after, count(DISTINCT show_chunks) AS chunks_after
+FROM concurrent_compressed_merge,
+     show_chunks('concurrent_compressed_merge');
+
+DROP TABLE concurrent_compressed_merge;


### PR DESCRIPTION
merge_chunks(... concurrently => true) on compressed chunks ran merge_chunks_finish twice -- once for the uncompressed heaps, once for the compressed heaps. Both finish calls relied on their new transient heaps surviving across an inter-transaction commit.

The cleanup loop inside the first merge_chunks_finish drops each non-result chunk via ts_chunk_delete_by_name, which cascades through ts_chunk_drop on the compressed heap and into ts_chunk_rewrite_delete. That helper interpreted the still-alive new_crelid as an "orphaned heap" and dropped it. By the time the second merge_chunks_finish ran, new_crelid's index was gone and the file swap failed with "cache lookup failed for relation N".

Preemptively delete the chunk_rewrite catalog rows for non-result chunks (uncompressed and compressed) before running the heap-swap calls, using delete_by_tid so only the row is removed. The cascade during chunk drop then has nothing to act on, and both heap swaps complete correctly.