### PR TITLE
Skip dropped chunks when trying to remove ts_cagg_invalidation_trigger

### DIFF
--- a/.unreleased/pr_9767
+++ b/.unreleased/pr_9767
@@ -1,0 +1,1 @@
+Fixes: #9767 Skip dropped chunks when trying to remove ts_cagg_invalidation_trigger

--- a/sql/updates/2.22.1--2.23.0.sql
+++ b/sql/updates/2.22.1--2.23.0.sql
@@ -32,7 +32,7 @@ BEGIN
     EXECUTE format('DROP TRIGGER IF EXISTS ts_cagg_invalidation_trigger ON %s;', rel);
   END LOOP;
   FOR rel IN SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk ch
+    FROM _timescaledb_catalog.chunk ch WHERE NOT dropped
   LOOP
     EXECUTE format('DROP TRIGGER IF EXISTS ts_cagg_invalidation_trigger ON %s;', rel);
   END LOOP;


### PR DESCRIPTION
When chunks marked as dropped are present the DROP TRIGGER statement
will produce an error aborting the upgrade with
ERROR: relation “_timescaledb_internal._hyper_1_1_chunk” does not exist
