### PR TITLE
Add `decompress_batch` SQL function

### DIFF
--- a/.unreleased/pr_9684
+++ b/.unreleased/pr_9684
@@ -1,0 +1,1 @@
+Implements: #9684 Add `decompress_batch` SQL function

--- a/sql/compression.sql
+++ b/sql/compression.sql
@@ -12,3 +12,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.compressed_data_column_size(_t
    AS '@MODULE_PATHNAME@', 'ts_compressed_data_column_size'
    LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.decompress_batch(record)
+   RETURNS SETOF record
+   AS '@MODULE_PATHNAME@', 'ts_decompress_batch'
+   LANGUAGE C STRICT;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -293,3 +293,4 @@ CREATE TABLE _timescaledb_catalog.telemetry_event (
 );
 GRANT SELECT ON _timescaledb_catalog.telemetry_event TO PUBLIC;
 
+DROP FUNCTION IF EXISTS _timescaledb_functions.decompress_batch(record);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -60,6 +60,7 @@ CROSSMODULE_WRAPPER(compressed_data_decompress_forward);
 CROSSMODULE_WRAPPER(compressed_data_decompress_reverse);
 CROSSMODULE_WRAPPER(compressed_data_column_size);
 CROSSMODULE_WRAPPER(compressed_data_to_array);
+CROSSMODULE_WRAPPER(decompress_batch);
 CROSSMODULE_WRAPPER(compressed_data_send);
 CROSSMODULE_WRAPPER(compressed_data_recv);
 CROSSMODULE_WRAPPER(compressed_data_in);
@@ -367,6 +368,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.compressed_data_decompress_reverse = error_no_default_fn_pg_community,
 	.compressed_data_column_size = error_no_default_fn_pg_community,
 	.compressed_data_to_array = error_no_default_fn_pg_community,
+	.decompress_batch = error_no_default_fn_pg_community,
 	.deltadelta_compressor_append = error_no_default_fn_pg_community,
 	.deltadelta_compressor_finish = error_no_default_fn_pg_community,
 	.gorilla_compressor_append = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -149,6 +149,7 @@ typedef struct CrossModuleFunctions
 	PGFunction compressed_data_decompress_reverse;
 	PGFunction compressed_data_column_size;
 	PGFunction compressed_data_to_array;
+	PGFunction decompress_batch;
 	PGFunction deltadelta_compressor_append;
 	PGFunction deltadelta_compressor_finish;
 	PGFunction gorilla_compressor_append;

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -7,6 +7,7 @@
 #include <access/attmap.h>
 #include <access/attnum.h>
 #include <access/detoast.h>
+#include <access/htup_details.h>
 #include <access/skey.h>
 #include <access/tupdesc.h>
 #include <catalog/heap.h>
@@ -146,7 +147,7 @@ static void row_compressor_process_ordered_slot(RowCompressor *row_compressor, T
 static void row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row);
 static bool row_compressor_new_row_is_in_new_group(RowCompressor *row_compressor,
 												   TupleTableSlot *row);
-static void create_per_compressed_column(RowDecompressor *decompressor);
+static void create_per_compressed_column(RowDecompressor *decompressor, bool internal_error);
 static void row_compressor_append_row(RowCompressor *row_compressor, TupleTableSlot *row);
 static void row_compressor_flush(RowCompressor *row_compressor, BulkWriter *writer,
 								 bool changed_groups);
@@ -2022,8 +2023,9 @@ bulk_writer_close(BulkWriter *writer)
  ** decompress_chunk **
  **********************/
 
-RowDecompressor
-build_decompressor(const TupleDesc in_desc, const TupleDesc out_desc, Oid in_oid, Oid out_oid)
+static inline RowDecompressor
+build_decompressor_common(const TupleDesc in_desc, const TupleDesc out_desc, Oid in_oid,
+						  Oid out_oid, bool internal_error)
 {
 	AttrNumber count_meta_attnum = InvalidAttrNumber;
 	AttrMap *attrmap = build_decompress_attrmap(out_desc, in_desc, &count_meta_attnum);
@@ -2054,7 +2056,7 @@ build_decompressor(const TupleDesc in_desc, const TupleDesc out_desc, Oid in_oid
 		.attrmap = attrmap,
 	};
 
-	create_per_compressed_column(&decompressor);
+	create_per_compressed_column(&decompressor, internal_error);
 
 	/*
 	 * We need to make sure decompressed_is_nulls is in a defined state. While this
@@ -2069,6 +2071,12 @@ build_decompressor(const TupleDesc in_desc, const TupleDesc out_desc, Oid in_oid
 	row_decompressor_init_stats(&decompressor, in_oid, out_oid, CMD_SELECT);
 
 	return decompressor;
+}
+
+RowDecompressor
+build_decompressor(const TupleDesc in_desc, const TupleDesc out_desc, Oid in_oid, Oid out_oid)
+{
+	return build_decompressor_common(in_desc, out_desc, in_oid, out_oid, true);
 }
 
 void
@@ -2190,7 +2198,7 @@ decompress_chunk(Oid in_table, Oid out_table)
 }
 
 static void
-create_per_compressed_column(RowDecompressor *decompressor)
+create_per_compressed_column(RowDecompressor *decompressor, bool internal_error)
 {
 	Oid compressed_data_type_oid = ts_custom_type_cache_get(CUSTOM_TYPE_COMPRESSED_DATA)->type_oid;
 	Assert(OidIsValid(compressed_data_type_oid));
@@ -2234,12 +2242,14 @@ create_per_compressed_column(RowDecompressor *decompressor)
 		is_compressed = compressed_attr->atttypid == compressed_data_type_oid;
 		if (!is_compressed && compressed_attr->atttypid != decompressed_type)
 		{
-			elog(ERROR,
-				 "compressed table type '%s' does not match decompressed table type '%s' for "
-				 "segment-by column \"%s\"",
-				 format_type_be(compressed_attr->atttypid),
-				 format_type_be(decompressed_type),
-				 col_name);
+			ereport(ERROR,
+					(errcode(internal_error ? ERRCODE_INTERNAL_ERROR :
+											  ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("compressed table type '%s' does not match decompressed "
+							"table type '%s' for segment-by column \"%s\"",
+							format_type_be(compressed_attr->atttypid),
+							format_type_be(decompressed_type),
+							col_name)));
 		}
 
 		*per_compressed_col = (PerCompressedColumn){
@@ -2765,6 +2775,130 @@ tsl_compressed_data_decompress_reverse(PG_FUNCTION_ARGS)
 
 	SRF_RETURN_NEXT(funcctx, res.val);
 	;
+}
+
+/*
+ * decompress_batch(compressed_tuple record) RETURNS SETOF record
+ *
+ * Decompresses a single compressed batch (one row of a compressed chunk) into
+ * the individual rows it represents. The shape of the input compressed tuple
+ * is taken from the record's own type info (typeId/typmod in the header).
+ * The shape of the output rows is taken from the call site's column
+ * definition list (the AS t(...) clause).
+ */
+typedef struct DecompressBatchSRFContext
+{
+	RowDecompressor decompressor;
+	int next_row;
+	int total_rows;
+} DecompressBatchSRFContext;
+
+Datum
+tsl_decompress_batch(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	DecompressBatchSRFContext *decompress_ctx;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		funcctx = SRF_FIRSTCALL_INIT();
+		MemoryContext oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		TupleDesc out_desc;
+		if (get_call_result_type(fcinfo, NULL, &out_desc) != TYPEFUNC_COMPOSITE)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("function returning record called in context "
+							"that cannot accept type record")));
+		}
+		BlessTupleDesc(out_desc);
+
+		HeapTupleHeader td = PG_GETARG_HEAPTUPLEHEADER(0);
+		TupleDesc in_desc =
+			lookup_rowtype_tupdesc(HeapTupleHeaderGetTypeId(td), HeapTupleHeaderGetTypMod(td));
+
+		/*
+		 * Verify that the input record actually looks like a compressed-chunk
+		 * row before handing it to the decompressor. We are looking for the
+		 * "_ts_meta_count" metadata column which the decompressor uses to
+		 * identify the number of rows in the batch.
+		 */
+		bool has_count_column = false;
+		for (int i = 0; i < in_desc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(in_desc, i);
+
+			if (attr->attisdropped)
+			{
+				continue;
+			}
+
+			if (strcmp(NameStr(attr->attname), COMPRESSION_COLUMN_METADATA_COUNT_NAME) == 0)
+			{
+				if (attr->atttypid != INT4OID)
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+							 errmsg("input record is not a compressed batch"),
+							 errdetail("Column \"%s\" must have type integer.",
+									   COMPRESSION_COLUMN_METADATA_COUNT_NAME)));
+				}
+
+				has_count_column = true;
+				break;
+			}
+		}
+
+		if (!has_count_column)
+		{
+			ReleaseTupleDesc(in_desc);
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("input record is not a compressed batch"),
+					 errdetail("A compressed batch must have a \"%s\" metadata column.",
+							   COMPRESSION_COLUMN_METADATA_COUNT_NAME)));
+		}
+
+		decompress_ctx = palloc0(sizeof(DecompressBatchSRFContext));
+		decompress_ctx->decompressor =
+			build_decompressor_common(in_desc, out_desc, InvalidOid, InvalidOid, false);
+
+		HeapTupleData compressed_tuple;
+		compressed_tuple.t_len = HeapTupleHeaderGetDatumLength(td);
+		ItemPointerSetInvalid(&compressed_tuple.t_self);
+		compressed_tuple.t_tableOid = InvalidOid;
+		compressed_tuple.t_data = td;
+
+		heap_deform_tuple(&compressed_tuple,
+						  in_desc,
+						  decompress_ctx->decompressor.compressed_datums,
+						  decompress_ctx->decompressor.compressed_is_nulls);
+
+		ReleaseTupleDesc(in_desc);
+
+		decompress_ctx->total_rows = decompress_batch(&decompress_ctx->decompressor);
+		decompress_ctx->next_row = 0;
+
+		funcctx->user_fctx = decompress_ctx;
+		funcctx->tuple_desc = decompress_ctx->decompressor.out_desc;
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	decompress_ctx = (DecompressBatchSRFContext *) funcctx->user_fctx;
+
+	if (decompress_ctx->next_row >= decompress_ctx->total_rows)
+	{
+		row_decompressor_close(&decompress_ctx->decompressor);
+		SRF_RETURN_DONE(funcctx);
+	}
+
+	TupleTableSlot *slot =
+		decompress_ctx->decompressor.decompressed_slots[decompress_ctx->next_row++];
+	bool should_free;
+	HeapTuple tuple = ExecFetchSlotHeapTuple(slot, false, &should_free);
+	SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
 }
 
 /*

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -351,6 +351,7 @@ extern Datum tsl_compressed_data_info(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_has_nulls(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_column_size(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_to_array(PG_FUNCTION_ARGS);
+extern Datum tsl_decompress_batch(PG_FUNCTION_ARGS);
 
 static void
 pg_attribute_unused() assert_num_compression_algorithms_sane(void)

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -142,6 +142,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.compressed_data_decompress_reverse = tsl_compressed_data_decompress_reverse,
 	.compressed_data_column_size = tsl_compressed_data_column_size,
 	.compressed_data_to_array = tsl_compressed_data_to_array,
+	.decompress_batch = tsl_decompress_batch,
 	.compressed_data_send = tsl_compressed_data_send,
 	.compressed_data_recv = tsl_compressed_data_recv,
 	.compressed_data_in = tsl_compressed_data_in,

--- a/tsl/test/expected/decompress_batch.out
+++ b/tsl/test/expected/decompress_batch.out
@@ -1,0 +1,138 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- _timescaledb_functions.decompress_batch(record) RETURNS SETOF record
+-- expands a single row of a compressed chunk into the user-visible rows it
+-- was compressed from.
+SET datestyle TO ISO;
+CREATE TABLE metrics(time timestamptz NOT NULL, device_id int, value float)
+    WITH (tsdb.hypertable, tsdb.orderby = 'time', tsdb.segmentby = 'device_id');
+NOTICE:  using column "time" as partitioning column
+-- Populate with test data
+INSERT INTO metrics
+SELECT '2025-01-01'::timestamptz + (g || ' minute')::interval, g % 3, g::float
+FROM generate_series(1, 30) g;
+INSERT INTO metrics VALUES ('2025-01-01 02:00', NULL, NULL);
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- Capture the compressed chunk relation name
+SELECT format('%I.%I', cc.schema_name, cc.table_name) AS compressed_chunk
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk cc ON c.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id
+WHERE h.table_name = 'metrics' \gset
+-- Verify set equality: no source row missing, no extra row introduced
+SELECT count(*) AS missing FROM (
+    TABLE metrics
+    EXCEPT ALL
+    SELECT decomp.time, decomp.device_id, decomp.value
+    FROM :compressed_chunk t,
+         LATERAL _timescaledb_functions.decompress_batch(t)
+             AS decomp(time timestamptz, device_id int, value float)
+) m;
+ missing 
+---------
+       0
+
+SELECT count(*) AS extras FROM (
+    SELECT decomp.time, decomp.device_id, decomp.value
+    FROM :compressed_chunk t,
+         LATERAL _timescaledb_functions.decompress_batch(t)
+             AS decomp(time timestamptz, device_id int, value float)
+    EXCEPT ALL
+    TABLE metrics
+) e;
+ extras 
+--------
+      0
+
+-- Decompressing a single batch yields exactly that batch.
+SELECT decomp.time, decomp.device_id, decomp.value
+FROM (SELECT t FROM :compressed_chunk t WHERE t.device_id = 1) comp,
+     LATERAL _timescaledb_functions.decompress_batch(comp.t)
+         AS decomp(time timestamptz, device_id int, value float)
+ORDER BY decomp.time;
+          time          | device_id | value 
+------------------------+-----------+-------
+ 2025-01-01 00:01:00-08 |         1 |     1
+ 2025-01-01 00:04:00-08 |         1 |     4
+ 2025-01-01 00:07:00-08 |         1 |     7
+ 2025-01-01 00:10:00-08 |         1 |    10
+ 2025-01-01 00:13:00-08 |         1 |    13
+ 2025-01-01 00:16:00-08 |         1 |    16
+ 2025-01-01 00:19:00-08 |         1 |    19
+ 2025-01-01 00:22:00-08 |         1 |    22
+ 2025-01-01 00:25:00-08 |         1 |    25
+ 2025-01-01 00:28:00-08 |         1 |    28
+
+DROP TABLE metrics CASCADE;
+\set ON_ERROR_STOP 0
+-- Calling `decompress_batch()` on a non-compressed record
+SELECT decomp.*
+FROM (VALUES (1, 2)) AS r(a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+ERROR:  input record is not a compressed batch
+-- Calling `decompress_batch()` on a "fake" compressed record with the
+-- `_ts_meta_count` column of incorrect type
+SELECT decomp.*
+FROM (VALUES (1::INT8, 2, 3)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+ERROR:  input record is not a compressed batch
+-- Calling `decompress_batch()` on a "fake" compressed record with zero
+-- compressed columns
+SELECT decomp.*
+FROM (VALUES (1,2,3)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+ a | b 
+---+---
+ 2 | 3
+
+-- Input and output type mismatch. Here we make sure that the error message has
+-- a "user-friendly" error code (`22023`) and not the internal error code (`XX000`)
+DO $$
+BEGIN
+    SELECT decomp.*
+    FROM (VALUES (1, 2, 3::int8)) AS r(_ts_meta_count, a, b),
+    LATERAL _timescaledb_functions.decompress_batch(r)
+        AS decomp(a int, b int4);
+EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'SQLSTATE %: %', SQLSTATE, SQLERRM;
+END $$;
+WARNING:  SQLSTATE 22023: compressed table type 'bigint' does not match decompressed table type 'integer' for segment-by column "b"
+-- Decompress a batch into an incompatible type. The compressed data here is
+-- built from a single text value `test` which is being decompressed into an
+-- integer
+SELECT decomp.*
+FROM (VALUES (1, 2, 'AQBwZ19jYXRhbG9nAHRleHQAAAEAAAABAAAABHRlc3Q='::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+ERROR:  the compressed data is corrupt
+-- Try decompressing a batch while `_ts_meta_count` (10) is larger than the
+-- actual number of compressed values (1)
+SELECT decomp.*
+FROM (VALUES (10, 2, 'AQBwZ19jYXRhbG9nAHRleHQAAAEAAAABAAAABHRlc3Q='::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b text);
+ERROR:  the compressed data is corrupt
+-- Run `decompress_batch()` with NULL as compressed data and as a "segment by"
+-- column -- both should be fine
+SELECT decomp.*
+FROM (VALUES (1, NULL::int, NULL::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+ a | b 
+---+---
+   |  
+
+-- Decompressing a batch with NULL in the `_ts_meta_count` column should fail
+SELECT decomp.*
+FROM (VALUES (NULL, NULL, NULL::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b text);
+ERROR:  input record is not a compressed batch

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -57,6 +57,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.constraint_clone(oid,regclass)
  _timescaledb_functions.create_chunk(regclass,jsonb,name,name,regclass)
  _timescaledb_functions.create_compressed_chunk(regclass,regclass,bigint,bigint,bigint,bigint,bigint,bigint,bigint,bigint)
+ _timescaledb_functions.decompress_batch(record)
  _timescaledb_functions.dimension_info_in(cstring)
  _timescaledb_functions.dimension_info_out(_timescaledb_internal.dimension_info)
  _timescaledb_functions.drop_chunk(regclass)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -67,6 +67,7 @@ set(TEST_FILES
     compression_trigger.sql
     compression_uuid.sql
     create_table_with.sql
+    decompress_batch.sql
     decompress_index.sql
     direct_compress_analyze_segmentby.sql
     direct_compress_insert.sql

--- a/tsl/test/sql/decompress_batch.sql
+++ b/tsl/test/sql/decompress_batch.sql
@@ -1,0 +1,117 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- _timescaledb_functions.decompress_batch(record) RETURNS SETOF record
+-- expands a single row of a compressed chunk into the user-visible rows it
+-- was compressed from.
+
+SET datestyle TO ISO;
+
+CREATE TABLE metrics(time timestamptz NOT NULL, device_id int, value float)
+    WITH (tsdb.hypertable, tsdb.orderby = 'time', tsdb.segmentby = 'device_id');
+
+-- Populate with test data
+INSERT INTO metrics
+SELECT '2025-01-01'::timestamptz + (g || ' minute')::interval, g % 3, g::float
+FROM generate_series(1, 30) g;
+INSERT INTO metrics VALUES ('2025-01-01 02:00', NULL, NULL);
+
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+
+-- Capture the compressed chunk relation name
+SELECT format('%I.%I', cc.schema_name, cc.table_name) AS compressed_chunk
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk cc ON c.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id
+WHERE h.table_name = 'metrics' \gset
+
+-- Verify set equality: no source row missing, no extra row introduced
+SELECT count(*) AS missing FROM (
+    TABLE metrics
+    EXCEPT ALL
+    SELECT decomp.time, decomp.device_id, decomp.value
+    FROM :compressed_chunk t,
+         LATERAL _timescaledb_functions.decompress_batch(t)
+             AS decomp(time timestamptz, device_id int, value float)
+) m;
+
+SELECT count(*) AS extras FROM (
+    SELECT decomp.time, decomp.device_id, decomp.value
+    FROM :compressed_chunk t,
+         LATERAL _timescaledb_functions.decompress_batch(t)
+             AS decomp(time timestamptz, device_id int, value float)
+    EXCEPT ALL
+    TABLE metrics
+) e;
+
+-- Decompressing a single batch yields exactly that batch.
+SELECT decomp.time, decomp.device_id, decomp.value
+FROM (SELECT t FROM :compressed_chunk t WHERE t.device_id = 1) comp,
+     LATERAL _timescaledb_functions.decompress_batch(comp.t)
+         AS decomp(time timestamptz, device_id int, value float)
+ORDER BY decomp.time;
+
+DROP TABLE metrics CASCADE;
+
+\set ON_ERROR_STOP 0
+
+-- Calling `decompress_batch()` on a non-compressed record
+SELECT decomp.*
+FROM (VALUES (1, 2)) AS r(a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+
+-- Calling `decompress_batch()` on a "fake" compressed record with the
+-- `_ts_meta_count` column of incorrect type
+SELECT decomp.*
+FROM (VALUES (1::INT8, 2, 3)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+
+-- Calling `decompress_batch()` on a "fake" compressed record with zero
+-- compressed columns
+SELECT decomp.*
+FROM (VALUES (1,2,3)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+
+-- Input and output type mismatch. Here we make sure that the error message has
+-- a "user-friendly" error code (`22023`) and not the internal error code (`XX000`)
+DO $$
+BEGIN
+    SELECT decomp.*
+    FROM (VALUES (1, 2, 3::int8)) AS r(_ts_meta_count, a, b),
+    LATERAL _timescaledb_functions.decompress_batch(r)
+        AS decomp(a int, b int4);
+EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'SQLSTATE %: %', SQLSTATE, SQLERRM;
+END $$;
+
+-- Decompress a batch into an incompatible type. The compressed data here is
+-- built from a single text value `test` which is being decompressed into an
+-- integer
+SELECT decomp.*
+FROM (VALUES (1, 2, 'AQBwZ19jYXRhbG9nAHRleHQAAAEAAAABAAAABHRlc3Q='::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+
+-- Try decompressing a batch while `_ts_meta_count` (10) is larger than the
+-- actual number of compressed values (1)
+SELECT decomp.*
+FROM (VALUES (10, 2, 'AQBwZ19jYXRhbG9nAHRleHQAAAEAAAABAAAABHRlc3Q='::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b text);
+
+-- Run `decompress_batch()` with NULL as compressed data and as a "segment by"
+-- column -- both should be fine
+SELECT decomp.*
+FROM (VALUES (1, NULL::int, NULL::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b int);
+
+-- Decompressing a batch with NULL in the `_ts_meta_count` column should fail
+SELECT decomp.*
+FROM (VALUES (NULL, NULL, NULL::_timescaledb_internal.compressed_data)) AS r(_ts_meta_count, a, b),
+LATERAL _timescaledb_functions.decompress_batch(r)
+    AS decomp(a int, b text);


### PR DESCRIPTION
Introduce _timescaledb_functions.decompress_batch(record), which expands a single compressed-chunk row back into the individual rows it represents. The function is intended for use from a custom logical decoding plugin that needs to materialize the original tuples from a compressed batch.

The input descriptor is recovered from the record's own type info (typeId/typmod in the HeapTupleHeader) via lookup_rowtype_tupdesc, so callers can pass a row from a compressed chunk directly. The output descriptor is taken from the call site's column definition list through get_call_result_type, letting the caller specify the shape of the decompressed rows in the AS t(...) clause.

Internally the function is a value-per-call SRF that calls build_decompressor, deforms the input record into the decompressor's compressed_datums/_is_nulls arrays, runs decompress_batch once, and yields each tuple from decompressed_slots. row_decompressor_close runs on SRF_RETURN_DONE.

Example:

```sql
  SELECT x.*
  FROM _timescaledb_internal.compress_hyper_2_2_chunk t
  LIMIT 1
  CROSS JOIN LATERAL _timescaledb_functions.decompress_batch(t)
      AS x(time timestamptz, device_id int, value float);
```