### PR TITLE
Allow BatchSortedMerge with no segmentby or sorted on segmentbys pinned to Consts

### DIFF
--- a/.unreleased/pr_9702
+++ b/.unreleased/pr_9702
@@ -1,0 +1,1 @@
+Implements: #9702 Allow Batch Sorted Merge for unordered chunks with no segmentby or when all segmentby columns are pinned to a Const

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -3001,7 +3001,6 @@ build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 	if (compression_info->num_segmentby_columns > 0)
 	{
 		Bitmapset *segmentby_columns;
-
 		/*
 		 * initialize segmentby with equality constraints from baserestrictinfo because
 		 * those columns dont need to be prefix of pathkeys
@@ -3053,8 +3052,7 @@ build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 		 * If pathkeys still has items, but we didn't find all segmentby columns,
 		 * we cannot satisfy these pathkeys by sorting the compressed chunk table.
 		 */
-		if (i != list_length(pathkeys) &&
-			bms_num_members(segmentby_columns) != compression_info->num_segmentby_columns)
+		if (bms_num_members(segmentby_columns) != compression_info->num_segmentby_columns)
 		{
 			/*
 			 * If we didn't have any segmentby columns in pathkeys, try batch sorted merge
@@ -3074,12 +3072,34 @@ build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 		}
 	}
 
+	/* We are here when either compression doesn't have segmentby
+	 * or pathkeys prefix matches all segmentby columns but there are more pathkeys to match, for
+	 * example: (order by segcol1, segcol2, obycol1, obycol2) for
+	 * (compress.segmentby='segcol1,segcol2').
+	 */
+
 	/*
 	 * Cannot push down sort on non-segmentby columns
 	 * if the chunk has batches overlapping on orderby columns
 	 */
 	if (ts_chunk_is_unordered(chunk))
 	{
+		/*
+		 * If compression has no segmentby columns or all segmentby columns in a query are pinned to
+		 * a Const, try batch sorted merge instead.
+		 */
+		if (compression_info->num_segmentby_columns == 0 ||
+			bms_num_members(compression_info->chunk_const_segmentby) ==
+				compression_info->num_segmentby_columns)
+		{
+			sort_info.use_batch_sorted_merge =
+				match_pathkeys_to_compression_orderby(pathkeys,
+													  chunk_em_exprs,
+													  /* starting_pathkey_offset = */ 0,
+													  compression_info,
+													  /* for_bsm = */ true,
+													  &sort_info.reverse);
+		}
 		return sort_info;
 	}
 

--- a/tsl/test/expected/compress_unordered_sort.out
+++ b/tsl/test/expected/compress_unordered_sort.out
@@ -362,13 +362,15 @@ select distinct on (device) device, time from metrics order by device, time DESC
  d1     | Wed Jan 01 03:30:00 2025 UTC
  d2     | Wed Jan 01 03:30:00 2025 UTC
 
+-- Can use Batch Sort Merge though as all segmentby keys are pinned to a Const
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
 :PREFIX select time, avg(value) from metrics where device = 'd1' and sensor='A' group by time order by time DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_1_chunk."time" DESC
-   ->  HashAggregate
-         Group Key: _hyper_1_1_chunk."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk."time"
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
                      Index Cond: ((device = 'd1'::text) AND (sensor = 'A'::text))
 
@@ -380,6 +382,7 @@ select time, avg(value) from metrics  where device = 'd1' and sensor='A' group b
  Wed Jan 01 01:00:00 2025 UTC |  20.5
  Wed Jan 01 00:00:00 2025 UTC |    10
 
+RESET timescaledb.debug_require_batch_sorted_merge;
 -- Cannot use compressed sort on unordered chunk when columnstore doesn't have segmentby keys
 CREATE TABLE metrics2(
     time timestamptz NOT NULL,

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1625,11 +1625,13 @@ SELECT * FROM i9314 ORDER BY time;
 SET timescaledb.enable_direct_compress_insert = true;
 -- Insert >= 10 rows to trigger direct compress path
 INSERT INTO i9314 SELECT '2024-02-01'::timestamptz + format('%s day',i)::interval, i + 10 FROM generate_series(1, 10) i;
+-- Should use BatchSortedMerge for unordered chunks with no segmentby and matching orderby
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_50_103_chunk."time"
-   ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+ Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+   ->  Sort
+         Sort Key: compress_hyper_51_104_chunk._ts_meta_min_1
          ->  Seq Scan on compress_hyper_51_104_chunk
 
 SELECT * FROM i9314 ORDER BY time;
@@ -1650,6 +1652,7 @@ SELECT * FROM i9314 ORDER BY time;
  Sat Feb 10 00:00:00 2024 PST |    19 |      38
  Sun Feb 11 00:00:00 2024 PST |    20 |      40
 
+RESET timescaledb.debug_require_batch_sorted_merge;
 -- test copy
 COPY i9314 FROM STDIN DELIMITER ',' CSV;
 SELECT compress_chunk(show_chunks('i9314'));
@@ -1657,11 +1660,13 @@ SELECT compress_chunk(show_chunks('i9314'));
 -------------------------------------------
  _timescaledb_internal._hyper_50_103_chunk
 
+-- Should use BatchSortedMerge for unordered chunks with no segmentby and matching orderby
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_50_103_chunk."time"
-   ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+ Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+   ->  Sort
+         Sort Key: compress_hyper_51_104_chunk._ts_meta_min_1
          ->  Seq Scan on compress_hyper_51_104_chunk
 
 SELECT * FROM i9314 ORDER BY time;
@@ -1687,19 +1692,22 @@ SELECT * FROM i9314 ORDER BY time;
  Sat Mar 16 00:00:00 2024 PDT |    23 |      46
  Sun Mar 17 00:00:00 2024 PDT |    24 |      48
 
+RESET timescaledb.debug_require_batch_sorted_merge;
 SET timescaledb.enable_direct_compress_copy = true;
 COPY i9314 FROM STDIN DELIMITER ',' CSV;
+-- Should use BatchSortedMerge for unordered chunks with no segmentby and matching orderby
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 --- QUERY PLAN ---
  Custom Scan (ChunkAppend) on i9314
    Order: i9314."time"
-   ->  Sort
-         Sort Key: _hyper_50_103_chunk."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_50_103_chunk
+         ->  Sort
+               Sort Key: compress_hyper_51_104_chunk._ts_meta_min_1
                ->  Seq Scan on compress_hyper_51_104_chunk
-   ->  Sort
-         Sort Key: _hyper_50_105_chunk."time"
-         ->  Custom Scan (ColumnarScan) on _hyper_50_105_chunk
+   ->  Custom Scan (ColumnarScan) on _hyper_50_105_chunk
+         ->  Sort
+               Sort Key: compress_hyper_51_106_chunk._ts_meta_min_1
                ->  Seq Scan on compress_hyper_51_106_chunk
 
 SELECT * FROM i9314 ORDER BY time;
@@ -1730,4 +1738,5 @@ SELECT * FROM i9314 ORDER BY time;
  Tue Apr 16 00:00:00 2024 PDT |    33 |      66
  Wed Apr 17 00:00:00 2024 PDT |    34 |      68
 
+RESET timescaledb.debug_require_batch_sorted_merge;
 RESET timescaledb.enable_direct_compress_insert;

--- a/tsl/test/expected/compression_sorted_merge_unordered.out
+++ b/tsl/test/expected/compression_sorted_merge_unordered.out
@@ -1431,8 +1431,8 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 
 ROLLBACK;
 -- Test with segmentby
--- Should show that BSM works even with segmentby
--- Using segmentby column for ordering should not use BSM or compressed index ordering
+-- Should show that BatchSortedMerge works even with segmentby
+-- Using segmentby column for ordering should not use BatchSortedMerge or compressed index ordering
 CREATE TABLE test_segby (
 	segby int,
 	time timestamptz NOT NULL,
@@ -1454,6 +1454,11 @@ INSERT INTO test_segby (time, segby, val) values
 ('2000-01-01 01:00:00-00', 1, 3),
 ('2000-01-01 02:00:00-00', 2, 1),
 ('2000-01-01 03:00:00-00', 1, 2);
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_segby') chunk;
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
 set timescaledb.debug_require_batch_sorted_merge to 'force';
 -- Should be optimized (implicit NULLS first)
 :PREFIX
@@ -1538,39 +1543,6 @@ SELECT * FROM test_segby ORDER BY time ASC NULLS LAST;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_8_8_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_8_8_chunk._ts_meta_count, compress_hyper_8_8_chunk.segby, compress_hyper_8_8_chunk._ts_meta_min_1, compress_hyper_8_8_chunk._ts_meta_max_1, compress_hyper_8_8_chunk."time", compress_hyper_8_8_chunk.val
 
--- Should be optimized
-:PREFIX
-SELECT * FROM test2 ORDER BY time ASC;
---- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_3_3_chunk (actual rows=12.00 loops=1)
-   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Chunk Status: UNORDERED
-   Batch Sorted Merge: true
-   Bulk Decompression: false
-   ->  Sort (actual rows=3.00 loops=1)
-         Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-         Sort Key: compress_hyper_4_4_chunk._ts_meta_min_1
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3.00 loops=1)
-               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-
--- Should be optimized (backward scan)
-:PREFIX
-SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
---- QUERY PLAN ---
- Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_3_3_chunk (actual rows=12.00 loops=1)
-   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
-   Chunk Status: UNORDERED
-   Batch Sorted Merge: true
-   Reverse: true
-   Bulk Decompression: false
-   ->  Sort (actual rows=3.00 loops=1)
-         Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-         Sort Key: compress_hyper_4_4_chunk._ts_meta_max_1 DESC
-         Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=3.00 loops=1)
-               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
-
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 -- Should not be optimized (NULL order wrong)
 :PREFIX
@@ -1617,7 +1589,7 @@ SELECT * FROM test_segby ORDER BY segby, time;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_8_8_chunk (actual rows=2.00 loops=1)
                Output: compress_hyper_8_8_chunk._ts_meta_count, compress_hyper_8_8_chunk.segby, compress_hyper_8_8_chunk._ts_meta_min_1, compress_hyper_8_8_chunk._ts_meta_max_1, compress_hyper_8_8_chunk."time", compress_hyper_8_8_chunk.val
 
--- Tests for #9445: forbid BSM on nullable orderby columns
+-- Tests for #9445: forbid BatchSortedMerge on nullable orderby columns
 CREATE TABLE t(time int NOT NULL, device int, val int);
 SELECT create_hypertable('t', 'time', chunk_time_interval => 10000);
  create_hypertable 
@@ -1643,7 +1615,7 @@ INSERT INTO t SELECT 1, 1, g FROM generate_series(500, 800) g;
 INSERT INTO t SELECT 1, 1, g FROM generate_series(900, 1000) g;
 SET timescaledb.debug_require_batch_sorted_merge = 'forbid';
 -- In DESC order NULLs come first; a NULL after a non-NULL is wrong.
--- Should not use BSM here, should return 0
+-- Should not use BatchSortedMerge here, should return 0
 SELECT count(*) AS wrong_rows FROM (
     SELECT val, lag(val) OVER (ORDER BY val DESC) AS prev FROM t
 ) t WHERE val IS NULL AND prev IS NOT NULL;
@@ -1651,7 +1623,7 @@ SELECT count(*) AS wrong_rows FROM (
 ------------
           0
 
--- Can use BSM if we can exclude NULLs from val
+-- Can use BatchSortedMerge if we can exclude NULLs from val
 SET timescaledb.debug_require_batch_sorted_merge = 'force';
 SELECT val, lag(val) OVER (ORDER BY val DESC NULLS FIRST) AS prev FROM t where val > 995;
  val  | prev 
@@ -1662,6 +1634,206 @@ SELECT val, lag(val) OVER (ORDER BY val DESC NULLS FIRST) AS prev FROM t where v
   997 |  998
   996 |  997
 
+-- Tests for BatchSortedMerge over one-segment data
+--------------------------------------
+-- Should be optimized (all segmentby columns are pinned to a Const, orderby columns match)
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+:PREFIX
+SELECT * FROM test_segby WHERE segby = 1 ORDER BY time DESC;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_7_7_chunk (actual rows=9.00 loops=1)
+   Output: _hyper_7_7_chunk.segby, _hyper_7_7_chunk."time", _hyper_7_7_chunk.val
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_8_8_chunk._ts_meta_count, compress_hyper_8_8_chunk.segby, compress_hyper_8_8_chunk._ts_meta_min_1, compress_hyper_8_8_chunk._ts_meta_max_1, compress_hyper_8_8_chunk."time", compress_hyper_8_8_chunk.val
+         Sort Key: compress_hyper_8_8_chunk._ts_meta_max_1 DESC
+         Sort Method: quicksort 
+         ->  Index Scan using compress_hyper_8_8_chunk_segby__ts_meta_min_1__ts_meta_max__idx on _timescaledb_internal.compress_hyper_8_8_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_8_8_chunk._ts_meta_count, compress_hyper_8_8_chunk.segby, compress_hyper_8_8_chunk._ts_meta_min_1, compress_hyper_8_8_chunk._ts_meta_max_1, compress_hyper_8_8_chunk."time", compress_hyper_8_8_chunk.val
+               Index Cond: (compress_hyper_8_8_chunk.segby = 1)
+
+:PREFIX
+SELECT * FROM test1 WHERE x1 = 1 AND x2 = 2 AND x5 = 0 ORDER BY x1, x2, x5, time DESC;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=6.00 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.x1, _hyper_1_1_chunk.x2, _hyper_1_1_chunk.x3, _hyper_1_1_chunk.x4, _hyper_1_1_chunk.x5, _hyper_1_1_chunk.c1, _hyper_1_1_chunk.c2
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+         Sort Key: compress_hyper_2_2_chunk._ts_meta_max_1 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_2_2_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_2_2_chunk."time", compress_hyper_2_2_chunk._ts_meta_min_1, compress_hyper_2_2_chunk._ts_meta_max_1, compress_hyper_2_2_chunk.x1, compress_hyper_2_2_chunk.x2, compress_hyper_2_2_chunk.x3, compress_hyper_2_2_chunk._ts_meta_min_2, compress_hyper_2_2_chunk._ts_meta_max_2, compress_hyper_2_2_chunk.x4, compress_hyper_2_2_chunk._ts_meta_min_3, compress_hyper_2_2_chunk._ts_meta_max_3, compress_hyper_2_2_chunk.x5, compress_hyper_2_2_chunk.c1, compress_hyper_2_2_chunk.c2, compress_hyper_2_2_chunk._ts_meta_count
+               Filter: ((compress_hyper_2_2_chunk.x1 = 1) AND (compress_hyper_2_2_chunk.x2 = 2) AND (compress_hyper_2_2_chunk.x5 = 0))
+               Rows Removed by Filter: 2
+
+:PREFIX
+SELECT * FROM test2 WHERE x1 = 1 AND x2 = 2 AND x5 = 0 ORDER BY time ASC, x3 DESC;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_3_3_chunk (actual rows=6.00 loops=1)
+   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+         Sort Key: compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_2 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+               Filter: ((compress_hyper_4_4_chunk.x1 = 1) AND (compress_hyper_4_4_chunk.x2 = 2) AND (compress_hyper_4_4_chunk.x5 = 0))
+               Rows Removed by Filter: 2
+
+:PREFIX
+SELECT * FROM test2 WHERE x1 = 1 AND x2 = 2 AND x5 = 0 ORDER BY x1 DESC, x2 DESC, x5 DESC, time DESC, x3 ASC;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_3_3_chunk (actual rows=6.00 loops=1)
+   Output: _hyper_3_3_chunk."time", _hyper_3_3_chunk.x1, _hyper_3_3_chunk.x2, _hyper_3_3_chunk.x3, _hyper_3_3_chunk.x4, _hyper_3_3_chunk.x5
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Reverse: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+         Sort Key: compress_hyper_4_4_chunk._ts_meta_max_1 DESC, compress_hyper_4_4_chunk._ts_meta_min_2
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_4_4_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_4_4_chunk._ts_meta_count, compress_hyper_4_4_chunk.x1, compress_hyper_4_4_chunk.x2, compress_hyper_4_4_chunk.x5, compress_hyper_4_4_chunk._ts_meta_min_1, compress_hyper_4_4_chunk._ts_meta_max_1, compress_hyper_4_4_chunk."time", compress_hyper_4_4_chunk._ts_meta_min_2, compress_hyper_4_4_chunk._ts_meta_max_2, compress_hyper_4_4_chunk.x3, compress_hyper_4_4_chunk._ts_meta_min_3, compress_hyper_4_4_chunk._ts_meta_max_3, compress_hyper_4_4_chunk.x4
+               Filter: ((compress_hyper_4_4_chunk.x1 = 1) AND (compress_hyper_4_4_chunk.x2 = 2) AND (compress_hyper_4_4_chunk.x5 = 0))
+               Rows Removed by Filter: 2
+
+-- No segmentby
+CREATE TABLE test_nosegby (
+	segby int NOT NULL,
+	time timestamptz NOT NULL,
+	val int);
+SELECT FROM create_hypertable('test_nosegby', 'time');
+--
+
+ALTER TABLE test_nosegby SET (timescaledb.compress, timescaledb.compress_orderby = 'segby,time DESC');
+INSERT INTO test_nosegby (time, segby, val) values
+('2000-01-01 00:00:00-00', 1, 2),
+('2000-01-01 01:00:00-00', 1, 3),
+('2000-01-01 02:00:00-00', 2, 1),
+('2000-01-01 03:00:00-00', 1, 2),
+('2000-01-01 00:00:00-00', 1, 2),
+('2000-01-01 01:00:00-00', 1, 3),
+('2000-01-01 02:00:00-00', 2, 1),
+('2000-01-01 03:00:00-00', 1, 2),
+('2000-01-01 00:00:00-00', 1, 2),
+('2000-01-01 01:00:00-00', 1, 3),
+('2000-01-01 02:00:00-00', 2, 1),
+('2000-01-01 03:00:00-00', 1, 2);
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_nosegby') chunk;
+   chunk_status_text    
+------------------------
+ {COMPRESSED,UNORDERED}
+
+-- Should be optimized (implicit NULLS first)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby, time DESC;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_11_11_chunk (actual rows=12.00 loops=1)
+   Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+         Sort Key: compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_2 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_12_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+
+-- Should be optimized
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby, time DESC NULLS FIRST;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_11_11_chunk (actual rows=12.00 loops=1)
+   Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+         Sort Key: compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_2 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_12_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+
+-- Should be optimized (backward scan, NULLS last)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby DESC, time ASC NULLS LAST;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_11_11_chunk (actual rows=12.00 loops=1)
+   Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Reverse: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+         Sort Key: compress_hyper_12_12_chunk._ts_meta_max_1 DESC, compress_hyper_12_12_chunk._ts_meta_min_2
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_12_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+
+-- Should be optimized (backward scan)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby DESC;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_11_11_chunk (actual rows=12.00 loops=1)
+   Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+   Chunk Status: UNORDERED
+   Batch Sorted Merge: true
+   Reverse: true
+   Bulk Decompression: false
+   ->  Sort (actual rows=1.00 loops=1)
+         Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+         Sort Key: compress_hyper_12_12_chunk._ts_meta_max_1 DESC
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_12_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby, time DESC NULLS LAST;
+--- QUERY PLAN ---
+ Sort (actual rows=12.00 loops=1)
+   Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+   Sort Key: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time" DESC NULLS LAST
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_11_11_chunk (actual rows=12.00 loops=1)
+         Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_12_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby DESC NULLS LAST;
+--- QUERY PLAN ---
+ Sort (actual rows=12.00 loops=1)
+   Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+   Sort Key: _hyper_11_11_chunk.segby DESC NULLS LAST
+   Sort Method: quicksort 
+   ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_11_11_chunk (actual rows=12.00 loops=1)
+         Output: _hyper_11_11_chunk.segby, _hyper_11_11_chunk."time", _hyper_11_11_chunk.val
+         Chunk Status: UNORDERED
+         Bulk Decompression: true
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_12_12_chunk (actual rows=1.00 loops=1)
+               Output: compress_hyper_12_12_chunk._ts_meta_count, compress_hyper_12_12_chunk._ts_meta_min_1, compress_hyper_12_12_chunk._ts_meta_max_1, compress_hyper_12_12_chunk.segby, compress_hyper_12_12_chunk._ts_meta_min_2, compress_hyper_12_12_chunk._ts_meta_max_2, compress_hyper_12_12_chunk."time", compress_hyper_12_12_chunk.val
+
+drop table test1 cascade;
+drop table test2 cascade;
+drop table test_segby cascade;
+drop table test_nosegby cascade;
 drop table t cascade;
 RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.debug_require_batch_sorted_merge;

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -751,13 +751,15 @@ SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks
  {COMPRESSED,UNORDERED}
 
 -- Output would be incorrectly ordered if the flag was cleared
--- We have to see a sort on top of the ColumnarScan node due to UNORDERED flag
+-- We can use BatchSortedMerge for UNORDERED chunk because segmentby is pinned to a Const i.e. we are dealing with 1 segment only
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
 EXPLAIN (COSTS OFF) SELECT a, time FROM segwise_unordered WHERE a = 2 ORDER BY a, time;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_25_27_chunk."time"
-   ->  Custom Scan (ColumnarScan) on _hyper_25_27_chunk
+ Custom Scan (ColumnarScan) on _hyper_25_27_chunk
+   ->  Sort
+         Sort Key: compress_hyper_26_28_chunk._ts_meta_min_1
          ->  Index Scan using compress_hyper_26_28_chunk_a__ts_meta_min_1__ts_meta_max_1_idx on compress_hyper_26_28_chunk
                Index Cond: (a = 2)
 
+RESET timescaledb.debug_require_batch_sorted_merge;
 DROP TABLE segwise_unordered;

--- a/tsl/test/sql/compress_unordered_sort.sql
+++ b/tsl/test/sql/compress_unordered_sort.sql
@@ -118,8 +118,13 @@ select device, sensor, time from metrics group by device, sensor, time order by 
 :PREFIX select distinct on (device) device, time from metrics order by device, time DESC;
 select distinct on (device) device, time from metrics order by device, time DESC;
 
+-- Can use Batch Sort Merge though as all segmentby keys are pinned to a Const
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+
 :PREFIX select time, avg(value) from metrics where device = 'd1' and sensor='A' group by time order by time DESC;
 select time, avg(value) from metrics  where device = 'd1' and sensor='A' group by time order by time DESC;
+
+RESET timescaledb.debug_require_batch_sorted_merge;
 
 -- Cannot use compressed sort on unordered chunk when columnstore doesn't have segmentby keys
 CREATE TABLE metrics2(

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -1211,8 +1211,13 @@ SET timescaledb.enable_direct_compress_insert = true;
 -- Insert >= 10 rows to trigger direct compress path
 INSERT INTO i9314 SELECT '2024-02-01'::timestamptz + format('%s day',i)::interval, i + 10 FROM generate_series(1, 10) i;
 
+-- Should use BatchSortedMerge for unordered chunks with no segmentby and matching orderby
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 SELECT * FROM i9314 ORDER BY time;
+
+RESET timescaledb.debug_require_batch_sorted_merge;
 
 -- test copy
 COPY i9314 FROM STDIN DELIMITER ',' CSV;
@@ -1225,8 +1230,13 @@ COPY i9314 FROM STDIN DELIMITER ',' CSV;
 
 SELECT compress_chunk(show_chunks('i9314'));
 
+-- Should use BatchSortedMerge for unordered chunks with no segmentby and matching orderby
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 SELECT * FROM i9314 ORDER BY time;
+
+RESET timescaledb.debug_require_batch_sorted_merge;
 
 SET timescaledb.enable_direct_compress_copy = true;
 COPY i9314 FROM STDIN DELIMITER ',' CSV;
@@ -1237,7 +1247,12 @@ COPY i9314 FROM STDIN DELIMITER ',' CSV;
 2024-04-17,34
 \.
 
+-- Should use BatchSortedMerge for unordered chunks with no segmentby and matching orderby
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+
 :PREFIX SELECT * FROM i9314 ORDER BY time;
 SELECT * FROM i9314 ORDER BY time;
+
+RESET timescaledb.debug_require_batch_sorted_merge;
 
 RESET timescaledb.enable_direct_compress_insert;

--- a/tsl/test/sql/compression_sorted_merge_unordered.sql
+++ b/tsl/test/sql/compression_sorted_merge_unordered.sql
@@ -416,8 +416,8 @@ SELECT * FROM test1 ORDER BY time ASC NULLS LAST;
 ROLLBACK;
 
 -- Test with segmentby
--- Should show that BSM works even with segmentby
--- Using segmentby column for ordering should not use BSM or compressed index ordering
+-- Should show that BatchSortedMerge works even with segmentby
+-- Using segmentby column for ordering should not use BatchSortedMerge or compressed index ordering
 
 CREATE TABLE test_segby (
 	segby int,
@@ -441,6 +441,7 @@ INSERT INTO test_segby (time, segby, val) values
 ('2000-01-01 01:00:00-00', 1, 3),
 ('2000-01-01 02:00:00-00', 2, 1),
 ('2000-01-01 03:00:00-00', 1, 2);
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_segby') chunk;
 
 set timescaledb.debug_require_batch_sorted_merge to 'force';
 
@@ -464,14 +465,6 @@ SELECT * FROM test_segby ORDER BY time ASC NULLS LAST;
 :PREFIX
 SELECT * FROM test_segby ORDER BY time ASC NULLS LAST;
 
--- Should be optimized
-:PREFIX
-SELECT * FROM test2 ORDER BY time ASC;
-
--- Should be optimized (backward scan)
-:PREFIX
-SELECT * FROM test2 ORDER BY time DESC NULLS FIRST;
-
 set timescaledb.debug_require_batch_sorted_merge to 'forbid';
 
 -- Should not be optimized (NULL order wrong)
@@ -486,7 +479,7 @@ SELECT * FROM test_segby ORDER BY time ASC NULLS FIRST;
 :PREFIX
 SELECT * FROM test_segby ORDER BY segby, time;
 
--- Tests for #9445: forbid BSM on nullable orderby columns
+-- Tests for #9445: forbid BatchSortedMerge on nullable orderby columns
 CREATE TABLE t(time int NOT NULL, device int, val int);
 SELECT create_hypertable('t', 'time', chunk_time_interval => 10000);
 ALTER TABLE t SET (timescaledb.compress,
@@ -508,15 +501,89 @@ INSERT INTO t SELECT 1, 1, g FROM generate_series(900, 1000) g;
 SET timescaledb.debug_require_batch_sorted_merge = 'forbid';
 
 -- In DESC order NULLs come first; a NULL after a non-NULL is wrong.
--- Should not use BSM here, should return 0
+-- Should not use BatchSortedMerge here, should return 0
 SELECT count(*) AS wrong_rows FROM (
     SELECT val, lag(val) OVER (ORDER BY val DESC) AS prev FROM t
 ) t WHERE val IS NULL AND prev IS NOT NULL;
 
--- Can use BSM if we can exclude NULLs from val
+-- Can use BatchSortedMerge if we can exclude NULLs from val
 SET timescaledb.debug_require_batch_sorted_merge = 'force';
 SELECT val, lag(val) OVER (ORDER BY val DESC NULLS FIRST) AS prev FROM t where val > 995;
 
+-- Tests for BatchSortedMerge over one-segment data
+--------------------------------------
+
+-- Should be optimized (all segmentby columns are pinned to a Const, orderby columns match)
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
+:PREFIX
+SELECT * FROM test_segby WHERE segby = 1 ORDER BY time DESC;
+
+:PREFIX
+SELECT * FROM test1 WHERE x1 = 1 AND x2 = 2 AND x5 = 0 ORDER BY x1, x2, x5, time DESC;
+
+:PREFIX
+SELECT * FROM test2 WHERE x1 = 1 AND x2 = 2 AND x5 = 0 ORDER BY time ASC, x3 DESC;
+
+:PREFIX
+SELECT * FROM test2 WHERE x1 = 1 AND x2 = 2 AND x5 = 0 ORDER BY x1 DESC, x2 DESC, x5 DESC, time DESC, x3 ASC;
+
+-- No segmentby
+CREATE TABLE test_nosegby (
+	segby int NOT NULL,
+	time timestamptz NOT NULL,
+	val int);
+
+SELECT FROM create_hypertable('test_nosegby', 'time');
+
+ALTER TABLE test_nosegby SET (timescaledb.compress, timescaledb.compress_orderby = 'segby,time DESC');
+
+INSERT INTO test_nosegby (time, segby, val) values
+('2000-01-01 00:00:00-00', 1, 2),
+('2000-01-01 01:00:00-00', 1, 3),
+('2000-01-01 02:00:00-00', 2, 1),
+('2000-01-01 03:00:00-00', 1, 2),
+('2000-01-01 00:00:00-00', 1, 2),
+('2000-01-01 01:00:00-00', 1, 3),
+('2000-01-01 02:00:00-00', 2, 1),
+('2000-01-01 03:00:00-00', 1, 2),
+('2000-01-01 00:00:00-00', 1, 2),
+('2000-01-01 01:00:00-00', 1, 3),
+('2000-01-01 02:00:00-00', 2, 1),
+('2000-01-01 03:00:00-00', 1, 2);
+
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('test_nosegby') chunk;
+
+-- Should be optimized (implicit NULLS first)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby, time DESC;
+
+-- Should be optimized
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby, time DESC NULLS FIRST;
+
+-- Should be optimized (backward scan, NULLS last)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby DESC, time ASC NULLS LAST;
+
+-- Should be optimized (backward scan)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby DESC;
+
+set timescaledb.debug_require_batch_sorted_merge to 'forbid';
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby, time DESC NULLS LAST;
+
+-- Should not be optimized (NULL order wrong)
+:PREFIX
+SELECT * FROM test_nosegby ORDER BY segby DESC NULLS LAST;
+
+drop table test1 cascade;
+drop table test2 cascade;
+drop table test_segby cascade;
+drop table test_nosegby cascade;
 drop table t cascade;
+
 RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.debug_require_batch_sorted_merge;

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -441,7 +441,9 @@ SELECT _timescaledb_functions.recompress_chunk_segmentwise(:'chunk_to_compress')
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('segwise_unordered') chunk;
 
 -- Output would be incorrectly ordered if the flag was cleared
--- We have to see a sort on top of the ColumnarScan node due to UNORDERED flag
+-- We can use BatchSortedMerge for UNORDERED chunk because segmentby is pinned to a Const i.e. we are dealing with 1 segment only
+SET timescaledb.debug_require_batch_sorted_merge = 'force';
 EXPLAIN (COSTS OFF) SELECT a, time FROM segwise_unordered WHERE a = 2 ORDER BY a, time;
+RESET timescaledb.debug_require_batch_sorted_merge;
 
 DROP TABLE segwise_unordered;


### PR DESCRIPTION
Addresses the easiest scenario for https://github.com/timescale/eng-database/issues/811: for unordered chunks, allow BatchSortedMerge for columnstores with no segmentby. 
Also a trivial case when we sort on all (segmentby + orderby) when all segmentby columns are pinned to Consts, meaning we are sorting one segment only.

Some existing tests can use BatchSortedMerge now because of the above changes, those tests were recapped.