### PR TITLE
Fix extend last bucket (#9660)

### DIFF
--- a/.unreleased/pr_9660
+++ b/.unreleased/pr_9660
@@ -1,0 +1,1 @@
+Fixes: #9660 Fix incremental CAgg refresh so that extend_last_bucket only applies to the boundary batch.

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -447,6 +447,16 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 			 ts_internal_to_time_string(refresh_window->end, refresh_window->type));
 
 		context.processing_batch = ++processing_batch;
+
+		/* extend_last_bucket must only apply to the boundary batch — the one
+		 * whose window abuts the adjacent policy.  For newest-first ordering
+		 * that is batch 1; for oldest-first it is the final batch.
+		 * In non-batched mode (single batch) the one batch is always the boundary. */
+		bool apply_extend =
+			extend_last_bucket &&
+			(policy_data.refresh_newest_first ? processing_batch == 1 :
+												processing_batch == context.number_of_batches);
+
 		continuous_agg_refresh_internal(policy_data.cagg,
 										refresh_window,
 										context,
@@ -455,7 +465,7 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 										(context.callctx != CAGG_REFRESH_POLICY_BATCHED),
 										false, /* force */
 										policy_data.process_hypertable_invalidations,
-										extend_last_bucket);
+										apply_extend);
 		DEBUG_ERROR_INJECTION(psprintf("cagg_policy_batch_%d_after_refresh", processing_batch));
 		if (processing_batch >= policy_data.max_batches_per_execution &&
 			processing_batch < context.number_of_batches &&

--- a/tsl/test/isolation/expected/cagg_incremental_concurrent.out
+++ b/tsl/test/isolation/expected/cagg_incremental_concurrent.out
@@ -1,4 +1,4 @@
-Parsed test spec with 5 sessions
+Parsed test spec with 7 sessions
 
 starting permutation: wp_enable r1_run s1_refresh_ranges s1_count r2_refresh wp_release s1_count s1_check_duplicates
 step wp_enable: 
@@ -106,6 +106,12 @@ R2: LOG:  statement:
     SET SESSION lock_timeout = '500ms';
     SET SESSION deadlock_timeout = '500ms';
     SET SESSION client_min_messages = 'LOG';
+
+R3: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+    SET timescaledb.current_timestamp_mock TO '2026-04-01 00:30:00+00';
 
 step wp_enable: 
     SELECT debug_waitpoint_enable('cagg_policy_batch_2_after_txn_1_wait');
@@ -229,6 +235,12 @@ R2: LOG:  statement:
     SET SESSION deadlock_timeout = '500ms';
     SET SESSION client_min_messages = 'LOG';
 
+R3: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+    SET timescaledb.current_timestamp_mock TO '2026-04-01 00:30:00+00';
+
 step wp_enable: 
     SELECT debug_waitpoint_enable('cagg_policy_batch_2_after_txn_1_wait');
 
@@ -327,3 +339,185 @@ step s1_check_duplicates:
 bucket|device_id|copies
 ------+---------+------
 
+
+starting permutation: wp_enable r3_run i2_insert wp_release
+R1: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+
+R2: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+
+R3: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+    SET timescaledb.current_timestamp_mock TO '2026-04-01 00:30:00+00';
+
+step wp_enable: 
+    SELECT debug_waitpoint_enable('cagg_policy_batch_2_after_txn_1_wait');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+R3: LOG:  statement: 
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'sensor_hourly'
+        AND proc_name = 'policy_refresh_continuous_aggregate'
+        ORDER BY job_id DESC
+        LIMIT 1; --get the job with highest id (i.e, policy B)
+        CALL run_job(jid);
+    END;
+    $$;
+
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 13:00:00 2026 PDT, Tue Mar 31 15:00:00 2026 PDT ] (batch 1 of 7)
+R3: LOG:  deleted 2 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 2 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+step r3_run: 
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'sensor_hourly'
+        AND proc_name = 'policy_refresh_continuous_aggregate'
+        ORDER BY job_id DESC
+        LIMIT 1; --get the job with highest id (i.e, policy B)
+        CALL run_job(jid);
+    END;
+    $$;
+ <waiting ...>
+step i2_insert: 
+    INSERT INTO sensor_data
+    SELECT t, random()
+    FROM generate_series(
+        '2026-04-01 00:30:00+00'::timestamptz - INTERVAL '10 hours',
+        '2026-04-01 00:30:00+00'::timestamptz,
+        INTERVAL '10 minutes'
+    ) t;
+
+step wp_release: 
+    SELECT debug_waitpoint_release('cagg_policy_batch_2_after_txn_1_wait');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 12:00:00 2026 PDT, Tue Mar 31 13:00:00 2026 PDT ] (batch 2 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 11:00:00 2026 PDT, Tue Mar 31 12:00:00 2026 PDT ] (batch 3 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 10:00:00 2026 PDT, Tue Mar 31 11:00:00 2026 PDT ] (batch 4 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 09:00:00 2026 PDT, Tue Mar 31 10:00:00 2026 PDT ] (batch 5 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 08:00:00 2026 PDT, Tue Mar 31 09:00:00 2026 PDT ] (batch 6 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly" in window [ Tue Mar 31 07:00:00 2026 PDT, Tue Mar 31 08:00:00 2026 PDT ] (batch 7 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+step r3_run: <... completed>
+
+starting permutation: wp_enable r3_run_oldest_first i2_insert wp_release
+R1: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+
+R2: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+
+R3: LOG:  statement: 
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+    SET timescaledb.current_timestamp_mock TO '2026-04-01 00:30:00+00';
+
+step wp_enable: 
+    SELECT debug_waitpoint_enable('cagg_policy_batch_2_after_txn_1_wait');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+R3: LOG:  statement: 
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'sensor_hourly_oldest_first'
+        AND proc_name = 'policy_refresh_continuous_aggregate'
+        ORDER BY job_id DESC
+        LIMIT 1; --get the job with highest id (i.e, policy B)
+        CALL run_job(jid);
+    END;
+    $$;
+
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 07:00:00 2026 PDT, Tue Mar 31 08:00:00 2026 PDT ] (batch 1 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+step r3_run_oldest_first: 
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'sensor_hourly_oldest_first'
+        AND proc_name = 'policy_refresh_continuous_aggregate'
+        ORDER BY job_id DESC
+        LIMIT 1; --get the job with highest id (i.e, policy B)
+        CALL run_job(jid);
+    END;
+    $$;
+ <waiting ...>
+step i2_insert: 
+    INSERT INTO sensor_data
+    SELECT t, random()
+    FROM generate_series(
+        '2026-04-01 00:30:00+00'::timestamptz - INTERVAL '10 hours',
+        '2026-04-01 00:30:00+00'::timestamptz,
+        INTERVAL '10 minutes'
+    ) t;
+
+step wp_release: 
+    SELECT debug_waitpoint_release('cagg_policy_batch_2_after_txn_1_wait');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 08:00:00 2026 PDT, Tue Mar 31 09:00:00 2026 PDT ] (batch 2 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 09:00:00 2026 PDT, Tue Mar 31 10:00:00 2026 PDT ] (batch 3 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 10:00:00 2026 PDT, Tue Mar 31 11:00:00 2026 PDT ] (batch 4 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 11:00:00 2026 PDT, Tue Mar 31 12:00:00 2026 PDT ] (batch 5 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 12:00:00 2026 PDT, Tue Mar 31 13:00:00 2026 PDT ] (batch 6 of 7)
+R3: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  continuous aggregate refresh (individual invalidation) on "sensor_hourly_oldest_first" in window [ Tue Mar 31 13:00:00 2026 PDT, Tue Mar 31 15:00:00 2026 PDT ] (batch 7 of 7)
+R3: LOG:  deleted 2 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_X"
+R3: LOG:  inserted 2 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_X"
+step r3_run_oldest_first: <... completed>

