### PR TITLE
Check constrainsts when adding unique constraints to chunks

### DIFF
--- a/.unreleased/pr_9745
+++ b/.unreleased/pr_9745
@@ -1,0 +1,1 @@
+Fixes: #9745 Check constrainsts when adding unique constraints to chunks

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3693,19 +3693,48 @@ process_index_start(ProcessUtilityArgs *args)
 		if (cagg)
 		{
 			ht = ts_hypertable_get_by_id(cagg->data.mat_hypertable_id);
+
+			if (stmt->unique)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("continuous aggregates do not support UNIQUE indexes")));
+			}
+		}
+
+		if (stmt->unique || stmt->primary)
+		{
+			/*
+			 * When building a unique index on a chunk, there may be compressed data
+			 * present on the chunk that would not be considered by postgres validity
+			 * check. We need to check for constraint violations ourselves in those
+			 * cases.
+			 */
+			Oid relid = RangeVarGetRelid(stmt->relation, NoLock, true);
+
+			if (OidIsValid(relid))
+			{
+				Chunk *chunk = ts_chunk_get_by_relid(relid, false);
+
+				if (chunk && ts_chunk_is_compressed(chunk))
+				{
+					/*
+					 * Expression index elements are still raw parse trees at that point
+					 * and cannot be passed to deparse_expression directly, so run the
+					 * standard PostgreSQL transformation first.
+					 */
+					Relation rel = table_open(chunk->table_id, AccessShareLock);
+					IndexStmt *transformed = transformIndexStmt(chunk->table_id, stmt, NULL);
+					table_close(rel, NoLock);
+					validate_index_constraints(chunk, transformed);
+				}
+			}
 		}
 
 		if (!ht)
 		{
 			ts_cache_release(&hcache);
 			return DDL_CONTINUE;
-		}
-
-		if (stmt->unique)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("continuous aggregates do not support UNIQUE indexes")));
 		}
 
 		/* Make the RangeVar for the underlying materialization hypertable */

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -856,5 +856,47 @@ SELECT show_chunks('osm_table');
  show_chunks 
 -------------
 
+\set ON_ERROR_STOP 0
 SELECT compress_chunk(:'CHUNK_NAME');
 ERROR:  compress_chunk not permitted on tiered chunk "_hyper_44_31_chunk" 
+\set ON_ERROR_STOP 1
+-- #9720 CREATE UNIQUE INDEX directly on a compressed chunk must reject
+-- duplicates that already live on the compressed side.
+CREATE TABLE i9720(device_id int NOT NULL, ts timestamptz NOT NULL, v float8);
+SELECT create_hypertable('i9720', 'ts');
+  create_hypertable  
+---------------------
+ (46,public,i9720,t)
+
+ALTER TABLE i9720 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
+INSERT INTO i9720 VALUES (1, '2026-01-01', 1.0), (1, '2026-01-01', 2.0);
+SELECT compress_chunk(show_chunks('i9720'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_46_32_chunk
+
+SELECT format('%I.%I', chunk_schema, chunk_name) AS "CHUNK"
+FROM timescaledb_information.chunks WHERE hypertable_name = 'i9720' \gset
+\set ON_ERROR_STOP 0
+-- duplicates on the compressed side: must be rejected
+CREATE UNIQUE INDEX dup_idx ON :CHUNK (device_id, ts);
+ERROR:  duplicate key value violates unique constraint
+CREATE UNIQUE INDEX CONCURRENTLY dup_idx_c ON :CHUNK (device_id, ts);
+ERROR:  duplicate key value violates unique constraint
+CREATE UNIQUE INDEX dup_idx ON :CHUNK ((device_id + 1), ts);
+ERROR:  duplicate key value violates unique constraint
+CREATE UNIQUE INDEX CONCURRENTLY dup_idx_c ON :CHUNK ((device_id + 1), ts);
+ERROR:  duplicate key value violates unique constraint
+\set ON_ERROR_STOP 1
+-- non-unique index is unaffected
+CREATE INDEX nonunique_idx ON :CHUNK (device_id);
+DROP INDEX _timescaledb_internal.nonunique_idx;
+-- after removing the duplicate, the unique index should succeed
+DELETE FROM i9720 WHERE v = 2.0;
+CREATE UNIQUE INDEX ok_idx ON :CHUNK (device_id, ts);
+SELECT indisunique FROM pg_index WHERE indexrelid::regclass::text LIKE '%ok_idx';
+ indisunique 
+-------------
+ t
+
+DROP TABLE i9720;

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -546,5 +546,36 @@ UPDATE _timescaledb_catalog.chunk ch SET osm_chunk = true FROM _timescaledb_cata
 
 -- show_chunks should not show any OSM chunks
 SELECT show_chunks('osm_table');
+\set ON_ERROR_STOP 0
 SELECT compress_chunk(:'CHUNK_NAME');
+\set ON_ERROR_STOP 1
+
+-- #9720 CREATE UNIQUE INDEX directly on a compressed chunk must reject
+-- duplicates that already live on the compressed side.
+CREATE TABLE i9720(device_id int NOT NULL, ts timestamptz NOT NULL, v float8);
+SELECT create_hypertable('i9720', 'ts');
+ALTER TABLE i9720 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
+INSERT INTO i9720 VALUES (1, '2026-01-01', 1.0), (1, '2026-01-01', 2.0);
+SELECT compress_chunk(show_chunks('i9720'));
+
+SELECT format('%I.%I', chunk_schema, chunk_name) AS "CHUNK"
+FROM timescaledb_information.chunks WHERE hypertable_name = 'i9720' \gset
+
+\set ON_ERROR_STOP 0
+-- duplicates on the compressed side: must be rejected
+CREATE UNIQUE INDEX dup_idx ON :CHUNK (device_id, ts);
+CREATE UNIQUE INDEX CONCURRENTLY dup_idx_c ON :CHUNK (device_id, ts);
+CREATE UNIQUE INDEX dup_idx ON :CHUNK ((device_id + 1), ts);
+CREATE UNIQUE INDEX CONCURRENTLY dup_idx_c ON :CHUNK ((device_id + 1), ts);
+\set ON_ERROR_STOP 1
+
+-- non-unique index is unaffected
+CREATE INDEX nonunique_idx ON :CHUNK (device_id);
+DROP INDEX _timescaledb_internal.nonunique_idx;
+
+-- after removing the duplicate, the unique index should succeed
+DELETE FROM i9720 WHERE v = 2.0;
+CREATE UNIQUE INDEX ok_idx ON :CHUNK (device_id, ts);
+SELECT indisunique FROM pg_index WHERE indexrelid::regclass::text LIKE '%ok_idx';
+DROP TABLE i9720;
 


### PR DESCRIPTION
CREATE UNIQUE INDEX run directly on a compressed chunk would succeed
even when the compressed data contained duplicate keys, because
postgres own validity check would only include uncompressed data.
Run our own validity check that includes compressed/uncompressed
tuple when adding unique constraints to chunks with compressed
data.

Fixes: #9720