### PR TITLE
Add missing ORDER to compression settings output

### DIFF
--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -840,14 +840,14 @@ ALTER TABLE test_orderby_not_segmentby SET (timescaledb.compress);
 SET timescaledb.enable_direct_compress_insert = on;
 INSERT INTO test_orderby_not_segmentby SELECT '2024-06-01'::timestamptz + (i||' min')::interval,
     (i%5)+1, random() FROM generate_series(1,2000) i;
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text COLLATE "C";
                    relid                   |                  compress_relid                   | segmentby |     orderby      | orderby_desc | orderby_nullsfirst |                                                            index                                                            
 -------------------------------------------+---------------------------------------------------+-----------+------------------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------
- metrics                                   |                                                   |           | {time}           | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
- metrics_status                            |                                                   |           |                  |              |                    | 
- _timescaledb_internal._hyper_7_57_chunk   | _timescaledb_internal.compress_hyper_8_58_chunk   |           | {time}           | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
- metrics_chunk                             |                                                   |           |                  |              |                    | 
- test_orderby_not_segmentby                |                                                   |           |                  |              |                    | 
  _timescaledb_internal._hyper_21_106_chunk | _timescaledb_internal.compress_hyper_22_107_chunk |           | {time,device_id} | {t,f}        | {t,f}              | [{"type": "minmax", "column": "time", "source": "orderby"}, {"type": "minmax", "column": "device_id", "source": "orderby"}]
+ _timescaledb_internal._hyper_7_57_chunk   | _timescaledb_internal.compress_hyper_8_58_chunk   |           | {time}           | {t}          | {t}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics                                   |                                                   |           | {time}           | {f}          | {f}                | [{"type": "minmax", "column": "time", "source": "orderby"}]
+ metrics_chunk                             |                                                   |           |                  |              |                    | 
+ metrics_status                            |                                                   |           |                  |              |                    | 
+ test_orderby_not_segmentby                |                                                   |           |                  |              |                    | 
 
 ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -493,6 +493,6 @@ ALTER TABLE test_orderby_not_segmentby SET (timescaledb.compress);
 SET timescaledb.enable_direct_compress_insert = on;
 INSERT INTO test_orderby_not_segmentby SELECT '2024-06-01'::timestamptz + (i||' min')::interval,
     (i%5)+1, random() FROM generate_series(1,2000) i;
-SELECT * FROM _timescaledb_catalog.compression_settings;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text COLLATE "C";
 ROLLBACK;
 


### PR DESCRIPTION
Explicit ordering stabilizes direct_compress_insert test.

Recent test failure: https://github.com/timescale/timescaledb/actions/runs/25104275679?pr=9687

Disable-check: approval-count