### PR TITLE
Fixing composite bloom filter column naming

### DIFF
--- a/.unreleased/pr_9743
+++ b/.unreleased/pr_9743
@@ -1,0 +1,2 @@
+Fixes: #9743 Fixes the composite bloom metadata column naming scheme
+Thanks: @pavanmanishd for the first version of the fix

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -269,7 +269,6 @@ init_upsert_bloom_state(ChunkInsertState *cis)
 
 		/* Verify bloom column exists in the compressed chunk */
 		AttrNumber compressed_attnum = get_attnum(compressed_relid, col_name);
-		Assert(AttributeNumberIsValid(compressed_attnum));
 		if (!AttributeNumberIsValid(compressed_attnum))
 		{
 			continue;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -174,8 +174,10 @@ compressed_column_metadata_name_v2(const char *metadata_type, const char **colum
 	Assert(num_columns <= MAX_BLOOM_FILTER_COLUMNS);
 
 	int len = 0;
-	StringInfoData buf = { 0 };
+	/* Use a separate buffer for the hash computation */
+	StringInfoData buf = { 0 }, hash_buf = { 0 };
 	initStringInfo(&buf);
+	initStringInfo(&hash_buf);
 
 	for (int i = 0; i < num_columns; i++)
 	{
@@ -187,8 +189,12 @@ compressed_column_metadata_name_v2(const char *metadata_type, const char **colum
 		if (i > 0)
 		{
 			appendStringInfoChar(&buf, '_');
+			/* The separator for hash purposes needs to be something
+			 * that is not valid in Postgres, hence the zero byte */
+			appendStringInfoChar(&hash_buf, '\0');
 		}
 		appendStringInfo(&buf, "%s", column_names[i]);
+		appendBinaryStringInfo(&hash_buf, column_names[i], strlen(column_names[i]));
 	}
 
 	len = buf.len;
@@ -197,14 +203,16 @@ compressed_column_metadata_name_v2(const char *metadata_type, const char **colum
 	 * We have to fit the name into NAMEDATALEN - 1 which is 63 bytes:
 	 * 12 (_ts_meta_v2_) + 6 (metadata_type) + [1 (_) + x (column_name)]x num_columns  + 1 (_) + 4
 	 * (hash) = 63; x = 63 - 24 = 39.
+	 *
+	 * Fix for bug #9578: we need to differentiate between ('a_b', 'c') and ('a', 'b_c') composite
+	 * column names, for this reason we always go through the hash path for composite column names.
 	 */
-
 	char *result;
-	if (len > 39)
+	if (len > 39 || num_columns > 1)
 	{
 		const char *errstr = NULL;
 		char hash[33];
-		Ensure(pg_md5_hash(buf.data, len, hash, &errstr), "md5 computation failure");
+		Ensure(pg_md5_hash(hash_buf.data, hash_buf.len, hash, &errstr), "md5 computation failure");
 		result = psprintf("_ts_meta_v2_%.6s_%.4s_%.39s", metadata_type, hash, buf.data);
 	}
 	else

--- a/tsl/test/expected/compress_bloom_dml.out
+++ b/tsl/test/expected/compress_bloom_dml.out
@@ -31,7 +31,7 @@ select * from dml_test where foo = 1001 and boo = 1002;
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
    Vectorized Filter: ((foo = 1001) AND (boo = 1002))
    ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_boo_foo, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_boo, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_701f_boo_foo, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_boo, TEST-HASHES::bigint[]))
          Rows Removed by Filter: 50
 
 SET timescaledb.enable_dml_bloom_filter = off;

--- a/tsl/test/expected/compress_compbloom_basics.out
+++ b/tsl/test/expected/compress_compbloom_basics.out
@@ -41,23 +41,23 @@ select min(big1), max(big2) from sparse where value < 100 and value > 10;
   11 |  99
 
 select relname,attname from metacols order by 1,2;
-         relname          |              attname               
---------------------------+------------------------------------
+         relname          |                 attname                 
+--------------------------+-----------------------------------------
  compress_hyper_2_2_chunk | _ts_meta_count
  compress_hyper_2_2_chunk | _ts_meta_max_1
  compress_hyper_2_2_chunk | _ts_meta_max_2
  compress_hyper_2_2_chunk | _ts_meta_min_1
  compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_27f1_big1_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_4328_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_5c7a_value_big1_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_9774_o_big2
  compress_hyper_2_2_chunk | regress-test-bloom_big1
- compress_hyper_2_2_chunk | regress-test-bloom_big1_big2
  compress_hyper_2_2_chunk | regress-test-bloom_big2
- compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
- compress_hyper_2_2_chunk | regress-test-bloom_num_hello
- compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
- compress_hyper_2_2_chunk | regress-test-bloom_o_big2
- compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_2_2_chunk | regress-test-bloom_value
- compress_hyper_2_2_chunk | regress-test-bloom_value_big1_big2
 
 select index from settings where relid = (select oid from pg_class where relname = 'sparse') and index is not null group by 1 order by 1;
                                                                                                                                                                                                                                                                                                                                                                                             index                                                                                                                                                                                                                                                                                                                                                                                            
@@ -82,21 +82,21 @@ explain (buffers off, costs off) select * from sparse where o = 1 and big2 = 1;
    Vectorized Filter: ((o = 1) AND (big2 = 1))
    ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]))
 
 explain (buffers off, costs off) select * from sparse where num = 1 and hello = md5('1')::bytea;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Filter: ((num = '1'::numeric) AND (hello = '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_num_hello, TEST-HASHES::bigint[])
+         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_c250_num_hello, TEST-HASHES::bigint[])
 
 explain (buffers off, costs off) select * from sparse where small1 = 1 and small2 = 1;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Vectorized Filter: ((small1 = 1) AND (small2 = 1))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_small1_small2, TEST-HASHES::bigint[])
