### PR TITLE
Point to new docs repo to generate GUCs documentation

### DIFF
--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
         run: |
-          if gh workflow run tsdb-refresh-gucs-list.yaml -R timescale/docs -f tag=${{ github.event.release.tag_name }}; then
+          if gh workflow run tsdb-refresh-gucs-list.yaml -R timescale/Tiger-Data-Docs -f tag=${{ github.event.release.tag_name }}; then
             echo "✅ Triggered generation of GUC list in docs" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ docs workflow to generate the GUCs failed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
We moved the docs to a new repo and need to point to it for generating the GUCs.

Disable-check: force-changelog-file
Disable-check: approval-count