### PR TITLE
Enable hypertable expansion for non-target relations in DML queries

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -432,12 +432,18 @@ preprocess_query(Node *node, PreprocessQueryContext *context)
 
 					if (ht)
 					{
-						/* Mark hypertable RTEs we'd like to expand ourselves.
-						 * We skip the DML target relation (resultRelation != 0
-						 * in the current query) but allow non-target hypertables
-						 * in subqueries of UPDATE/DELETE to use TSDB expansion. */
+						/*
+						 * Mark hypertable RTEs we'd like to expand ourselves.
+						 * We always do this for SELECTs from hypertables.
+						 *
+						 * For DML, we also always expand the non-target relations.
+						 *
+						 * The hypertables that are not expanded by our custom code
+						 * here fall back to the standard Postgres inheritance
+						 * hierarchy expansion.
+						 */
 						if (ts_guc_enable_optimizations && ts_guc_enable_constraint_exclusion &&
-							query->resultRelation == 0 && rte->inh)
+							rte->inh && (Index) query->resultRelation != rti)
 						{
 							rte_mark_for_expansion(rte);
 						}
@@ -1429,10 +1435,14 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 	{
 		case TS_REL_HYPERTABLE:
 		{
-			/* Mark hypertable RTEs we'd like to expand ourselves.
+			/*
+			 * Mark hypertable RTEs we'd like to expand ourselves.
 			 * Hypertables inside inlineable functions don't get marked during
-			 * the query preprocessing step. Therefore we do an extra try here.
-			 * We skip the DML target relation identified by resultRelation.
+			 * the query preprocessing step handled in preprocess_query().
+			 * Therefore we do an extra try here.
+			 *
+			 * For the explanation of the logic, see the comments in
+			 * preprocess_query().
 			 */
 			if (ts_guc_enable_optimizations && ts_guc_enable_constraint_exclusion && inhparent &&
 				rte->ctename == NULL && rel->relid != (Index) query->resultRelation)

--- a/test/expected/expand_hypertable_target.out
+++ b/test/expected/expand_hypertable_target.out
@@ -1,0 +1,29 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test a case of hypertable expansion in a DML query where it is not a target
+-- relation.
+CREATE TABLE ht_target (time timestamptz NOT NULL, val int);
+SELECT create_hypertable('ht_target', 'time');
+   create_hypertable    
+------------------------
+ (1,public,ht_target,t)
+
+INSERT INTO ht_target VALUES ('2024-03-15', 1);
+CREATE TABLE ht_empty (time timestamptz NOT NULL, val int);
+SELECT create_hypertable('ht_empty', 'time');
+   create_hypertable   
+-----------------------
+ (2,public,ht_empty,t)
+
+EXPLAIN (costs off)
+UPDATE ht_target SET val = ht_empty.val
+FROM ht_empty
+WHERE ht_target.time = ht_empty.time;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Update on ht_target
+         Update on _hyper_1_1_chunk ht_target
+         ->  Result
+               One-Time Filter: false
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_FILES
     drop_rename_hypertable.sql
     drop_schema.sql
     dump_meta.sql
+    expand_hypertable_target.sql
     extension_scripts.sql
     generated_as_identity.sql
     hash.sql

--- a/test/sql/expand_hypertable_target.sql
+++ b/test/sql/expand_hypertable_target.sql
@@ -1,0 +1,19 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Test a case of hypertable expansion in a DML query where it is not a target
+-- relation.
+
+CREATE TABLE ht_target (time timestamptz NOT NULL, val int);
+SELECT create_hypertable('ht_target', 'time');
+INSERT INTO ht_target VALUES ('2024-03-15', 1);
+
+CREATE TABLE ht_empty (time timestamptz NOT NULL, val int);
+SELECT create_hypertable('ht_empty', 'time');
+
+EXPLAIN (costs off)
+UPDATE ht_target SET val = ht_empty.val
+FROM ht_empty
+WHERE ht_target.time = ht_empty.time;
+


### PR DESCRIPTION
We have two code paths that handle this, and previously it was only enabled in one but not in another by oversight. Fix this.

Follow up for https://github.com/timescale/timescaledb/pull/9584

Needed for https://github.com/timescale/timescaledb/pull/9315

Disable-check: force-changelog-file