### PR TITLE
Add GUC to flush batch on first orderby change

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -124,6 +124,7 @@ TSDLLEXPORT bool ts_guc_enable_bool_compression = true;
 TSDLLEXPORT bool ts_guc_enable_uuid_compression = true;
 TSDLLEXPORT int ts_guc_compression_batch_size_limit = TARGET_COMPRESSED_BATCH_SIZE;
 TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit = false;
+TSDLLEXPORT bool ts_guc_compression_flush_batch_on_first_orderby_change = false;
 TSDLLEXPORT CompressTruncateBehaviour ts_guc_compress_truncate_behaviour = COMPRESS_TRUNCATE_ONLY;
 bool ts_guc_enable_event_triggers = false;
 bool ts_guc_enable_chunk_auto_publication = false;
@@ -1141,6 +1142,19 @@ _guc_init(void)
 							 "limit those compressors by reducing the size of the batch and thus "
 							 "avoid hitting the limit.",
 							 &ts_guc_compression_enable_compressor_batch_limit,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+	DefineCustomBoolVariable(MAKE_EXTOPTION("compression_flush_batch_on_first_orderby_change"),
+							 "Finish a compressed batch when the first orderby column changes",
+							 "When enabled, the row compressor finishes the current batch as "
+							 "soon as the value of the first orderby column changes between "
+							 "consecutive rows. This keeps every batch aligned to a single "
+							 "value of the first orderby column.",
+							 &ts_guc_compression_flush_batch_on_first_orderby_change,
 							 false,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -75,6 +75,7 @@ extern TSDLLEXPORT bool ts_guc_enable_bool_compression;
 extern TSDLLEXPORT bool ts_guc_enable_uuid_compression;
 extern TSDLLEXPORT int ts_guc_compression_batch_size_limit;
 extern TSDLLEXPORT bool ts_guc_compression_enable_compressor_batch_limit;
+extern TSDLLEXPORT bool ts_guc_compression_flush_batch_on_first_orderby_change;
 #if PG16_GE
 extern TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates;
 #endif

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1227,6 +1227,8 @@ row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *se
 		.num_compressed_rows = 0,
 		.first_iteration = true,
 		.sort_state = NULL,
+		.first_orderby_col_offset = -1,
+		.first_orderby_segment_info = NULL,
 	};
 
 	memset(row_compressor->compressed_is_null, 1, sizeof(bool) * compressed_tupdesc->natts);
@@ -1243,6 +1245,27 @@ row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *se
 	row_compressor->needs_fullness_check =
 		check_for_limited_size_compressors(row_compressor->per_column,
 										   row_compressor->n_input_columns);
+
+	/*
+	 * Look up the first orderby column so we can track its value across rows
+	 * when flushing per first-orderby change is requested via GUC.
+	 */
+	if (settings->fd.orderby != NULL && ts_array_length(settings->fd.orderby) >= 1)
+	{
+		const char *first_orderby_name = ts_array_get_element_text(settings->fd.orderby, 1);
+		for (int i = 0; i < noncompressed_tupdesc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(noncompressed_tupdesc, i);
+			if (attr->attisdropped)
+				continue;
+			if (strcmp(NameStr(attr->attname), first_orderby_name) == 0)
+			{
+				row_compressor->first_orderby_col_offset = AttrNumberGetAttrOffset(attr->attnum);
+				row_compressor->first_orderby_segment_info = segment_info_new(attr);
+				break;
+			}
+		}
+	}
 }
 
 void
@@ -1349,12 +1372,40 @@ row_compressor_process_ordered_slot(RowCompressor *row_compressor, TupleTableSlo
 	}
 	bool changed_groups = row_compressor_new_row_is_in_new_group(row_compressor, slot);
 	bool compressed_row_is_full = row_compressor_is_full(row_compressor, slot);
