### PR TITLE
Remove wrong assertion in first/last initplan optimization

### DIFF
--- a/src/planner/agg_bookend.c
+++ b/src/planner/agg_bookend.c
@@ -723,7 +723,6 @@ build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, Oid eqop, Oi
 		{
 			ListCell *prev = NULL;
 			ListCell *next = list_head(subroot->append_rel_list);
-			Assert(rte->inh);
 			rte->inh = false;
 			/* query planner gets confused when entries in the
 			 * append_rel_list refer to entries in the relarray that
@@ -756,17 +755,6 @@ build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, Oid eqop, Oi
 	}
 
 	final_rel = query_planner(subroot, first_last_qp_callback, NULL);
-
-	/* we need to disable inheritance so the chunks are re-expanded correctly in the subroot */
-	foreach (lc, root->parse->rtable)
-	{
-		RangeTblEntry *rte = lfirst_node(RangeTblEntry, lc);
-
-		if (ts_rte_is_hypertable(rte))
-		{
-			rte->inh = true;
-		}
-	}
 
 	/*
 	 * Since we didn't go through subquery_planner() to handle the subquery,

--- a/test/expected/agg_bookends-15.out
+++ b/test/expected/agg_bookends-15.out
@@ -501,6 +501,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
                ->  Seq Scan on _hyper_1_4_chunk (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 --- QUERY PLAN ---
@@ -940,6 +951,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
   2 | 35.3
   2 | 35.3
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+ first 
+-------
+      
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+ last 
+------
+     
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
  first 
@@ -1132,6 +1154,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization
@@ -1252,6 +1277,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization

--- a/test/expected/agg_bookends-16.out
+++ b/test/expected/agg_bookends-16.out
@@ -501,6 +501,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
                ->  Seq Scan on _hyper_1_4_chunk (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 --- QUERY PLAN ---
@@ -940,6 +951,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
   2 | 35.3
   2 | 35.3
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+ first 
+-------
+      
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+ last 
+------
+     
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
  first 
@@ -1132,6 +1154,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization
@@ -1252,6 +1277,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization

--- a/test/expected/agg_bookends-17.out
+++ b/test/expected/agg_bookends-17.out
@@ -461,6 +461,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
                ->  Seq Scan on _hyper_1_4_chunk (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 --- QUERY PLAN ---
@@ -890,6 +901,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
   2 | 35.3
   2 | 35.3
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+ first 
+-------
+      
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+ last 
+------
+     
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
  first 
@@ -1082,6 +1104,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization
@@ -1202,6 +1227,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization

--- a/test/expected/agg_bookends-18.out
+++ b/test/expected/agg_bookends-18.out
@@ -461,6 +461,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
                ->  Seq Scan on _hyper_1_4_chunk (actual rows=1.00 loops=1)
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+--- QUERY PLAN ---
+ Aggregate (actual rows=1.00 loops=1)
+   ->  Seq Scan on btest (actual rows=0.00 loops=1)
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 --- QUERY PLAN ---
@@ -890,6 +901,17 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
   2 | 35.3
   2 | 35.3
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+ first 
+-------
+      
+
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+ last 
+------
+     
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
  first 
@@ -1082,6 +1104,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization
@@ -1202,6 +1227,9 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 :PREFIX SELECT first(temp, time) FROM btest WHERE time >= '2017-01-20 09:00:47';
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 -- create an index so we can test optimization

--- a/test/sql/include/agg_bookends_query.sql
+++ b/test/sql/include/agg_bookends_query.sql
@@ -103,6 +103,10 @@ INSERT INTO btest_numeric VALUES('2020-01-20T09:00:43', 30.5);
 -- can't do index scan when using WINDOW function
 :PREFIX SELECT gp, last(temp, time) OVER (PARTITION BY gp) AS last FROM btest;
 
+-- parent-only scan
+:PREFIX SELECT first(temp, time) FROM ONLY btest;
+:PREFIX SELECT last(temp, time) FROM ONLY btest;
+
 -- test constants
 :PREFIX SELECT first(100, 100) FROM btest;
 


### PR DESCRIPTION
It did not correctly handle the case of SELECT FROM ONLY hypertable.

Besides that, the code that restored RangeTblEntry.inh was targeting the wrong PlannerInfo -- the one from original query instead of the copy used for the optimization. Remove this code as well, since it doesn't do anything useful.

Part of https://github.com/timescale/timescaledb/pull/9714

Disable-check: force-changelog-file