### PR TITLE
Release 2.26.4

### DIFF
--- a/.unreleased/pr_9360
+++ b/.unreleased/pr_9360
@@ -1,1 +1,0 @@
-Fixes: #9360 Sanitize DT_NOBEGIN next_start to recover jobs stuck after primary failover

--- a/.unreleased/pr_9515
+++ b/.unreleased/pr_9515
@@ -1,2 +1,0 @@
-Fixes: #9515 Fix now() constification for continuous aggregate queries
-Thanks: @ivaaaan for reporting an issue with cosntraint pushdown in continuous aggregate queries

--- a/.unreleased/pr_9550
+++ b/.unreleased/pr_9550
@@ -1,2 +1,0 @@
-Fixes: #9550 Fix out of memory when propagating ALTER TABLE to many chunks
-Thanks: @patstrom for reporting an out of memory error when dropping constraints

--- a/.unreleased/pr_9605
+++ b/.unreleased/pr_9605
@@ -1,2 +1,0 @@
-Fixes: #9605 Fix InstrStartNode called twice in a row
-Thanks: @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain

--- a/.unreleased/pr_9607_followup
+++ b/.unreleased/pr_9607_followup
@@ -1,1 +1,0 @@
-Fixes: #9607 Fix use-after-free of PlaceHolderVar.phrels in cached ChunkAppend plans

--- a/.unreleased/pr_9612
+++ b/.unreleased/pr_9612
@@ -1,2 +1,0 @@
-Fixes: #9612 Fix PlaceHolderVar error in runtime chunk exclusion
-Thanks: @pcayen for reporting an issue with GROUP BY ROLLUP on views over hypertables

--- a/.unreleased/pr_9614
+++ b/.unreleased/pr_9614
@@ -1,1 +1,0 @@
-Fixes: #9614 Remove stale hypertable entries during upgrade

--- a/.unreleased/pr_9615
+++ b/.unreleased/pr_9615
@@ -1,2 +1,0 @@
-Fixes: #9615 Fix segfault with transition tables after column drop
-Thanks: @patstrom for reporting a segfault with transition table triggers after dropping a column

--- a/.unreleased/pr_9616
+++ b/.unreleased/pr_9616
@@ -1,1 +1,0 @@
-Fixes: #9616 Use DROP CASCADE for trigger removal

--- a/.unreleased/pr_9623
+++ b/.unreleased/pr_9623
@@ -1,2 +1,0 @@
-Fixes: #9623 Error when querying compressed chunks under Apache license
-Thanks: @igor2x for reporting a problem when trying to query compressed data with apache license

--- a/.unreleased/pr_9625
+++ b/.unreleased/pr_9625
@@ -1,1 +1,0 @@
-Fixes: #9625 Make timescaledb_post_restore() reliably restart background workers in a single call

--- a/.unreleased/pr_9639
+++ b/.unreleased/pr_9639
@@ -1,1 +1,0 @@
-Fixes: #9639 Fix lost orderby sparse index

--- a/.unreleased/pr_9641
+++ b/.unreleased/pr_9641
@@ -1,1 +1,0 @@
-Fixes: #9641 Fix corrupted transition table tuples with COPY after column drop

--- a/.unreleased/pr_9646
+++ b/.unreleased/pr_9646
@@ -1,1 +1,0 @@
-Fixes: #9646 Replace ERRCODE_INTERNAL_ERROR on user-reachable error paths

--- a/.unreleased/pr_9652
+++ b/.unreleased/pr_9652
@@ -1,1 +1,0 @@
-Fixes: #9652 Error on missing custom job function in ts_bgw_job_get_funcid

--- a/.unreleased/pr_9654
+++ b/.unreleased/pr_9654
@@ -1,1 +1,0 @@
-Fixes: #9654 Fix backend crash in sort_transform with hypertable on nullable side of outer join

--- a/.unreleased/pr_9655
+++ b/.unreleased/pr_9655
@@ -1,1 +1,0 @@
-Fixes: #9655 Reject merge_chunks across chunks with different compression settings to prevent data corruption

--- a/.unreleased/pr_9656
+++ b/.unreleased/pr_9656
@@ -1,1 +1,0 @@
-Fixes: #9656 Fix concurrent merge of compressed chunks failing with cache lookup error

