### PR TITLE
Avoid scan on hypertable relation

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1470,8 +1470,8 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 			{
 				ts_planner_constraint_cleanup(root, rel);
 			}
-
 			break;
+
 		case TS_REL_CHUNK_STANDALONE:
 		case TS_REL_CHUNK_CHILD:
 			/* Check for UPDATE/DELETE/MERGE (DML) on compressed chunks */
@@ -1482,10 +1482,14 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 				{
 					ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
 				}
-				break;
 			}
-			TS_FALLTHROUGH;
-		default:
+			else
+			{
+				apply_optimizations(root, reltype, rel, rte, ht);
+			}
+			break;
+
+		case TS_REL_HYPERTABLE:
 			/*
 			 * Set the indexlist for a hypertable parent to NIL since we
 			 * should not try to do any index scans on hypertable parents,
@@ -1497,10 +1501,26 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 			 * This has to be after the hypertable is expanded, since the
 			 * indexlist is used during hypertable expansion.
 			 */
-			if (reltype == TS_REL_HYPERTABLE)
+
+			rel->indexlist = NIL;
+
+			if (!rte->inh)
 			{
-				rel->indexlist = NIL;
+				/*
+				 * This happens with SELECT FROM ONLY hypertable or with an
+				 * empty hypertable. Mark it as dummy, otherwise we'll get a
+				 * scan on hypertable relation itself. It's always empty, so
+				 * this scan is useless and looks misleading.
+				 */
+				mark_dummy_rel(rel);
 			}
+			else
+			{
+				apply_optimizations(root, reltype, rel, rte, ht);
+			}
+			break;
+
+		default:
 			apply_optimizations(root, reltype, rel, rte, ht);
 			break;
 	}

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -259,7 +259,8 @@ SELECT * FROM ONLY PUBLIC."Hypertable_1";
 
 EXPLAIN (buffers off, costs off) SELECT * FROM ONLY PUBLIC."Hypertable_1";
 --- QUERY PLAN ---
- Seq Scan on "Hypertable_1"
+ Result
+   One-Time Filter: false
 
 SELECT * FROM test.show_columns('PUBLIC."Hypertable_1"');
   Column   |  Type   | NotNull 