+         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_cab4_small1_small2, TEST-HASHES::bigint[])
 
 explain (buffers off, costs off) select * from sparse where num = 1 and nowts = now()::timestamptz;
 --- QUERY PLAN ---
@@ -106,7 +106,7 @@ explain (buffers off, costs off) select * from sparse where num = 1 and nowts = 
          Filter: (num = '1'::numeric)
          Vectorized Filter: (nowts = now())
          ->  Seq Scan on compress_hyper_2_2_chunk
-               Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_num_nowts, TEST-HASHES::bigint[])
+               Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_4328_num_nowts, TEST-HASHES::bigint[])
 
 explain (buffers off, costs off) select * from sparse where o in (1,2) and big2 = 1;
 --- QUERY PLAN ---
@@ -156,7 +156,7 @@ explain (buffers off, costs off) select * from sparse where o = sby and big2 = s
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Filter: ((o = sby) AND (sby = big2))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
 
 explain (buffers off, costs off) select * from sparse where o = 1 and big2 = sby;
 --- QUERY PLAN ---
@@ -165,7 +165,7 @@ explain (buffers off, costs off) select * from sparse where o = 1 and big2 = sby
    Vectorized Filter: (o = 1)
    ->  Index Scan using compress_hyper_2_2_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_2_2_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(1, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(1, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
 
 explain (buffers off, costs off) select * from sparse where o = sby and big2 = 1;
 --- QUERY PLAN ---
@@ -173,7 +173,7 @@ explain (buffers off, costs off) select * from sparse where o = sby and big2 = 1
    Filter: (o = sby)
    Vectorized Filter: (big2 = 1)
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, 1))]))
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, 1))]))
 
 -- create a sister table where the same composite blooms should be auto created
 create table sparse_sister as select * from sparse where ts < -1;
@@ -207,38 +207,38 @@ select min(big1), max(big2) from sparse_sister where value < 100 and value > 10;
   11 |  99
 
 select relname,attname from metacols order by 1,2;
-         relname          |              attname               
---------------------------+------------------------------------
+         relname          |                 attname                 
+--------------------------+-----------------------------------------
  compress_hyper_2_2_chunk | _ts_meta_count
  compress_hyper_2_2_chunk | _ts_meta_max_1
  compress_hyper_2_2_chunk | _ts_meta_max_2
  compress_hyper_2_2_chunk | _ts_meta_min_1
  compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_27f1_big1_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_4328_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_5c7a_value_big1_big2
+ compress_hyper_2_2_chunk | regress-test-bloom_9774_o_big2
  compress_hyper_2_2_chunk | regress-test-bloom_big1
- compress_hyper_2_2_chunk | regress-test-bloom_big1_big2
  compress_hyper_2_2_chunk | regress-test-bloom_big2
- compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
- compress_hyper_2_2_chunk | regress-test-bloom_num_hello
- compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
- compress_hyper_2_2_chunk | regress-test-bloom_o_big2
- compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_2_2_chunk | regress-test-bloom_value
- compress_hyper_2_2_chunk | regress-test-bloom_value_big1_big2
  compress_hyper_4_4_chunk | _ts_meta_count
  compress_hyper_4_4_chunk | _ts_meta_max_1
  compress_hyper_4_4_chunk | _ts_meta_max_2
  compress_hyper_4_4_chunk | _ts_meta_min_1
  compress_hyper_4_4_chunk | _ts_meta_min_2
+ compress_hyper_4_4_chunk | regress-test-bloom_27f1_big1_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_4328_num_nowts
+ compress_hyper_4_4_chunk | regress-test-bloom_9774_o_big2
  compress_hyper_4_4_chunk | regress-test-bloom_big1
- compress_hyper_4_4_chunk | regress-test-bloom_big1_big2
  compress_hyper_4_4_chunk | regress-test-bloom_big2
  compress_hyper_4_4_chunk | regress-test-bloom_boo
