### PR TITLE
Allow database owner to configure hypertables and policies

### DIFF
--- a/.unreleased/pr_9668
+++ b/.unreleased/pr_9668
@@ -1,0 +1,1 @@
+Implements: #9668 Allow database owner to configure hypertables and policies

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -905,7 +905,7 @@ ts_bgw_job_check_max_retries(BgwJob *job)
 void
 ts_bgw_job_permission_check(BgwJob *job, const char *cmd)
 {
-	if (!has_privs_of_role(GetUserId(), job->fd.owner))
+	if (!ts_has_owner_privs(GetUserId(), job->fd.owner))
 	{
 		const char *owner_name = GetUserNameFromId(job->fd.owner, false);
 		const char *user_name = GetUserNameFromId(GetUserId(), false);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -5028,7 +5028,7 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 
 	Oid ht_ownerid = ts_rel_get_owner(parent_ht->main_table_relid);
 
-	if (!has_privs_of_role(GetUserId(), ht_ownerid))
+	if (!ts_has_owner_privs(GetUserId(), ht_ownerid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -103,7 +103,7 @@ ts_rel_get_owner(Oid relid)
 bool
 ts_hypertable_has_privs_of(Oid hypertable_oid, Oid userid)
 {
-	return has_privs_of_role(userid, ts_rel_get_owner(hypertable_oid));
+	return ts_has_owner_privs(userid, ts_rel_get_owner(hypertable_oid));
 }
 
 /*
@@ -118,7 +118,7 @@ ts_hypertable_permissions_check(Oid hypertable_oid, Oid userid)
 {
 	Oid ownerid = ts_rel_get_owner(hypertable_oid);
 
-	if (!has_privs_of_role(userid, ownerid))
+	if (!ts_has_owner_privs(userid, ownerid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4908,7 +4908,7 @@ continuous_agg_with_clause_perm_check(ContinuousAgg *cagg, Oid view_relid)
 {
 	Oid ownerid = ts_rel_get_owner(view_relid);
 
-	if (!has_privs_of_role(GetUserId(), ownerid))
+	if (!ts_has_owner_privs(GetUserId(), ownerid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1540,7 +1540,7 @@ ts_cagg_permissions_check(Oid cagg_oid, Oid userid)
 {
 	Oid ownerid = ts_rel_get_owner(cagg_oid);
 
-	if (!has_privs_of_role(userid, ownerid))
+	if (!ts_has_owner_privs(userid, ownerid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/utils.c
+++ b/src/utils.c
@@ -14,6 +14,7 @@
 #include <catalog/namespace.h>
 #include <catalog/objectaccess.h>
 #include <catalog/pg_am.h>
+#include <catalog/pg_authid_d.h>
 #include <catalog/pg_cast.h>
 #include <catalog/pg_inherits.h>
 #include <catalog/pg_operator.h>
@@ -935,6 +936,17 @@ ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
 {
 	EquivalenceMember *em = ts_find_em_for_rel(ec, rel);
 	return em ? em->em_expr : NULL;
+}
+
+/*
+ * True if `userid` has privileges of `ownerid` or of `pg_database_owner`.
+ * Used to gate hypertable/CAGG/job configuration: the table owner and the
+ * database owner are both allowed.
+ */
+bool
+ts_has_owner_privs(Oid userid, Oid ownerid)
+{
+	return has_privs_of_role(userid, ownerid) || has_privs_of_role(userid, ROLE_PG_DATABASE_OWNER);
 }
 
 bool

--- a/src/utils.h
+++ b/src/utils.h
@@ -143,6 +143,7 @@ extern TSDLLEXPORT Expr *ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInf
 extern TSDLLEXPORT EquivalenceMember *ts_find_em_for_rel(EquivalenceClass *ec, RelOptInfo *rel);
 
 extern TSDLLEXPORT bool ts_has_row_security(Oid relid);
+extern TSDLLEXPORT bool ts_has_owner_privs(Oid userid, Oid ownerid);
 
 extern TSDLLEXPORT List *ts_get_reloptions(Oid relid);
 

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -22,6 +22,7 @@
 #include "job.h"
 #include "job_api.h"
 #include "policies_v2.h"
+#include "utils.h"
 
 /* Default max runtime for a custom job is unlimited for now */
 #define DEFAULT_MAX_RUNTIME 0
@@ -261,7 +262,7 @@ job_delete(PG_FUNCTION_ARGS)
 
 	job = find_job(job_id, PG_ARGISNULL(0), false);
 
-	if (!has_privs_of_role(GetUserId(), job->fd.owner))
+	if (!ts_has_owner_privs(GetUserId(), job->fd.owner))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/tsl/test/expected/cagg_permissions-15.out
+++ b/tsl/test/expected/cagg_permissions-15.out
@@ -311,3 +311,39 @@ WHERE user_view = 'test_default_privileges.devices_summary'::regclass;
 ----------
  t
 
+-- Verify that members of pg_database_owner (the database owner) can
+-- configure continuous aggregates alongside the CAgg owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_metrics (
+    timec INT NOT NULL,
+    val   DOUBLE PRECISION
+);
+SELECT FROM create_hypertable('dbowner_metrics', 'timec', chunk_time_interval => 100);
+--
+
+CREATE OR REPLACE FUNCTION dbowner_now() RETURNS INT LANGUAGE SQL STABLE AS $$ SELECT 0::INT $$;
+SELECT set_integer_now_func('dbowner_metrics', 'dbowner_now');
+ set_integer_now_func 
+----------------------
+ 
+
+CREATE MATERIALIZED VIEW dbowner_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(100, timec) AS bucket, max(val)
+FROM dbowner_metrics
+GROUP BY bucket WITH NO DATA;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval);
+ERROR:  must be owner of continuous aggregate "dbowner_summary"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval) IS NOT NULL AS added;
+ added 
+-------
+ t
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/cagg_permissions-16.out
+++ b/tsl/test/expected/cagg_permissions-16.out
@@ -311,3 +311,39 @@ WHERE user_view = 'test_default_privileges.devices_summary'::regclass;
 ----------
  t
 
+-- Verify that members of pg_database_owner (the database owner) can
+-- configure continuous aggregates alongside the CAgg owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_metrics (
+    timec INT NOT NULL,
+    val   DOUBLE PRECISION
+);
+SELECT FROM create_hypertable('dbowner_metrics', 'timec', chunk_time_interval => 100);
+--
+
+CREATE OR REPLACE FUNCTION dbowner_now() RETURNS INT LANGUAGE SQL STABLE AS $$ SELECT 0::INT $$;
+SELECT set_integer_now_func('dbowner_metrics', 'dbowner_now');
+ set_integer_now_func 
+----------------------
+ 
+
+CREATE MATERIALIZED VIEW dbowner_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(100, timec) AS bucket, max(val)
+FROM dbowner_metrics
+GROUP BY bucket WITH NO DATA;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval);
+ERROR:  must be owner of continuous aggregate "dbowner_summary"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval) IS NOT NULL AS added;
+ added 
+-------
+ t
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/cagg_permissions-17.out
+++ b/tsl/test/expected/cagg_permissions-17.out
@@ -311,3 +311,39 @@ WHERE user_view = 'test_default_privileges.devices_summary'::regclass;
 ----------
  t
 
