### PR TITLE
Error on missing custom job function in ts_bgw_job_get_funcid

### DIFF
--- a/.unreleased/pr_9652
+++ b/.unreleased/pr_9652
@@ -1,0 +1,1 @@
+Fixes: #9652 Error on missing custom job function in ts_bgw_job_get_funcid

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -955,16 +955,21 @@ ts_bgw_job_get_funcid(BgwJob *job)
 								 makeString(NameStr(job->fd.proc_name)));
 	object->objargs = list_make2(SystemTypeName("int4"), SystemTypeName("jsonb"));
 
-	/* Return InvalidOid if don't found */
-	return LookupFuncWithArgs(OBJECT_ROUTINE, object, true);
+	Oid funcid = LookupFuncWithArgs(OBJECT_ROUTINE, object, true);
+	if (!OidIsValid(funcid))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("function or procedure \"%s.%s(integer, jsonb)\" does not exist",
+						NameStr(job->fd.proc_schema),
+						NameStr(job->fd.proc_name)),
+				 errhint("Custom job actions must accept (integer, jsonb) arguments.")));
+	return funcid;
 }
 
 const char *
 ts_bgw_job_function_call_string(BgwJob *job)
 {
-	Oid funcid = ts_bgw_job_get_funcid(job);
-	/* If do not found the function or procedure then fallback to PROKIND_FUNCTION */
-	char prokind = OidIsValid(funcid) ? get_func_prokind(funcid) : PROKIND_FUNCTION;
+	char prokind = get_func_prokind(ts_bgw_job_get_funcid(job));
 	StringInfoData stmt;
 	initStringInfo(&stmt);
 	char *jsonb_str = "NULL";

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -1074,20 +1074,11 @@ SELECT ts_test_bgw_job_function_call_string(:job_proc);
 ----------------------------------------------------------
  CALL public.custom_proc('1021', '{"type": "procedure"}')
 
--- Remove the procedure and let's check it fallingback to PROKIND_FUNCTION
+-- Remove the procedure and let's check it errors out when we try to call the function that gets the proc name
 DROP PROCEDURE custom_proc(jobid int, args jsonb);
-SELECT ts_test_bgw_job_function_call_string(:job_proc);
-            ts_test_bgw_job_function_call_string            
-------------------------------------------------------------
- SELECT public.custom_proc('1021', '{"type": "procedure"}')
-
 \set ON_ERROR_STOP 0
--- Mess with pg catalog to don't identify the PROKIND
-BEGIN;
-UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_func(int,jsonb)'::regprocedure;
-SELECT ts_test_bgw_job_function_call_string(:job_func);
-ERROR:  unsupported function type: X
-ROLLBACK;
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
+ERROR:  function or procedure "public.custom_proc(integer, jsonb)" does not exist
 \set ON_ERROR_STOP 1
 SELECT delete_job(:job_func);
  delete_job 

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -716,16 +716,10 @@ SELECT add_job('custom_proc', '1h', config => '{"type":"procedure"}'::jsonb) AS 
 SELECT ts_test_bgw_job_function_call_string(:job_func);
 SELECT ts_test_bgw_job_function_call_string(:job_proc);
 
--- Remove the procedure and let's check it fallingback to PROKIND_FUNCTION
+-- Remove the procedure and let's check it errors out when we try to call the function that gets the proc name
 DROP PROCEDURE custom_proc(jobid int, args jsonb);
-SELECT ts_test_bgw_job_function_call_string(:job_proc);
-
 \set ON_ERROR_STOP 0
--- Mess with pg catalog to don't identify the PROKIND
-BEGIN;
-UPDATE pg_catalog.pg_proc SET prokind = 'X' WHERE oid = 'custom_func(int,jsonb)'::regprocedure;
-SELECT ts_test_bgw_job_function_call_string(:job_func);
-ROLLBACK;
+SELECT ts_test_bgw_job_function_call_string(:job_proc);
 \set ON_ERROR_STOP 1
 
 SELECT delete_job(:job_func);


### PR DESCRIPTION
ts_bgw_job_get_funcid previously returned InvalidOid when the custom
action's (integer, jsonb) function could not be resolved, which forced
every caller to either guard against InvalidOid or risk crashing in
get_func_prokind. Raise a clear error with the expected signature in
the lookup itself and drop the now-unreachable fallback in
ts_bgw_job_function_call_string.