- compress_hyper_4_4_chunk | regress-test-bloom_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_4_4_chunk | regress-test-bloom_hello
- compress_hyper_4_4_chunk | regress-test-bloom_num_hello
- compress_hyper_4_4_chunk | regress-test-bloom_num_nowts
- compress_hyper_4_4_chunk | regress-test-bloom_o_big2
- compress_hyper_4_4_chunk | regress-test-bloom_small1_small2
  compress_hyper_4_4_chunk | _ts_meta_v2_max_nowts
  compress_hyper_4_4_chunk | _ts_meta_v2_max_num
  compress_hyper_4_4_chunk | _ts_meta_v2_max_small1
@@ -273,21 +273,21 @@ explain (buffers off, costs off) select * from sparse_sister where o = 1 and big
    Vectorized Filter: ((o = 1) AND (big2 = 1))
    ->  Index Scan using compress_hyper_4_4_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_4_4_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]))
 
 explain (buffers off, costs off) select * from sparse_sister where num = 1 and hello = md5('1')::bytea;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
    Filter: ((num = '1'::numeric) AND (hello = '\x6334636134323338613062393233383230646363353039613666373538343962'::bytea))
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_num_hello, TEST-HASHES::bigint[]) AND (_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_hello, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_c250_num_hello, TEST-HASHES::bigint[]) AND (_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_hello, TEST-HASHES::bigint[]))
 
 explain (buffers off, costs off) select * from sparse_sister where small1 = 1 and small2 = 1;
 --- QUERY PLAN ---
  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
    Vectorized Filter: ((small1 = 1) AND (small2 = 1))
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_small1_small2, TEST-HASHES::bigint[]) AND (_ts_meta_v2_min_small1 <= 1) AND (_ts_meta_v2_max_small1 >= 1) AND (_ts_meta_v2_min_small2 <= 1) AND (_ts_meta_v2_max_small2 >= 1))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_cab4_small1_small2, TEST-HASHES::bigint[]) AND (_ts_meta_v2_min_small1 <= 1) AND (_ts_meta_v2_max_small1 >= 1) AND (_ts_meta_v2_min_small2 <= 1) AND (_ts_meta_v2_max_small2 >= 1))
 
 explain (buffers off, costs off) select * from sparse_sister where num = 1 and nowts = now()::timestamptz;
 --- QUERY PLAN ---
@@ -297,7 +297,7 @@ explain (buffers off, costs off) select * from sparse_sister where num = 1 and n
          Filter: (num = '1'::numeric)
          Vectorized Filter: (nowts = now())
          ->  Seq Scan on compress_hyper_4_4_chunk
-               Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_num_nowts, TEST-HASHES::bigint[]) AND (_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND (_ts_meta_v2_min_nowts <= now()) AND (_ts_meta_v2_max_nowts >= now()))
+               Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_4328_num_nowts, TEST-HASHES::bigint[]) AND (_ts_meta_v2_min_num <= '1'::numeric) AND (_ts_meta_v2_max_num >= '1'::numeric) AND (_ts_meta_v2_min_nowts <= now()) AND (_ts_meta_v2_max_nowts >= now()))
 
 -- segmentby = bloom
 explain (buffers off, costs off) select * from sparse_sister where big1 = sby and value = 1;
@@ -313,7 +313,7 @@ explain (buffers off, costs off) select * from sparse_sister where o = sby and b
  Custom Scan (ColumnarScan) on _hyper_3_3_chunk
    Filter: ((o = sby) AND (sby = big2))
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
 
 explain (buffers off, costs off) select * from sparse_sister where o = 1 and big2 = sby;
 --- QUERY PLAN ---
@@ -322,7 +322,7 @@ explain (buffers off, costs off) select * from sparse_sister where o = 1 and big
    Vectorized Filter: (o = 1)
    ->  Index Scan using compress_hyper_4_4_chunk_sby__ts_meta_min_1__ts_meta_max_1__idx on compress_hyper_4_4_chunk
          Index Cond: ((_ts_meta_min_1 <= 1) AND (_ts_meta_max_1 >= 1))
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(1, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(1, sby))]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, ARRAY[_timescaledb_functions.bloom1_hash(sby)]))
 
 explain (buffers off, costs off) select * from sparse_sister where o = sby and big2 = 1;
 --- QUERY PLAN ---
@@ -330,43 +330,43 @@ explain (buffers off, costs off) select * from sparse_sister where o = sby and b
    Filter: (o = sby)
    Vectorized Filter: (big2 = 1)
    ->  Seq Scan on compress_hyper_4_4_chunk
-         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, 1))]))
+         Filter: ((_ts_meta_min_1 <= sby) AND (_ts_meta_max_1 >= sby) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_big2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_9774_o_big2, ARRAY[_timescaledb_functions.bloom1_hash(ROW(sby, 1))]))
 
 -- renaming a column that participates in a composite bloom filter
 alter table sparse rename big2 to xxl;
 select relname,attname from metacols order by 1,2;
