### PR TITLE
Add chunk status to output of compression_bgw

### DIFF
--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -754,6 +754,12 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE chunk_schema = :'chunk
 
 -- should recompress
 CALL run_job(:JOB_COMPRESS);
+-- chunk should be fully compressed now (status = 1) so reindex can run
+SELECT chunk_status FROM compressed_chunk_info_view WHERE chunk_schema = :'chunk_schema' AND chunk_name = :'chunk_name';
+ chunk_status 
+--------------
+            1
+
 -- index size should decrease due to reindexing (8kB or 16kB)
 VACUUM ANALYZE metrics2;
 SELECT pg_indexes_size(:'RECOMPRESS_CHUNK_NAME') <= 16384 as size_empty;

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -334,6 +334,9 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE chunk_schema = :'chunk
 -- should recompress
 CALL run_job(:JOB_COMPRESS);
 
+-- chunk should be fully compressed now (status = 1) so reindex can run
+SELECT chunk_status FROM compressed_chunk_info_view WHERE chunk_schema = :'chunk_schema' AND chunk_name = :'chunk_name';
+
 -- index size should decrease due to reindexing (8kB or 16kB)
 VACUUM ANALYZE metrics2;
 SELECT pg_indexes_size(:'RECOMPRESS_CHUNK_NAME') <= 16384 as size_empty;


### PR DESCRIPTION
This test has intermittent failures when checking the index was reindexed after segmentwise recompression. Adding chunk status to confirm the chunk is indeed fully compressed after job run so next time it fails we can double-check the chunk status.

Disable-check: approval-count