### PR TITLE
Fix segmentby crash in cagg invalidation tracking

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1417,7 +1417,8 @@ row_compressor_flush(RowCompressor *row_compressor, BulkWriter *writer, bool cha
 	if (row_compressor->invalidation)
 	{
 		InvalidationSettings *settings = row_compressor->invalidation;
-		AttrNumber dim_attnum = AttrOffsetGetAttrNumber(settings->invalidation_column_offset);
+		int16 dim_offset = settings->invalidation_column_offset;
+		AttrNumber dim_attnum = AttrOffsetGetAttrNumber(dim_offset);
 
 		BatchMetadataBuilderMinMax *minmax_builder = NULL;
 		ListCell *lc;
@@ -1435,11 +1436,32 @@ row_compressor_flush(RowCompressor *row_compressor, BulkWriter *writer, bool cha
 			}
 		}
 
-		Assert(minmax_builder != NULL);
-		Datum min = row_compressor->compressed_values[minmax_builder->min_metadata_attr_offset];
-		Datum max = row_compressor->compressed_values[minmax_builder->max_metadata_attr_offset];
-		int64 start = ts_time_value_to_internal(min, minmax_builder->type_oid);
-		int64 end = ts_time_value_to_internal(max, minmax_builder->type_oid);
+		Datum min;
+		Datum max;
+		Oid type_oid;
+		if (minmax_builder != NULL)
+		{
+			min = row_compressor->compressed_values[minmax_builder->min_metadata_attr_offset];
+			max = row_compressor->compressed_values[minmax_builder->max_metadata_attr_offset];
+			type_oid = minmax_builder->type_oid;
+		}
+		else
+		{
+			/*
+			 * No minmax sparse index for the cagg invalidation column means it
+			 * is configured as segmentby. Every row in the batch shares the
+			 * same segmentby value, so use it as both bounds.
+			 */
+			PerColumn *dim_column = &row_compressor->per_column[dim_offset];
+			Ensure(dim_column->compressor == NULL && dim_column->segment_info != NULL,
+				   "cagg invalidation column has no minmax builder and is not segmentby");
+			Ensure(!dim_column->segment_info->is_null, "cagg invalidation column is NULL");
+			int16 compressed_col = row_compressor->uncompressed_col_to_compressed_col[dim_offset];
+			min = max = row_compressor->compressed_values[compressed_col];
+			type_oid = TupleDescAttr(row_compressor->in_desc, dim_offset)->atttypid;
+		}
+		int64 start = ts_time_value_to_internal(min, type_oid);
+		int64 end = ts_time_value_to_internal(max, type_oid);
 		continuous_agg_invalidate_range(settings->hypertable_id, settings->chunk_relid, start, end);
 	}
 

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -526,24 +526,40 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	if (delete_only && ht_state->has_continuous_aggregate)
 	{
 		const Dimension *time_dim = hyperspace_get_open_dimension(ht_state->ht->space, 0);
-		AttrNumber chunk_time_attno =
-			get_attnum(chunk->table_id, NameStr(time_dim->fd.column_name));
+		const char *time_col_name = NameStr(time_dim->fd.column_name);
+		AttrNumber chunk_time_attno = get_attnum(chunk->table_id, time_col_name);
 
 		invalidation_ctx.hypertable_id = ht_state->ht->fd.id;
 		invalidation_ctx.chunk_relid = chunk->table_id;
 		invalidation_ctx.time_type_oid = time_dim->fd.column_type;
-		invalidation_ctx.min_time_attno =
-			compressed_column_metadata_attno(settings,
-											 chunk->table_id,
-											 chunk_time_attno,
-											 settings->fd.compress_relid,
-											 "min");
-		invalidation_ctx.max_time_attno =
-			compressed_column_metadata_attno(settings,
-											 chunk->table_id,
-											 chunk_time_attno,
-											 settings->fd.compress_relid,
-											 "max");
+
+		if (ts_array_is_member(settings->fd.segmentby, time_col_name))
+		{
+			/*
+			 * Time column is segmentby: every row in the batch shares the same
+			 * value, so use the segmentby column's compressed-tuple attno for
+			 * both bounds. Segmentby columns don't have _ts_meta_min/max
+			 * sparse-index columns to look up.
+			 */
+			AttrNumber compressed_attno = get_attnum(settings->fd.compress_relid, time_col_name);
+			invalidation_ctx.min_time_attno = compressed_attno;
+			invalidation_ctx.max_time_attno = compressed_attno;
+		}
+		else
+		{
+			invalidation_ctx.min_time_attno =
+				compressed_column_metadata_attno(settings,
+												 chunk->table_id,
+												 chunk_time_attno,
+												 settings->fd.compress_relid,
+												 "min");
+			invalidation_ctx.max_time_attno =
+				compressed_column_metadata_attno(settings,
+												 chunk->table_id,
+												 chunk_time_attno,
+												 settings->fd.compress_relid,
+												 "max");
+		}
 	}
 
 	process_predicates(chunk,

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -3222,3 +3222,52 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log O
             45 |      1577865600000000 |        1577865600000000
             45 |      1609488000000000 |        1609488000000000
 
+-- direct batch delete with time column as segmentby. Segmentby columns don't
+-- have _ts_meta_min/max, so the invalidation context must read the segmentby
+-- value directly. The invalidation log entry's bounds must equal the deleted
+-- segmentby value; without the fix the consumer reads compressed_datums[-1]
+-- and produces garbage bounds.
+SET TIME ZONE 'UTC';
+SET
+CREATE TABLE cagg_inval_segmentby_time(time timestamptz NOT NULL, device text, value float)
+    WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+HINT:  Use "timescaledb.partition_column" to specify a different column to use as partitioning column.
+CREATE TABLE
+INSERT INTO cagg_inval_segmentby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+INSERT 0 50
+-- Refresh on creation sets the cagg invalidation threshold so subsequent
+-- DELETEs below it write to the hypertable invalidation log.
+CREATE MATERIALIZED VIEW cagg_inval_segmentby_time_cagg
+    WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) FROM cagg_inval_segmentby_time GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_inval_segmentby_time_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+ALTER TABLE cagg_inval_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+ALTER TABLE
+SELECT count(compress_chunk(c)) FROM show_chunks('cagg_inval_segmentby_time') c;
+ count 
+-------
+     1
+
+DELETE FROM cagg_inval_segmentby_time WHERE time = '2025-01-01 00:05:00+00';
+DELETE 1
+-- The single deleted segmentby batch covers exactly time = 2025-01-01 00:05:00 UTC.
+-- Convert internal microseconds back to a timestamptz for a stable comparison.
+SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
+       to_timestamp(greatest_modified_value / 1000000.0) AS greatest
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                         WHERE table_name = 'cagg_inval_segmentby_time');
+            lowest            |           greatest           
+------------------------------+------------------------------
+ Wed Jan 01 00:05:00 2025 UTC | Wed Jan 01 00:05:00 2025 UTC
+
+RESET TIME ZONE;
+RESET

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -3222,3 +3222,52 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log O
             45 |      1577865600000000 |        1577865600000000
             45 |      1609488000000000 |        1609488000000000
 