-         relname          |              attname              
---------------------------+-----------------------------------
+         relname          |                attname                 
+--------------------------+----------------------------------------
  compress_hyper_2_2_chunk | _ts_meta_count
  compress_hyper_2_2_chunk | _ts_meta_max_1
  compress_hyper_2_2_chunk | _ts_meta_max_2
  compress_hyper_2_2_chunk | _ts_meta_min_1
  compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_07a7_value_big1_xxl
+ compress_hyper_2_2_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_4328_num_nowts
+ compress_hyper_2_2_chunk | regress-test-bloom_43c0_o_xxl
+ compress_hyper_2_2_chunk | regress-test-bloom_b99a_big1_xxl
  compress_hyper_2_2_chunk | regress-test-bloom_big1
- compress_hyper_2_2_chunk | regress-test-bloom_big1_xxl
- compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
- compress_hyper_2_2_chunk | regress-test-bloom_num_hello
- compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
- compress_hyper_2_2_chunk | regress-test-bloom_o_xxl
- compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_2_2_chunk | regress-test-bloom_value
- compress_hyper_2_2_chunk | regress-test-bloom_value_big1_xxl
  compress_hyper_2_2_chunk | regress-test-bloom_xxl
  compress_hyper_4_4_chunk | _ts_meta_count
  compress_hyper_4_4_chunk | _ts_meta_max_1
  compress_hyper_4_4_chunk | _ts_meta_max_2
  compress_hyper_4_4_chunk | _ts_meta_min_1
  compress_hyper_4_4_chunk | _ts_meta_min_2
+ compress_hyper_4_4_chunk | regress-test-bloom_27f1_big1_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_4328_num_nowts
+ compress_hyper_4_4_chunk | regress-test-bloom_9774_o_big2
  compress_hyper_4_4_chunk | regress-test-bloom_big1
- compress_hyper_4_4_chunk | regress-test-bloom_big1_big2
  compress_hyper_4_4_chunk | regress-test-bloom_big2
  compress_hyper_4_4_chunk | regress-test-bloom_boo
- compress_hyper_4_4_chunk | regress-test-bloom_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_4_4_chunk | regress-test-bloom_hello
- compress_hyper_4_4_chunk | regress-test-bloom_num_hello
- compress_hyper_4_4_chunk | regress-test-bloom_num_nowts
- compress_hyper_4_4_chunk | regress-test-bloom_o_big2
- compress_hyper_4_4_chunk | regress-test-bloom_small1_small2
  compress_hyper_4_4_chunk | _ts_meta_v2_max_nowts
  compress_hyper_4_4_chunk | _ts_meta_v2_max_num
  compress_hyper_4_4_chunk | _ts_meta_v2_max_small1
@@ -390,34 +390,34 @@ select distinct(attname) from compressedcols where relname = 'sparse' order by 1
 -- dropping a column that participates in a composite bloom filter
 alter table sparse drop column xxl;
 select relname,attname from metacols order by 1,2;
-         relname          |             attname              
---------------------------+----------------------------------
+         relname          |                attname                
+--------------------------+---------------------------------------
  compress_hyper_2_2_chunk | _ts_meta_count
  compress_hyper_2_2_chunk | _ts_meta_max_1
  compress_hyper_2_2_chunk | _ts_meta_max_2
  compress_hyper_2_2_chunk | _ts_meta_min_1
  compress_hyper_2_2_chunk | _ts_meta_min_2
+ compress_hyper_2_2_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_2_2_chunk | regress-test-bloom_4328_num_nowts
  compress_hyper_2_2_chunk | regress-test-bloom_big1
- compress_hyper_2_2_chunk | regress-test-bloom_boo_big1
- compress_hyper_2_2_chunk | regress-test-bloom_num_hello
- compress_hyper_2_2_chunk | regress-test-bloom_num_nowts
- compress_hyper_2_2_chunk | regress-test-bloom_small1_small2
+ compress_hyper_2_2_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_2_2_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_2_2_chunk | regress-test-bloom_value
  compress_hyper_4_4_chunk | _ts_meta_count
  compress_hyper_4_4_chunk | _ts_meta_max_1
  compress_hyper_4_4_chunk | _ts_meta_max_2
  compress_hyper_4_4_chunk | _ts_meta_min_1
  compress_hyper_4_4_chunk | _ts_meta_min_2
+ compress_hyper_4_4_chunk | regress-test-bloom_27f1_big1_big2
+ compress_hyper_4_4_chunk | regress-test-bloom_2cb5_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_4328_num_nowts
+ compress_hyper_4_4_chunk | regress-test-bloom_9774_o_big2
  compress_hyper_4_4_chunk | regress-test-bloom_big1
- compress_hyper_4_4_chunk | regress-test-bloom_big1_big2
  compress_hyper_4_4_chunk | regress-test-bloom_big2
  compress_hyper_4_4_chunk | regress-test-bloom_boo