--- a/test/expected/dml_system_columns.out
+++ b/test/expected/dml_system_columns.out
@@ -434,17 +434,17 @@ VACUUM FREEZE ANALYZE ht_zero_chunks;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    ->  Update on public.ht_zero_chunks (actual rows=0.00 loops=1)
-         ->  Seq Scan on public.ht_zero_chunks (actual rows=0.00 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                Output: 1, ctid
-               Filter: (ht_zero_chunks."time" = 'Wed Jan 15 00:00:00 2020 PST'::timestamp with time zone)
+               One-Time Filter: false
 
 :PREFIX DELETE FROM ht_zero_chunks WHERE time = '2020-01-15';
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    ->  Delete on public.ht_zero_chunks (actual rows=0.00 loops=1)
-         ->  Seq Scan on public.ht_zero_chunks (actual rows=0.00 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                Output: ctid
-               Filter: (ht_zero_chunks."time" = 'Wed Jan 15 00:00:00 2020 PST'::timestamp with time zone)
+               One-Time Filter: false
 
 :PREFIX UPDATE ht_zero_chunks SET v = 1 RETURNING ctid, xmin, tableoid::regclass, *;
 --- QUERY PLAN ---
@@ -452,8 +452,9 @@ VACUUM FREEZE ANALYZE ht_zero_chunks;
    Output: ctid, xmin, ((tableoid)::regclass), "time", v
    ->  Update on public.ht_zero_chunks (actual rows=0.00 loops=1)
          Output: ctid, xmin, (tableoid)::regclass, "time", v
-         ->  Seq Scan on public.ht_zero_chunks (actual rows=0.00 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                Output: 1, ctid
+               One-Time Filter: false
 
 :PREFIX DELETE FROM ht_zero_chunks RETURNING ctid, xmin, tableoid::regclass, *;
 --- QUERY PLAN ---
@@ -461,8 +462,9 @@ VACUUM FREEZE ANALYZE ht_zero_chunks;
    Output: ctid, xmin, ((tableoid)::regclass), "time", v
    ->  Delete on public.ht_zero_chunks (actual rows=0.00 loops=1)
          Output: ctid, xmin, (tableoid)::regclass, "time", v
-         ->  Seq Scan on public.ht_zero_chunks (actual rows=0.00 loops=1)
+         ->  Result (actual rows=0.00 loops=1)
                Output: ctid
+               One-Time Filter: false
 
 DROP TABLE ht_zero_chunks;
 -- UPDATE/DELETE on a hypertable that becomes a dummy rel due to

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -3236,13 +3236,9 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10);
  Subquery Scan on f_t1_2
    ->  Unique
          ->  Sort
-               Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Unique
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               Sort Key: a
+               ->  Result
+                     One-Time Filter: false
 
 EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
 --- QUERY PLAN ---
@@ -3250,21 +3246,11 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
    ->  Unique
          ->  Sort
                Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Unique
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               ->  Result
+                     One-Time Filter: false
    ->  Unique
-         ->  Nested Loop
-               ->  Unique
-                     ->  Index Scan using t1_b_idx on t1 t1_1
-                           Index Cond: (b = 10)
-                           Filter: (a = t1.a)
-               ->  Index Scan using t2_b_idx on t2 j_1
-                     Index Cond: (b = 10)
-                     Filter: (a = t1.a)
+         ->  Result
+               One-Time Filter: false
 
 CREATE TABLE metrics_int1(time int, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=1);
 INSERT INTO metrics_int1 SELECT i, i::text, i FROM generate_series(3,7) i;

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -3234,13 +3234,9 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10);
  Subquery Scan on f_t1_2
    ->  Unique
          ->  Sort
-               Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Limit
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               Sort Key: a
+               ->  Result
+                     One-Time Filter: false
 
 EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
 --- QUERY PLAN ---
@@ -3248,21 +3244,11 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
    ->  Unique
          ->  Sort
                Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Limit
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               ->  Result
+                     One-Time Filter: false
    ->  Limit
-         ->  Nested Loop
-               ->  Limit
-                     ->  Index Scan using t1_b_idx on t1 t1_1
-                           Index Cond: (b = 10)
-                           Filter: (a = t1.a)
-               ->  Index Scan using t2_b_idx on t2 j_1
-                     Index Cond: (b = 10)
-                     Filter: (a = t1.a)
+         ->  Result
+               One-Time Filter: false
 
 CREATE TABLE metrics_int1(time int, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=1);
 INSERT INTO metrics_int1 SELECT i, i::text, i FROM generate_series(3,7) i;

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -3234,13 +3234,9 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10);
  Subquery Scan on f_t1_2
    ->  Unique
          ->  Sort
-               Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Limit
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               Sort Key: a
+               ->  Result
+                     One-Time Filter: false
 
 EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
 --- QUERY PLAN ---
@@ -3248,21 +3244,11 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
    ->  Unique
          ->  Sort
                Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Limit
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               ->  Result
+                     One-Time Filter: false
    ->  Limit
-         ->  Nested Loop
-               ->  Limit
-                     ->  Index Scan using t1_b_idx on t1 t1_1
-                           Index Cond: (b = 10)
-                           Filter: (a = t1.a)
-               ->  Index Scan using t2_b_idx on t2 j_1
-                     Index Cond: (b = 10)
-                     Filter: (a = t1.a)
+         ->  Result
+               One-Time Filter: false
 
 CREATE TABLE metrics_int1(time int, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=1);
 INSERT INTO metrics_int1 SELECT i, i::text, i FROM generate_series(3,7) i;

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -3234,13 +3234,9 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10);
  Subquery Scan on f_t1_2
    ->  Unique
          ->  Sort
-               Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Limit
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               Sort Key: a
+               ->  Result
+                     One-Time Filter: false
 
 EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
 --- QUERY PLAN ---
@@ -3248,21 +3244,11 @@ EXPLAIN (buffers off, costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
    ->  Unique
          ->  Sort
                Sort Key: j.a
-               ->  Nested Loop
-                     ->  Seq Scan on t1 j
-                     ->  Limit
-                           ->  Index Scan using t1_b_idx on t1
-                                 Index Cond: (b = 10)
-                                 Filter: (a = j.a)
+               ->  Result
+                     One-Time Filter: false
    ->  Limit
-         ->  Nested Loop
-               ->  Limit
-                     ->  Index Scan using t1_b_idx on t1 t1_1
-                           Index Cond: (b = 10)
-                           Filter: (a = t1.a)
-               ->  Index Scan using t2_b_idx on t2 j_1
-                     Index Cond: (b = 10)
-                     Filter: (a = t1.a)
+         ->  Result
+               One-Time Filter: false
 
 CREATE TABLE metrics_int1(time int, device text, value float) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.chunk_interval=1);
 INSERT INTO metrics_int1 SELECT i, i::text, i FROM generate_series(3,7) i;