+-- direct batch delete with time column as segmentby. Segmentby columns don't
+-- have _ts_meta_min/max, so the invalidation context must read the segmentby
+-- value directly. The invalidation log entry's bounds must equal the deleted
+-- segmentby value; without the fix the consumer reads compressed_datums[-1]
+-- and produces garbage bounds.
+SET TIME ZONE 'UTC';
+SET
+CREATE TABLE cagg_inval_segmentby_time(time timestamptz NOT NULL, device text, value float)
+    WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+HINT:  Use "timescaledb.partition_column" to specify a different column to use as partitioning column.
+CREATE TABLE
+INSERT INTO cagg_inval_segmentby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+INSERT 0 50
+-- Refresh on creation sets the cagg invalidation threshold so subsequent
+-- DELETEs below it write to the hypertable invalidation log.
+CREATE MATERIALIZED VIEW cagg_inval_segmentby_time_cagg
+    WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) FROM cagg_inval_segmentby_time GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_inval_segmentby_time_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+ALTER TABLE cagg_inval_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+ALTER TABLE
+SELECT count(compress_chunk(c)) FROM show_chunks('cagg_inval_segmentby_time') c;
+ count 
+-------
+     1
+
+DELETE FROM cagg_inval_segmentby_time WHERE time = '2025-01-01 00:05:00+00';
+DELETE 1
+-- The single deleted segmentby batch covers exactly time = 2025-01-01 00:05:00 UTC.
+-- Convert internal microseconds back to a timestamptz for a stable comparison.
+SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
+       to_timestamp(greatest_modified_value / 1000000.0) AS greatest
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                         WHERE table_name = 'cagg_inval_segmentby_time');
+            lowest            |           greatest           
+------------------------------+------------------------------
+ Wed Jan 01 00:05:00 2025 UTC | Wed Jan 01 00:05:00 2025 UTC
+
+RESET TIME ZONE;
+RESET

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -3228,3 +3228,52 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log O
             45 |      1577865600000000 |        1577865600000000
             45 |      1609488000000000 |        1609488000000000
 