- compress_hyper_4_4_chunk | regress-test-bloom_boo_big1
+ compress_hyper_4_4_chunk | regress-test-bloom_c250_num_hello
+ compress_hyper_4_4_chunk | regress-test-bloom_cab4_small1_small2
  compress_hyper_4_4_chunk | regress-test-bloom_hello
- compress_hyper_4_4_chunk | regress-test-bloom_num_hello
- compress_hyper_4_4_chunk | regress-test-bloom_num_nowts
- compress_hyper_4_4_chunk | regress-test-bloom_o_big2
- compress_hyper_4_4_chunk | regress-test-bloom_small1_small2
  compress_hyper_4_4_chunk | _ts_meta_v2_max_nowts
  compress_hyper_4_4_chunk | _ts_meta_v2_max_num
  compress_hyper_4_4_chunk | _ts_meta_v2_max_small1

--- a/tsl/test/expected/compress_compbloom_config.out
+++ b/tsl/test/expected/compress_compbloom_config.out
@@ -74,15 +74,15 @@ select relid,compress_relid,segmentby,orderby,orderby_desc,orderby_nullsfirst,in
 
 -- Check the auto generated compressed columns
 select relname,attname from compressedcols order by 1,2;
-         relname          |         attname          
---------------------------+--------------------------
+         relname          |            attname            
+--------------------------+-------------------------------
  compress_hyper_4_2_chunk | _ts_meta_count
  compress_hyper_4_2_chunk | _ts_meta_max_1
  compress_hyper_4_2_chunk | _ts_meta_max_2
  compress_hyper_4_2_chunk | _ts_meta_min_1
  compress_hyper_4_2_chunk | _ts_meta_min_2
- compress_hyper_4_2_chunk | regress-test-bloom_a_b_c
  compress_hyper_4_2_chunk | regress-test-bloom_c
+ compress_hyper_4_2_chunk | regress-test-bloom_ed4b_a_b_c
  compress_hyper_4_2_chunk | a
  compress_hyper_4_2_chunk | b
  compress_hyper_4_2_chunk | c
@@ -148,9 +148,9 @@ select relname,attname from compressedcols order by 1,2;
  compress_hyper_6_4_chunk | _ts_meta_max_2
  compress_hyper_6_4_chunk | _ts_meta_min_1
  compress_hyper_6_4_chunk | _ts_meta_min_2
+ compress_hyper_6_4_chunk | regress-test-bloom_76d9_a_01234567890123456789_b_01234567890123
  compress_hyper_6_4_chunk | regress-test-bloom_c_01234567890123456789
  compress_hyper_6_4_chunk | regress-test-bloom_d_01234567890123456789
- compress_hyper_6_4_chunk | regress-test-bloom_ddd4_a_01234567890123456789_b_01234567890123
  compress_hyper_6_4_chunk | regress-test-bloom_e_01234567890123456789
  compress_hyper_6_4_chunk | a_01234567890123456789
  compress_hyper_6_4_chunk | b_01234567890123456789

--- a/tsl/test/expected/compress_compbloom_hash_pushdown.out
+++ b/tsl/test/expected/compress_compbloom_hash_pushdown.out
@@ -37,7 +37,7 @@ select * from hash_pushdown_test where a = 1 and b = 2;
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
    Vectorized Filter: ((a = 1) AND (b = 2))
    ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]))
          Rows Removed by Filter: 10
 
 -- saop with single bloom

--- a/tsl/test/expected/compress_compbloom_index_add.out
+++ b/tsl/test/expected/compress_compbloom_index_add.out
@@ -97,7 +97,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0.00 loops=1)
-                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
+                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
                      Rows Removed by Filter: 1
 
 DROP TABLE IF EXISTS mixed_avail_add CASCADE;

--- a/tsl/test/expected/compress_compbloom_index_drop.out
+++ b/tsl/test/expected/compress_compbloom_index_drop.out
@@ -42,7 +42,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
-                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
+                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
                      Rows Removed by Filter: 2
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.seg
@@ -50,7 +50,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=0.00 loops=1)
-                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
+                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
                      Rows Removed by Filter: 3
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.seg
@@ -87,7 +87,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
-                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
+                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
                      Rows Removed by Filter: 2
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.seg
@@ -95,7 +95,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=0.00 loops=1)
-                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
+                     Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b, TEST-HASHES::bigint[]))
                      Rows Removed by Filter: 3
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.seg

--- a/tsl/test/expected/compress_compbloom_manual_config.out
+++ b/tsl/test/expected/compress_compbloom_manual_config.out
@@ -55,7 +55,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
-                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[])
+                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[])
                      Rows Removed by Filter: 2
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.c
@@ -175,7 +175,7 @@ ORDER BY 1,2,3,4;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
                Vectorized Filter: ((a = 1) AND (b = 2))
                ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=0.00 loops=1)
