### PR TITLE
Propagate consider_startup flag to compressed chunk table

### DIFF
--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -325,7 +325,9 @@ ts_debug_point_raise_error_oneshot(const char *name)
 		case LOCKACQUIRE_OK:
 			LockRelease(&point.tag, ShareLock, true);
 			if (LockHeldByMeCompat(&point.tag, ExclusiveLock, false))
+			{
 				break;
+			}
 			return;
 		case LOCKACQUIRE_ALREADY_HELD:
 		case LOCKACQUIRE_ALREADY_CLEAR:

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -1185,7 +1185,7 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 	 *
 	 * First, check if this query is candidate for SELECT DISTINCT SkipScan.
 	 */
-	const bool potential_select_distinct = list_length(root->distinct_pathkeys) == 1;
+	const bool potential_select_distinct = list_length(root->distinct_pathkeys) >= 1;
 
 	/* Next, candidate for DISTINCT aggregate SkipScan */
 	const bool potential_distinct_aggregate =

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -1175,6 +1175,27 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 	chunk_rel->pathlist = NIL;
 	chunk_rel->partial_pathlist = NIL;
 
+	/*
+	 * We want to consider startup costs so that IndexScan is preferred to
+	 * sorted SeqScan when we may have a chance to use SkipScan. We consider
+	 * startup costs for LIMIT queries, and SkipScan is basically a
+	 * "LIMIT 1" query run "ndistinct" times. At this point we don't have
+	 * all information to check if SkipScan can be used, but we can narrow
+	 * it down.
+	 *
+	 * First, check if this query is candidate for SELECT DISTINCT SkipScan.
+	 */
+	const bool potential_select_distinct = list_length(root->distinct_pathkeys) == 1;
+
+	/* Next, candidate for DISTINCT aggregate SkipScan */
+	const bool potential_distinct_aggregate =
+		root->numOrderedAggs >= 1 && list_length(root->group_pathkeys) == 1;
+
+	if (potential_select_distinct || potential_distinct_aggregate)
+	{
+		chunk_rel->consider_startup = true;
+	}
+
 	/* add RangeTblEntry and RelOptInfo for compressed chunk */
 	columnar_scan_add_plannerinfo(root,
 								  compression_info,
@@ -1192,8 +1213,6 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 	}
 
 	RelOptInfo *compressed_rel = compression_info->compressed_rel;
-
-	compressed_rel->consider_parallel = chunk_rel->consider_parallel;
 
 	/* translate chunk_rel->baserestrictinfo */
 	if (ts_guc_enable_columnar_scan_filter_pushdown)
@@ -1266,25 +1285,6 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 																   uncompressed_table_pathlist,
 																   &sort_info,
 																   compression_info);
-
-		/*
-		 * We want to consider startup costs so that IndexScan is preferred to
-		 * sorted SeqScan when we may have a chance to use SkipScan. We consider
-		 * startup costs for LIMIT queries, and SkipScan is basically a
-		 * "LIMIT 1" query run "ndistinct" times. At this point we don't have
-		 * all information to check if SkipScan can be used, but we can narrow
-		 * it down.
-		 */
-		if (!chunk_rel->consider_startup && IsA(compressed_path, IndexPath))
-		{
-			/* Candidate for SELECT DISTINCT SkipScan */
-			if (list_length(root->distinct_pathkeys) == 1
-				/* Candidate for DISTINCT aggregate SkipScan */
-				|| (root->numOrderedAggs >= 1 && list_length(root->group_pathkeys) == 1))
-			{
-				chunk_rel->consider_startup = true;
-			}
-		}
 
 		/*
 		 * Add the paths to the chunk relation.
@@ -2403,6 +2403,9 @@ columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Ch
 	compressed_rel_setup_equivalence_classes(root, info);
 	/* translate chunk_rel->joininfo for compressed_rel */
 	compressed_rel_setup_joininfo(compressed_rel, info);
+
+	compressed_rel->consider_parallel = chunk_rel->consider_parallel;
+	compressed_rel->consider_startup = chunk_rel->consider_startup;
 
 	/*
 	 * Force parallel plan creation, see compute_parallel_worker().

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -2878,6 +2878,10 @@ psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hype
 psql:include/skip_scan_multi_query.sql:44: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(region NOT NULL, dev NOT NULL)
 -- RowCompareExpr
 :PREFIX SELECT DISTINCT ON (status, dev) * FROM :TABLE WHERE region = 'reg_1' and (status, dev) > (1,2);
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_73_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_74_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_75_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
+psql:include/skip_scan_multi_query.sql:47: INFO:  SkipScan used on compress_hyper_9_76_chunk_status_region_dev_dev_name__ts_me_idx(status NOT NULL, dev NOT NULL)
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev > NULL and status > NULL and region > NULL;
 -- no tuples matching


### PR DESCRIPTION
It seems at the moment it's just not set, which might lead to suboptimal plan choice.

We also have an heuristic to trigger it for queries that might need SkipScan, so move this to happen earlier. Also update it to work for multicolumn DISTINCT.

The flag propagation itself doesn't influence anything at the moment, because the Index paths are still kept based on pathkeys. But logically it's more correct.

Disable-check: force-changelog-file