+-- Verify that members of pg_database_owner (the database owner) can
+-- configure continuous aggregates alongside the CAgg owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_metrics (
+    timec INT NOT NULL,
+    val   DOUBLE PRECISION
+);
+SELECT FROM create_hypertable('dbowner_metrics', 'timec', chunk_time_interval => 100);
+--
+
+CREATE OR REPLACE FUNCTION dbowner_now() RETURNS INT LANGUAGE SQL STABLE AS $$ SELECT 0::INT $$;
+SELECT set_integer_now_func('dbowner_metrics', 'dbowner_now');
+ set_integer_now_func 
+----------------------
+ 
+
+CREATE MATERIALIZED VIEW dbowner_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(100, timec) AS bucket, max(val)
+FROM dbowner_metrics
+GROUP BY bucket WITH NO DATA;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval);
+ERROR:  must be owner of continuous aggregate "dbowner_summary"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval) IS NOT NULL AS added;
+ added 
+-------
+ t
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/cagg_permissions-18.out
+++ b/tsl/test/expected/cagg_permissions-18.out
@@ -311,3 +311,39 @@ WHERE user_view = 'test_default_privileges.devices_summary'::regclass;
 ----------
  t
 
+-- Verify that members of pg_database_owner (the database owner) can
+-- configure continuous aggregates alongside the CAgg owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_metrics (
+    timec INT NOT NULL,
+    val   DOUBLE PRECISION
+);
+SELECT FROM create_hypertable('dbowner_metrics', 'timec', chunk_time_interval => 100);
+--
+
+CREATE OR REPLACE FUNCTION dbowner_now() RETURNS INT LANGUAGE SQL STABLE AS $$ SELECT 0::INT $$;
+SELECT set_integer_now_func('dbowner_metrics', 'dbowner_now');
+ set_integer_now_func 
+----------------------
+ 
+
+CREATE MATERIALIZED VIEW dbowner_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(100, timec) AS bucket, max(val)
+FROM dbowner_metrics
+GROUP BY bucket WITH NO DATA;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval);
+ERROR:  must be owner of continuous aggregate "dbowner_summary"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval) IS NOT NULL AS added;
+ added 
+-------
+ t
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/compression_permissions-15.out
+++ b/tsl/test/expected/compression_permissions-15.out
@@ -364,3 +364,58 @@ SELECT count(*) FROM ( SELECT show_chunks('conditions'))q;
 -------
     11
 