-                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_b, TEST-HASHES::bigint[])
+                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7035_a_b, TEST-HASHES::bigint[])
                      Rows Removed by Filter: 2
    ->  Sort (actual rows=0.00 loops=1)
          Sort Key: _hyper_1_2_chunk.ts, _hyper_1_2_chunk.c
@@ -212,7 +212,7 @@ ORDER BY 1,2,3,4;
                Vectorized Filter: ((a = 1) AND (c = 2))
                Rows Removed by Filter: 2328
                ->  Seq Scan on compress_hyper_2_5_chunk (actual rows=3.00 loops=1)
-                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_a_c, TEST-HASHES::bigint[])
+                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_e8f0_a_c, TEST-HASHES::bigint[])
    ->  Sort (actual rows=27.00 loops=1)
          Sort Key: _hyper_1_3_chunk.ts, _hyper_1_3_chunk.b
          Sort Method: quicksort 
@@ -248,6 +248,6 @@ ORDER BY 1,2,3,4;
                Vectorized Filter: ((b = 1) AND (c = 2))
                Rows Removed by Filter: 846
                ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=1.00 loops=1)
-                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_b_c, TEST-HASHES::bigint[])
+                     Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_7ba1_b_c, TEST-HASHES::bigint[])
 
 DROP TABLE IF EXISTS mixed_avail_manual CASCADE;

--- a/tsl/test/expected/compress_compbloom_naming.out
+++ b/tsl/test/expected/compress_compbloom_naming.out
@@ -1,0 +1,73 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Testcase for issue #9578: the composite bloom filter naming
+-- allowed to generate the same column name for ('a_b', 'c') and ('a', 'b_c').
+CREATE TABLE t (
+      ts timestamptz NOT NULL,
+      a_b int,
+      c   int,
+      a   int,
+      b_c int
+);
+SELECT create_hypertable('t', 'ts');
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+
+ALTER TABLE t SET (
+      timescaledb.compress,
+      timescaledb.compress_orderby = 'ts',
+      timescaledb.compress_index = 'bloom(a_b, c), bloom(a, b_c)'
+);
+INSERT INTO t VALUES ('2024-01-01', 1, 2, 3, 4);
+SELECT compress_chunk(c) FROM show_chunks('t') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+-- If the below error doesn't appear, then the bugfix worked:
+-- ERROR:  column regress-test-bloom_a_b_c specified more than once
+-- Check the bloom column names in the compressed chunk
+SELECT
+      relname,
+      attname
+FROM
+      pg_attribute a,
+      pg_class c
+WHERE
+      c.oid=a.attrelid AND
+      attname LIKE '%_ts_meta%bloom%a_b_c%' AND
+      relname LIKE '%chunk'
+ORDER BY
+      relname::text COLLATE "C",
+      attname::text COLLATE "C";
+         relname          |            attname            
+--------------------------+-------------------------------
+ compress_hyper_2_2_chunk | regress-test-bloom_c66a_a_b_c
+ compress_hyper_2_2_chunk | regress-test-bloom_ee9c_a_b_c
+
+-- Verify the assumption that the zero byte separator used in the
+-- bloom column names is not allowed in Postgres column names:
+-- 'a' || chr(0) || 'b' = 'a\u0000b'
+\set ON_ERROR_STOP 0
+CREATE TABLE t2 (
+      ts timestamptz NOT NULL,
+      U&"a\0000b" int,
+      c int,
+      a int,
+      U&"b\0000c" int);
+ERROR:  invalid Unicode escape value at character 60
+CREATE TABLE t3 (
+      ts timestamptz NOT NULL,
+      E'a\000b' int,
+      c int,
+      a int,
+      E'b\000c' int);
+ERROR:  invalid byte sequence for encoding "UTF8": 0x00
+DO $$
+BEGIN
+  EXECUTE format('CREATE TABLE t4 (%I int)', E'a\000b');
+END $$;
+ERROR:  invalid byte sequence for encoding "UTF8": 0x00
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/compress_composite_bloom_debug.out
+++ b/tsl/test/expected/compress_composite_bloom_debug.out
@@ -199,7 +199,7 @@ WHERE attrelid = :'chunk'::regclass
   LIMIT 1
 \gset
 \echo 'Composite bloom column: ' :composite_bloom_col
-Composite bloom column:  regress-test-bloom_device_id_sensor_type
+Composite bloom column:  regress-test-bloom_d3fa_device_id_sensor_type
 -----------------------------------------------------------
 -- Filtering Effectiveness Tests
 -----------------------------------------------------------
@@ -211,7 +211,7 @@ SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'temp'
    Vectorized Filter: ((device_id = 1) AND (sensor_type = 'temp'::text))
    Rows Removed by Filter: 600
    ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=2.00 loops=1)
-         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_device_id_sensor_type, TEST-HASHES::bigint[])
+         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_d3fa_device_id_sensor_type, TEST-HASHES::bigint[])
          Rows Removed by Filter: 2
 
 -- Expected behavior:
@@ -227,7 +227,7 @@ SELECT * FROM composite_filter_test WHERE device_id = 2 AND sensor_type = 'humid
    Vectorized Filter: ((device_id = 2) AND (sensor_type = 'humidity'::text))
    Rows Removed by Filter: 600
    ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=2.00 loops=1)
-         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_device_id_sensor_type, TEST-HASHES::bigint[])
+         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_d3fa_device_id_sensor_type, TEST-HASHES::bigint[])
          Rows Removed by Filter: 2
 
 -- Expected: Similar pruning as Test 5.1
@@ -238,7 +238,7 @@ SELECT * FROM composite_filter_test WHERE device_id = 5 AND sensor_type = 'temp'
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
    Vectorized Filter: ((device_id = 5) AND (sensor_type = 'temp'::text))
    ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
-         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_device_id_sensor_type, TEST-HASHES::bigint[])
+         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_d3fa_device_id_sensor_type, TEST-HASHES::bigint[])
          Rows Removed by Filter: 4
 
 -- Expected:
@@ -251,7 +251,7 @@ SELECT * FROM composite_filter_test WHERE device_id = 1 AND sensor_type = 'humid
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=0.00 loops=1)
    Vectorized Filter: ((device_id = 1) AND (sensor_type = 'humidity'::text))
    ->  Seq Scan on compress_hyper_2_2_chunk (actual rows=0.00 loops=1)
-         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_device_id_sensor_type, TEST-HASHES::bigint[])
+         Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_d3fa_device_id_sensor_type, TEST-HASHES::bigint[])
          Rows Removed by Filter: 4
 
 -- Expected:

--- a/tsl/test/expected/compress_qualpushdown_complex.out
+++ b/tsl/test/expected/compress_qualpushdown_complex.out
@@ -148,7 +148,7 @@ mm1 % 10 = 1 AND blm2 = 10 AND other = 11 AND blm1 = 12;
    Filter: ((mm1 % 10) = 1)
    Vectorized Filter: ((blm2 = 10) AND (other = 11) AND (blm1 = 12))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2_other, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm1, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_077e_blm2_other, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm1, TEST-HASHES::bigint[]))
 
 -- R2: we cannot omit any qual from a disjunction, so segby cannot be pushed down
 explain (buffers off, costs off)
@@ -217,7 +217,7 @@ blm2 = 10 AND other = 11;
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Vectorized Filter: ((blm2 = 10) AND (other = 11))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2_other, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_077e_blm2_other, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2, TEST-HASHES::bigint[]))
 
 -- another variation for the composite bloom, different order
 explain (buffers off, costs off)
@@ -227,7 +227,7 @@ other = 11 AND blm2 = 10;
  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
    Vectorized Filter: ((other = 11) AND (blm2 = 10))
    ->  Seq Scan on compress_hyper_2_2_chunk
-         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2_other, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2, TEST-HASHES::bigint[]))
+         Filter: (_timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_077e_blm2_other, TEST-HASHES::bigint[]) AND _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_blm2, TEST-HASHES::bigint[]))
 
 -- partial composite bloom cannot be pushed down
 explain (buffers off, costs off)

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -662,20 +662,20 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
 \gset
 -- Show columns before drop
 select * from test.show_columns_ext(:'chunk'::regclass);
-           Column           |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
-----------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
- _ts_meta_count             | integer                               |           |          |         | plain    |         1000 | 
- _ts_meta_min_1             | integer                               |           |          |         | plain    |         1000 | 
- _ts_meta_max_1             | integer                               |           |          |         | plain    |         1000 | 
- x                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
- value                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- regress-test-bloom_u       | _timescaledb_internal.bloom1          |           |          |         | external |         1000 | 
- u                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
- _ts_meta_v2_min_ts         | timestamp without time zone           |           |          |         | plain    |         1000 | 
- _ts_meta_v2_max_ts         | timestamp without time zone           |           |          |         | plain    |         1000 | 
- ts                         | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
- extra                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- regress-test-bloom_u_extra | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
+             Column              |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+---------------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count                  | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1                  | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1                  | integer                               |           |          |         | plain    |         1000 | 
+ x                               | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ value                           | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_u            | _timescaledb_internal.bloom1          |           |          |         | external |         1000 | 
+ u                               | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ _ts_meta_v2_min_ts              | timestamp without time zone           |           |          |         | plain    |         1000 | 
+ _ts_meta_v2_max_ts              | timestamp without time zone           |           |          |         | plain    |         1000 | 
+ ts                              | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ extra                           | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_9a42_u_extra | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
 
 -- Drop column with minmax sparse index
 alter table test_drop_sparse drop column ts;
@@ -686,17 +686,17 @@ select * from settings;
  _timescaledb_internal._hyper_7_11_chunk | _timescaledb_internal.compress_hyper_8_12_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "bloom", "column": ["u", "extra"], "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}]
 
 select * from test.show_columns_ext(:'chunk'::regclass);
