### PR TITLE
Test the handling of a PG partitioned table in skip scan planner

### DIFF
--- a/tsl/test/expected/plan_skip_scan_pg_partition.out
+++ b/tsl/test/expected/plan_skip_scan_pg_partition.out
@@ -1,0 +1,34 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- DISTINCT on a regular PostgreSQL partitioned table (not a TimescaleDB
+-- hypertable) must produce a correct plan. The SkipScan upper-paths hook
+-- is invoked for every UPPERREL_DISTINCT, so get_distinct_var has to bail
+-- out when the input rel is not a hypertable child.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE pg_part (a int, b int) PARTITION BY RANGE (a);
+CREATE TABLE pg_part_p1 PARTITION OF pg_part FOR VALUES FROM (0) TO (100);
+CREATE TABLE pg_part_p2 PARTITION OF pg_part FOR VALUES FROM (100) TO (200);
+INSERT INTO pg_part SELECT i % 200, i FROM generate_series(0, 999) i;
+CREATE INDEX ON pg_part_p1 (b);
+CREATE INDEX ON pg_part_p2 (b);
+ANALYZE pg_part;
+SET enable_hashagg = off;
+SET enable_seqscan = off;
+-- A Var from a non-hypertable parent reaches get_distinct_var through the
+-- MergeAppend subpath and is rejected; the resulting plan is plain Unique
+-- over MergeAppend over per-partition Index Only Scan, with no SkipScan.
+EXPLAIN (costs off) SELECT DISTINCT b FROM pg_part ORDER BY b;
+--- QUERY PLAN ---
+ Unique
+   ->  Merge Append
+         Sort Key: pg_part.b
+         ->  Index Only Scan using pg_part_p1_b_idx on pg_part_p1 pg_part_1
+         ->  Index Only Scan using pg_part_p2_b_idx on pg_part_p2 pg_part_2
+
+SELECT count(*) FROM (SELECT DISTINCT b FROM pg_part ORDER BY b) s;
+ count 
+-------
+  1000
+
+DROP TABLE pg_part;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TEST_FILES
     direct_compress_insert.sql
     move.sql
     plan_skip_scan_notnull.sql
+    plan_skip_scan_pg_partition.sql
     policy_generalization.sql
     rebuild_columnstore_tests.sql
     recompression_integrity_tests.sql

--- a/tsl/test/sql/plan_skip_scan_pg_partition.sql
+++ b/tsl/test/sql/plan_skip_scan_pg_partition.sql
@@ -1,0 +1,29 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- DISTINCT on a regular PostgreSQL partitioned table (not a TimescaleDB
+-- hypertable) must produce a correct plan. The SkipScan upper-paths hook
+-- is invoked for every UPPERREL_DISTINCT, so get_distinct_var has to bail
+-- out when the input rel is not a hypertable child.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE TABLE pg_part (a int, b int) PARTITION BY RANGE (a);
+CREATE TABLE pg_part_p1 PARTITION OF pg_part FOR VALUES FROM (0) TO (100);
+CREATE TABLE pg_part_p2 PARTITION OF pg_part FOR VALUES FROM (100) TO (200);
+INSERT INTO pg_part SELECT i % 200, i FROM generate_series(0, 999) i;
+CREATE INDEX ON pg_part_p1 (b);
+CREATE INDEX ON pg_part_p2 (b);
+ANALYZE pg_part;
+
+SET enable_hashagg = off;
+SET enable_seqscan = off;
+
+-- A Var from a non-hypertable parent reaches get_distinct_var through the
+-- MergeAppend subpath and is rejected; the resulting plan is plain Unique
+-- over MergeAppend over per-partition Index Only Scan, with no SkipScan.
+EXPLAIN (costs off) SELECT DISTINCT b FROM pg_part ORDER BY b;
+SELECT count(*) FROM (SELECT DISTINCT b FROM pg_part ORDER BY b) s;
+
+DROP TABLE pg_part;


### PR DESCRIPTION
The skip-scan upper-paths hook fires for every UPPERREL_DISTINCT, even for regular Postgres tables. There's a check for this case already, but it is not triggered by the existing tests according to the line coverage info, so add a small test for this.