### PR TITLE
Return bigint from compressed_data_column_size

### DIFF
--- a/.unreleased/pr_9710
+++ b/.unreleased/pr_9710
@@ -1,0 +1,1 @@
+Fixes: #9710 Return bigint from compressed_data_column_size

--- a/sql/compression.sql
+++ b/sql/compression.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.compressed_data_to_array(_time
    LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_functions.compressed_data_column_size(_timescaledb_internal.compressed_data, ANYELEMENT)
-   RETURNS INTEGER
+   RETURNS BIGINT
    AS '@MODULE_PATHNAME@', 'ts_compressed_data_column_size'
    LANGUAGE C IMMUTABLE PARALLEL SAFE;
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -87,6 +87,10 @@ DROP PROCEDURE IF EXISTS _timescaledb_functions.policy_process_hypertable_invali
 DROP PROCEDURE IF EXISTS @extschema@.add_process_hypertable_invalidations_policy(REGCLASS, INTERVAL, BOOL, TIMESTAMPTZ, TEXT);
 DROP PROCEDURE IF EXISTS @extschema@.remove_process_hypertable_invalidations_policy(REGCLASS, BOOL);
 
+-- Return type widened from INTEGER to BIGINT; per-batch byte count can
+-- exceed INT32_MAX for wide varlena columns and was silently wrapping.
+DROP FUNCTION IF EXISTS _timescaledb_functions.compressed_data_column_size(_timescaledb_internal.compressed_data, ANYELEMENT);
+
 -- Migration: refresh orderby sparse index entries in compression_settings
 UPDATE _timescaledb_catalog.compression_settings
 SET index = (

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -5,3 +5,7 @@ ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_
 
 DROP FUNCTION IF EXISTS _timescaledb_functions.bloom1_contains_any_hashes(_timescaledb_internal.bloom1, bigint[]);
 DROP FUNCTION IF EXISTS _timescaledb_functions.bloom1_hash(anyelement);
+
+-- Drop BIGINT-returning version so the downgrade script can recreate the
+-- INTEGER-returning version of compressed_data_column_size.
+DROP FUNCTION IF EXISTS _timescaledb_functions.compressed_data_column_size(_timescaledb_internal.compressed_data, ANYELEMENT);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2811,14 +2811,14 @@ tsl_compressed_data_column_size(PG_FUNCTION_ARGS)
 	if (header->compression_algorithm == COMPRESSION_ALGORITHM_NULL)
 	{
 		/* All values are NULL, so size is 0 */
-		PG_RETURN_INT32(0);
+		PG_RETURN_INT64(0);
 	}
 
 	/* Initialize the decompression iterator */
 	iter = definitions[header->compression_algorithm].iterator_init_forward(PointerGetDatum(header),
 																			element_type);
 
-	int32 column_size = 0;
+	int64 column_size = 0;
 	/* Iterate through all compressed values */
 	for (;;)
 	{
@@ -2849,7 +2849,7 @@ tsl_compressed_data_column_size(PG_FUNCTION_ARGS)
 		}
 	}
 
-	PG_RETURN_INT32(column_size);
+	PG_RETURN_INT64(column_size);
 }
 
 Datum


### PR DESCRIPTION
The function summed the byte size of every value in a compressed batch
into an int32 accumulator and returned int32. A batch can hold up to
1000 rows, and for wide varlena columns (large text, jsonb, bytea) the
sum can pass 2 GB, at which point the accumulator silently wraps and
the function reports a wrong size.

Switch the accumulator and return type to int64 so the full per-batch
size is preserved. The SQL function signature changes from INTEGER to
BIGINT, so the upgrade and downgrade scripts drop the function before
the new version is created.

The in-tree caller in size_utils.sql wraps the result in sum(), which
keeps working unchanged.

No regression test is added: triggering the overflow needs more than
2 GB of varlena data in a single batch, which is too resource intensive
to run as part of the normal test suite.