-           Column           |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
-----------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
- _ts_meta_count             | integer                               |           |          |         | plain    |         1000 | 
- _ts_meta_min_1             | integer                               |           |          |         | plain    |         1000 | 
- _ts_meta_max_1             | integer                               |           |          |         | plain    |         1000 | 
- x                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
- value                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- regress-test-bloom_u       | _timescaledb_internal.bloom1          |           |          |         | external |         1000 | 
- u                          | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
- extra                      | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- regress-test-bloom_u_extra | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
+             Column              |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+---------------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count                  | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1                  | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1                  | integer                               |           |          |         | plain    |         1000 | 
+ x                               | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ value                           | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_u            | _timescaledb_internal.bloom1          |           |          |         | external |         1000 | 
+ u                               | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ extra                           | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_9a42_u_extra | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
 
 -- Verify data is still queryable
 select count(*) from test_drop_sparse;
@@ -758,16 +758,16 @@ select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
             where table_name = 'test_drop_sparse2') limit 1)
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
-          Column          |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
---------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
- _ts_meta_count           | integer                               |           |          |         | plain    |         1000 | 
- _ts_meta_min_1           | integer                               |           |          |         | plain    |         1000 | 
- _ts_meta_max_1           | integer                               |           |          |         | plain    |         1000 | 
- x                        | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
- a                        | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- b                        | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- c                        | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
- regress-test-bloom_a_b_c | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
+            Column             |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
+-------------------------------+---------------------------------------+-----------+----------+---------+----------+--------------+-------------
+ _ts_meta_count                | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_min_1                | integer                               |           |          |         | plain    |         1000 | 
+ _ts_meta_max_1                | integer                               |           |          |         | plain    |         1000 | 
+ x                             | _timescaledb_internal.compressed_data |           |          |         | external |            0 | 
+ a                             | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ b                             | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ c                             | _timescaledb_internal.compressed_data |           |          |         | extended |            0 | 
+ regress-test-bloom_ed4b_a_b_c | _timescaledb_internal.bloom1          |           |          |         | main     |         1000 | 
 
 -- Drop one column from the composite bloom
 alter table test_drop_sparse2 drop column b;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_FILES
     compress_compbloom_index_add.sql
     compress_compbloom_index_drop.sql
     compress_compbloom_manual_config.sql
+    compress_compbloom_naming.sql
     compress_compbloom_upsert.sql
     compress_default.sql
     compress_dml_copy.sql

--- a/tsl/test/sql/compress_compbloom_naming.sql
+++ b/tsl/test/sql/compress_compbloom_naming.sql
@@ -1,0 +1,70 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Testcase for issue #9578: the composite bloom filter naming
+-- allowed to generate the same column name for ('a_b', 'c') and ('a', 'b_c').
+
+CREATE TABLE t (
+      ts timestamptz NOT NULL,
+      a_b int,
+      c   int,
+      a   int,
+      b_c int
+);
+
+SELECT create_hypertable('t', 'ts');
+
+ALTER TABLE t SET (
+      timescaledb.compress,
+      timescaledb.compress_orderby = 'ts',
+      timescaledb.compress_index = 'bloom(a_b, c), bloom(a, b_c)'
+);
+
+INSERT INTO t VALUES ('2024-01-01', 1, 2, 3, 4);
+
+SELECT compress_chunk(c) FROM show_chunks('t') c;
+
+-- If the below error doesn't appear, then the bugfix worked:
+-- ERROR:  column "_ts_meta_v2_bloomh_a_b_c" specified more than once
+
+-- Check the bloom column names in the compressed chunk
+SELECT
+      relname,
+      attname
+FROM
+      pg_attribute a,
+      pg_class c
+WHERE
+      c.oid=a.attrelid AND
+      attname LIKE '%_ts_meta%bloom%a_b_c%' AND
+      relname LIKE '%chunk'
+ORDER BY
+      relname::text COLLATE "C",
+      attname::text COLLATE "C";
+
+-- Verify the assumption that the zero byte separator used in the
+-- bloom column names is not allowed in Postgres column names:
+-- 'a' || chr(0) || 'b' = 'a\u0000b'
+
+\set ON_ERROR_STOP 0
+CREATE TABLE t2 (
+      ts timestamptz NOT NULL,
+      U&"a\0000b" int,
+      c int,
+      a int,
+      U&"b\0000c" int);
+
+CREATE TABLE t3 (
+      ts timestamptz NOT NULL,
+      E'a\000b' int,
+      c int,
+      a int,
+      E'b\000c' int);
+
+DO $$
+BEGIN
+  EXECUTE format('CREATE TABLE t4 (%I int)', E'a\000b');
+END $$;
+
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
As reported in issue #9578, there was a case when concatenating two
columns could create overlapping results. For example ('a_b','c') and
('a','b_c') resulted the same composite bloom metadata column name.
This caused an error during the compression of the chunk.
    
This change modifies the column naming scheme for composite bloom
columns and thus eliminates the issue.
    
Fixes: #9578