### PR TITLE
Use a fixed call string for the telemetry job in TSS recording

### DIFF
--- a/.unreleased/pr_9744
+++ b/.unreleased/pr_9744
@@ -1,0 +1,1 @@
+Fixes: #9744 Use a fixed call string for the telemetry job in ts_stat_statements recording

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1267,7 +1267,20 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 
 	if (!job_failed && ts_is_tss_enabled() && scheduler_test_hook == NULL)
 	{
-		const char *stmt = ts_bgw_job_function_call_string(job);
+		const char *stmt;
+#ifdef USE_TELEMETRY
+		/*
+		 * The telemetry job has no real procedure backing its
+		 * proc_schema/proc_name pair, so looking up its funcid would fail.
+		 * Use a fixed synthetic call string instead.
+		 */
+		if (ts_is_telemetry_job(job))
+		{
+			stmt = "CALL _timescaledb_functions.policy_telemetry()";
+		}
+		else
+#endif
+			stmt = ts_bgw_job_function_call_string(job);
 		ts_end_tss_store_callback(stmt, -1, (int) strlen(stmt), 0, 0);
 	}
 


### PR DESCRIPTION
The bgw entrypoint records the executed job's call string via the
ts_stat_statements hook after a successful run. The telemetry job has
no real procedure behind its proc_schema/proc_name pair, so the lookup
failed with "function or procedure ... does not exist" whenever
ts_stat_statements was active. Use a fixed synthetic call string for
the telemetry job instead.
