### PR TITLE
Only freeze compressed rows when truncating uncompressed chunk

### DIFF
--- a/.unreleased/pr_9705
+++ b/.unreleased/pr_9705
@@ -1,1 +1,2 @@
 Fixes: #9705 Only freeze compressed rows when truncating uncompressed chunk
+Fixes: #9705 Avoid double TOAST delete when DELETE-after-compression is enabled

--- a/.unreleased/pr_9705
+++ b/.unreleased/pr_9705
@@ -1,0 +1,1 @@
+Fixes: #9705 Only freeze compressed rows when truncating uncompressed chunk

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -44,6 +44,7 @@
 #include "debug_point.h"
 #include "error_utils.h"
 #include "errors.h"
+#include "guc.h"
 #include "hypercube.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
@@ -505,9 +506,14 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	 * In contrast, when the compressed chunk part is created in the same transaction as the tuples
 	 * are written, the compressed chunk (i.e., the catalog entry) becomes visible to other
 	 * transactions only after the transaction that performs the compression is committed and
-	 * the uncompressed chunk is truncated.
+	 * the uncompressed chunk is truncated. This only holds for truncate_only behaviour; the
+	 * other behaviours may DELETE instead, which leaves the uncompressed rows visible to
+	 * concurrent readers and would expose duplicates when combined with HEAP_INSERT_FROZEN.
 	 */
-	int insert_options = new_compressed_chunk ? HEAP_INSERT_FROZEN : 0;
+	int insert_options =
+		(new_compressed_chunk && ts_guc_compress_truncate_behaviour == COMPRESS_TRUNCATE_ONLY) ?
+			HEAP_INSERT_FROZEN :
+			0;
 
 	before_size = ts_relation_size_impl(cxt.srcht_chunk->table_id);
 

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -251,16 +251,13 @@ delete_relation_rows(Oid table_oid)
 	Relation rel = table_open(table_oid, RowExclusiveLock);
 	Snapshot snap = RegisterSnapshot(GetLatestSnapshot());
 
-	/* Delete the rows in the table */
+	/*
+	 * Delete the rows in the table. heap_delete also deletes any out-of-line
+	 * TOAST values via heap_toast_delete, so the TOAST relation does not need
+	 * a separate pass; doing one would re-visit those TOAST tuples in the
+	 * same command and fail with "tuple already updated by self".
+	 */
 	RelationDeleteAllRows(rel, snap);
-
-	/* Delete the rows in the toast table */
-	if (OidIsValid(rel->rd_rel->reltoastrelid))
-	{
-		Relation toast_rel = table_open(rel->rd_rel->reltoastrelid, RowExclusiveLock);
-		RelationDeleteAllRows(toast_rel, snap);
-		table_close(toast_rel, NoLock);
-	}
 
 	table_close(rel, NoLock);
 	UnregisterSnapshot(snap);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -2783,3 +2783,28 @@ SELECT txid_current_if_assigned() IS NULL;
 
 COMMIT;
 DROP TABLE test_xid_compressed;
+-- Compress a chunk that has externally stored TOAST values when the
+-- DELETE-after-compression path is taken. The main heap delete also
+-- removes TOAST chunks via heap_toast_delete, so the cleanup must not
+-- visit the TOAST relation a second time (would fail with
+-- "tuple already updated by self").
+CREATE TABLE hyper_toast_delete(time timestamptz NOT NULL, data text);
+SELECT create_hypertable('hyper_toast_delete', 'time');
+        create_hypertable         
+----------------------------------
+ (61,public,hyper_toast_delete,t)
+
+ALTER TABLE hyper_toast_delete SET (timescaledb.compress, timescaledb.compress_orderby = 'time');
+INSERT INTO hyper_toast_delete
+SELECT t, string_agg(md5(random()::text), '')
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 01:00:00'::timestamptz, '1 minute') t,
+     generate_series(1, 100) s
+GROUP BY t;
+SET timescaledb.compress_truncate_behaviour TO truncate_disabled;
+SELECT count(*) FROM (SELECT compress_chunk(c) FROM show_chunks('hyper_toast_delete') c) s;
+ count 
+-------
+     1
+
+RESET timescaledb.compress_truncate_behaviour;
+DROP TABLE hyper_toast_delete;

--- a/tsl/test/isolation/expected/compression_freeze.out
+++ b/tsl/test/isolation/expected/compression_freeze.out
@@ -298,3 +298,37 @@ compression_status|count
 ------------------+-----
 Compressed        |    2
 
+
+starting permutation: s2_begin_rr s1_compress_delete_then_insert s2_count_in_tx s2_commit
+step s2_begin_rr: 
+    BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+    SELECT count(*) FROM sensor_data;
+
+count
+-----
+16850
+
+step s1_compress_delete_then_insert: 
+   BEGIN;
+   SET LOCAL timescaledb.compress_truncate_behaviour TO truncate_disabled;
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+   -- Insert new rows so the chunks become partially compressed; this forces
+   -- the scan to read from BOTH the compressed and uncompressed sides.
+   INSERT INTO sensor_data VALUES ('2022-01-05 00:00', 999, 0, 0);
+   INSERT INTO sensor_data VALUES ('2022-01-12 00:00', 999, 0, 0);
+   COMMIT;
+
+count
+-----
+    2
+
+step s2_count_in_tx: 
+    SELECT count(*) FROM sensor_data;
+
+count
+-----
+16850
+
+step s2_commit: 
+    COMMIT;
+