--- a/.unreleased/pr_9660
+++ b/.unreleased/pr_9660
@@ -1,1 +1,0 @@
-Fixes: #9660 Fix incremental CAgg refresh so that extend_last_bucket only applies to the boundary batch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This release contains bug fixes since the 2.26.3 release. We recommend that you 
 * [#9656](https://github.com/timescale/timescaledb/pull/9656) Fix concurrent merge of compressed chunks dropping the new heap
 * [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix `COPY` path with transition tables after column drop
 * [#9660](https://github.com/timescale/timescaledb/pull/9660) Fix incremental continuous aggregate refresh so that `extend_last_bucket` only applies to the boundary batch
+* [#9674](https://github.com/timescale/timescaledb/pull/9674) Fix segmentby crash in cagg invalidation tracking
 
 **Thanks**
 * @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This release contains bug fixes since the 2.26.3 release. We recommend that you 
 * [#9654](https://github.com/timescale/timescaledb/pull/9654) Fix `sort_transform` crash with hypertable on nullable side of outer join
 * [#9656](https://github.com/timescale/timescaledb/pull/9656) Fix concurrent merge of compressed chunks dropping the new heap
 * [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix `COPY` path with transition tables after column drop
+* [#9660](https://github.com/timescale/timescaledb/pull/9660) Fix incremental continuous aggregate refresh so that `extend_last_bucket` only applies to the boundary batch
 
 **Thanks**
 * @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ This release contains bug fixes since the 2.26.3 release. We recommend that you 
 
 **Thanks**
 * @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain
-* @igor2x for reporting a problem when trying to query compressed data with apache license
-* @ivaaaan for reporting an issue with cosntraint pushdown in continuous aggregate queries
+* @igor2x for reporting a problem when trying to query compressed data with the Apache license
+* @ivaaaan for reporting an issue with constraint pushdown in continuous aggregate queries
 * @patstrom for reporting a segfault with transition table triggers after dropping a column
-* @patstrom for reporting an out of memory error when dropping constraints
+* @patstrom for reporting an out-of-memory error when dropping constraints
 * @pcayen for reporting an issue with GROUP BY ROLLUP on views over hypertables
 
 ## 2.26.3 (2026-04-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This release contains performance improvements and bug fixes since the 2.26.3 re
 * [#9655](https://github.com/timescale/timescaledb/pull/9655) Fix data corruption when merging chunks with different compression settings
 * [#9654](https://github.com/timescale/timescaledb/pull/9654) Fix `sort_transform` crash with hypertable on nullable side of outer join
 * [#9656](https://github.com/timescale/timescaledb/pull/9656) Fix concurrent merge of compressed chunks dropping the new heap
-* [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix COPY path with transition tables after column drop
+* [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix `COPY` path with transition tables after column drop
 
 **New Settings**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ This page lists all the latest features and updates to TimescaleDB. When
 you use psql to update your database, use the -X flag and prevent any .psqlrc
 commands from accidentally triggering the load of a previous DB version.**
 
+## 2.26.4 (2026-04-28)
+
+This release contains performance improvements and bug fixes since the 2.26.3 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.26.4**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* [#9360](https://github.com/timescale/timescaledb/pull/9360) Sanitize DT_NOBEGIN next_start to recover jobs stuck after primary failover
+* [#9515](https://github.com/timescale/timescaledb/pull/9515) Fix now() constification for continuous aggregate queries
+* [#9550](https://github.com/timescale/timescaledb/pull/9550) Fix out of memory when propagating ALTER TABLE to many chunks
+* [#9605](https://github.com/timescale/timescaledb/pull/9605) Fix InstrStartNode called twice in a row
+* [#9607](https://github.com/timescale/timescaledb/pull/9607) Fix use-after-free of PlaceHolderVar.phrels in cached ChunkAppend plans
+* [#9612](https://github.com/timescale/timescaledb/pull/9612) Fix PlaceHolderVar error in runtime chunk exclusion
+* [#9614](https://github.com/timescale/timescaledb/pull/9614) Remove stale hypertable entries during upgrade
+* [#9615](https://github.com/timescale/timescaledb/pull/9615) Fix segfault with transition tables after column drop
+* [#9616](https://github.com/timescale/timescaledb/pull/9616) Use DROP CASCADE for trigger removal
+* [#9623](https://github.com/timescale/timescaledb/pull/9623) Error when querying compressed chunks under Apache license
+* [#9625](https://github.com/timescale/timescaledb/pull/9625) Make timescaledb_post_restore() reliably restart background workers in a single call
+* [#9639](https://github.com/timescale/timescaledb/pull/9639) Fix lost orderby sparse index
+* [#9646](https://github.com/timescale/timescaledb/pull/9646) Replace ERRCODE_INTERNAL_ERROR on user-reachable error paths
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain
+* @igor2x for reporting a problem when trying to query compressed data with apache license
+* @ivaaaan for reporting an issue with cosntraint pushdown in continuous aggregate queries
+* @patstrom for reporting a segfault with transition table triggers after dropping a column
+* @patstrom for reporting an out of memory error when dropping constraints
+* @pcayen for reporting an issue with GROUP BY ROLLUP on views over hypertables
+
 ## 2.26.3 (2026-04-14)
 
 This release contains bug fixes since the 2.26.2 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,17 @@ This release contains performance improvements and bug fixes since the 2.26.3 re
 **Features**
 
 **Bugfixes**
-* [#9360](https://github.com/timescale/timescaledb/pull/9360) Sanitize DT_NOBEGIN next_start to recover jobs stuck after primary failover
-* [#9515](https://github.com/timescale/timescaledb/pull/9515) Fix now() constification for continuous aggregate queries
-* [#9550](https://github.com/timescale/timescaledb/pull/9550) Fix out of memory when propagating ALTER TABLE to many chunks
-* [#9605](https://github.com/timescale/timescaledb/pull/9605) Fix InstrStartNode called twice in a row
-* [#9607](https://github.com/timescale/timescaledb/pull/9607) Fix use-after-free of PlaceHolderVar.phrels in cached ChunkAppend plans
-* [#9612](https://github.com/timescale/timescaledb/pull/9612) Fix PlaceHolderVar error in runtime chunk exclusion
+* [#9360](https://github.com/timescale/timescaledb/pull/9360) Sanitize `DT_NOBEGIN` next_start to recover jobs stuck after primary failover
+* [#9515](https://github.com/timescale/timescaledb/pull/9515) Fix `now()` constification for continuous aggregate queries
+* [#9550](https://github.com/timescale/timescaledb/pull/9550) Fix out of memory when propagating `ALTER TABLE` to many chunks
+* [#9605](https://github.com/timescale/timescaledb/pull/9605) Fix `InstrStartNode` called twice in a row
+* [#9607](https://github.com/timescale/timescaledb/pull/9607) Fix use-after-free of `PlaceHolderVar.phrels` in cached ChunkAppend plans
+* [#9612](https://github.com/timescale/timescaledb/pull/9612) Fix `PlaceHolderVar` error in runtime chunk exclusion
 * [#9614](https://github.com/timescale/timescaledb/pull/9614) Remove stale hypertable entries during upgrade
 * [#9615](https://github.com/timescale/timescaledb/pull/9615) Fix segfault with transition tables after column drop
-* [#9616](https://github.com/timescale/timescaledb/pull/9616) Use DROP CASCADE for trigger removal
+* [#9616](https://github.com/timescale/timescaledb/pull/9616) Use `DROP CASCADE` for trigger removal
 * [#9623](https://github.com/timescale/timescaledb/pull/9623) Error when querying compressed chunks under Apache license
-* [#9625](https://github.com/timescale/timescaledb/pull/9625) Make timescaledb_post_restore() reliably restart background workers in a single call
+* [#9625](https://github.com/timescale/timescaledb/pull/9625) Make `timescaledb_post_restore()` reliably restart background workers in a single call
 * [#9639](https://github.com/timescale/timescaledb/pull/9639) Fix lost orderby sparse index
 * [#9646](https://github.com/timescale/timescaledb/pull/9646) Replace `ERRCODE_INTERNAL_ERROR` on user-reachable error paths
 * [#9652](https://github.com/timescale/timescaledb/pull/9652) Add Error on missing custom job function in `ts_bgw_job_get_funci`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ commands from accidentally triggering the load of a previous DB version.**
 This release contains performance improvements and bug fixes since the 2.26.3 release. We recommend that you upgrade at the next available opportunity.
 
 **Highlighted features in TimescaleDB v2.26.4**
-* 
 
 **Backward-Incompatible Changes**
 
@@ -29,7 +28,8 @@ This release contains performance improvements and bug fixes since the 2.26.3 re
 * [#9623](https://github.com/timescale/timescaledb/pull/9623) Error when querying compressed chunks under Apache license
 * [#9625](https://github.com/timescale/timescaledb/pull/9625) Make timescaledb_post_restore() reliably restart background workers in a single call
 * [#9639](https://github.com/timescale/timescaledb/pull/9639) Fix lost orderby sparse index
-* [#9646](https://github.com/timescale/timescaledb/pull/9646) Replace ERRCODE_INTERNAL_ERROR on user-reachable error paths
+* [#9646](https://github.com/timescale/timescaledb/pull/9646) Replace `ERRCODE_INTERNAL_ERROR` on user-reachable error paths
+* [#9652](https://github.com/timescale/timescaledb/pull/9652) Add Error on missing custom job function in `ts_bgw_job_get_funci`
 
 **New Settings**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ This release contains performance improvements and bug fixes since the 2.26.3 re
 * [#9639](https://github.com/timescale/timescaledb/pull/9639) Fix lost orderby sparse index
 * [#9646](https://github.com/timescale/timescaledb/pull/9646) Replace `ERRCODE_INTERNAL_ERROR` on user-reachable error paths
 * [#9652](https://github.com/timescale/timescaledb/pull/9652) Add Error on missing custom job function in `ts_bgw_job_get_funci`
+* [#9655](https://github.com/timescale/timescaledb/pull/9655) Fix data corruption when merging chunks with different compression settings
+* [#9654](https://github.com/timescale/timescaledb/pull/9654) Fix `sort_transform` crash with hypertable on nullable side of outer join
+* [#9656](https://github.com/timescale/timescaledb/pull/9656) Fix concurrent merge of compressed chunks dropping the new heap
+* [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix COPY path with transition tables after column drop
 
 **New Settings**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,7 @@ commands from accidentally triggering the load of a previous DB version.**
 
 ## 2.26.4 (2026-04-28)
 
-This release contains performance improvements and bug fixes since the 2.26.3 release. We recommend that you upgrade at the next available opportunity.
-
-**Highlighted features in TimescaleDB v2.26.4**
-
-**Backward-Incompatible Changes**
-
-**Features**
+This release contains bug fixes since the 2.26.3 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
 * [#9360](https://github.com/timescale/timescaledb/pull/9360) Sanitize `DT_NOBEGIN` next_start to recover jobs stuck after primary failover
@@ -34,10 +28,6 @@ This release contains performance improvements and bug fixes since the 2.26.3 re
 * [#9654](https://github.com/timescale/timescaledb/pull/9654) Fix `sort_transform` crash with hypertable on nullable side of outer join
 * [#9656](https://github.com/timescale/timescaledb/pull/9656) Fix concurrent merge of compressed chunks dropping the new heap
 * [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix `COPY` path with transition tables after column drop
-
-**New Settings**
-
-**GUCs**
 
 **Thanks**
 * @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain


### PR DESCRIPTION
## 2.26.4 (2026-04-28)

This release contains bug fixes since the 2.26.3 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#9360](https://github.com/timescale/timescaledb/pull/9360) Sanitize `DT_NOBEGIN` next_start to recover jobs stuck after primary failover
* [#9515](https://github.com/timescale/timescaledb/pull/9515) Fix `now()` constification for continuous aggregate queries
* [#9550](https://github.com/timescale/timescaledb/pull/9550) Fix out of memory when propagating `ALTER TABLE` to many chunks
* [#9605](https://github.com/timescale/timescaledb/pull/9605) Fix `InstrStartNode` called twice in a row
* [#9607](https://github.com/timescale/timescaledb/pull/9607) Fix use-after-free of `PlaceHolderVar.phrels` in cached ChunkAppend plans
* [#9612](https://github.com/timescale/timescaledb/pull/9612) Fix `PlaceHolderVar` error in runtime chunk exclusion
* [#9614](https://github.com/timescale/timescaledb/pull/9614) Remove stale hypertable entries during upgrade
* [#9615](https://github.com/timescale/timescaledb/pull/9615) Fix segfault with transition tables after column drop
* [#9616](https://github.com/timescale/timescaledb/pull/9616) Use `DROP CASCADE` for trigger removal
* [#9623](https://github.com/timescale/timescaledb/pull/9623) Error when querying compressed chunks under Apache license
* [#9625](https://github.com/timescale/timescaledb/pull/9625) Make `timescaledb_post_restore()` reliably restart background workers in a single call
* [#9639](https://github.com/timescale/timescaledb/pull/9639) Fix lost orderby sparse index
* [#9646](https://github.com/timescale/timescaledb/pull/9646) Replace `ERRCODE_INTERNAL_ERROR` on user-reachable error paths
* [#9652](https://github.com/timescale/timescaledb/pull/9652) Add Error on missing custom job function in `ts_bgw_job_get_funci`
* [#9655](https://github.com/timescale/timescaledb/pull/9655) Fix data corruption when merging chunks with different compression settings
* [#9654](https://github.com/timescale/timescaledb/pull/9654) Fix `sort_transform` crash with hypertable on nullable side of outer join
* [#9656](https://github.com/timescale/timescaledb/pull/9656) Fix concurrent merge of compressed chunks dropping the new heap
* [#9641](https://github.com/timescale/timescaledb/pull/9641) Fix `COPY` path with transition tables after column drop
* [#9660](https://github.com/timescale/timescaledb/pull/9660) Fix incremental continuous aggregate refresh so that `extend_last_bucket` only applies to the boundary batch
* [#9674](https://github.com/timescale/timescaledb/pull/9674) Fix segmentby crash in cagg invalidation tracking

**Thanks**
* @GetsuDer and @WeiJie-JL for reporting an error with timescaledb and extensions using Explain
* @igor2x for reporting a problem when trying to query compressed data with the Apache license
* @ivaaaan for reporting an issue with constraint pushdown in continuous aggregate queries
* @patstrom for reporting a segfault with transition table triggers after dropping a column
* @patstrom for reporting an out-of-memory error when dropping constraints
* @pcayen for reporting an issue with GROUP BY ROLLUP on views over hypertables