### PR TITLE
Update bgw_custom test to be more deterministic

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -1029,30 +1029,37 @@ BEGIN
   RAISE EXCEPTION 'wait_for_job_status(%): timeout after % tries', job_param_id, spins;
 END;
 $$;
--- Proc that sleeps for 1m - to keep the test jobs in running state
-CREATE OR REPLACE PROCEDURE proc_that_sleeps(job_id INT, config JSONB)
+-- Proc that blocks on a session advisory lock held by the test session.
+-- This deterministically pins the worker in 'Running' state until the test
+-- releases the lock, removing any dependency on wall-clock timing.
+CREATE OR REPLACE PROCEDURE proc_that_blocks(job_id INT, config JSONB)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    PERFORM pg_sleep(60);
+    PERFORM pg_advisory_lock(8584);
+    PERFORM pg_advisory_unlock(8584);
 END
 $$;
--- create new jobs and ensure that the second one gets scheduled
--- before the first one by adjusting the initial_start values
-SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz + interval '2s') AS job_id_1 \gset
-SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz - interval '2s') AS job_id_2 \gset
+-- Hold the lock so any worker running proc_that_blocks waits on it.
+SELECT pg_advisory_lock(8584);
+ pg_advisory_lock 
+------------------
+ 
+
+SELECT add_job('proc_that_blocks', '1h', initial_start => now()) AS job_id_1 \gset
+SELECT add_job('proc_that_blocks', '1h', initial_start => now()) AS job_id_2 \gset
 SELECT _timescaledb_functions.restart_background_workers();
  restart_background_workers 
 ----------------------------
  t
 
--- wait for the jobs to start running job_2 will start running first
-CALL wait_for_job_status(:job_id_2, 'Running');
+-- wait for both jobs to be picked up and blocked on the lock
 CALL wait_for_job_status(:job_id_1, 'Running');
+CALL wait_for_job_status(:job_id_2, 'Running');
 -- add a new job and wait for it to start
-SELECT add_job('proc_that_sleeps', '1h') AS job_id_3 \gset
+SELECT add_job('proc_that_blocks', '1h', initial_start => now()) AS job_id_3 \gset
 CALL wait_for_job_status(:job_id_3, 'Running');
--- verify that none of the jobs crashed
+-- verify that all three jobs are concurrently in Running state and none crashed
 SELECT job_id, job_status, next_start,
        total_runs, total_successes, total_failures
   FROM timescaledb_information.job_stats
@@ -1069,6 +1076,12 @@ SELECT job_id, err_message
   WHERE job_id IN (:job_id_1, :job_id_2, :job_id_3);
  job_id | err_message 
 --------+-------------
+
+-- release the lock so the workers complete naturally
+SELECT pg_advisory_unlock(8584);
+ pg_advisory_unlock 
+--------------------
+ t
 
 -- cleanup
 SELECT _timescaledb_functions.stop_background_workers();

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -701,30 +701,34 @@ BEGIN
 END;
 $$;
 
--- Proc that sleeps for 1m - to keep the test jobs in running state
-CREATE OR REPLACE PROCEDURE proc_that_sleeps(job_id INT, config JSONB)
+-- Proc that blocks on a session advisory lock held by the test session.
+-- This deterministically pins the worker in 'Running' state until the test
+-- releases the lock, removing any dependency on wall-clock timing.
+CREATE OR REPLACE PROCEDURE proc_that_blocks(job_id INT, config JSONB)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    PERFORM pg_sleep(60);
+    PERFORM pg_advisory_lock(8584);
+    PERFORM pg_advisory_unlock(8584);
 END
 $$;
 
--- create new jobs and ensure that the second one gets scheduled
--- before the first one by adjusting the initial_start values
-SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz + interval '2s') AS job_id_1 \gset
-SELECT add_job('proc_that_sleeps', '1h', initial_start => now()::timestamptz - interval '2s') AS job_id_2 \gset
+-- Hold the lock so any worker running proc_that_blocks waits on it.
+SELECT pg_advisory_lock(8584);
+
+SELECT add_job('proc_that_blocks', '1h', initial_start => now()) AS job_id_1 \gset
+SELECT add_job('proc_that_blocks', '1h', initial_start => now()) AS job_id_2 \gset
 
 SELECT _timescaledb_functions.restart_background_workers();
--- wait for the jobs to start running job_2 will start running first
-CALL wait_for_job_status(:job_id_2, 'Running');
+-- wait for both jobs to be picked up and blocked on the lock
 CALL wait_for_job_status(:job_id_1, 'Running');
+CALL wait_for_job_status(:job_id_2, 'Running');
 
 -- add a new job and wait for it to start
-SELECT add_job('proc_that_sleeps', '1h') AS job_id_3 \gset
+SELECT add_job('proc_that_blocks', '1h', initial_start => now()) AS job_id_3 \gset
 CALL wait_for_job_status(:job_id_3, 'Running');
 
--- verify that none of the jobs crashed
+-- verify that all three jobs are concurrently in Running state and none crashed
 SELECT job_id, job_status, next_start,
        total_runs, total_successes, total_failures
   FROM timescaledb_information.job_stats
@@ -733,6 +737,9 @@ SELECT job_id, job_status, next_start,
 SELECT job_id, err_message
   FROM timescaledb_information.job_errors
   WHERE job_id IN (:job_id_1, :job_id_2, :job_id_3);
+
+-- release the lock so the workers complete naturally
+SELECT pg_advisory_unlock(8584);
 
 -- cleanup
 SELECT _timescaledb_functions.stop_background_workers();


### PR DESCRIPTION
This test has relied on timer based synchronisation which can be unreliable and cause failures. Switch to advisory-lock based synchronisation to deterministically pin workers in the Running state and reduce test flakes.

Disable-check: force-changelog-file
Disable-check: approval-count