### PR TITLE
Install matching version of Postgres client in WSL

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -70,11 +70,12 @@ jobs:
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         pg_config: ["-cfsync=off -cstatement_timeout=60s -clisten_addresses=0.0.0.0"]
         event_name: ["${{ github.event_name }}"]
+        run_installcheck: ["${{ needs.check_paths.outputs.run_installcheck }}"]
         exclude:
           - versions: { pg: 15, pg_version: "${{ needs.config.outputs.pg15_latest }}" }
-            event_name: "pull_request"
+            run_installcheck: false
           - versions: { pg: 16, pg_version: "${{ needs.config.outputs.pg16_latest }}" }
-            event_name: "pull_request"
+            run_installcheck: false
     env:
       # PostgreSQL configuration
       PGPORT: 55432
@@ -149,7 +150,8 @@ jobs:
       shell: wsl-bash {0}
       run: |
         apt-get update
-        apt-get install --yes --no-install-recommends ca-certificates cmake gawk gcc git gnupg jq make postgresql-client postgresql-common tree
+        apt-get install --yes --no-install-recommends ca-certificates cmake gawk \
+          gcc git gnupg jq make postgresql-client-${{ matrix.versions.pg }} tree
 
     - name: Configure git
       # Since we want to reuse the checkout in the WSL environment

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -153,7 +153,7 @@ jobs:
         apt-get install --yes --no-install-recommends ca-certificates cmake gawk \
           gcc git gnupg jq make postgresql-common tree
 
-        /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
         apt-get update
         apt-get install postgresql-client-${{ matrix.versions.pg }}
 

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -151,7 +151,11 @@ jobs:
       run: |
         apt-get update
         apt-get install --yes --no-install-recommends ca-certificates cmake gawk \
-          gcc git gnupg jq make postgresql-client-${{ matrix.versions.pg }} tree
+          gcc git gnupg jq make postgresql-common tree
+
+        /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        apt-get update
+        apt-get install postgresql-client-${{ matrix.versions.pg }}
 
     - name: Configure git
       # Since we want to reuse the checkout in the WSL environment

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -155,7 +155,7 @@ jobs:
 
         /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
         apt-get update
-        apt-get install postgresql-client-${{ matrix.versions.pg }}
+        apt-get install --yes postgresql-client-${{ matrix.versions.pg }}
 
     - name: Configure git
       # Since we want to reuse the checkout in the WSL environment


### PR DESCRIPTION
After upgrade to Debian 13, the tests started failing due to a mismatched Postgres version.

Example: https://github.com/timescale/timescaledb/actions/runs/25323432506/job/74238010568