### PR TITLE
Invalidate catalog OIDs on REINDEX CONCURRENTLY

### DIFF
--- a/.unreleased/pr_9713
+++ b/.unreleased/pr_9713
@@ -1,0 +1,2 @@
+Fixes: #9713 Drop cached catalog OIDs on REINDEX CONCURRENTLY
+Thanks: @pmenke-de for reporting that REINDEX CONCURRENTLY of _timescaledb_catalog indexes left sessions unable to access the catalog

--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -58,6 +58,7 @@ cache_invalidate_relcache_all(void)
 {
 	ts_hypertable_cache_invalidate_callback();
 	ts_bgw_job_cache_invalidate_callback();
+	ts_catalog_invalidate();
 }
 
 static Oid hypertable_proxy_table_oid = InvalidOid;
@@ -98,6 +99,15 @@ cache_invalidate_relcache_callback(Datum arg, Oid relid)
 	else if (relid == bgw_proxy_table_oid)
 	{
 		ts_bgw_job_cache_invalidate_callback();
+	}
+	else if (ts_catalog_relid(relid))
+	{
+		/*
+		 * REINDEX CONCURRENTLY on a TimescaleDB catalog table or index
+		 * rotates the relation OID. Drop the cached OIDs so the next
+		 * ts_catalog_get() resolves them again from pg_class.
+		 */
+		ts_catalog_invalidate();
 	}
 }
 

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -557,6 +557,52 @@ ts_catalog_reset(void)
 	ts_cache_invalidate_set_proxy_tables(InvalidOid, InvalidOid);
 }
 
+/*
+ * Mark the cached catalog OIDs as stale so the next ts_catalog_get()
+ * resolves them again from pg_class. Used by the relcache invalidation
+ * callback after operations like REINDEX CONCURRENTLY that change a
+ * catalog table or index OID without going through extension state
+ * transitions. Unlike ts_catalog_reset() this leaves database_info and
+ * proxy-table tracking in place since those are unaffected.
+ */
+void
+ts_catalog_invalidate(void)
+{
+	s_catalog.initialized = false;
+}
+
+/*
+ * Return true if relid is one of our cached catalog table or index OIDs.
+ * Safe to call from a relcache invalidation callback: only reads our own
+ * static state, no syscache or relcache lookups.
+ */
+bool
+ts_catalog_relid(Oid relid)
+{
+	if (!OidIsValid(relid) || !s_catalog.initialized)
+	{
+		return false;
+	}
+
+	for (int i = 0; i < _MAX_CATALOG_TABLES; i++)
+	{
+		if (s_catalog.tables[i].id == relid)
+		{
+			return true;
+		}
+
+		for (int j = 0; j < _MAX_TABLE_INDEXES; j++)
+		{
+			if (s_catalog.tables[i].index_ids[j] == relid)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 static CatalogTable
 catalog_get_table(Catalog *catalog, Oid relid)
 {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1403,6 +1403,8 @@ extern void ts_catalog_table_info_init(CatalogTableInfo *tables, int max_table,
 extern TSDLLEXPORT CatalogDatabaseInfo *ts_catalog_database_info_get(void);
 extern TSDLLEXPORT Catalog *ts_catalog_get(void);
 extern void ts_catalog_reset(void);
+extern void ts_catalog_invalidate(void);
+extern bool ts_catalog_relid(Oid relid);
 extern bool ts_is_catalog_table(Oid relid);
 
 /* Functions should operate on a passed-in Catalog struct */

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -606,3 +606,26 @@ SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_15_21_chunk');
  _timescaledb_internal._hyper_15_21_chunk_test_temp_idx | {temp}  |      | f      | f       | f         | 
  _timescaledb_internal._hyper_15_21_chunk_test_time_idx | {time}  |      | f      | f       | f         | 
 
+-- #7590 REINDEX CONCURRENTLY on _timescaledb_catalog tables/indexes
+-- rotates relation OIDs. The session-local catalog cache must drop the
+-- stale OIDs, otherwise the next catalog access fails with
+-- "could not open relation with OID".
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE i7590(time timestamptz NOT NULL, v int);
+SELECT table_name FROM create_hypertable('i7590', 'time');
+ table_name 
+------------
+ i7590
+
+INSERT INTO i7590 VALUES ('2024-01-01', 1);
+REINDEX INDEX CONCURRENTLY _timescaledb_catalog.chunk_schema_name_table_name_key;
+REINDEX INDEX CONCURRENTLY _timescaledb_catalog.hypertable_table_name_schema_name_key;
+INSERT INTO i7590 VALUES ('2024-01-02', 2);
+REINDEX TABLE CONCURRENTLY _timescaledb_catalog.chunk;
+INSERT INTO i7590 VALUES ('2024-01-03', 3);
+SELECT count(*) AS rows_after_reindex FROM i7590;
+ rows_after_reindex 
+--------------------
+                  3
+
+DROP TABLE i7590;

--- a/test/sql/index.sql
+++ b/test/sql/index.sql
@@ -343,3 +343,23 @@ CREATE INDEX test_temp_idx ON ONLY test (time);
 
 SELECT * FROM test.show_indexes('test');
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_15_21_chunk');
+
+-- #7590 REINDEX CONCURRENTLY on _timescaledb_catalog tables/indexes
+-- rotates relation OIDs. The session-local catalog cache must drop the
+-- stale OIDs, otherwise the next catalog access fails with
+-- "could not open relation with OID".
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE TABLE i7590(time timestamptz NOT NULL, v int);
+SELECT table_name FROM create_hypertable('i7590', 'time');
+INSERT INTO i7590 VALUES ('2024-01-01', 1);
+
+REINDEX INDEX CONCURRENTLY _timescaledb_catalog.chunk_schema_name_table_name_key;
+REINDEX INDEX CONCURRENTLY _timescaledb_catalog.hypertable_table_name_schema_name_key;
+INSERT INTO i7590 VALUES ('2024-01-02', 2);
+
+REINDEX TABLE CONCURRENTLY _timescaledb_catalog.chunk;
+INSERT INTO i7590 VALUES ('2024-01-03', 3);
+
+SELECT count(*) AS rows_after_reindex FROM i7590;
+DROP TABLE i7590;


### PR DESCRIPTION
Catalog table and index OIDs are cached per backend in s_catalog. The relcache invalidation callback only watched the proxy tables, so when REINDEX CONCURRENTLY rotated a catalog index OID the cached entry stayed stale and the next catalog access failed with "could not open relation with OID".

Match catalog table or index OIDs in the relcache callback and reset the cache flag so the next ts_catalog_get() resolves them again. Use a narrow ts_catalog_invalidate() helper instead of ts_catalog_reset() to keep proxy-table tracking and database_info in place, since neither is affected by REINDEX.

Fixes #7590 