### PR TITLE
Fix policy name comparison in remove_policies

### DIFF
--- a/.unreleased/pr_9707
+++ b/.unreleased/pr_9707
@@ -1,0 +1,1 @@
+Fixes: #9707 Fix policy name comparison in remove_policies

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -393,7 +393,7 @@ policies_remove(PG_FUNCTION_ARGS)
 
 	for (i = 0; i < npolicies; i++)
 	{
-		char *curr_policy = VARDATA(policy[i]);
+		char *curr_policy = TextDatumGetCString(policy[i]);
 
 		if (pg_strcasecmp(curr_policy, POLICY_REFRESH_CAGG_PROC_NAME) == 0)
 		{
@@ -403,9 +403,7 @@ policies_remove(PG_FUNCTION_ARGS)
 		{
 			success = policy_compression_remove_internal(cagg_oid, if_exists);
 		}
-		else if (pg_strncasecmp(curr_policy,
-								POLICY_RETENTION_PROC_NAME,
-								strlen(POLICY_RETENTION_PROC_NAME)) == 0)
+		else if (pg_strcasecmp(curr_policy, POLICY_RETENTION_PROC_NAME) == 0)
 		{
 			success = policy_retention_remove_internal(cagg_oid, if_exists);
 		}
@@ -413,6 +411,7 @@ policies_remove(PG_FUNCTION_ARGS)
 		{
 			ereport(NOTICE, (errmsg("No relevant policy found")));
 		}
+		pfree(curr_policy);
 		if (!success)
 		{
 			++failures;

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -523,6 +523,25 @@ NOTICE:  No relevant policy found
 -----------------
  f
 
+-- Short and prefix-matching policy names must not match a real policy
+SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'a');
+NOTICE:  No relevant policy found
+ remove_policies 
+-----------------
+ f
+
+SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'policy_retention_extra');
+NOTICE:  No relevant policy found
+ remove_policies 
+-----------------
+ f
+
+SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'p');
+NOTICE:  No relevant policy found
+ remove_policies 
+-----------------
+ f
+
 SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'policy_refresh_continuous_aggregate', 'policy_compression');
  remove_policies 
 -----------------

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -254,6 +254,11 @@ SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false);
 -- Code coverage: incorrect name of policy
 SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'refresh_policy');
 
+-- Short and prefix-matching policy names must not match a real policy
+SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'a');
+SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'policy_retention_extra');
+SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'p');
+
 SELECT timescaledb_experimental.remove_policies('max_mat_view_date', false, 'policy_refresh_continuous_aggregate', 'policy_compression');
 SELECT timescaledb_experimental.show_policies('max_mat_view_date');
 


### PR DESCRIPTION
The policy name from the user was compared without first turning it
into a proper C string, so the comparison could read past the input.
The retention branch also matched on a prefix only, which let names
like "policy_retention_extra" remove the retention policy. Convert
the input to a C string and require an exact match for all three
policy names.