--- a/test/expected/rowsecurity-15.out
+++ b/test/expected/rowsecurity-15.out
@@ -1407,7 +1407,8 @@ DROP TABLE dependee CASCADE;
 NOTICE:  drop cascades to policy d1 on table dependent
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualified
 --- QUERY PLAN ---
- Seq Scan on dependent
+ Result
+   One-Time Filter: false
 
 -----   RECURSION    ----
 --
@@ -1510,26 +1511,8 @@ NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b);
 --- QUERY PLAN ---
- Seq Scan on s1
-   Filter: ((hashed SubPlan 1) AND f_leak(b))
-   SubPlan 1
-     ->  Append
-           ->  Seq Scan on s2 s2_1
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_27_chunk s2_2
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_28_chunk s2_3
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_29_chunk s2_4
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_30_chunk s2_5
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_31_chunk s2_6
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_32_chunk s2_7
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_33_chunk s2_8
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_alice;
 ALTER POLICY p1 ON s1 USING (a in (select x from v2)); -- using VIEW in RLS policy
@@ -2336,7 +2319,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 PREPARE plancache_test2 AS WITH q AS MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2348,14 +2332,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test4 AS WITH q AS (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2367,14 +2349,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test6 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2386,62 +2366,37 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test3 AS WITH q AS MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 PREPARE plancache_test5 AS WITH q AS (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 PREPARE plancache_test7 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test7;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group1;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2480,7 +2435,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2492,13 +2448,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2510,43 +2464,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2585,7 +2525,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2597,13 +2538,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2615,43 +2554,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group2;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2690,7 +2615,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2702,13 +2628,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2720,43 +2644,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 --
 -- Views should follow policy for view owner.
@@ -3329,24 +3239,24 @@ PREPARE role_inval AS SELECT * FROM t1;
 -- Check plan
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change to regress_rls_carol
 SET ROLE regress_rls_carol;
 -- Check plan- should be different
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 4) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change back to regress_rls_bob
 SET ROLE regress_rls_bob;
 -- Check plan- should be back to original
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 --
 -- CTE and RLS

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -1407,7 +1407,8 @@ DROP TABLE dependee CASCADE;
 NOTICE:  drop cascades to policy d1 on table dependent
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualified
 --- QUERY PLAN ---
- Seq Scan on dependent
+ Result
+   One-Time Filter: false
 
 -----   RECURSION    ----
 --
@@ -1510,26 +1511,8 @@ NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b);
 --- QUERY PLAN ---
- Seq Scan on s1
-   Filter: ((hashed SubPlan 1) AND f_leak(b))
-   SubPlan 1
-     ->  Append
-           ->  Seq Scan on s2 s2_1
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_27_chunk s2_2
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_28_chunk s2_3
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_29_chunk s2_4
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_30_chunk s2_5
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_31_chunk s2_6
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_32_chunk s2_7
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_33_chunk s2_8
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_alice;
 ALTER POLICY p1 ON s1 USING (a in (select x from v2)); -- using VIEW in RLS policy
@@ -2336,7 +2319,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 PREPARE plancache_test2 AS WITH q AS MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2348,14 +2332,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test4 AS WITH q AS (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2367,14 +2349,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test6 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2386,62 +2366,37 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test3 AS WITH q AS MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 PREPARE plancache_test5 AS WITH q AS (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 PREPARE plancache_test7 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test7;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group1;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2480,7 +2435,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2492,13 +2448,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2510,43 +2464,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2585,7 +2525,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2597,13 +2538,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2615,43 +2554,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group2;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2690,7 +2615,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2702,13 +2628,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2720,43 +2644,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 --
 -- Views should follow policy for view owner.
@@ -3329,24 +3239,24 @@ PREPARE role_inval AS SELECT * FROM t1;
 -- Check plan
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change to regress_rls_carol
 SET ROLE regress_rls_carol;
 -- Check plan- should be different
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 4) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change back to regress_rls_bob
 SET ROLE regress_rls_bob;
 -- Check plan- should be back to original
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 --
 -- CTE and RLS

--- a/test/expected/rowsecurity-17.out
+++ b/test/expected/rowsecurity-17.out
@@ -1407,7 +1407,8 @@ DROP TABLE dependee CASCADE;
 NOTICE:  drop cascades to policy d1 on table dependent
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualified
 --- QUERY PLAN ---
- Seq Scan on dependent
+ Result
+   One-Time Filter: false
 
 -----   RECURSION    ----
 --
@@ -1510,26 +1511,8 @@ NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b);
 --- QUERY PLAN ---