--- a/tsl/test/isolation/specs/compression_freeze.spec
+++ b/tsl/test/isolation/specs/compression_freeze.spec
@@ -49,6 +49,17 @@ step "s1_compress_delete" {
    SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
 }
 
+step "s1_compress_delete_then_insert" {
+   BEGIN;
+   SET LOCAL timescaledb.compress_truncate_behaviour TO truncate_disabled;
+   SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
+   -- Insert new rows so the chunks become partially compressed; this forces
+   -- the scan to read from BOTH the compressed and uncompressed sides.
+   INSERT INTO sensor_data VALUES ('2022-01-05 00:00', 999, 0, 0);
+   INSERT INTO sensor_data VALUES ('2022-01-12 00:00', 999, 0, 0);
+   COMMIT;
+}
+
 step "s1_compress_truncate_or_delete" {
    SET timescaledb.compress_truncate_behaviour TO truncate_or_delete;
    SELECT count(*) FROM (SELECT compress_chunk(i, if_not_compressed => true) FROM show_chunks('sensor_data') i) i;
@@ -100,6 +111,19 @@ step "s2_unlock_compression_after_truncate_or_delete" {
     SELECT debug_waitpoint_release('compression_done_after_truncate_or_delete_uncompressed');
 }
 
+step "s2_begin_rr" {
+    BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+    SELECT count(*) FROM sensor_data;
+}
+
+step "s2_count_in_tx" {
+    SELECT count(*) FROM sensor_data;
+}
+
+step "s2_commit" {
+    COMMIT;
+}
+
 permutation "s1_select_count" "s2_select_count_and_stats"
 permutation "s1_select_count" "s1_compress" "s1_select_count" "s2_select_count_and_stats"
 permutation "s2_lock_compression" "s2_select_count_and_stats" "s1_compress" "s2_select_count_and_stats" "s2_unlock_compression" "s2_select_count_and_stats"
@@ -115,3 +139,21 @@ permutation "s2_lock_compression_after_delete" "s2_select_count_and_stats" "s1_c
 # However, spin locks don't play well with isolation tests, so that is tesed in a TAP test instead `tsl/test/t/004_truncate_or_delete_spin_lock_test.pl`
 
 permutation "s2_lock_compression_after_truncate_or_delete" "s2_select_count_and_stats" "s1_compress_truncate_or_delete" "s2_unlock_compression_after_truncate_or_delete" "s2_select_count_and_stats"
+
+# Test that a concurrent reader does not observe duplicate rows when a
+# compression commits with truncate_disabled and the chunks are left
+# partially compressed.
+#
+# Scenario:
+#   s2 starts a REPEATABLE READ transaction and takes a count snapshot.
+#   s1 compresses every chunk with truncate_disabled (DELETE on the
+#   uncompressed side) and then INSERTs new rows into the same chunks in
+#   the same transaction. The chunks end up partially compressed, so the
+#   planner scans both the compressed companion and the uncompressed
+#   chunk relation.
+#
+# Expected: s2's count stays the same across s1's commit. The DELETE is
+# invisible to s2's older snapshot, so the uncompressed rows are still
+# visible; if the compressed rows were inserted with HEAP_INSERT_FROZEN
+# they would also be visible to that snapshot and the count would double.
+permutation "s2_begin_rr" "s1_compress_delete_then_insert" "s2_count_in_tx" "s2_commit"

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -1299,3 +1299,22 @@ COMMIT;
 
 DROP TABLE test_xid_compressed;
 
+-- Compress a chunk that has externally stored TOAST values when the
+-- DELETE-after-compression path is taken. The main heap delete also
+-- removes TOAST chunks via heap_toast_delete, so the cleanup must not
+-- visit the TOAST relation a second time (would fail with
+-- "tuple already updated by self").
+CREATE TABLE hyper_toast_delete(time timestamptz NOT NULL, data text);
+SELECT create_hypertable('hyper_toast_delete', 'time');
+ALTER TABLE hyper_toast_delete SET (timescaledb.compress, timescaledb.compress_orderby = 'time');
+INSERT INTO hyper_toast_delete
+SELECT t, string_agg(md5(random()::text), '')
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 01:00:00'::timestamptz, '1 minute') t,
+     generate_series(1, 100) s
+GROUP BY t;
+
+SET timescaledb.compress_truncate_behaviour TO truncate_disabled;
+SELECT count(*) FROM (SELECT compress_chunk(c) FROM show_chunks('hyper_toast_delete') c) s;
+RESET timescaledb.compress_truncate_behaviour;
+DROP TABLE hyper_toast_delete;
+


### PR DESCRIPTION
HEAP_INSERT_FROZEN makes inserted rows visible to all transactions right
away. That is only safe when the uncompressed rows are removed atomically
on commit, which is true for truncate_only but not for truncate_or_delete
(may fall back to DELETE) or truncate_disabled (always DELETE). In the
DELETE paths concurrent readers could see both the compressed and the
uncompressed copy of the rows.

Disable-check: commit-count