### PR TITLE
Fix registration row leak when continuous aggregate refresh fails

### DIFF
--- a/.unreleased/pr_9711
+++ b/.unreleased/pr_9711
@@ -1,0 +1,1 @@
+Fixes: #9711 Fix registration row leak when continuous aggregate refresh fails

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -915,13 +915,20 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg,
 	}
 
 	DEBUG_WAITPOINT("cagg_refresh_before_first_txn_commit");
-	SPI_commit_and_chain();
 
 	volatile bool refreshed = false;
 	volatile ErrorData *edata = NULL;
 	PG_TRY();
 	{
-		/* Commit and Start a new transaction */
+		/*
+		 * Commit the registration row and start a new transaction. Kept inside
+		 * PG_TRY so that an error here (e.g. cancel arriving after the commit
+		 * is durable but before the chained transaction has started) is routed
+		 * through rollback_and_error, which deletes the just-committed
+		 * registration row in a fresh transaction.
+		 */
+		SPI_commit_and_chain();
+		DEBUG_ERROR_INJECTION("cagg_refresh_fail_at_txn1_start");
 
 		DEBUG_WAITPOINT("cagg_refresh_after_register");
 

--- a/tsl/test/expected/cagg_refresh_cleanup.out
+++ b/tsl/test/expected/cagg_refresh_cleanup.out
@@ -131,6 +131,28 @@ SELECT debug_waitpoint_release('cagg_refresh_fail_in_registration');
 -------------------------
  
 
+-- Test 4b: refresh fails at the start of Txn1 (right after registration commit)
+BEGIN; INSERT INTO conditions VALUES ('2026-03-01', 333), ('2026-03-05', 333); COMMIT;
+SELECT debug_waitpoint_enable('cagg_refresh_fail_at_txn1_start');
+ debug_waitpoint_enable 
+------------------------
+ 
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+ERROR:  error injected at debug point 'cagg_refresh_fail_at_txn1_start'
+\set ON_ERROR_STOP 1
+SELECT count(*) AS jobs_after_txn1_start_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+ jobs_after_txn1_start_fail 
+----------------------------
+                          0
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_at_txn1_start');
+ debug_waitpoint_release 
+-------------------------
+ 
+
 -- Test 5: stale entry with a dead PID is cleaned up by the next refresh.
 -- Inserting a row with PID 0 as a dummy job.
 INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges

--- a/tsl/test/sql/cagg_refresh_cleanup.sql
+++ b/tsl/test/sql/cagg_refresh_cleanup.sql
@@ -97,6 +97,20 @@ FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
 
 SELECT debug_waitpoint_release('cagg_refresh_fail_in_registration');
 
+-- Test 4b: refresh fails at the start of Txn1 (right after registration commit)
+BEGIN; INSERT INTO conditions VALUES ('2026-03-01', 333), ('2026-03-05', 333); COMMIT;
+
+SELECT debug_waitpoint_enable('cagg_refresh_fail_at_txn1_start');
+
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('cond_daily', '2026-01-05', '2026-03-15');
+\set ON_ERROR_STOP 1
+
+SELECT count(*) AS jobs_after_txn1_start_fail
+FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges;
+
+SELECT debug_waitpoint_release('cagg_refresh_fail_at_txn1_start');
+
 -- Test 5: stale entry with a dead PID is cleaned up by the next refresh.
 -- Inserting a row with PID 0 as a dummy job.
 INSERT INTO _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges


### PR DESCRIPTION
The registration row in continuous_aggs_jobs_refresh_ranges was
committed outside the PG_TRY block, so an error between the commit
and the start of PG_TRY left the row in the catalog. Other backends
trying to refresh an overlapping window would then fail until the
PID-based cleanup ran.

Move the commit back inside PG_TRY so any error is routed through
the existing rollback_and_error path, which deletes the row in a
fresh transaction.
