### PR TITLE
Fix NULL derefencing in columnar_result_set_row

### DIFF
--- a/tsl/src/nodes/vector_agg/exec.c
+++ b/tsl/src/nodes/vector_agg/exec.c
@@ -194,6 +194,8 @@ columnar_result_set_row(ColumnarResult *columnar_result, DecompressBatchState co
 			memcpy(&columnar_result->body_buffer[columnar_result->current_offset],
 				   VARDATA_ANY(datum),
 				   result_bytes);
+			/* offset_buffer should be allocated for ArrowText type */
+			Assert(columnar_result->offset_buffer != NULL);
 			columnar_result->offset_buffer[row] = columnar_result->current_offset;
 			columnar_result->current_offset += result_bytes;
 			break;


### PR DESCRIPTION
Fix Coverity report issue: 

    >>>     CID 503639:           (FORWARD_NULL)
    >>>     Passing "&columnar_result" to "columnar_result_set_row", which dereferences null     "columnar_result.offset_buffer".
    577     		columnar_result_set_row(&columnar_result, batch_state, row, result, isnull);

Disable-check: force-changelog-file