--- a/tsl/test/isolation/specs/cagg_incremental_concurrent.spec
+++ b/tsl/test/isolation/specs/cagg_incremental_concurrent.spec
@@ -14,6 +14,8 @@ setup
 {
     SELECT _timescaledb_functions.stop_background_workers();
 
+    SET timescaledb.current_timestamp_mock TO '2026-04-01 0:30:00+00';
+
     CREATE TABLE conditions(time int, device_id int, temperature float);
     SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
 
@@ -43,6 +45,34 @@ setup
     FROM conditions
     GROUP BY 1, 2
     WITH NO DATA;
+
+    CREATE TABLE sensor_data (time TIMESTAMPTZ NOT NULL, value FLOAT);
+    SELECT create_hypertable('sensor_data', 'time', chunk_time_interval => INTERVAL '1 day');
+
+    -- 10h of data anchored to mock time
+    INSERT INTO sensor_data
+    SELECT t, random()
+    FROM generate_series(
+        '2026-04-01 00:30:00+00'::timestamptz - INTERVAL '10 hours',
+        '2026-04-01 00:30:00+00'::timestamptz,
+        INTERVAL '1 minute'
+    ) t;
+
+    -- Hourly CAgg
+    CREATE MATERIALIZED VIEW sensor_hourly
+    WITH (timescaledb.continuous) AS
+    SELECT time_bucket('1 hour', time) AS bucket, avg(value), count(*)
+    FROM sensor_data
+    GROUP BY 1
+    WITH NO DATA;
+
+    -- Another cagg so we can test the "refresh oldest first" incremental refresh policy
+    CREATE MATERIALIZED VIEW sensor_hourly_oldest_first
+    WITH (timescaledb.continuous) AS
+    SELECT time_bucket('1 hour', time) AS bucket, avg(value), count(*)
+    FROM sensor_data
+    GROUP BY 1
+    WITH NO DATA;
 }
 
 # Initial refresh to set up the invalidation threshold
