### PR TITLE
Remove libpq build dependency

### DIFF
--- a/tsl/src/CMakeLists.txt
+++ b/tsl/src/CMakeLists.txt
@@ -35,12 +35,6 @@ target_include_directories(${TSL_LIBRARY_NAME} PRIVATE ${PG_INCLUDEDIR})
 target_compile_definitions(${TSL_LIBRARY_NAME} PUBLIC TS_TSL)
 target_compile_definitions(${TSL_LIBRARY_NAME} PUBLIC TS_SUBMODULE)
 
-if(WIN32)
-  target_link_libraries(${TSL_LIBRARY_NAME} ${PG_LIBDIR}/libpq.lib)
-else()
-  target_link_libraries(${TSL_LIBRARY_NAME} pq)
-endif()
-
 install(TARGETS ${TSL_LIBRARY_NAME} DESTINATION ${PG_PKGLIBDIR})
 
 # if (WIN32) target_link_libraries(${PROJECT_NAME}

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -17,7 +17,6 @@
 #include <commands/event_trigger.h>
 #include <commands/tablecmds.h>
 #include <commands/trigger.h>
-#include <libpq-fe.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
 #include <nodes/parsenodes.h>


### PR DESCRIPTION
The TSL library was linked against libpq, but no client library
functions were used. The only remaining reference was a stale
include of libpq-fe.h in compression/api.c. Drop both so the
build no longer requires libpq.

Disable-check: force-changelog-file