-	if (compressed_row_is_full || changed_groups)
+
+	bool track_first_orderby = ts_guc_compression_flush_batch_on_first_orderby_change &&
+							   row_compressor->first_orderby_segment_info != NULL;
+	bool first_orderby_is_null = false;
+	Datum first_orderby_val = (Datum) 0;
+	bool first_orderby_changed = false;
+	if (track_first_orderby)
+	{
+		first_orderby_val =
+			slot_getattr(slot,
+						 AttrOffsetGetAttrNumber(row_compressor->first_orderby_col_offset),
+						 &first_orderby_is_null);
+		if (row_compressor->rows_compressed_into_current_value > 0)
+			first_orderby_changed =
+				!segment_info_datum_is_in_group(row_compressor->first_orderby_segment_info,
+												first_orderby_val,
+												first_orderby_is_null);
+	}
+
+	if (compressed_row_is_full || changed_groups || first_orderby_changed)
 	{
 		if (row_compressor->rows_compressed_into_current_value > 0)
 			row_compressor_flush(row_compressor, writer, changed_groups);
 		if (changed_groups)
 			row_compressor_update_group(row_compressor, slot);
+	}
+
+	if (track_first_orderby)
+	{
+		MemoryContext segment_ctx = MemoryContextSwitchTo(row_compressor->per_row_ctx->parent);
+		segment_info_update(row_compressor->first_orderby_segment_info,
+							first_orderby_val,
+							first_orderby_is_null);
+		MemoryContextSwitchTo(segment_ctx);
 	}
 
 	row_compressor_append_row(row_compressor, slot);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1251,8 +1251,8 @@ row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *se
 	if (ts_array_length(settings->fd.orderby) > 0)
 	{
 		AttrNumber attnum =
-			get_attnum(settings->fd.relid,
-					   ts_array_get_element_text(settings->fd.orderby, 1));
+			TupleDescGetAttrNumber(noncompressed_tupdesc,
+								   ts_array_get_element_text(settings->fd.orderby, 1));
 		if (AttributeNumberIsValid(attnum))
 			row_compressor->first_orderby_segment_info = segment_info_new(
 				TupleDescAttr(noncompressed_tupdesc, AttrNumberGetAttrOffset(attnum)));

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1387,9 +1387,9 @@ row_compressor_process_ordered_slot(RowCompressor *row_compressor, TupleTableSlo
 
 	if (first_ob)
 	{
-		MemoryContext seg_ctx = MemoryContextSwitchTo(row_compressor->per_row_ctx->parent);
+		MemoryContext old = MemoryContextSwitchTo(GetMemoryChunkContext(first_ob));
 		segment_info_update(first_ob, first_ob_val, first_ob_isnull);
-		MemoryContextSwitchTo(seg_ctx);
+		MemoryContextSwitchTo(old);
 	}
 
 	row_compressor_append_row(row_compressor, slot);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1227,8 +1227,6 @@ row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *se
 		.num_compressed_rows = 0,
 		.first_iteration = true,
 		.sort_state = NULL,
-		.first_orderby_col_offset = -1,
-		.first_orderby_segment_info = NULL,
 	};
 
 	memset(row_compressor->compressed_is_null, 1, sizeof(bool) * compressed_tupdesc->natts);
@@ -1250,21 +1248,14 @@ row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *se
 	 * Look up the first orderby column so we can track its value across rows
 	 * when flushing per first-orderby change is requested via GUC.
 	 */
-	if (settings->fd.orderby != NULL && ts_array_length(settings->fd.orderby) >= 1)
+	if (ts_array_length(settings->fd.orderby) > 0)
 	{
-		const char *first_orderby_name = ts_array_get_element_text(settings->fd.orderby, 1);
-		for (int i = 0; i < noncompressed_tupdesc->natts; i++)
-		{
-			Form_pg_attribute attr = TupleDescAttr(noncompressed_tupdesc, i);
-			if (attr->attisdropped)
-				continue;
-			if (strcmp(NameStr(attr->attname), first_orderby_name) == 0)
-			{
-				row_compressor->first_orderby_col_offset = AttrNumberGetAttrOffset(attr->attnum);
-				row_compressor->first_orderby_segment_info = segment_info_new(attr);
-				break;
-			}
-		}
+		AttrNumber attnum =
+			get_attnum(settings->fd.relid,
+					   ts_array_get_element_text(settings->fd.orderby, 1));
+		if (AttributeNumberIsValid(attnum))
+			row_compressor->first_orderby_segment_info = segment_info_new(
+				TupleDescAttr(noncompressed_tupdesc, AttrNumberGetAttrOffset(attnum)));
 	}
 }
 
