### PR TITLE
Reject inheriting from a hypertable

### DIFF
--- a/.unreleased/pr_9747
+++ b/.unreleased/pr_9747
@@ -1,0 +1,1 @@
+Fixes: #9747 Reject inheriting from a hypertable

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -5776,6 +5776,20 @@ static DDLResult
 process_create_stmt(ProcessUtilityArgs *args)
 {
 	CreateStmt *stmt = castNode(CreateStmt, args->parsetree);
+	ListCell *lc;
+
+	foreach (lc, stmt->inhRelations)
+	{
+		RangeVar *parent = lfirst_node(RangeVar, lc);
+		Oid parent_relid = RangeVarGetRelid(parent, NoLock, true);
+
+		if (OidIsValid(parent_relid) && ts_is_hypertable(parent_relid))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("hypertables do not support inheritance")));
+		}
+	}
 
 	List *pg_options = NIL, *hypertable_options = NIL;
 	ts_with_clause_filter(stmt->options, &hypertable_options, NULL, &pg_options);

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -56,6 +56,10 @@ ALTER TABLE _timescaledb_internal._hyper_1_1_chunk INHERIT "Parent";
 ERROR:  operation not supported on chunk tables
 ALTER TABLE _timescaledb_internal._hyper_1_1_chunk NO INHERIT "Parent";
 ERROR:  operation not supported on chunk tables
+CREATE TABLE PUBLIC."Hyper_Child" () INHERITS ("Hypertable_1");
+ERROR:  hypertables do not support inheritance
+CREATE TABLE PUBLIC."Hyper_Child" (extra int) INHERITS (PUBLIC."Hypertable_1", PUBLIC."Parent");
+ERROR:  hypertables do not support inheritance
 \set ON_ERROR_STOP 1
 CREATE TABLE PUBLIC."Child" () INHERITS ("Parent");
 \set ON_ERROR_STOP 0

--- a/test/sql/ddl_errors.sql
+++ b/test/sql/ddl_errors.sql
@@ -51,6 +51,8 @@ CREATE TABLE PUBLIC."Parent" (
 ALTER TABLE "Hypertable_1" INHERIT "Parent";
 ALTER TABLE _timescaledb_internal._hyper_1_1_chunk INHERIT "Parent";
 ALTER TABLE _timescaledb_internal._hyper_1_1_chunk NO INHERIT "Parent";
+CREATE TABLE PUBLIC."Hyper_Child" () INHERITS ("Hypertable_1");
+CREATE TABLE PUBLIC."Hyper_Child" (extra int) INHERITS (PUBLIC."Hypertable_1", PUBLIC."Parent");
 \set ON_ERROR_STOP 1
 
 CREATE TABLE PUBLIC."Child" () INHERITS ("Parent");


### PR DESCRIPTION
A child table created with INHERITS (hypertable) is silently invisible
to queries against the hypertable, leading to surprising data loss.
Throw an error at CREATE TABLE time, matching the existing rejection
of ALTER TABLE ... INHERIT on hypertables.
