### PR TITLE
Fix segfault in direct compress insert on hypertable with dropped column

### DIFF
--- a/.unreleased/pr_9680
+++ b/.unreleased/pr_9680
@@ -1,0 +1,1 @@
+Fixes: #9680 Fix segfault in direct compress insert on hypertable with dropped column

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2433,7 +2433,7 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 
 		if (operation == CMD_INSERT || (operation == CMD_MERGE && (node->mt_merge_subcommands & MERGE_INSERT)))
 		{
-			TupleTableSlot *slot = context.planSlot;
+			TupleTableSlot *hypertable_slot = context.planSlot;
 			if (operation == CMD_MERGE)
 			{
 				/*
@@ -2452,8 +2452,8 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 					CmdType commandType = action->mas_action->commandType;
 					if (commandType == CMD_INSERT)
 					{
-						action->mas_proj->pi_exprContext->ecxt_innertuple = slot;
-						slot = ExecProject(action->mas_proj);
+						action->mas_proj->pi_exprContext->ecxt_innertuple = hypertable_slot;
+						hypertable_slot = ExecProject(action->mas_proj);
 						break;
 					}
 				}
@@ -2461,12 +2461,12 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 
 			/* do tuple routing in short lived memory context */
 			MemoryContext oldctx = MemoryContextSwitchTo(estate->es_per_tuple_exprcontext->ecxt_per_tuple_memory);
-			Point *point = ts_hyperspace_calculate_point(ctr->hypertable->space, slot);
+			Point *point = ts_hyperspace_calculate_point(ctr->hypertable->space, hypertable_slot);
 
 			/* Find or create the insert state matching the point */
 			ctr->cis = ts_chunk_tuple_routing_find_chunk(ctr, point);
 			bool update_counter = ctr->cis->onConflictAction == ONCONFLICT_UPDATE;
-			ts_chunk_tuple_routing_decompress_for_insert(ctr->cis, ctr->root_rri, slot, ctr->estate, update_counter);
+			ts_chunk_tuple_routing_decompress_for_insert(ctr->cis, ctr->root_rri, hypertable_slot, ctr->estate, update_counter);
 			MemoryContextSwitchTo(oldctx);
 
 			/* ON CONFLICT DO NOTHING optimization for columnstore */
@@ -2525,11 +2525,25 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 				Relation rel = ctr->cis->rel;
 				if (rel->rd_att->constr && rel->rd_att->constr->has_generated_stored)
 				{
-					slot->tts_tableOid = RelationGetRelid(rel);
-					ExecComputeStoredGenerated(ctr->root_rri, estate, slot, CMD_INSERT);
+					hypertable_slot->tts_tableOid = RelationGetRelid(rel);
+					ExecComputeStoredGenerated(ctr->root_rri, estate, hypertable_slot, CMD_INSERT);
 				}
 
-				ts_cm_functions->compressor_add_slot(ht_state->compressor, ht_state->bulk_writer, slot);
+				/*
+				 * Convert the slot to the chunk's rowtype if the chunk's
+				 * TupleDesc differs from the hypertable (e.g. due to dropped
+				 * columns). The compressor was initialized with the chunk's
+				 * descriptor and indexes per-column state by chunk attribute
+				 * offsets, so passing a parent-format slot reads the wrong
+				 * columns.
+				 */
+				TupleTableSlot *chunk_slot = hypertable_slot;
+				if (ctr->cis->hyper_to_chunk_map != NULL)
+					chunk_slot = execute_attr_map_slot(ctr->cis->hyper_to_chunk_map->attrMap,
+													   hypertable_slot,
+													   ctr->cis->slot);
+
+				ts_cm_functions->compressor_add_slot(ht_state->compressor, ht_state->bulk_writer, chunk_slot);
 				estate->es_processed++;
 				continue;
 			}

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -786,6 +786,46 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  _timescaledb_internal._hyper_17_97_chunk | _timescaledb_internal.compress_hyper_18_98_chunk | {device_id} | {time}  | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
 
 ROLLBACK;
+-- Direct compress on a hypertable with a dropped column before the time
+-- dimension. Chunks created after the drop have a different TupleDesc than
+-- the hypertable, so the slot must be converted to chunk format before being
+-- passed to the compressor. Cover both INSERT and COPY entry points.
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_dropcol(col1 int, time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('test_dropcol', 'time');
+     create_hypertable      
+----------------------------
+ (19,public,test_dropcol,t)
+
+ALTER TABLE test_dropcol DROP COLUMN col1;
+INSERT INTO test_dropcol(time, device, value)
+SELECT '2025-01-01'::timestamptz + (i * interval '5 minutes'), 'd1', i::float
+FROM generate_series(1, 50) i;
+ALTER TABLE test_dropcol SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+SELECT count(compress_chunk(c)) FROM show_chunks('test_dropcol') c;
+ count 
+-------
+     1
+
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO test_dropcol(time, device, value)
+SELECT '2025-02-01'::timestamptz + (i * interval '1 second'), 'd2', i::float
+FROM generate_series(1, 5000) i;
+SELECT count(*), min(time), max(time), min(value), max(value) FROM test_dropcol WHERE device = 'd2';
+ count |             min              |             max              | min | max  
+-------+------------------------------+------------------------------+-----+------
+  5000 | Sat Feb 01 00:00:01 2025 PST | Sat Feb 01 01:23:20 2025 PST |   1 | 5000
+
+RESET timescaledb.enable_direct_compress_insert;
+SET timescaledb.enable_direct_compress_copy = true;
+COPY test_dropcol(time, device, value) FROM STDIN WITH (FORMAT csv);
+SELECT count(*), min(time), max(time), min(value), max(value) FROM test_dropcol WHERE device = 'd3';
+ count |             min              |             max              | min | max 
+-------+------------------------------+------------------------------+-----+-----
+     3 | Fri Feb 28 16:00:01 2025 PST | Fri Feb 28 16:00:03 2025 PST |   1 |   3
+
+ROLLBACK;
 -- Test orderby columns are not selected by DC segmentby default
 BEGIN;
 RESET timescaledb.enable_direct_compress_insert;
@@ -808,6 +848,6 @@ SELECT * FROM _timescaledb_catalog.compression_settings;
  _timescaledb_internal._hyper_7_57_chunk   | _timescaledb_internal.compress_hyper_8_58_chunk   |           | {time}           | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
  metrics_chunk                             |                                                   |           |                  |              |                    | 
  test_orderby_not_segmentby                |                                                   |           |                  |              |                    | 
- _timescaledb_internal._hyper_19_100_chunk | _timescaledb_internal.compress_hyper_20_101_chunk |           | {time,device_id} | {t,f}        | {t,f}              | [{"type": "minmax", "column": "time", "source": "orderby"}, {"type": "minmax", "column": "device_id", "source": "orderby"}]
+ _timescaledb_internal._hyper_21_106_chunk | _timescaledb_internal.compress_hyper_22_107_chunk |           | {time,device_id} | {t,f}        | {t,f}              | [{"type": "minmax", "column": "time", "source": "orderby"}, {"type": "minmax", "column": "device_id", "source": "orderby"}]
 
 ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -451,6 +451,35 @@ ANALYZE test_segmentby_stats;
 SELECT * FROM _timescaledb_catalog.compression_settings;
 ROLLBACK;
 
+-- Direct compress on a hypertable with a dropped column before the time
+-- dimension. Chunks created after the drop have a different TupleDesc than
+-- the hypertable, so the slot must be converted to chunk format before being
+-- passed to the compressor. Cover both INSERT and COPY entry points.
+BEGIN;
+RESET timescaledb.enable_direct_compress_insert;
+CREATE TABLE test_dropcol(col1 int, time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('test_dropcol', 'time');
+ALTER TABLE test_dropcol DROP COLUMN col1;
+INSERT INTO test_dropcol(time, device, value)
+SELECT '2025-01-01'::timestamptz + (i * interval '5 minutes'), 'd1', i::float
+FROM generate_series(1, 50) i;
+ALTER TABLE test_dropcol SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+SELECT count(compress_chunk(c)) FROM show_chunks('test_dropcol') c;
+SET timescaledb.enable_direct_compress_insert = true;
+INSERT INTO test_dropcol(time, device, value)
+SELECT '2025-02-01'::timestamptz + (i * interval '1 second'), 'd2', i::float
+FROM generate_series(1, 5000) i;
+SELECT count(*), min(time), max(time), min(value), max(value) FROM test_dropcol WHERE device = 'd2';
+RESET timescaledb.enable_direct_compress_insert;
+SET timescaledb.enable_direct_compress_copy = true;
+COPY test_dropcol(time, device, value) FROM STDIN WITH (FORMAT csv);
+2025-03-01 00:00:01+00,d3,1.0
+2025-03-01 00:00:02+00,d3,2.0
+2025-03-01 00:00:03+00,d3,3.0
+\.
+SELECT count(*), min(time), max(time), min(value), max(value) FROM test_dropcol WHERE device = 'd3';
+ROLLBACK;
+
 -- Test orderby columns are not selected by DC segmentby default
 BEGIN;
 RESET timescaledb.enable_direct_compress_insert;


### PR DESCRIPTION
Insert path did not do the necessary slot conversion from hypertable to chunk necessary to insert the tuple correctly. COPY path does do it but added a test for it nonetheless.