+-- direct batch delete with time column as segmentby. Segmentby columns don't
+-- have _ts_meta_min/max, so the invalidation context must read the segmentby
+-- value directly. The invalidation log entry's bounds must equal the deleted
+-- segmentby value; without the fix the consumer reads compressed_datums[-1]
+-- and produces garbage bounds.
+SET TIME ZONE 'UTC';
+SET
+CREATE TABLE cagg_inval_segmentby_time(time timestamptz NOT NULL, device text, value float)
+    WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+HINT:  Use "timescaledb.partition_column" to specify a different column to use as partitioning column.
+CREATE TABLE
+INSERT INTO cagg_inval_segmentby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+INSERT 0 50
+-- Refresh on creation sets the cagg invalidation threshold so subsequent
+-- DELETEs below it write to the hypertable invalidation log.
+CREATE MATERIALIZED VIEW cagg_inval_segmentby_time_cagg
+    WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) FROM cagg_inval_segmentby_time GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_inval_segmentby_time_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+ALTER TABLE cagg_inval_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+ALTER TABLE
+SELECT count(compress_chunk(c)) FROM show_chunks('cagg_inval_segmentby_time') c;
+ count 
+-------
+     1
+
+DELETE FROM cagg_inval_segmentby_time WHERE time = '2025-01-01 00:05:00+00';
+DELETE 1
+-- The single deleted segmentby batch covers exactly time = 2025-01-01 00:05:00 UTC.
+-- Convert internal microseconds back to a timestamptz for a stable comparison.
+SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
+       to_timestamp(greatest_modified_value / 1000000.0) AS greatest
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                         WHERE table_name = 'cagg_inval_segmentby_time');
+            lowest            |           greatest           
+------------------------------+------------------------------
+ Wed Jan 01 00:05:00 2025 UTC | Wed Jan 01 00:05:00 2025 UTC
+
+RESET TIME ZONE;
+RESET

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -3228,3 +3228,52 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log O
             45 |      1577865600000000 |        1577865600000000
             45 |      1609488000000000 |        1609488000000000
 
+-- direct batch delete with time column as segmentby. Segmentby columns don't
+-- have _ts_meta_min/max, so the invalidation context must read the segmentby
+-- value directly. The invalidation log entry's bounds must equal the deleted
+-- segmentby value; without the fix the consumer reads compressed_datums[-1]
+-- and produces garbage bounds.
+SET TIME ZONE 'UTC';
+SET
+CREATE TABLE cagg_inval_segmentby_time(time timestamptz NOT NULL, device text, value float)
+    WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+HINT:  Use "timescaledb.partition_column" to specify a different column to use as partitioning column.
+CREATE TABLE
+INSERT INTO cagg_inval_segmentby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+INSERT 0 50
+-- Refresh on creation sets the cagg invalidation threshold so subsequent
+-- DELETEs below it write to the hypertable invalidation log.
+CREATE MATERIALIZED VIEW cagg_inval_segmentby_time_cagg
+    WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) FROM cagg_inval_segmentby_time GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_inval_segmentby_time_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW
+ALTER TABLE cagg_inval_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+ALTER TABLE
+SELECT count(compress_chunk(c)) FROM show_chunks('cagg_inval_segmentby_time') c;
+ count 
+-------
+     1
+
+DELETE FROM cagg_inval_segmentby_time WHERE time = '2025-01-01 00:05:00+00';
+DELETE 1
+-- The single deleted segmentby batch covers exactly time = 2025-01-01 00:05:00 UTC.
+-- Convert internal microseconds back to a timestamptz for a stable comparison.
+SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
+       to_timestamp(greatest_modified_value / 1000000.0) AS greatest
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                         WHERE table_name = 'cagg_inval_segmentby_time');
+            lowest            |           greatest           
+------------------------------+------------------------------
+ Wed Jan 01 00:05:00 2025 UTC | Wed Jan 01 00:05:00 2025 UTC
+
+RESET TIME ZONE;
+RESET

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -433,6 +433,39 @@ SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id
       3
 
 ROLLBACK;
