### PR TITLE
Better env variables for the LLM Fuzzer

### DIFF
--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -173,6 +173,9 @@ jobs:
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       run: |
+        export PATH=$HOME/$PG_INSTALL_DIR/bin:$PATH
+        export PGDATABASE=postgres
+
         rc=0
         claude -p --output-format stream-json --verbose \
           --max-budget-usd 5.00 --dangerously-skip-permissions \


### PR DESCRIPTION
Set PATH and PGDATABASE because the agent wastes some turns on figuring this out.