### PR TITLE
Report error if codecov.io upload fails

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -232,6 +232,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/coverage/timescaledb-coverage.info
+        fail_ci_if_error: true
 
     - name: Save LCOV coverage report
       if: matrix.coverage

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -232,7 +232,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/coverage/timescaledb-coverage.info
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name != 'pull_request' }}
 
     - name: Save LCOV coverage report
       if: matrix.coverage


### PR DESCRIPTION
Sometimes the upload of coverage results for the main branch breaks, and it takes us a long time to notice. This leads to gradually deteriorating coverage change reports on PRs. Report the errors as they occur.