@@ -1373,25 +1364,20 @@ row_compressor_process_ordered_slot(RowCompressor *row_compressor, TupleTableSlo
 	bool changed_groups = row_compressor_new_row_is_in_new_group(row_compressor, slot);
 	bool compressed_row_is_full = row_compressor_is_full(row_compressor, slot);
 
-	bool track_first_orderby = ts_guc_compression_flush_batch_on_first_orderby_change &&
-							   row_compressor->first_orderby_segment_info != NULL;
-	bool first_orderby_is_null = false;
-	Datum first_orderby_val = (Datum) 0;
-	bool first_orderby_changed = false;
-	if (track_first_orderby)
+	SegmentInfo *first_ob = ts_guc_compression_flush_batch_on_first_orderby_change
+								? row_compressor->first_orderby_segment_info
+								: NULL;
+	Datum first_ob_val = (Datum) 0;
+	bool first_ob_isnull = false;
+	bool first_ob_changed = false;
+	if (first_ob)
 	{
-		first_orderby_val =
-			slot_getattr(slot,
-						 AttrOffsetGetAttrNumber(row_compressor->first_orderby_col_offset),
-						 &first_orderby_is_null);
-		if (row_compressor->rows_compressed_into_current_value > 0)
-			first_orderby_changed =
-				!segment_info_datum_is_in_group(row_compressor->first_orderby_segment_info,
-												first_orderby_val,
-												first_orderby_is_null);
+		first_ob_val = slot_getattr(slot, first_ob->attnum, &first_ob_isnull);
+		first_ob_changed = row_compressor->rows_compressed_into_current_value > 0 &&
+						   !segment_info_datum_is_in_group(first_ob, first_ob_val, first_ob_isnull);
 	}
 
-	if (compressed_row_is_full || changed_groups || first_orderby_changed)
+	if (compressed_row_is_full || changed_groups || first_ob_changed)
 	{
 		if (row_compressor->rows_compressed_into_current_value > 0)
 			row_compressor_flush(row_compressor, writer, changed_groups);
@@ -1399,13 +1385,11 @@ row_compressor_process_ordered_slot(RowCompressor *row_compressor, TupleTableSlo
 			row_compressor_update_group(row_compressor, slot);
 	}
 
-	if (track_first_orderby)
+	if (first_ob)
 	{
-		MemoryContext segment_ctx = MemoryContextSwitchTo(row_compressor->per_row_ctx->parent);
-		segment_info_update(row_compressor->first_orderby_segment_info,
-							first_orderby_val,
-							first_orderby_is_null);
-		MemoryContextSwitchTo(segment_ctx);
+		MemoryContext seg_ctx = MemoryContextSwitchTo(row_compressor->per_row_ctx->parent);
+		segment_info_update(first_ob, first_ob_val, first_ob_isnull);
+		MemoryContextSwitchTo(seg_ctx);
 	}
 
 	row_compressor_append_row(row_compressor, slot);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -303,6 +303,15 @@ typedef struct RowCompressor
 	bool needs_analyze_segmentby;
 
 	List *metadata_builders; /* List of BatchMetadataBuilder */
+
+	/*
+	 * Tracks the previous row's value of the first orderby column. Used when
+	 * ts_guc_compression_flush_batch_on_first_orderby_change is enabled to
+	 * finish the current batch as soon as that value changes. NULL if the
+	 * table has no orderby column.
+	 */
+	int16 first_orderby_col_offset;
+	SegmentInfo *first_orderby_segment_info;
 } RowCompressor;
 
 /*

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -310,7 +310,6 @@ typedef struct RowCompressor
 	 * finish the current batch as soon as that value changes. NULL if the
 	 * table has no orderby column.
 	 */
-	int16 first_orderby_col_offset;
 	SegmentInfo *first_orderby_segment_info;
 } RowCompressor;
 

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -347,6 +347,18 @@ extern Datum tsl_compressed_data_has_nulls(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_column_size(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_to_array(PG_FUNCTION_ARGS);
 
+static inline AttrNumber
+TupleDescGetAttrNumber(TupleDesc desc, const char *name)
+{
+	for (int i = 0; i < desc->natts; i++)
+	{
+		if (strcmp(name, NameStr(TupleDescAttr(desc, i)->attname)) == 0)
+			return TupleDescAttr(desc, i)->attnum;
+	}
+
+	return InvalidAttrNumber;
+}
+
 static void
 pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 {

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -93,18 +93,6 @@ static void update_scankeys(ScanKeyWithAttnos *scankeys, TupleTableSlot *slot, i
 static void init_upsert_bloom_state(ChunkInsertState *cis);
 static Bitmapset *get_arbiter_index_attnums(ChunkInsertState *cis);
 
-static AttrNumber
-TupleDescGetAttrNumber(TupleDesc desc, const char *name)
-{
-	for (int i = 0; i < desc->natts; i++)
-	{
-		if (strcmp(name, NameStr(TupleDescAttr(desc, i)->attname)) == 0)
-			return TupleDescAttr(desc, i)->attnum;
-	}
-
-	return InvalidAttrNumber;
-}
-
 typedef struct MatchedBloom
 {
 	char *column_name;

--- a/tsl/test/expected/compress_flush_on_orderby_change.out
+++ b/tsl/test/expected/compress_flush_on_orderby_change.out
@@ -1,0 +1,195 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for timescaledb.compression_flush_batch_on_first_orderby_change.
+-- When the GUC is on, the row compressor must finish the current batch as
+-- soon as the value of the first orderby column changes.
+CREATE TABLE flush_orderby(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'ts',
+          tsdb.chunk_interval = 1000000);
+-- 100 distinct ts values, 10 rows each. With the default batch target each
+-- compressed batch covers many distinct ts values.
+INSERT INTO flush_orderby
+SELECT 1, t, r FROM generate_series(0, 99) t, generate_series(1, 10) r;
+ALTER TABLE flush_orderby SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+NOTICE:  updated compression settings will only apply to future compressions
+-- Default behavior: GUC off, batches span multiple ts values.
+SHOW timescaledb.compression_flush_batch_on_first_orderby_change;
+ timescaledb.compression_flush_batch_on_first_orderby_change 
+-------------------------------------------------------------
+ off
+
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby') c;
+ count 
+-------
+     1
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+-- Without flushing on orderby change there should be at least one batch
+-- covering more than one ts value.
+SELECT bool_or(_ts_meta_min_1 <> _ts_meta_max_1) AS has_multi_value_batch
+FROM :CCHUNK;
+ has_multi_value_batch 
+-----------------------
+ t
+
+-- Recompress with the GUC enabled.
+SELECT count(decompress_chunk(c)) FROM show_chunks('flush_orderby') c;
+ count 
+-------
+     1
+
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby') c;
+ count 
+-------
+     1
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+-- Every batch must now cover exactly one ts value (min == max) and
+-- the number of batches must equal the number of distinct ts values.
+SELECT bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value,
+       count(*) AS num_batches
+FROM :CCHUNK;
+ every_batch_single_value | num_batches 
+--------------------------+-------------
+ t                        |         100
+
+SELECT count(*) FROM (SELECT DISTINCT ts FROM flush_orderby) s;
+ count 
+-------
+   100
+
+-- Data round-trips cleanly.
+SELECT count(*), sum(val) FROM flush_orderby;
+ count | sum  
+-------+------
+  1000 | 5500
+
+DROP TABLE flush_orderby;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+-- Multiple segmentby groups: the per-orderby flush still applies within
+-- every segment.
+CREATE TABLE flush_orderby_multi(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'ts',
+          tsdb.chunk_interval = 1000000);
+INSERT INTO flush_orderby_multi
+SELECT s, t, r
+FROM generate_series(1, 3) s, generate_series(0, 19) t, generate_series(1, 5) r;
+ALTER TABLE flush_orderby_multi SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+NOTICE:  updated compression settings will only apply to future compressions
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_multi') c;
+ count 
+-------
+     1
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+SELECT seg, count(*) AS num_batches,
+       bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value
+FROM :CCHUNK GROUP BY seg ORDER BY seg;
+ seg | num_batches | every_batch_single_value 
+-----+-------------+--------------------------
+   1 |          20 | t
+   2 |          20 | t
+   3 |          20 | t
+
+SELECT count(*), sum(val) FROM flush_orderby_multi;
+ count | sum 
+-------+-----
+   300 | 900
+
+DROP TABLE flush_orderby_multi;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+-- NULL values in the first orderby column. With NULLS LAST (the default)
+-- the trailing run of NULLs ends up in its own batch.
+CREATE TABLE flush_orderby_null(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'val', tsdb.chunk_interval = 1000000);
+INSERT INTO flush_orderby_null
+SELECT 1, CASE WHEN x % 4 = 0 THEN NULL ELSE x % 5 END, x
+FROM generate_series(1, 40) x;
+ALTER TABLE flush_orderby_null SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+NOTICE:  updated compression settings will only apply to future compressions
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_null') c;
+ count 
+-------
+     1
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+SELECT _ts_meta_min_1, _ts_meta_max_1, _ts_meta_count
+FROM :CCHUNK ORDER BY _ts_meta_min_1 NULLS LAST, _ts_meta_max_1;
+ _ts_meta_min_1 | _ts_meta_max_1 | _ts_meta_count 
+----------------+----------------+----------------
+              0 |              0 |              6
+              1 |              1 |              6
+              2 |              2 |              6
+              3 |              3 |              6
+              4 |              4 |              6
+                |                |             10
+
+SELECT count(*), sum(val), count(ts) FROM flush_orderby_null;
+ count | sum | count 
+-------+-----+-------
+    40 | 820 |    30
+
+DROP TABLE flush_orderby_null;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+-- A single first-orderby value with more rows than the target batch size:
+-- the batch fills up and gets flushed even though the orderby value has
+-- not changed, so we get multiple batches that all share the same min/max.
+CREATE TABLE flush_orderby_big(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'val',
+          tsdb.chunk_interval = 100000);
+-- 2500 rows with ts = 1, then 500 rows with ts = 2.
+INSERT INTO flush_orderby_big
+SELECT 1, 1, x FROM generate_series(1, 2500) x;
+INSERT INTO flush_orderby_big
+SELECT 1, 2, x FROM generate_series(2501, 3000) x;
+ALTER TABLE flush_orderby_big SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+NOTICE:  updated compression settings will only apply to future compressions
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_big') c;
+ count 
+-------
+     1
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+-- Every batch still covers a single ts value (min == max), but we need
+-- more than one batch for ts = 1 because it exceeds the batch size limit.
+SELECT _ts_meta_min_1, _ts_meta_max_1, count(*) AS num_batches,
+       sum(_ts_meta_count) AS total_rows
+FROM :CCHUNK GROUP BY _ts_meta_min_1, _ts_meta_max_1
+ORDER BY _ts_meta_min_1;
+ _ts_meta_min_1 | _ts_meta_max_1 | num_batches | total_rows 
+----------------+----------------+-------------+------------
+              1 |              1 |           3 |       2500
+              2 |              2 |           1 |        500
+
+SELECT bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value
+FROM :CCHUNK;
+ every_batch_single_value 
+--------------------------
+ t
+
+SELECT count(*), sum(val) FROM flush_orderby_big;
+ count |   sum   
+-------+---------
+  3000 | 4501500
+
+DROP TABLE flush_orderby_big;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;

--- a/tsl/test/expected/compress_flush_on_orderby_change.out
+++ b/tsl/test/expected/compress_flush_on_orderby_change.out
@@ -193,3 +193,51 @@ SELECT count(*), sum(val) FROM flush_orderby_big;
 
 DROP TABLE flush_orderby_big;
 RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+-- First orderby column is text (pass-by-reference) to exercise the
+-- datumCopy path in segment_info_update.
+CREATE TABLE flush_orderby_text(seg int, label text, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'ts',
+          tsdb.chunk_interval = 1000000);
+INSERT INTO flush_orderby_text
+SELECT 1,
+       'label_' || lpad((x % 5)::text, 2, '0'),
+       x,
+       x
+FROM generate_series(1, 50) x;
+ALTER TABLE flush_orderby_text SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'label, ts');
+NOTICE:  updated compression settings will only apply to future compressions
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_text') c;
+ count 
+-------
+     1
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+-- One batch per distinct label, with min and max equal.
+SELECT _ts_meta_min_1, _ts_meta_max_1, _ts_meta_count
+FROM :CCHUNK ORDER BY _ts_meta_min_1;
+ _ts_meta_min_1 | _ts_meta_max_1 | _ts_meta_count 
+----------------+----------------+----------------
+ label_00       | label_00       |             10
+ label_01       | label_01       |             10
+ label_02       | label_02       |             10
+ label_03       | label_03       |             10
+ label_04       | label_04       |             10
+
+SELECT bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value,
+       count(*) AS num_batches
+FROM :CCHUNK;
+ every_batch_single_value | num_batches 
+--------------------------+-------------
+ t                        |           5
+
+SELECT count(*), sum(val), count(DISTINCT label) FROM flush_orderby_text;
+ count | sum  | count 
+-------+------+-------
+    50 | 1275 |     5
+
+DROP TABLE flush_orderby_text;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_FILES
     compress_dml_copy.sql
     compress_explain.sql
     compress_float8_corrupt.sql
+    compress_flush_on_orderby_change.sql
     compress_unordered_sort.sql
     compress_qualpushdown_saop.sql
     compress_qualpushdown_complex.sql

--- a/tsl/test/sql/compress_flush_on_orderby_change.sql
+++ b/tsl/test/sql/compress_flush_on_orderby_change.sql
@@ -1,0 +1,153 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Tests for timescaledb.compression_flush_batch_on_first_orderby_change.
+-- When the GUC is on, the row compressor must finish the current batch as
+-- soon as the value of the first orderby column changes.
+
+CREATE TABLE flush_orderby(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'ts',
+          tsdb.chunk_interval = 1000000);
+
+-- 100 distinct ts values, 10 rows each. With the default batch target each
+-- compressed batch covers many distinct ts values.
+INSERT INTO flush_orderby
+SELECT 1, t, r FROM generate_series(0, 99) t, generate_series(1, 10) r;
+
+ALTER TABLE flush_orderby SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+
+-- Default behavior: GUC off, batches span multiple ts values.
+SHOW timescaledb.compression_flush_batch_on_first_orderby_change;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby') c;
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+
+-- Without flushing on orderby change there should be at least one batch
+-- covering more than one ts value.
+SELECT bool_or(_ts_meta_min_1 <> _ts_meta_max_1) AS has_multi_value_batch
+FROM :CCHUNK;
+
+-- Recompress with the GUC enabled.
+SELECT count(decompress_chunk(c)) FROM show_chunks('flush_orderby') c;
+
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby') c;
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+
+-- Every batch must now cover exactly one ts value (min == max) and
+-- the number of batches must equal the number of distinct ts values.
+SELECT bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value,
+       count(*) AS num_batches
+FROM :CCHUNK;
+
+SELECT count(*) FROM (SELECT DISTINCT ts FROM flush_orderby) s;
+
+-- Data round-trips cleanly.
+SELECT count(*), sum(val) FROM flush_orderby;
+
+DROP TABLE flush_orderby;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+
+
+-- Multiple segmentby groups: the per-orderby flush still applies within
+-- every segment.
+CREATE TABLE flush_orderby_multi(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'ts',
+          tsdb.chunk_interval = 1000000);
+
+INSERT INTO flush_orderby_multi
+SELECT s, t, r
+FROM generate_series(1, 3) s, generate_series(0, 19) t, generate_series(1, 5) r;
+
+ALTER TABLE flush_orderby_multi SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_multi') c;
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+
+SELECT seg, count(*) AS num_batches,
+       bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value
+FROM :CCHUNK GROUP BY seg ORDER BY seg;
+
+SELECT count(*), sum(val) FROM flush_orderby_multi;
+
+DROP TABLE flush_orderby_multi;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+
+
+-- NULL values in the first orderby column. With NULLS LAST (the default)
+-- the trailing run of NULLs ends up in its own batch.
+CREATE TABLE flush_orderby_null(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'val', tsdb.chunk_interval = 1000000);
+
+INSERT INTO flush_orderby_null
+SELECT 1, CASE WHEN x % 4 = 0 THEN NULL ELSE x % 5 END, x
+FROM generate_series(1, 40) x;
+
+ALTER TABLE flush_orderby_null SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_null') c;
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+
+SELECT _ts_meta_min_1, _ts_meta_max_1, _ts_meta_count
+FROM :CCHUNK ORDER BY _ts_meta_min_1 NULLS LAST, _ts_meta_max_1;
+
+SELECT count(*), sum(val), count(ts) FROM flush_orderby_null;
+
+DROP TABLE flush_orderby_null;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+
+
+-- A single first-orderby value with more rows than the target batch size:
+-- the batch fills up and gets flushed even though the orderby value has
+-- not changed, so we get multiple batches that all share the same min/max.
+CREATE TABLE flush_orderby_big(seg int, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'val',
+          tsdb.chunk_interval = 100000);
+
+-- 2500 rows with ts = 1, then 500 rows with ts = 2.
+INSERT INTO flush_orderby_big
+SELECT 1, 1, x FROM generate_series(1, 2500) x;
+INSERT INTO flush_orderby_big
+SELECT 1, 2, x FROM generate_series(2501, 3000) x;
+
+ALTER TABLE flush_orderby_big SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'ts');
+
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_big') c;
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+
+-- Every batch still covers a single ts value (min == max), but we need
+-- more than one batch for ts = 1 because it exceeds the batch size limit.
+SELECT _ts_meta_min_1, _ts_meta_max_1, count(*) AS num_batches,
+       sum(_ts_meta_count) AS total_rows
+FROM :CCHUNK GROUP BY _ts_meta_min_1, _ts_meta_max_1
+ORDER BY _ts_meta_min_1;
+
+SELECT bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value
+FROM :CCHUNK;
+
+SELECT count(*), sum(val) FROM flush_orderby_big;
+
+DROP TABLE flush_orderby_big;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;

--- a/tsl/test/sql/compress_flush_on_orderby_change.sql
+++ b/tsl/test/sql/compress_flush_on_orderby_change.sql
@@ -151,3 +151,40 @@ SELECT count(*), sum(val) FROM flush_orderby_big;
 
 DROP TABLE flush_orderby_big;
 RESET timescaledb.compression_flush_batch_on_first_orderby_change;
+
+
+-- First orderby column is text (pass-by-reference) to exercise the
+-- datumCopy path in segment_info_update.
+CREATE TABLE flush_orderby_text(seg int, label text, ts int, val int)
+    WITH (tsdb.hypertable, tsdb.partition_column = 'ts',
+          tsdb.chunk_interval = 1000000);
+
+INSERT INTO flush_orderby_text
+SELECT 1,
+       'label_' || lpad((x % 5)::text, 2, '0'),
+       x,
+       x
+FROM generate_series(1, 50) x;
+
+ALTER TABLE flush_orderby_text SET (tsdb.compress, tsdb.compress_segmentby = 'seg',
+    tsdb.compress_orderby = 'label, ts');
+
+SET timescaledb.compression_flush_batch_on_first_orderby_change = on;
+SELECT count(compress_chunk(c)) FROM show_chunks('flush_orderby_text') c;
+
+SELECT format('%I.%I', schema_name, table_name) AS "CCHUNK"
+FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NULL
+ORDER BY id DESC LIMIT 1 \gset
+
+-- One batch per distinct label, with min and max equal.
+SELECT _ts_meta_min_1, _ts_meta_max_1, _ts_meta_count
+FROM :CCHUNK ORDER BY _ts_meta_min_1;
+
+SELECT bool_and(_ts_meta_min_1 = _ts_meta_max_1) AS every_batch_single_value,
+       count(*) AS num_batches
+FROM :CCHUNK;
+
+SELECT count(*), sum(val), count(DISTINCT label) FROM flush_orderby_text;
+
+DROP TABLE flush_orderby_text;
+RESET timescaledb.compression_flush_batch_on_first_orderby_change;


### PR DESCRIPTION
Adds timescaledb.compression_flush_batch_on_first_orderby_change. When
turned on, the row compressor finishes the current batch as soon as the
value of the first orderby column changes between rows, so each batch
covers a single value of that column. Default is off, keeping the
current behavior.

Also adds a regression test that covers the default case, the GUC
turned on with one and many segmentby groups, and NULL values in the
first orderby column.
