### PR TITLE
Remove orphaned function declarations

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -102,7 +102,6 @@ extern TSDLLEXPORT void ts_bgw_job_validate_schedule_interval(Interval *schedule
 extern TSDLLEXPORT char *ts_bgw_job_validate_timezone(Datum timezone);
 
 extern TSDLLEXPORT bool ts_is_telemetry_job(BgwJob *job);
-ScanTupleResult ts_bgw_job_change_owner(TupleInfo *ti, void *data);
 
 extern TSDLLEXPORT Oid ts_bgw_job_get_funcid(BgwJob *job);
 extern TSDLLEXPORT const char *ts_bgw_job_function_call_string(BgwJob *job);

--- a/src/import/planner.h
+++ b/src/import/planner.h
@@ -52,8 +52,6 @@ extern TSDLLEXPORT List *ts_build_path_tlist(PlannerInfo *root, Path *path);
 
 extern TSDLLEXPORT Node *ts_replace_nestloop_params(PlannerInfo *root, Node *expr);
 
-extern void ts_ExecSetTupleBound(int64 tuples_needed, PlanState *child_node);
-
 #if PG18_GE
 /* In PG18, child ems are not added to ec_members
  * but need to be maintained in separate Lists.

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -9,7 +9,6 @@
 
 #include <chunk.h>
 
-extern Datum chunk_status(PG_FUNCTION_ARGS);
 extern Datum chunk_show(PG_FUNCTION_ARGS);
 extern Datum chunk_create(PG_FUNCTION_ARGS);
 extern Datum chunk_detach(PG_FUNCTION_ARGS);

--- a/tsl/src/compression/algorithms/array.h
+++ b/tsl/src/compression/algorithms/array.h
@@ -36,7 +36,6 @@ extern void array_compressor_append_null(ArrayCompressor *compressor);
 extern void array_compressor_append(ArrayCompressor *compressor, Datum val);
 extern void *array_compressor_finish(ArrayCompressor *compressor);
 
-extern ArrayDecompressionIterator *array_decompression_iterator_alloc(void);
 extern DecompressionIterator *
 tsl_array_decompression_iterator_from_datum_forward(Datum compressed_array, Oid element_type);
 extern DecompressResult array_decompression_iterator_try_next_forward(DecompressionIterator *iter);

--- a/tsl/src/process_utility.h
+++ b/tsl/src/process_utility.h
@@ -10,5 +10,3 @@
 
 extern void tsl_process_altertable_cmd(Hypertable *ht, const AlterTableCmd *cmd);
 extern void tsl_process_rename_cmd(Oid relid, Cache *hcache, const RenameStmt *stmt);
-extern DDLResult tsl_ddl_command_start(ProcessUtilityArgs *args);
-extern void tsl_ddl_command_end(EventTriggerData *command);


### PR DESCRIPTION
These header declarations had no implementation and no callers
anywhere in the source tree:

- ts_bgw_job_change_owner (src/bgw/job.h)
- ts_ExecSetTupleBound (src/import/planner.h)
- chunk_status (tsl/src/chunk_api.h)
- array_decompression_iterator_alloc (tsl/src/compression/algorithms/array.h)
- tsl_ddl_command_start (tsl/src/process_utility.h)
- tsl_ddl_command_end (tsl/src/process_utility.h)

Disable-check: force-changelog-file