+-- Verify that members of pg_database_owner (the database owner) can run
+-- hypertable and policy configuration alongside the relation/job owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_conditions (
+    timec       TIMESTAMPTZ      NOT NULL,
+    location    TEXT             NOT NULL,
+    temperature DOUBLE PRECISION NULL
+);
+SELECT FROM create_hypertable('dbowner_conditions', 'timec', chunk_time_interval => INTERVAL '1 day');
+--
+
+ALTER TABLE dbowner_conditions SET (timescaledb.compress);
+SELECT add_retention_policy('dbowner_conditions', INTERVAL '1 year') AS dbowner_retention_id \gset
+-- ROLE_DEFAULT_PERM_USER_2 is currently neither the table owner nor
+-- the database owner: all configuration calls below must fail.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour');
+ERROR:  insufficient permissions to alter job 1001
+SELECT delete_job(:dbowner_retention_id);
+ERROR:  insufficient permissions to delete job owned by "default_perm_user"
+\set ON_ERROR_STOP 1
+-- Make ROLE_DEFAULT_PERM_USER_2 the database owner. They become an
+-- implicit member of pg_database_owner.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ set_chunk_time_interval 
+-------------------------
+ 
+
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months') > 0 AS added;
+ added 
+-------
+ t
+
+SELECT (alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour')).schedule_interval AS altered;
+ altered  
+----------
+ @ 1 hour
+
+SELECT delete_job(:dbowner_retention_id);
+ delete_job 
+------------
+ 
+
+-- Restore the database owner so the runner can drop the database
+-- during teardown.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/compression_permissions-16.out
+++ b/tsl/test/expected/compression_permissions-16.out
@@ -364,3 +364,58 @@ SELECT count(*) FROM ( SELECT show_chunks('conditions'))q;
 -------
     11
 
+-- Verify that members of pg_database_owner (the database owner) can run
+-- hypertable and policy configuration alongside the relation/job owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_conditions (
+    timec       TIMESTAMPTZ      NOT NULL,
+    location    TEXT             NOT NULL,
+    temperature DOUBLE PRECISION NULL
+);
+SELECT FROM create_hypertable('dbowner_conditions', 'timec', chunk_time_interval => INTERVAL '1 day');
+--
+
+ALTER TABLE dbowner_conditions SET (timescaledb.compress);
+SELECT add_retention_policy('dbowner_conditions', INTERVAL '1 year') AS dbowner_retention_id \gset
+-- ROLE_DEFAULT_PERM_USER_2 is currently neither the table owner nor
+-- the database owner: all configuration calls below must fail.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour');
+ERROR:  insufficient permissions to alter job 1001
+SELECT delete_job(:dbowner_retention_id);
+ERROR:  insufficient permissions to delete job owned by "default_perm_user"
+\set ON_ERROR_STOP 1
+-- Make ROLE_DEFAULT_PERM_USER_2 the database owner. They become an
+-- implicit member of pg_database_owner.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ set_chunk_time_interval 
+-------------------------
+ 
+
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months') > 0 AS added;
+ added 
+-------
+ t
+
+SELECT (alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour')).schedule_interval AS altered;
+ altered  
+----------
+ @ 1 hour
+
+SELECT delete_job(:dbowner_retention_id);
+ delete_job 
+------------
+ 
+
+-- Restore the database owner so the runner can drop the database
+-- during teardown.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/compression_permissions-17.out
+++ b/tsl/test/expected/compression_permissions-17.out
@@ -364,3 +364,58 @@ SELECT count(*) FROM ( SELECT show_chunks('conditions'))q;
 -------
     11
 
+-- Verify that members of pg_database_owner (the database owner) can run
+-- hypertable and policy configuration alongside the relation/job owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_conditions (
+    timec       TIMESTAMPTZ      NOT NULL,
+    location    TEXT             NOT NULL,
+    temperature DOUBLE PRECISION NULL
+);
+SELECT FROM create_hypertable('dbowner_conditions', 'timec', chunk_time_interval => INTERVAL '1 day');
+--
+
+ALTER TABLE dbowner_conditions SET (timescaledb.compress);
+SELECT add_retention_policy('dbowner_conditions', INTERVAL '1 year') AS dbowner_retention_id \gset
+-- ROLE_DEFAULT_PERM_USER_2 is currently neither the table owner nor
+-- the database owner: all configuration calls below must fail.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour');
+ERROR:  insufficient permissions to alter job 1001
+SELECT delete_job(:dbowner_retention_id);
+ERROR:  insufficient permissions to delete job owned by "default_perm_user"
+\set ON_ERROR_STOP 1
+-- Make ROLE_DEFAULT_PERM_USER_2 the database owner. They become an
+-- implicit member of pg_database_owner.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ set_chunk_time_interval 
+-------------------------
+ 
+
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months') > 0 AS added;
+ added 
+-------
+ t
+
+SELECT (alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour')).schedule_interval AS altered;
+ altered  
+----------
+ @ 1 hour
+
+SELECT delete_job(:dbowner_retention_id);
+ delete_job 
+------------
+ 
+
+-- Restore the database owner so the runner can drop the database
+-- during teardown.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/expected/compression_permissions-18.out
+++ b/tsl/test/expected/compression_permissions-18.out
@@ -364,3 +364,58 @@ SELECT count(*) FROM ( SELECT show_chunks('conditions'))q;
 -------
     11
 
+-- Verify that members of pg_database_owner (the database owner) can run
+-- hypertable and policy configuration alongside the relation/job owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_conditions (
+    timec       TIMESTAMPTZ      NOT NULL,
+    location    TEXT             NOT NULL,
+    temperature DOUBLE PRECISION NULL
+);
+SELECT FROM create_hypertable('dbowner_conditions', 'timec', chunk_time_interval => INTERVAL '1 day');
+--
+
+ALTER TABLE dbowner_conditions SET (timescaledb.compress);
+SELECT add_retention_policy('dbowner_conditions', INTERVAL '1 year') AS dbowner_retention_id \gset
+-- ROLE_DEFAULT_PERM_USER_2 is currently neither the table owner nor
+-- the database owner: all configuration calls below must fail.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months');
+ERROR:  must be owner of hypertable "dbowner_conditions"
+SELECT alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour');
+ERROR:  insufficient permissions to alter job 1001
+SELECT delete_job(:dbowner_retention_id);
+ERROR:  insufficient permissions to delete job owned by "default_perm_user"
+\set ON_ERROR_STOP 1
+-- Make ROLE_DEFAULT_PERM_USER_2 the database owner. They become an
+-- implicit member of pg_database_owner.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+ set_chunk_time_interval 
+-------------------------
+ 
+
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months') > 0 AS added;
+ added 
+-------
+ t
+
+SELECT (alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour')).schedule_interval AS altered;
+ altered  
+----------
+ @ 1 hour
+
+SELECT delete_job(:dbowner_retention_id);
+ delete_job 
+------------
+ 
+
+-- Restore the database owner so the runner can drop the database
+-- during teardown.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/sql/cagg_permissions.sql.in
+++ b/tsl/test/sql/cagg_permissions.sql.in
@@ -274,3 +274,34 @@ WITH NO DATA;
 SELECT user_view_perm IS NOT DISTINCT FROM mat_table_perm
 FROM cagg_info
 WHERE user_view = 'test_default_privileges.devices_summary'::regclass;
+
+-- Verify that members of pg_database_owner (the database owner) can
+-- configure continuous aggregates alongside the CAgg owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE dbowner_metrics (
+    timec INT NOT NULL,
+    val   DOUBLE PRECISION
+);
+SELECT FROM create_hypertable('dbowner_metrics', 'timec', chunk_time_interval => 100);
+CREATE OR REPLACE FUNCTION dbowner_now() RETURNS INT LANGUAGE SQL STABLE AS $$ SELECT 0::INT $$;
+SELECT set_integer_now_func('dbowner_metrics', 'dbowner_now');
+
+CREATE MATERIALIZED VIEW dbowner_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(100, timec) AS bucket, max(val)
+FROM dbowner_metrics
+GROUP BY bucket WITH NO DATA;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval);
+\set ON_ERROR_STOP 1
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT add_continuous_aggregate_policy('dbowner_summary', NULL, -200, '12 h'::interval) IS NOT NULL AS added;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;

--- a/tsl/test/sql/compression_permissions.sql.in
+++ b/tsl/test/sql/compression_permissions.sql.in
@@ -189,3 +189,42 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 INSERT INTO conditions VALUES( '2018-12-02 00:00'::timestamp, 'NYC', 75, 95);
 SELECT count(*) FROM conditions;
 SELECT count(*) FROM ( SELECT show_chunks('conditions'))q;
+
+-- Verify that members of pg_database_owner (the database owner) can run
+-- hypertable and policy configuration alongside the relation/job owner.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE dbowner_conditions (
+    timec       TIMESTAMPTZ      NOT NULL,
+    location    TEXT             NOT NULL,
+    temperature DOUBLE PRECISION NULL
+);
+SELECT FROM create_hypertable('dbowner_conditions', 'timec', chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE dbowner_conditions SET (timescaledb.compress);
+SELECT add_retention_policy('dbowner_conditions', INTERVAL '1 year') AS dbowner_retention_id \gset
+
+-- ROLE_DEFAULT_PERM_USER_2 is currently neither the table owner nor
+-- the database owner: all configuration calls below must fail.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months');
+SELECT alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour');
+SELECT delete_job(:dbowner_retention_id);
+\set ON_ERROR_STOP 1
+
+-- Make ROLE_DEFAULT_PERM_USER_2 the database owner. They become an
+-- implicit member of pg_database_owner.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+SELECT set_chunk_time_interval('dbowner_conditions', INTERVAL '7 days');
+SELECT add_compression_policy('dbowner_conditions', INTERVAL '6 months') > 0 AS added;
+SELECT (alter_job(:dbowner_retention_id, schedule_interval => INTERVAL '1 hour')).schedule_interval AS altered;
+SELECT delete_job(:dbowner_retention_id);
+
+-- Restore the database owner so the runner can drop the database
+-- during teardown.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE :TEST_DBNAME OWNER TO :ROLE_SUPERUSER;


### PR DESCRIPTION
The database owner can now run TimescaleDB configuration commands.
Until now only the table or job owner was allowed.

What the database owner can now do:
  - Hypertables: set_chunk_time_interval, add_dimension and the
    other dimension setters, add and remove a compression,
    retention, or reorder policy.
  - Continuous aggregates: add and remove the refresh policy.
  - Jobs: alter_job, run_job, delete_job.

What still needs the table owner:
  ALTER TABLE, ALTER MATERIALIZED VIEW, REINDEX, and CREATE INDEX
  on hypertables or continuous aggregates. PostgreSQL checks the
  table owner before TimescaleDB sees the command, so the database
  owner is rejected upfront.
