### PR TITLE
Don't rewrite pathkeys on compressed sub-paths

### DIFF
--- a/.unreleased/pr_9697
+++ b/.unreleased/pr_9697
@@ -1,0 +1,1 @@
+Implements: #9697 Improve pathkey handling for compressed sub-paths during sort transformation

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -282,7 +282,6 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.create_upper_paths_hook = NULL,
 	.set_rel_pathlist_dml = NULL,
 	.set_rel_pathlist_query = NULL,
-	.sort_transform_replace_pathkeys = NULL,
 	.process_altertable_cmd = NULL,
 	.process_rename_cmd = NULL,
 

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -76,8 +76,6 @@ typedef struct CrossModuleFunctions
 	void (*set_rel_pathlist_dml)(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
 	void (*set_rel_pathlist_query)(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *,
 								   Hypertable *);
-	void (*sort_transform_replace_pathkeys)(void *path, List *transformed_pathkeys,
-											List *original_pathkeys);
 
 	/* gapfill */
 	PGFunction gapfill_marker;

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -604,18 +604,11 @@ ts_sort_transform_replace_pathkeys(void *node, List *transformed_pathkeys, List 
 
 	if (IsA(path, CustomPath))
 	{
-		CustomPath *custom = castNode(CustomPath, path);
-		ts_sort_transform_replace_pathkeys(custom->custom_paths,
-										   transformed_pathkeys,
-										   original_pathkeys);
-
-		/* Need to handle tsl-specific custom path types */
-		if (ts_cm_functions->sort_transform_replace_pathkeys != NULL)
-		{
-			ts_cm_functions->sort_transform_replace_pathkeys(path,
-															 transformed_pathkeys,
-															 original_pathkeys);
-		}
+		/*
+		 * Don't recurse. The only CustomPath at this level is
+		 * ColumnarScan. Upper plan nodes only see ColumnarScan's own
+		 * pathkeys, which the top-level swap above already handles.
+		 */
 	}
 	else if (IsA(path, MergeAppendPath))
 	{

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -72,7 +72,6 @@ CrossModuleFunctions tsl_cm_functions = {
 	.create_upper_paths_hook = tsl_create_upper_paths_hook,
 	.set_rel_pathlist_dml = tsl_set_rel_pathlist_dml,
 	.set_rel_pathlist_query = tsl_set_rel_pathlist_query,
-	.sort_transform_replace_pathkeys = tsl_sort_transform_replace_pathkeys,
 
 	/* bgw policies */
 	.policy_compression_add = policy_compression_add,

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -281,32 +281,6 @@ tsl_preprocess_query(Query *parse, int *cursor_opts)
 }
 
 /*
- * Replaces pathkeys in tsl-specific custom path types during sort transformation.
- *
- * This hook is called from ts_sort_transform_replace_pathkeys() in sort_transform.c
- * after the basic pathkey replacement has been performed. It handles tsl-specific
- * path types (such as ColumnarScan) that contain additional pathkey fields beyond
- * the standard path.pathkeys field.
- */
-void
-tsl_sort_transform_replace_pathkeys(void *path, List *transformed_pathkeys, List *original_pathkeys)
-{
-	if (!path)
-	{
-		return;
-	}
-	if (ts_is_columnar_scan_path(path))
-	{
-		ColumnarScanPath *dcpath = (ColumnarScanPath *) path;
-		if (compare_pathkeys(dcpath->required_compressed_pathkeys, transformed_pathkeys) ==
-			PATHKEYS_EQUAL)
-		{
-			dcpath->required_compressed_pathkeys = original_pathkeys;
-		}
-	}
-}
-
-/*
  * Run plan postprocessing optimizations.
  */
 void

--- a/tsl/src/planner.h
+++ b/tsl/src/planner.h
@@ -15,7 +15,5 @@ void tsl_create_upper_paths_hook(PlannerInfo *, UpperRelationKind, RelOptInfo *,
 								 TsRelType, Hypertable *, void *);
 void tsl_set_rel_pathlist_query(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
 void tsl_set_rel_pathlist_dml(PlannerInfo *, RelOptInfo *, Index, RangeTblEntry *, Hypertable *);
-void tsl_sort_transform_replace_pathkeys(void *path, List *transformed_pathkeys,
-										 List *original_pathkeys);
 void tsl_preprocess_query(Query *parse, int *cursor_opts);
 void tsl_postprocess_plan(PlannedStmt *stmt);

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -613,3 +613,39 @@ select * from booltab where flag = (ts = 99);
    ->  Seq Scan on compress_hyper_14_15_chunk (actual rows=2.00 loops=1)
 
 drop table booltab;
+-- Regression: GROUP BY time_bucket() with a filter on the bucket expression
+-- must not error when compress_segmentby is the time column. Previously
+-- failed with: could not find pathkey item to sort.
+SET TIME ZONE 'UTC';
+CREATE TABLE pathkey_segby_time(time timestamptz NOT NULL, value float);
+SELECT FROM create_hypertable('pathkey_segby_time', 'time', chunk_time_interval => interval '1 day');
+--
+
+INSERT INTO pathkey_segby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i || ' hour')::interval, i::float
+FROM generate_series(0, 47) i;
+ALTER TABLE pathkey_segby_time SET (timescaledb.compress, timescaledb.compress_segmentby = 'time');
+SELECT count(compress_chunk(c)) FROM show_chunks('pathkey_segby_time') c;
+ count 
+-------
+     2
+
+SELECT time_bucket('6 hours', time) AS bucket, avg(value)
+FROM pathkey_segby_time
+GROUP BY 1
+HAVING time_bucket('6 hours', time) >= '2025-01-01 00:00:00+00'
+   AND time_bucket('6 hours', time) <  '2025-01-03 00:00:00+00'
+ORDER BY 1;
+            bucket            | avg  
+------------------------------+------
+ Wed Jan 01 00:00:00 2025 UTC |  2.5
+ Wed Jan 01 06:00:00 2025 UTC |  8.5
+ Wed Jan 01 12:00:00 2025 UTC | 14.5
+ Wed Jan 01 18:00:00 2025 UTC | 20.5
+ Thu Jan 02 00:00:00 2025 UTC | 26.5
+ Thu Jan 02 06:00:00 2025 UTC | 32.5
+ Thu Jan 02 12:00:00 2025 UTC | 38.5
+ Thu Jan 02 18:00:00 2025 UTC | 44.5
+
+DROP TABLE pathkey_segby_time;
+RESET TIME ZONE;

--- a/tsl/test/sql/compression_qualpushdown.sql
+++ b/tsl/test/sql/compression_qualpushdown.sql
@@ -269,3 +269,25 @@ explain (analyze, buffers off, costs off, timing off, summary off)
 select * from booltab where flag = (ts = 99);
 
 drop table booltab;
+
+-- Regression: GROUP BY time_bucket() with a filter on the bucket expression
+-- must not error when compress_segmentby is the time column. Previously
+-- failed with: could not find pathkey item to sort.
+SET TIME ZONE 'UTC';
+CREATE TABLE pathkey_segby_time(time timestamptz NOT NULL, value float);
+SELECT FROM create_hypertable('pathkey_segby_time', 'time', chunk_time_interval => interval '1 day');
+INSERT INTO pathkey_segby_time
+SELECT '2025-01-01 00:00:00+00'::timestamptz + (i || ' hour')::interval, i::float
+FROM generate_series(0, 47) i;
+ALTER TABLE pathkey_segby_time SET (timescaledb.compress, timescaledb.compress_segmentby = 'time');
+SELECT count(compress_chunk(c)) FROM show_chunks('pathkey_segby_time') c;
+
+SELECT time_bucket('6 hours', time) AS bucket, avg(value)
+FROM pathkey_segby_time
+GROUP BY 1
+HAVING time_bucket('6 hours', time) >= '2025-01-01 00:00:00+00'
+   AND time_bucket('6 hours', time) <  '2025-01-03 00:00:00+00'
+ORDER BY 1;
+
+DROP TABLE pathkey_segby_time;
+RESET TIME ZONE;


### PR DESCRIPTION
Sort transform lets the planner pick a different sort order for path generation, then rewrites the pathkeys back when it's done.

The only CustomPath at this level is ColumnarScan. Upper plan nodes see ColumnarScan's own pathkeys, which the top-level rewrite already handles. Skip the recursion into its compressed sub-path.

Cherry-picked from f8fc88ade1