### PR TITLE
chore: Pin pull-review docker image to digest

### DIFF
--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -37,4 +37,4 @@ jobs:
         shell: bash
         run: |
           PR_URL="https://github.com/${OWNER}/${REPO}/pull/${PULL_REQUEST_NUMBER}"
-          docker run ghcr.io/imsky/pull-review "$PR_URL" --github-token "${GITHUB_TOKEN}"
+          docker run ghcr.io/imsky/pull-review@sha256:80d099c92a3259322900b2d2d75ced5d628d1a182f917682c8fc411a750d650a "$PR_URL" --github-token "${GITHUB_TOKEN}"


### PR DESCRIPTION
Pin the `ghcr.io/imsky/pull-review` image referenced in `pr-handling.yaml` to a `@sha256:` digest.

The workflow runs on `pull_request_target` (so it has access to repo secrets even on PRs from forks) and passes `GITHUB_TOKEN` to the container. Without a digest pin, a hijacked or maliciously re-tagged image push would silently leak the token on the next PR. Digest pinning makes the image immutable from this workflow's perspective.

Note: the upstream [`imsky/pull-review`](https://github.com/imsky/pull-review/pkgs/container/pull-review) image hasn't been updated in 3+ years, so worth considering another alternative