### PR TITLE
Stabilize ordered_append test

### DIFF
--- a/tsl/test/expected/ordered_append-15.out
+++ b/tsl/test/expected/ordered_append-15.out
@@ -128,7 +128,7 @@ set enable_nestloop to off;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -782,7 +782,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -1847,7 +1847,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -2838,7 +2838,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time

--- a/tsl/test/expected/ordered_append-16.out
+++ b/tsl/test/expected/ordered_append-16.out
@@ -128,7 +128,7 @@ set enable_nestloop to off;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -782,7 +782,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -1847,7 +1847,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -2838,7 +2838,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time

--- a/tsl/test/expected/ordered_append-17.out
+++ b/tsl/test/expected/ordered_append-17.out
@@ -128,7 +128,7 @@ set enable_nestloop to off;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -770,7 +770,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -1799,7 +1799,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -2778,7 +2778,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time

--- a/tsl/test/expected/ordered_append-18.out
+++ b/tsl/test/expected/ordered_append-18.out
@@ -128,7 +128,7 @@ set enable_nestloop to off;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -770,7 +770,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -1799,7 +1799,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time
@@ -2778,7 +2778,7 @@ LIMIT 3;
 -- SequentialScans. Disable the optimization for the following tests to ensure we have
 -- stable query plans in all CI environments.
 SET timescaledb.enable_decompression_sorted_merge = 0;
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 -- test ASC for ordered chunks
 :PREFIX
 SELECT time

--- a/tsl/test/sql/include/ordered_append.sql
+++ b/tsl/test/sql/include/ordered_append.sql
@@ -11,7 +11,7 @@
 
 SET timescaledb.enable_decompression_sorted_merge = 0;
 
-vacuum analyze :TEST_TABLE;
+vacuum (analyze, freeze) :TEST_TABLE;
 
 -- test ASC for ordered chunks
 :PREFIX


### PR DESCRIPTION
Plan switches from Index Only Scan to Index Scan suggest visibility map race condition. Adding FREEZE to the VACUUM command makes sure visibility map is up to date and reduces plan time inconsistencies.

Recent example of test failure: https://github.com/timescale/timescaledb/actions/runs/25084728239/job/73497604763

Disable-check: approval-count
Disable-check: force-changelog-file