+-- cagg + direct compress where the cagg time column is segmentby.
+-- segmentby columns don't get _ts_meta_min/max columns, so no MINMAX builder
+-- is created for them; the flush path must still derive an invalidation range
+-- from the segmentby value rather than crashing.
+BEGIN;
+CREATE TABLE metrics_segmentby_time (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+    WITH (tsdb.hypertable);
+NOTICE:  using column "time" as partitioning column
+CREATE MATERIALIZED VIEW metrics_segmentby_time_cagg WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value
+    FROM metrics_segmentby_time GROUP BY bucket, device WITH NO DATA;
+ALTER TABLE metrics_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+INSERT INTO metrics_segmentby_time
+SELECT '2025-01-01'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO metrics_segmentby_time
+SELECT '2025-02-01'::timestamptz + (i * interval '1 second'), 'd1', random()
+FROM generate_series(1, 5000) i;
+-- The new chunk should be in COMPRESSED state, confirming the flush path ran.
+SELECT _timescaledb_functions.chunk_status_text(chunk)
+  FROM show_chunks('metrics_segmentby_time') chunk
+ WHERE chunk::text LIKE '%hyper_%'
+ ORDER BY chunk::text;
+   chunk_status_text    
+------------------------
+ {}
+ {COMPRESSED,UNORDERED}
+
+ROLLBACK;
 -- test chunk status handling
 CREATE TABLE metrics_status(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time');
 INSERT INTO metrics_status SELECT '2025-01-01';
@@ -511,7 +544,7 @@ SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics
 SELECT compress_chunk(show_chunks('metrics_status'));
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_4_54_chunk
+ _timescaledb_internal._hyper_7_57_chunk
 
 -- status should be COMPRESSED
 SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_status') chunk;
@@ -560,7 +593,7 @@ EXPLAIN (costs off,summary off,timing off) INSERT INTO :CHUNK SELECT '2025-01-01
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable)
    Direct Compress: true
-   ->  Insert on _hyper_6_56_chunk
+   ->  Insert on _hyper_9_59_chunk
          ->  Function Scan on generate_series i
 
 BEGIN;
@@ -582,8 +615,8 @@ EXPLAIN (analyze,buffers off,costs off,summary off,timing off) DELETE FROM :CHUN
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    Batches decompressed: 1
    Tuples decompressed: 101
-   ->  Delete on _hyper_6_56_chunk (actual rows=0.00 loops=1)
-         ->  Index Scan using _hyper_6_56_chunk_metrics_chunk_time_idx on _hyper_6_56_chunk (actual rows=100.00 loops=1)
+   ->  Delete on _hyper_9_59_chunk (actual rows=0.00 loops=1)
+         ->  Index Scan using _hyper_9_59_chunk_metrics_chunk_time_idx on _hyper_9_59_chunk (actual rows=100.00 loops=1)
                Index Cond: ("time" > 'Wed Jan 01 00:00:00 2025 PST'::timestamp with time zone)
 
 SELECT count(*) FROM :CHUNK;
@@ -611,8 +644,8 @@ SET timescaledb.direct_compress_insert_tuple_sort_limit = 1000;
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(1,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 --- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _hyper_1_59_chunk (actual rows=3000.00 loops=1)
-   ->  Seq Scan on compress_hyper_2_60_chunk (actual rows=3.00 loops=1)
+ Custom Scan (ColumnarScan) on _hyper_1_62_chunk (actual rows=3000.00 loops=1)
+   ->  Seq Scan on compress_hyper_2_63_chunk (actual rows=3.00 loops=1)
 
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
             first             |             last             

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1699,3 +1699,34 @@ EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cag
 -- should have invalidation entry from the direct batch delete
 SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
 
+-- direct batch delete with time column as segmentby. Segmentby columns don't
+-- have _ts_meta_min/max, so the invalidation context must read the segmentby
+-- value directly. The invalidation log entry's bounds must equal the deleted
+-- segmentby value; without the fix the consumer reads compressed_datums[-1]
+-- and produces garbage bounds.
+SET TIME ZONE 'UTC';
+CREATE TABLE cagg_inval_segmentby_time(time timestamptz NOT NULL, device text, value float)
+    WITH (tsdb.hypertable);
+INSERT INTO cagg_inval_segmentby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+-- Refresh on creation sets the cagg invalidation threshold so subsequent
+-- DELETEs below it write to the hypertable invalidation log.
+CREATE MATERIALIZED VIEW cagg_inval_segmentby_time_cagg
+    WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) FROM cagg_inval_segmentby_time GROUP BY 1;
+ALTER TABLE cagg_inval_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+SELECT count(compress_chunk(c)) FROM show_chunks('cagg_inval_segmentby_time') c;
+DELETE FROM cagg_inval_segmentby_time WHERE time = '2025-01-01 00:05:00+00';
+-- The single deleted segmentby batch covers exactly time = 2025-01-01 00:05:00 UTC.
+-- Convert internal microseconds back to a timestamptz for a stable comparison.
+SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
+       to_timestamp(greatest_modified_value / 1000000.0) AS greatest
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+ WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                         WHERE table_name = 'cagg_inval_segmentby_time');
+RESET TIME ZONE;
+

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -208,6 +208,34 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
 ROLLBACK;
 