@@ -51,7 +81,19 @@ setup
     CALL refresh_continuous_aggregate('cond_10', 1, 60);
 }
 
+setup
+{
+    CALL refresh_continuous_aggregate('sensor_hourly', NULL, NULL);
+}
+
+setup
+{
+    CALL refresh_continuous_aggregate('sensor_hourly_oldest_first', NULL, NULL);
+}
+
 # Add an incremental policy (1 bucket per batch) and generate invalidations
+# Add 2 adjacent policies for sensor_hourly
+# Add 2 adjacent policies for sensor_hourly_oldest_first
 setup
 {
     SELECT add_continuous_aggregate_policy(
@@ -68,11 +110,60 @@ setup
     FROM generate_series(1, 60, 1) AS t,
          generate_series(1, 3) AS d;
 
+
+    -- Policy A: the "last" policy (most-recent end_offset).
+    SELECT add_continuous_aggregate_policy('sensor_hourly',
+        start_offset      => INTERVAL '3 hours',
+        end_offset        => INTERVAL '5 minutes',
+        schedule_interval => INTERVAL '15 minutes',
+        buckets_per_batch => 1
+    );
+
+    -- Policy B: Because policy A has a more-recent end_offset,
+    -- check_if_last_policy() returns false for B, so extend_last_bucket=true is
+    -- set and applied to the boundary batch
+    SELECT add_continuous_aggregate_policy('sensor_hourly',
+        start_offset      => INTERVAL '12 hours',
+        end_offset        => INTERVAL '3 hours',
+        schedule_interval => INTERVAL '1 hour',
+        buckets_per_batch => 1
+    );
+
+    --Same pair of policies as above, but with refresh_newest_first = false for policy B
+    -- Policy A: the "last" policy (most-recent end_offset).
+    SELECT add_continuous_aggregate_policy('sensor_hourly_oldest_first',
+        start_offset      => INTERVAL '3 hours',
+        end_offset        => INTERVAL '5 minutes',
+        schedule_interval => INTERVAL '15 minutes',
+        buckets_per_batch => 1
+    );
+
+    -- Policy B: Because policy A has a more-recent end_offset,
+    -- check_if_last_policy() returns false for B, so extend_last_bucket=true is
+    -- set and applied to the boundary batch
+    SELECT add_continuous_aggregate_policy('sensor_hourly_oldest_first',
+        start_offset      => INTERVAL '12 hours',
+        end_offset        => INTERVAL '3 hours',
+        schedule_interval => INTERVAL '1 hour',
+        buckets_per_batch => 1,
+        refresh_newest_first  => false   -- oldest first
+    );
+
+
+    -- Generate invalidations anchored to mock time
+    INSERT INTO sensor_data
+    SELECT t, random()
+    FROM generate_series(
+        '2026-04-01 00:30:00+00'::timestamptz - INTERVAL '10 hours',
+        '2026-04-01 00:30:00+00'::timestamptz,
+        INTERVAL '1 minute'
+    ) t;
 }
 
 teardown
 {
     DROP TABLE conditions CASCADE;
+    DROP TABLE sensor_data CASCADE;
 }
 
 # Session to control the waitpoint — pauses after batch 1's txn 1 commits
@@ -162,6 +253,62 @@ step "s1_refresh_ranges"
     ORDER BY ca.user_view_name;
 }
 
