### PR TITLE
Fix MERGE NOT MATCHED INSERT failing with internal RTE error

### DIFF
--- a/.unreleased/pr_9692
+++ b/.unreleased/pr_9692
@@ -1,0 +1,1 @@
+Fixes: #9692 Fix internal "invalid perminfoindex 0 in RTE" error on MERGE NOT MATCHED INSERT into a hypertable

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -88,7 +88,18 @@ create_chunk_result_relation_info(ResultRelInfo *ht_rri, Relation rel, EState *e
 	ResultRelInfo *rri;
 	rri = makeNode(ResultRelInfo);
 
-	InitResultRelInfo(rri, rel, ht_rri->ri_RangeTableIndex, NULL, estate->es_instrument);
+	/*
+	 * For MERGE, the hypertable's ResultRelInfo points to an RTE with
+	 * perminfoindex = 0; the valid RTEPermissionInfo lives on the
+	 * rootResultRelInfo that PG sets up via ModifyTable->rootRelation.
+	 * Forward that link to the chunk so GetResultRTEPermissionInfo() can
+	 * find it during ExecConstraints, RLS checks, etc.
+	 */
+	InitResultRelInfo(rri,
+					  rel,
+					  ht_rri->ri_RangeTableIndex,
+					  ht_rri->ri_RootResultRelInfo,
+					  estate->es_instrument);
 
 	/* Copy options from the main table's (hypertable's) result relation info */
 	rri->ri_WithCheckOptions = ht_rri->ri_WithCheckOptions;

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -924,3 +924,23 @@ DROP TABLE target;
 DROP TABLE source;
 DROP USER priv_user;
 DROP USER non_priv_user;
+-- Regression test for "invalid perminfoindex 0 in RTE" on MERGE NOT MATCHED
+-- INSERT into a hypertable when a CHECK constraint is violated. The chunk
+-- ResultRelInfo used to inherit a NULL ri_RootResultRelInfo from the
+-- hypertable, which made GetResultRTEPermissionInfo() look up an RTE with
+-- perminfoindex = 0 instead of falling back to the rootResultRelInfo.
+CREATE TABLE merge_check_target(time timestamptz NOT NULL, a int CHECK (a > 0));
+SELECT FROM create_hypertable('merge_check_target', 'time');
+--
+
+INSERT INTO merge_check_target VALUES ('2024-01-01', 1);
+CREATE TABLE merge_check_source(time timestamptz, a int);
+INSERT INTO merge_check_source VALUES ('2025-01-01', -1);
+\set ON_ERROR_STOP 0
+-- Expect a CHECK constraint violation, not an internal "perminfoindex" error.
+MERGE INTO merge_check_target t USING merge_check_source s ON t.time = s.time
+WHEN NOT MATCHED THEN INSERT VALUES (s.time, s.a);
+ERROR:  new row for relation "_hyper_11_30_chunk" violates check constraint "merge_check_target_a_check"
+\set ON_ERROR_STOP 1
+DROP TABLE merge_check_target;
+DROP TABLE merge_check_source;

--- a/test/sql/merge.sql
+++ b/test/sql/merge.sql
@@ -899,3 +899,24 @@ DROP TABLE target;
 DROP TABLE source;
 DROP USER priv_user;
 DROP USER non_priv_user;
+
+-- Regression test for "invalid perminfoindex 0 in RTE" on MERGE NOT MATCHED
+-- INSERT into a hypertable when a CHECK constraint is violated. The chunk
+-- ResultRelInfo used to inherit a NULL ri_RootResultRelInfo from the
+-- hypertable, which made GetResultRTEPermissionInfo() look up an RTE with
+-- perminfoindex = 0 instead of falling back to the rootResultRelInfo.
+CREATE TABLE merge_check_target(time timestamptz NOT NULL, a int CHECK (a > 0));
+SELECT FROM create_hypertable('merge_check_target', 'time');
+INSERT INTO merge_check_target VALUES ('2024-01-01', 1);
+
+CREATE TABLE merge_check_source(time timestamptz, a int);
+INSERT INTO merge_check_source VALUES ('2025-01-01', -1);
+
+\set ON_ERROR_STOP 0
+-- Expect a CHECK constraint violation, not an internal "perminfoindex" error.
+MERGE INTO merge_check_target t USING merge_check_source s ON t.time = s.time
+WHEN NOT MATCHED THEN INSERT VALUES (s.time, s.a);
+\set ON_ERROR_STOP 1
+
+DROP TABLE merge_check_target;
+DROP TABLE merge_check_source;


### PR DESCRIPTION
When a MERGE NOT MATCHED INSERT into a hypertable triggered a
constraint check, the user saw an internal error of the form
"invalid perminfoindex 0 in RTE" instead of the expected constraint
violation.

In a MERGE plan, PostgreSQL keeps the original target permission
entry on a separate root result relation and leaves the per-target
range table entry without permission info. The chunk's result
relation was created without a link back to that root, so any code
path that looks up permissions on the chunk found an entry without
permission info and raised the internal error.

Forward the root link from the hypertable's result relation to the
chunk so permission lookups find the right entry.