+-- cagg + direct compress where the cagg time column is segmentby.
+-- segmentby columns don't get _ts_meta_min/max columns, so no MINMAX builder
+-- is created for them; the flush path must still derive an invalidation range
+-- from the segmentby value rather than crashing.
+BEGIN;
+CREATE TABLE metrics_segmentby_time (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+    WITH (tsdb.hypertable);
+CREATE MATERIALIZED VIEW metrics_segmentby_time_cagg WITH (tsdb.continuous) AS
+    SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value
+    FROM metrics_segmentby_time GROUP BY bucket, device WITH NO DATA;
+ALTER TABLE metrics_segmentby_time SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'time'
+);
+INSERT INTO metrics_segmentby_time
+SELECT '2025-01-01'::timestamptz + (i * interval '5 minutes'), 'd1', random()
+FROM generate_series(1, 50) i;
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO metrics_segmentby_time
+SELECT '2025-02-01'::timestamptz + (i * interval '1 second'), 'd1', random()
+FROM generate_series(1, 5000) i;
+-- The new chunk should be in COMPRESSED state, confirming the flush path ran.
+SELECT _timescaledb_functions.chunk_status_text(chunk)
+  FROM show_chunks('metrics_segmentby_time') chunk
+ WHERE chunk::text LIKE '%hyper_%'
+ ORDER BY chunk::text;
+ROLLBACK;
+
 -- test chunk status handling
 CREATE TABLE metrics_status(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time');
 


### PR DESCRIPTION
When direct-compress writes (INSERT/COPY/cagg refresh) and direct
batch delete record continuous aggregate invalidations, they look
up _ts_meta_min/max metadata columns for the cagg time dimension
to derive the invalidation range. Segmentby columns don't have
those metadata columns (they are stored as scalars, not as
compressed arrays with sparse-index columns), so when the time
column is configured as segmentby the lookup yields NULL/
InvalidAttrNumber and the code crashes:

* row_compressor_flush dereferences a NULL minmax_builder.
* The direct batch delete consumer reads
  compressed_datums[-1] (AttrNumberGetAttrOffset(0) = -1).

Detect the segmentby case in both paths and read the value from
the segmentby column directly: every row in the batch shares the
same segmentby value, so it serves as both bounds of the
invalidation range. The remaining "no minmax and not segmentby"
case shouldn't occur in a well-formed configuration; Ensure is
used in row_compressor_flush so the invariant produces a clean
ERROR rather than a crash if it ever does.
