### PR TITLE
Validate uniqueness on chunk-direct DDL

### DIFF
--- a/.unreleased/pr_9721
+++ b/.unreleased/pr_9721
@@ -1,0 +1,1 @@
+Fixes: #9720 Reject CREATE UNIQUE INDEX and ADD UNIQUE/PRIMARY KEY on chunk relations when the underlying compressed data contains duplicates

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2993,6 +2993,69 @@ validate_index_constraints(Chunk *chunk, const IndexStmt *stmt)
 	}
 }
 
+/*
+ * Run the unique-constraint check when CREATE UNIQUE INDEX or
+ * ALTER TABLE ADD UNIQUE/PRIMARY KEY targets a chunk relation directly.
+ *
+ * Without this, postgres builds the index over the empty user-facing chunk
+ * heap (data lives in compress_hyper_*) and silently records the index as
+ * unique even when the underlying data has duplicates. See issue #9720.
+ *
+ * validate_index_constraints itself only acts on compressed chunks; for
+ * uncompressed chunks postgres' own scan of the chunk heap is sufficient.
+ */
+static void
+validate_chunk_index_constraints(Oid relid, const IndexStmt *stmt)
+{
+	Chunk *chunk;
+
+	if (!OidIsValid(relid))
+	{
+		return;
+	}
+	if (!stmt->unique && !stmt->primary)
+	{
+		return;
+	}
+
+	chunk = ts_chunk_get_by_relid(relid, false /* fail_if_not_found */);
+	if (chunk != NULL)
+	{
+		validate_index_constraints(chunk, stmt);
+	}
+}
+
+/*
+ * Variant for ALTER TABLE ADD CONSTRAINT, where we receive a Constraint node
+ * instead of an IndexStmt. Synthesize the minimal IndexStmt that
+ * validate_index_constraints needs.
+ */
+static void
+validate_chunk_constraint_uniqueness(Oid relid, const Constraint *con)
+{
+	IndexStmt synth = { 0 };
+	ListCell *lc;
+
+	if (con->contype != CONSTR_PRIMARY && con->contype != CONSTR_UNIQUE)
+	{
+		return;
+	}
+
+	synth.type = T_IndexStmt;
+	synth.primary = (con->contype == CONSTR_PRIMARY);
+	synth.unique = (con->contype == CONSTR_UNIQUE);
+	synth.nulls_not_distinct = con->nulls_not_distinct;
+
+	foreach (lc, con->keys)
+	{
+		IndexElem *elem = makeNode(IndexElem);
+		elem->name = strVal(lfirst(lc));
+		synth.indexParams = lappend(synth.indexParams, elem);
+	}
+
+	validate_chunk_index_constraints(relid, &synth);
+}
+
 static void
 validate_check_constraint(Chunk *chunk, Constraint *con)
 {
@@ -3698,6 +3761,7 @@ process_index_start(ProcessUtilityArgs *args)
 		if (!ht)
 		{
 			ts_cache_release(&hcache);
+			validate_chunk_index_constraints(RangeVarGetRelid(stmt->relation, NoLock, true), stmt);
 			return DDL_CONTINUE;
 		}
 
@@ -4773,6 +4837,10 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 				if (ht)
 				{
 					verify_constraint_hypertable(ht, cmd->def);
+				}
+				else
+				{
+					validate_chunk_constraint_uniqueness(reloid, castNode(Constraint, cmd->def));
 				}
 				break;
 			case AT_AlterColumnType:

--- a/tsl/test/expected/compression_constraints.out
+++ b/tsl/test/expected/compression_constraints.out
@@ -108,6 +108,31 @@ ERROR:  duplicate key value violates unique constraint
 CREATE UNIQUE INDEX metrics_pk ON metrics(time,device);
 ERROR:  duplicate key value violates unique constraint
 \set ON_ERROR_STOP 1
+-- chunk-level direct paths must reject too: without this check, CREATE UNIQUE
+-- INDEX or ALTER TABLE ADD CONSTRAINT on a compressed chunk would silently
+-- record a unique constraint over data that contains duplicates (see #9720).
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT format('%I.%I', chunk_schema, chunk_name) AS chunk
+FROM timescaledb_information.chunks
+WHERE hypertable_name='metrics' \gset
+\set ON_ERROR_STOP 0
+BEGIN; CREATE UNIQUE INDEX metrics_chunk_pk ON :chunk (time); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint
+BEGIN; CREATE UNIQUE INDEX metrics_chunk_pk ON :chunk (time, device); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk PRIMARY KEY (time); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk PRIMARY KEY (time, device); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk UNIQUE (time); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk UNIQUE (time, device); ROLLBACK;
+ERROR:  duplicate key value violates unique constraint
+\set ON_ERROR_STOP 1
+-- non-unique CREATE INDEX on the chunk is fine even with duplicates
+CREATE INDEX metrics_chunk_idx ON :chunk (time);
+DROP INDEX _timescaledb_internal.metrics_chunk_idx;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 DROP TABLE metrics;
 -- test NULL behaviour
 CREATE TABLE dist_null(time timestamptz not null, device text, value float);

--- a/tsl/test/sql/compression_constraints.sql
+++ b/tsl/test/sql/compression_constraints.sql
@@ -102,6 +102,28 @@ CREATE UNIQUE INDEX metrics_pk ON metrics(time);
 CREATE UNIQUE INDEX metrics_pk ON metrics(time,device);
 \set ON_ERROR_STOP 1
 
+-- chunk-level direct paths must reject too: without this check, CREATE UNIQUE
+-- INDEX or ALTER TABLE ADD CONSTRAINT on a compressed chunk would silently
+-- record a unique constraint over data that contains duplicates (see #9720).
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT format('%I.%I', chunk_schema, chunk_name) AS chunk
+FROM timescaledb_information.chunks
+WHERE hypertable_name='metrics' \gset
+
+\set ON_ERROR_STOP 0
+BEGIN; CREATE UNIQUE INDEX metrics_chunk_pk ON :chunk (time); ROLLBACK;
+BEGIN; CREATE UNIQUE INDEX metrics_chunk_pk ON :chunk (time, device); ROLLBACK;
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk PRIMARY KEY (time); ROLLBACK;
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk PRIMARY KEY (time, device); ROLLBACK;
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk UNIQUE (time); ROLLBACK;
+BEGIN; ALTER TABLE :chunk ADD CONSTRAINT metrics_chunk_pk UNIQUE (time, device); ROLLBACK;
+\set ON_ERROR_STOP 1
+
+-- non-unique CREATE INDEX on the chunk is fine even with duplicates
+CREATE INDEX metrics_chunk_idx ON :chunk (time);
+DROP INDEX _timescaledb_internal.metrics_chunk_idx;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 DROP TABLE metrics;
 
 -- test NULL behaviour


### PR DESCRIPTION
Creating a unique or primary-key index directly on a chunk skipped the duplicate-check that the hypertable-level path runs. On compressed chunks the user-facing heap is empty, so postgres built an empty btree and recorded the index as unique even when the data had duplicates.

Run the same duplicate-check whenever a unique or primary-key index is created directly against a chunk.


Fixes: https://github.com/timescale/timescaledb/issues/9720