### PR TITLE
Stabilize cagg_cancel_kill_refresh test

### DIFF
--- a/tsl/test/isolation/specs/cagg_cancel_kill_refresh.spec
+++ b/tsl/test/isolation/specs/cagg_cancel_kill_refresh.spec
@@ -45,50 +45,22 @@ setup
         pid INTEGER NOT NULL PRIMARY KEY
     );
 
-    -- Cancel backend procedure (waits for process to become inactive)
+    -- Signal cancel to registered backends. The isolation tester's
+    -- (blocked_step) annotation synchronizes step completion, so no polling
+    -- on pg_stat_activity is required here.
     CREATE OR REPLACE PROCEDURE cancelpids() AS
     $$
-    DECLARE
-        max_attempts INT := 100;
-        attempts INT := 0;
-        remaining_pids INT;
     BEGIN
         PERFORM pg_cancel_backend(pid) FROM cancelpid;
-        WHILE EXISTS (SELECT FROM pg_stat_activity WHERE pid IN (SELECT pid FROM cancelpid) AND state = 'active') AND attempts < max_attempts
-        LOOP
-            PERFORM pg_sleep(0.02);
-            attempts := attempts + 1;
-        END LOOP;
-        SELECT COUNT(*) INTO remaining_pids
-        FROM pg_stat_activity
-        WHERE pid IN (SELECT pid FROM cancelpid) AND state = 'active';
-        IF remaining_pids > 0 THEN
-            RAISE EXCEPTION 'Timeout waiting for % process(es) to become inactive after cancellation', remaining_pids;
-        END IF;
         DELETE FROM cancelpid;
     END;
     $$ LANGUAGE plpgsql;
 
-    -- Terminate backend procedure (waits for process to disappear from pg_stat_activity)
+    -- Signal terminate to registered backends. Same rationale as cancelpids().
     CREATE OR REPLACE PROCEDURE terminatepids() AS
     $$
-    DECLARE
-        max_attempts INT := 100;
-        attempts INT := 0;
-        remaining_pids INT;
     BEGIN
         PERFORM pg_terminate_backend(pid) FROM cancelpid;
-        WHILE EXISTS (SELECT FROM pg_stat_activity WHERE pid IN (SELECT pid FROM cancelpid)) AND attempts < max_attempts
-        LOOP
-            PERFORM pg_sleep(0.02);
-            attempts := attempts + 1;
-        END LOOP;
-        SELECT COUNT(*) INTO remaining_pids
-        FROM pg_stat_activity
-        WHERE pid IN (SELECT pid FROM cancelpid);
-        IF remaining_pids > 0 THEN
-            RAISE EXCEPTION 'Timeout waiting for % process(es) to terminate', remaining_pids;
-        END IF;
         DELETE FROM cancelpid;
     END;
     $$ LANGUAGE plpgsql;


### PR DESCRIPTION
The cancelpids/terminatepids helpers polled pg_stat_activity for up to 2 seconds after signaling the target backend, raising an exception on timeout. Slow CI runners (PG18.3 macos-15-intel) regularly exceeded this budget, producing a "Timeout waiting for 1 process(es) to terminate" diff.

The polling is redundant: the isolation tester's (blocked_step) permutation annotation already waits on the target session's socket state, so the next step does not run until the canceled/terminated backend has unwound (PG_CATCH cleanup or transaction rollback). Replace the polling with a single signal call and rely on the framework for synchronization.

Relevant recent test failure: https://github.com/timescale/timescaledb/actions/runs/25084728239/job/73497604788

Disable-check: force-changelog-file
Disable-check: approval-count