### PR TITLE
Use bigint in estimate_uncompressed_size calculations

### DIFF
--- a/.unreleased/pr_9706
+++ b/.unreleased/pr_9706
@@ -1,0 +1,1 @@
+Fixes: #9706 Use bigint in estimate_uncompressed_size calculations

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -637,7 +637,7 @@ BEGIN
 
   EXECUTE format('SELECT sum(_ts_meta_count) FROM %s', v_compressed_chunk) INTO tuples;
   -- we can optimize the following query if all columns are fixed size
-  EXECUTE format('SELECT ((%s * (%s + %s)) %s) * %s FROM %s', tuples, v_tuple_header, v_tuple_data, v_varlen_query, v_multiplier, v_compressed_chunk) INTO relation_size;
+  EXECUTE format('SELECT (((%s::bigint * (%s::bigint + %s::bigint)) %s) * %s)::bigint FROM %s', tuples, v_tuple_header, v_tuple_data, v_varlen_query, v_multiplier, v_compressed_chunk) INTO relation_size;
 
   index_size := 0;
   FOR v_index, v_varlen_query, v_columns IN
@@ -650,7 +650,7 @@ BEGIN
     v_index_header := 8; -- Index tuple header
 
     -- v_compressed_chunk is a regclass, which will be properly escaped when cast to `text`
-    EXECUTE format('SELECT ((%s * %s) %s) * %s FROM %s', tuples, v_index_header, v_varlen_query, v_index_multiplier, v_compressed_chunk) INTO v_index_size;
+    EXECUTE format('SELECT (((%s::bigint * %s::bigint) %s) * %s)::bigint FROM %s', tuples, v_index_header, v_varlen_query, v_index_multiplier, v_compressed_chunk) INTO v_index_size;
     index_size := index_size + v_index_size;
   END LOOP;
 


### PR DESCRIPTION
The function builds dynamic SQL that multiplies the row count by per-row
size values. With many rows, this product can exceed int4 range and the
query fails with an integer overflow. Cast the count and per-row sizes
to bigint inside the dynamic SQL so the arithmetic stays in 64 bits, and
cast the final result to bigint to match the function's output type.

Disable-check: approval-count
