### PR TITLE
Reset error context in debug injection points

### DIFF
--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -304,7 +304,7 @@ ts_debug_point_raise_error_if_enabled(const char *name)
 	/*
 	 * Drop error context, so that the error description doesn't inherit details
 	 * from the surrounding context (i.e. parse location).
-     */
+	 */
 	error_context_stack = NULL;
 
 	ereport(ERROR,
@@ -331,7 +331,9 @@ ts_debug_point_raise_error_oneshot(const char *name)
 		case LOCKACQUIRE_OK:
 			LockRelease(&point.tag, ShareLock, true);
 			if (LockHeldByMeCompat(&point.tag, ExclusiveLock, false))
+			{
 				break;
+			}
 			return;
 		case LOCKACQUIRE_ALREADY_HELD:
 		case LOCKACQUIRE_ALREADY_CLEAR:
@@ -346,7 +348,7 @@ ts_debug_point_raise_error_oneshot(const char *name)
 	/*
 	 * Drop error context, so that the error description doesn't inherit details
 	 * from the surrounding context (i.e. parse location).
-     */
+	 */
 	error_context_stack = NULL;
 
 	ereport(ERROR,

--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -301,6 +301,12 @@ ts_debug_point_raise_error_if_enabled(const char *name)
 			break;
 	}
 
+	/*
+	 * Drop error context, so that the error description doesn't inherit details
+	 * from the surrounding context (i.e. parse location).
+     */
+	error_context_stack = NULL;
+
 	ereport(ERROR,
 			(errcode(ERRCODE_TRIGGERED_ACTION_EXCEPTION),
 			 errmsg("error injected at debug point '%s'", point.name)));
@@ -336,6 +342,13 @@ ts_debug_point_raise_error_oneshot(const char *name)
 	}
 
 	debug_point_release(&point);
+
+	/*
+	 * Drop error context, so that the error description doesn't inherit details
+	 * from the surrounding context (i.e. parse location).
+     */
+	error_context_stack = NULL;
+
 	ereport(ERROR,
 			(errcode(ERRCODE_TRIGGERED_ACTION_EXCEPTION),
 			 errmsg("error injected at debug point '%s'", point.name)));


### PR DESCRIPTION
Otherwise it can inherit error details from the current error context, like location information during parsing. This leads to flaky error messages.


Example failure: https://github.com/timescale/timescaledb/actions/runs/25549661386/job/74994278605?pr=9125

Disable-check: force-changelog-file