### PR TITLE
Match PostgreSQL's MERGE NOT MATCHED slot handling

### DIFF
--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -45,8 +45,6 @@ ts_chunk_tuple_routing_create(EState *estate, Hypertable *ht, ResultRelInfo *rri
 										   estate->es_query_cxt,
 										   ts_guc_max_open_chunks_per_insert);
 
-	ctr->has_dropped_attrs = false;
-
 	return ctr;
 }
 

--- a/src/chunk_tuple_routing.h
+++ b/src/chunk_tuple_routing.h
@@ -27,7 +27,6 @@ typedef struct ChunkTupleRouting
 	SubspaceStore *subspace;
 	EState *estate;
 	bool create_compressed_chunk;
-	bool has_dropped_attrs;
 
 	ModifyHypertableState *mht_state; /* state for the ModifyHypertable custom scan node */
 	ChunkInsertState *cis;

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -7,7 +7,6 @@
 #include <postgres.h>
 #include <nodes/execnodes.h>
 #include <nodes/makefuncs.h>
-#include <utils/syscache.h>
 
 #include "compat/compat.h"
 #include "chunk_tuple_routing.h"
@@ -20,36 +19,6 @@
 #if PG18_GE
 #include <commands/explain_format.h>
 #endif
-
-static AttrNumber
-rel_get_natts(Oid relid)
-{
-	HeapTuple tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
-
-	if (!HeapTupleIsValid(tp))
-		elog(ERROR, "cache lookup failed for relation %u", relid);
-	AttrNumber natts = ((Form_pg_class) GETSTRUCT(tp))->relnatts;
-	ReleaseSysCache(tp);
-	return natts;
-}
-
-static bool
-rel_has_dropped_attrs(Oid relid)
-{
-	AttrNumber natts = rel_get_natts(relid);
-	for (AttrNumber attno = 1; attno <= natts; attno++)
-	{
-		HeapTuple tp = SearchSysCache2(ATTNUM, ObjectIdGetDatum(relid), Int16GetDatum(attno));
-		if (!HeapTupleIsValid(tp))
-			continue;
-		Form_pg_attribute att_tup = (Form_pg_attribute) GETSTRUCT(tp);
-		bool result = att_tup->attisdropped || att_tup->atthasmissing;
-		ReleaseSysCache(tp);
-		if (result)
-			return true;
-	}
-	return false;
-}
 
 static bool
 should_use_direct_compress(ModifyHypertableState *state)
@@ -155,10 +124,6 @@ modify_hypertable_begin(CustomScanState *node, EState *estate, int eflags)
 			state->columnstore_insert = true;
 			state->ctr->create_compressed_chunk = true;
 		}
-
-		if (mtstate->operation == CMD_MERGE)
-			state->ctr->has_dropped_attrs =
-				rel_has_dropped_attrs(state->ctr->hypertable->main_table_relid);
 
 		/* setup per tuple exprcontext for tuple routing */
 		if (!estate->es_per_tuple_exprcontext)

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -631,7 +631,7 @@ ExecPrepareTupleRouting(ModifyTableState *mtstate,
 		mtstate->mt_transition_capture->tcs_original_insert_tuple = slot;
 
 	/* Convert the tuple to the chunk's rowtype, if necessary */
-	if (cis->hyper_to_chunk_map != NULL && ctr->has_dropped_attrs == false)
+	if (cis->hyper_to_chunk_map != NULL)
 		slot = execute_attr_map_slot(cis->hyper_to_chunk_map->attrMap, slot, cis->slot);
 
 	*partRelInfo = cis->result_relation_info;
@@ -3488,36 +3488,7 @@ ExecMergeNotMatched(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 #else
 				context->relaction = action;
 #endif
-				if (ctr->has_dropped_attrs)
-				{
-					AttrMap *map;
-					TupleDesc parenttupdesc, chunktupdesc;
-					TupleTableSlot *chunk_slot = NULL;
-
-					parenttupdesc = RelationGetDescr(resultRelInfo->ri_RelationDesc);
-					chunktupdesc = RelationGetDescr(ctr->cis->result_relation_info->ri_RelationDesc);
-					/* map from parent to chunk */
-#if PG16_LT
-					map = build_attrmap_by_name_if_req(parenttupdesc, chunktupdesc);
-#else
-					map = build_attrmap_by_name_if_req(parenttupdesc, chunktupdesc, false);
-#endif
-					if (map != NULL)
-						chunk_slot =
-							execute_attr_map_slot(map,
-												  newslot,
-												  MakeSingleTupleTableSlot(chunktupdesc,
-																		   &TTSOpsVirtual));
-					rslot = ExecInsert(context,
-									   resultRelInfo,
-									   ctr,
-									   (chunk_slot ? chunk_slot : newslot),
-									   canSetTag);
-					if (chunk_slot)
-						ExecDropSingleTupleTableSlot(chunk_slot);
-				}
-				else
-					rslot = ExecInsert(context, resultRelInfo, ctr, newslot, canSetTag);
+				rslot = ExecInsert(context, resultRelInfo, ctr, newslot, canSetTag);
 				mtstate->mt_merge_inserted = 1;
 				break;
 			case CMD_NOTHING:


### PR DESCRIPTION
The MERGE NOT MATCHED INSERT path used to build a parent-to-chunk
attribute map and allocate a fresh slot for every inserted row,
and a flag on the routing state told the standard conversion
helper to skip its own work so the slot would not be converted
twice. PostgreSQL's ExecMergeNotMatched does none of that. It
just calls ExecInsert and lets the routing inside convert the
slot when the partition's TupleDesc differs from the parent's.

Match that here: drop the manual conversion, drop the flag, and
let ts_prepare_tuple_routing convert whenever the chunk's
TupleDesc differs from the parent's. The dropped-column helpers
in modify_hypertable.c had no other callers and are gone too.

The merge regression test already exercises MERGE NOT MATCHED
INSERT into a chunk created after a column was dropped from the
hypertable.

Disable-check: force-changelog-file