+# Session to run refresh policy for sensor_hourly,
+# Will be paused after first batch is done
+session "R3"
+setup
+{
+    SET SESSION lock_timeout = '500ms';
+    SET SESSION deadlock_timeout = '500ms';
+    SET SESSION client_min_messages = 'LOG';
+    SET timescaledb.current_timestamp_mock TO '2026-04-01 00:30:00+00';
+}
+step "r3_run"
+{
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'sensor_hourly'
+        AND proc_name = 'policy_refresh_continuous_aggregate'
+        ORDER BY job_id DESC
+        LIMIT 1; --get the job with highest id (i.e, policy B)
+        CALL run_job(jid);
+    END;
+    $$;
+}
+
+step "r3_run_oldest_first"
+{
+    DO $$
+    DECLARE
+        jid int;
+    BEGIN
+        SELECT job_id INTO jid FROM timescaledb_information.jobs
+        WHERE hypertable_name = 'sensor_hourly_oldest_first'
+        AND proc_name = 'policy_refresh_continuous_aggregate'
+        ORDER BY job_id DESC
+        LIMIT 1; --get the job with highest id (i.e, policy B)
+        CALL run_job(jid);
+    END;
+    $$;
+}
+
+#insert data to create invalidations when refresh is stopped after batch 1
+session "I2"
+step "i2_insert"
+{
+    INSERT INTO sensor_data
+    SELECT t, random()
+    FROM generate_series(
+        '2026-04-01 00:30:00+00'::timestamptz - INTERVAL '10 hours',
+        '2026-04-01 00:30:00+00'::timestamptz,
+        INTERVAL '10 minutes'
+    ) t;
+}
+
+
 # Test 1: Run 1 pauses after batch 1. Manual refresh on overlapping range [1,50).
 # After both complete, check for duplicate rows.
 permutation "wp_enable" "r1_run"("wp_enable") "s1_refresh_ranges" "s1_count" "r2_refresh" "wp_release" "s1_count" "s1_check_duplicates"
@@ -172,3 +319,10 @@ permutation "wp_enable" "r1_run"("wp_enable") "i1_insert" "s1_refresh_ranges" "r
 # Test 3: Manual refresh that overlaps with R1's registered batch range [50, 60).
 # Should be blocked.
 permutation "wp_enable" "r1_run"("wp_enable") "s1_refresh_ranges" "r2_refresh_overlap" "wp_release" "s1_count" "s1_check_duplicates"
+
+# Test 4: Refresh on sensor_hourly pauses after batch 2 window has been determined . Then some new data arrive on batch 2 window
+# refresh on batch 3 should be only 1 bucket and not overlap with batch 1
+permutation "wp_enable" "r3_run"("wp_enable") "i2_insert" "wp_release"
+
+# Test 5: Same as test 5, but the policy refreshes oldest batch first
+permutation "wp_enable" "r3_run_oldest_first"("wp_enable") "i2_insert" "wp_release"


### PR DESCRIPTION
Fix extend_last_bucket in incremental refresh
For incremental cagg refresh, extend_last_bucket should be called only on the batch that is adjacient to the next policy. Currently we call that on all batches. So if new data arrives within the refresh ranges, We will see the overlapping batches.

(Without new data, invalidations will be consumed by the previous batch, so the following batch will not overlap with the previous batch. That is, we still produce an overlapping window, but after intersecting with available invalidations the effective refresh window is correct.)

The issue is fixed by only extending last bucket for the boundary batch, i.e., the first batch if refresh newest first, and last batch otherwise.

Fixes #9660

( Cherry-pick from commit  cf36bbca2f7c1ed9f587d395b0a7d5d36b7b961c)