### PR TITLE
Make the "cache use-after-free" test a solo test

### DIFF
--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -113,7 +113,6 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     alter_table_memory.sql
     bgw_launcher.sql
     c_unit_tests.sql
-    cache_invalidate_uaf.sql
     copy_memory_usage.sql
     metadata.sql
     multi_transaction_index.sql
@@ -127,6 +126,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   if(USE_TELEMETRY)
     list(APPEND TEST_FILES telemetry.sql)
   endif()
+
+  list(APPEND SOLO_TESTS cache_invalidate_uaf.sql)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))


### PR DESCRIPTION
Sometimes a concurrent query can trigger the cache invalidation with our injected error in a different path, which leads to a different kind of failure than the one we want to test, and makes the test flaky.

Example failure: https://github.com/timescale/timescaledb/actions/runs/25665927392/job/75338757168#step:22:34