- Seq Scan on s1
-   Filter: ((ANY (a = (hashed SubPlan 1).col1)) AND f_leak(b))
-   SubPlan 1
-     ->  Append
-           ->  Seq Scan on s2 s2_1
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_27_chunk s2_2
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_28_chunk s2_3
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_29_chunk s2_4
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_30_chunk s2_5
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_31_chunk s2_6
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_32_chunk s2_7
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_33_chunk s2_8
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_alice;
 ALTER POLICY p1 ON s1 USING (a in (select x from v2)); -- using VIEW in RLS policy
@@ -2336,7 +2319,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 PREPARE plancache_test2 AS WITH q AS MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2348,14 +2332,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test4 AS WITH q AS (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2367,14 +2349,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test6 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2386,62 +2366,37 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test3 AS WITH q AS MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 PREPARE plancache_test5 AS WITH q AS (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 PREPARE plancache_test7 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test7;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group1;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2480,7 +2435,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2492,13 +2448,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2510,43 +2464,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2585,7 +2525,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2597,13 +2538,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2615,43 +2554,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group2;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2690,7 +2615,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2702,13 +2628,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2720,43 +2644,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 --
 -- Views should follow policy for view owner.
@@ -3329,24 +3239,24 @@ PREPARE role_inval AS SELECT * FROM t1;
 -- Check plan
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change to regress_rls_carol
 SET ROLE regress_rls_carol;
 -- Check plan- should be different
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 4) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change back to regress_rls_bob
 SET ROLE regress_rls_bob;
 -- Check plan- should be back to original
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 --
 -- CTE and RLS

--- a/test/expected/rowsecurity-18.out
+++ b/test/expected/rowsecurity-18.out
@@ -1409,7 +1409,8 @@ DROP TABLE dependee CASCADE;
 NOTICE:  drop cascades to policy d1 on table dependent
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM dependent; -- After drop, should be unqualified
 --- QUERY PLAN ---
- Seq Scan on dependent
+ Result
+   One-Time Filter: false
 
 -----   RECURSION    ----
 --
@@ -1512,26 +1513,8 @@ NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b);
 --- QUERY PLAN ---
- Seq Scan on s1
-   Filter: ((ANY (a = (hashed SubPlan 1).col1)) AND f_leak(b))
-   SubPlan 1
-     ->  Append
-           ->  Seq Scan on s2 s2_1
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_27_chunk s2_2
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_28_chunk s2_3
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_29_chunk s2_4
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_30_chunk s2_5
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_31_chunk s2_6
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_32_chunk s2_7
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
-           ->  Seq Scan on _hyper_7_33_chunk s2_8
-                 Filter: (((x % 2) = 0) AND (y ~~ '%2f%'::text))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_alice;
 ALTER POLICY p1 ON s1 USING (a in (select x from v2)); -- using VIEW in RLS policy
@@ -2338,7 +2321,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 PREPARE plancache_test2 AS WITH q AS MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2350,14 +2334,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test4 AS WITH q AS (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2369,14 +2351,12 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test6 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2388,62 +2368,37 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test6;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 PREPARE plancache_test3 AS WITH q AS MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 PREPARE plancache_test5 AS WITH q AS (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 PREPARE plancache_test7 AS WITH q AS NOT MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test7;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group1;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2482,7 +2437,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2494,13 +2450,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2512,43 +2466,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 0) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 0) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 0) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 0) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 0) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 0) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET SESSION AUTHORIZATION regress_rls_carol;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2587,7 +2527,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2599,13 +2540,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2617,43 +2556,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 SET ROLE regress_rls_group2;
 SELECT * FROM z1 WHERE f_leak(b);
@@ -2692,7 +2617,8 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test;
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2704,13 +2630,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test2;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
 --- QUERY PLAN ---
- Nested Loop
+ Result
+   One-Time Filter: false
    CTE q
      ->  Custom Scan (ChunkAppend) on z1
            Chunks excluded during startup: 0
@@ -2722,43 +2646,29 @@ EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test4;
                  Filter: (((a % 2) = 1) AND f_leak(b))
            ->  Seq Scan on _hyper_9_51_chunk z1_4
                  Filter: (((a % 2) = 1) AND f_leak(b))
-   ->  CTE Scan on q
-   ->  Materialize
-         ->  Seq Scan on z2
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test3;
 --- QUERY PLAN ---
  Nested Loop
    CTE q
-     ->  Seq Scan on z2
+     ->  Result
+           One-Time Filter: false
    ->  CTE Scan on q
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+   ->  Custom Scan (ChunkAppend) on z1
+         Chunks excluded during startup: 0
+         ->  Seq Scan on z1 z1_1
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_49_chunk z1_2
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_50_chunk z1_3
+               Filter: (((a % 2) = 1) AND f_leak(b))
+         ->  Seq Scan on _hyper_9_51_chunk z1_4
+               Filter: (((a % 2) = 1) AND f_leak(b))
 
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE plancache_test5;
 --- QUERY PLAN ---
- Nested Loop
-   ->  Seq Scan on z2
-   ->  Materialize
-         ->  Custom Scan (ChunkAppend) on z1
-               Chunks excluded during startup: 0
-               ->  Seq Scan on z1 z1_1
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_49_chunk z1_2
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_50_chunk z1_3
-                     Filter: (((a % 2) = 1) AND f_leak(b))
-               ->  Seq Scan on _hyper_9_51_chunk z1_4
-                     Filter: (((a % 2) = 1) AND f_leak(b))
+ Result
+   One-Time Filter: false
 
 --
 -- Views should follow policy for view owner.
@@ -3331,24 +3241,24 @@ PREPARE role_inval AS SELECT * FROM t1;
 -- Check plan
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change to regress_rls_carol
 SET ROLE regress_rls_carol;
 -- Check plan- should be different
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 4) = 0)
+ Result
+   One-Time Filter: false
 
 -- Change back to regress_rls_bob
 SET ROLE regress_rls_bob;
 -- Check plan- should be back to original
 EXPLAIN (BUFFERS OFF, COSTS OFF) EXECUTE role_inval;
 --- QUERY PLAN ---
- Seq Scan on t1
-   Filter: ((a % 2) = 0)
+ Result
+   One-Time Filter: false
 
 --
 -- CTE and RLS

--- a/tsl/test/expected/jit.out
+++ b/tsl/test/expected/jit.out
@@ -128,7 +128,6 @@ UPDATE jit_test_interval SET temp = temp * 2.3 WHERE id >= 23 and id < 73;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable)
    ->  Update on public.jit_test_interval
-         ->  Index Scan using jit_test_interval_id_idx on public.jit_test_interval
          ->  Result
                Output: (temp * '2.3'::double precision), ctid
                One-Time Filter: false

--- a/tsl/test/expected/jit.out
+++ b/tsl/test/expected/jit.out
@@ -130,6 +130,7 @@ UPDATE jit_test_interval SET temp = temp * 2.3 WHERE id >= 23 and id < 73;
    ->  Update on public.jit_test_interval
          ->  Index Scan using jit_test_interval_id_idx on public.jit_test_interval
          ->  Result
+               Output: (temp * '2.3'::double precision), ctid
                One-Time Filter: false
 
 :PREFIX

--- a/tsl/test/expected/jit.out
+++ b/tsl/test/expected/jit.out
@@ -129,8 +129,8 @@ UPDATE jit_test_interval SET temp = temp * 2.3 WHERE id >= 23 and id < 73;
  Custom Scan (ModifyHypertable)
    ->  Update on public.jit_test_interval
          ->  Index Scan using jit_test_interval_id_idx on public.jit_test_interval
-               Output: (temp * '2.3'::double precision), ctid
-               Index Cond: ((jit_test_interval.id >= 23) AND (jit_test_interval.id < 73))
+         ->  Result
+               One-Time Filter: false
 
 :PREFIX
 SELECT * FROM jit_test_interval ORDER BY id;


### PR DESCRIPTION
It's always empty, so this scan is useless and looks misleading. The common case when all chunks are excluded was already handled, but the cases of SELECT FROM ONLY hypertable or an empty hypertable were not.

Part of https://github.com/timescale/timescaledb/pull/9714

Disable-check: force-changelog-file