### PR TITLE
Expose hypertable partitioning functions

### DIFF
--- a/.unreleased/hypertables-partitioning-functions
+++ b/.unreleased/hypertables-partitioning-functions
@@ -1,0 +1,1 @@
+Implements: #6295 Expose partitioning functions in timescaledb_information.hypertables

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,4 +1,6 @@
 
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+
 -- Re-add self-referential foreign keys
 ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_compressed_hypertable_id_fkey FOREIGN KEY (compressed_hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
 ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk (id);

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -8,7 +8,8 @@ WITH
   hypertable_info AS (
     SELECT hypertable_id, schema_name, table_name,
            num_dimensions, compression_state, column_name,
-           column_type, interval_length,
+           column_type, interval_length, partitioning_func_schema,
+           partitioning_func,
            (compression_state = 1) AS compression_enabled,
            row_number() OVER (PARTITION BY hypertable_id ORDER BY di.id) AS dimension_num
       FROM _timescaledb_catalog.hypertable ht
@@ -28,10 +29,22 @@ SELECT
   ht.compression_enabled,
   srchtbs.tablespace_list AS tablespaces,
   ht.column_name AS primary_dimension,
-  ht.column_type AS primary_dimension_type
+  ht.column_type AS primary_dimension_type,
+  CASE WHEN ht.partitioning_func IS NULL THEN
+    NULL
+  ELSE
+    format('%I.%I', ht.partitioning_func_schema, ht.partitioning_func)
+  END AS primary_dimension_partitioning_func,
+  CASE WHEN secondary_ht.partitioning_func IS NULL THEN
+    NULL
+  ELSE
+    format('%I.%I', secondary_ht.partitioning_func_schema, secondary_ht.partitioning_func)
+  END AS secondary_dimension_partitioning_func
 FROM hypertable_info ht
 JOIN pg_tables t ON ht.table_name = t.tablename AND ht.schema_name = t.schemaname
 LEFT JOIN _timescaledb_catalog.continuous_agg ca ON ca.mat_hypertable_id = ht.hypertable_id
+LEFT JOIN hypertable_info secondary_ht ON secondary_ht.hypertable_id = ht.hypertable_id
+  AND secondary_ht.dimension_num = 2
 LEFT JOIN (
     SELECT hypertable_id,
       array_agg(tablespace_name ORDER BY id) AS tablespace_list

--- a/test/expected/information_views.out
+++ b/test/expected/information_views.out
@@ -2,8 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 SELECT * FROM timescaledb_information.hypertables;
- hypertable_schema | hypertable_name | owner | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension | primary_dimension_type 
--------------------+-----------------+-------+----------------+------------+---------------------+-------------+-------------------+------------------------
+ hypertable_schema | hypertable_name | owner | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension | primary_dimension_type | primary_dimension_partitioning_func | secondary_dimension_partitioning_func 
+-------------------+-----------------+-------+----------------+------------+---------------------+-------------+-------------------+------------------------+-------------------------------------+---------------------------------------
 
 -- create simple hypertable with 1 chunk
 CREATE TABLE ht1(time TIMESTAMPTZ NOT NULL);
@@ -23,10 +23,10 @@ SELECT create_hypertable('ht2','time');
 INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
 SELECT * FROM timescaledb_information.hypertables
 ORDER BY hypertable_schema, hypertable_name;
- hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  
--------------------+-----------------+-------------------+----------------+------------+---------------------+-------------+-------------------+--------------------------
- public            | ht1             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone
- public            | ht2             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone
+ hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  | primary_dimension_partitioning_func | secondary_dimension_partitioning_func 
+-------------------+-----------------+-------------------+----------------+------------+---------------------+-------------+-------------------+--------------------------+-------------------------------------+---------------------------------------
+ public            | ht1             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone |                                     | 
+ public            | ht2             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone |                                     | 
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 -- create schema open and hypertable with 3 chunks
@@ -52,113 +52,129 @@ SELECT create_hypertable('closed.closed_ht','time');
 INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
 SELECT * FROM timescaledb_information.hypertables
 ORDER BY hypertable_schema, hypertable_name;
- hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  
--------------------+-----------------+-------------------+----------------+------------+---------------------+-------------+-------------------+--------------------------
- closed            | closed_ht       | super_user        |              1 |          1 | f                   |             | time              | timestamp with time zone
- open              | open_ht         | super_user        |              1 |          3 | f                   |             | time              | timestamp with time zone
- public            | ht1             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone
- public            | ht2             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone
+ hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  | primary_dimension_partitioning_func | secondary_dimension_partitioning_func 
+-------------------+-----------------+-------------------+----------------+------------+---------------------+-------------+-------------------+--------------------------+-------------------------------------+---------------------------------------
+ closed            | closed_ht       | super_user        |              1 |          1 | f                   |             | time              | timestamp with time zone |                                     | 
+ open              | open_ht         | super_user        |              1 |          3 | f                   |             | time              | timestamp with time zone |                                     | 
+ public            | ht1             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone |                                     | 
+ public            | ht2             | default_perm_user |              1 |          1 | f                   |             | time              | timestamp with time zone |                                     | 
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 \set ON_ERROR_STOP 0
 \x
 SELECT * FROM timescaledb_information.hypertables
 ORDER BY hypertable_schema, hypertable_name;
--[ RECORD 1 ]----------+-------------------------
-hypertable_schema      | closed
-hypertable_name        | closed_ht
-owner                  | super_user
-num_dimensions         | 1
-num_chunks             | 1
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
--[ RECORD 2 ]----------+-------------------------
-hypertable_schema      | open
-hypertable_name        | open_ht
-owner                  | super_user
-num_dimensions         | 1
-num_chunks             | 3
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
--[ RECORD 3 ]----------+-------------------------
-hypertable_schema      | public
-hypertable_name        | ht1
-owner                  | default_perm_user
-num_dimensions         | 1
-num_chunks             | 1
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
--[ RECORD 4 ]----------+-------------------------
-hypertable_schema      | public
-hypertable_name        | ht2
-owner                  | default_perm_user
-num_dimensions         | 1
-num_chunks             | 1
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
+-[ RECORD 1 ]-------------------------+-------------------------
+hypertable_schema                     | closed
+hypertable_name                       | closed_ht
+owner                                 | super_user
+num_dimensions                        | 1
+num_chunks                            | 1
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
+-[ RECORD 2 ]-------------------------+-------------------------
+hypertable_schema                     | open
+hypertable_name                       | open_ht
+owner                                 | super_user
+num_dimensions                        | 1
+num_chunks                            | 3
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
+-[ RECORD 3 ]-------------------------+-------------------------
+hypertable_schema                     | public
+hypertable_name                       | ht1
+owner                                 | default_perm_user
+num_dimensions                        | 1
+num_chunks                            | 1
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
+-[ RECORD 4 ]-------------------------+-------------------------
+hypertable_schema                     | public
+hypertable_name                       | ht2
+owner                                 | default_perm_user
+num_dimensions                        | 1
+num_chunks                            | 1
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
 
 -- filter by schema
 SELECT * FROM timescaledb_information.hypertables
 WHERE hypertable_schema = 'closed'
 ORDER BY hypertable_schema, hypertable_name;
--[ RECORD 1 ]----------+-------------------------
-hypertable_schema      | closed
-hypertable_name        | closed_ht
-owner                  | super_user
-num_dimensions         | 1
-num_chunks             | 1
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
+-[ RECORD 1 ]-------------------------+-------------------------
+hypertable_schema                     | closed
+hypertable_name                       | closed_ht
+owner                                 | super_user
+num_dimensions                        | 1
+num_chunks                            | 1
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
 
 -- filter by table name
 SELECT * FROM timescaledb_information.hypertables
 WHERE hypertable_name = 'ht1'
 ORDER BY hypertable_schema, hypertable_name;
--[ RECORD 1 ]----------+-------------------------
-hypertable_schema      | public
-hypertable_name        | ht1
-owner                  | default_perm_user
-num_dimensions         | 1
-num_chunks             | 1
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
+-[ RECORD 1 ]-------------------------+-------------------------
+hypertable_schema                     | public
+hypertable_name                       | ht1
+owner                                 | default_perm_user
+num_dimensions                        | 1
+num_chunks                            | 1
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
 
 -- filter by owner
 SELECT * FROM timescaledb_information.hypertables
 WHERE owner = 'super_user'
 ORDER BY hypertable_schema, hypertable_name;
--[ RECORD 1 ]----------+-------------------------
-hypertable_schema      | closed
-hypertable_name        | closed_ht
-owner                  | super_user
-num_dimensions         | 1
-num_chunks             | 1
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
--[ RECORD 2 ]----------+-------------------------
-hypertable_schema      | open
-hypertable_name        | open_ht
-owner                  | super_user
-num_dimensions         | 1
-num_chunks             | 3
-compression_enabled    | f
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
+-[ RECORD 1 ]-------------------------+-------------------------
+hypertable_schema                     | closed
+hypertable_name                       | closed_ht
+owner                                 | super_user
+num_dimensions                        | 1
+num_chunks                            | 1
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
+-[ RECORD 2 ]-------------------------+-------------------------
+hypertable_schema                     | open
+hypertable_name                       | open_ht
+owner                                 | super_user
+num_dimensions                        | 1
+num_chunks                            | 3
+compression_enabled                   | f
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
 
 \x
 ---Add integer table --
@@ -282,3 +298,28 @@ integer_now_func  | table_int_now
 num_partitions    | 
 
 \x
+CREATE OR REPLACE FUNCTION info_view_time_part(unixtime float8)
+RETURNS bigint LANGUAGE SQL IMMUTABLE AS 'SELECT unixtime::bigint';
+CREATE OR REPLACE FUNCTION info_view_hash_part(device text)
+RETURNS integer LANGUAGE SQL IMMUTABLE AS 'SELECT _timescaledb_functions.get_partition_hash(device)';
+CREATE TABLE info_view_custom_part(time float8, device text);
+SELECT create_hypertable('info_view_custom_part',
+                         'time',
+                         'device',
+                         2,
+                         chunk_time_interval => 1,
+                         time_partitioning_func => 'info_view_time_part',
+                         partitioning_func => 'info_view_hash_part');
+         create_hypertable          
+------------------------------------
+ (6,public,info_view_custom_part,t)
+
+\pset format unaligned
+SELECT hypertable_name,
+       primary_dimension_partitioning_func,
+       secondary_dimension_partitioning_func
+FROM timescaledb_information.hypertables
+WHERE hypertable_name = 'info_view_custom_part';
+hypertable_name|primary_dimension_partitioning_func|secondary_dimension_partitioning_func
+info_view_custom_part|public.info_view_time_part|public.info_view_hash_part
+\pset format aligned

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -128,16 +128,18 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 \x
 SELECT * FROM timescaledb_information.hypertables
 ORDER BY hypertable_schema, hypertable_name;
--[ RECORD 1 ]----------+----------------------------
-hypertable_schema      | public
-hypertable_name        | tspace_2dim
-owner                  | default_perm_user
-num_dimensions         | 2
-num_chunks             | 2
-compression_enabled    | f
-tablespaces            | {tablespace1,tablespace2}
-primary_dimension      | time
-primary_dimension_type | timestamp without time zone
+-[ RECORD 1 ]-------------------------+------------------------------------------
+hypertable_schema                     | public
+hypertable_name                       | tspace_2dim
+owner                                 | default_perm_user
+num_dimensions                        | 2
+num_chunks                            | 2
+compression_enabled                   | f
+tablespaces                           | {tablespace1,tablespace2}
+primary_dimension                     | time
+primary_dimension_type                | timestamp without time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | _timescaledb_functions.get_partition_hash
 
 SELECT hypertable_schema,
        hypertable_name,

--- a/test/expected/trusted_extension.out
+++ b/test/expected/trusted_extension.out
@@ -33,9 +33,9 @@ SELECT * FROM t ORDER BY 1;
  Mon Jan 01 00:00:00 2001 PST
 
 SELECT * FROM timescaledb_information.hypertables;
- hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  
--------------------+-----------------+-------------+----------------+------------+---------------------+-------------+-------------------+--------------------------
- public            | t               | test_role_1 |              1 |          2 | f                   |             | time              | timestamp with time zone
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  | primary_dimension_partitioning_func | secondary_dimension_partitioning_func 
+-------------------+-----------------+-------------+----------------+------------+---------------------+-------------+-------------------+--------------------------+-------------------------------------+---------------------------------------
+ public            | t               | test_role_1 |              1 |          2 | f                   |             | time              | timestamp with time zone |                                     | 
 
 SELECT * FROM test.relation WHERE schema = '_timescaledb_internal' AND name LIKE '\_hyper%';
         schema         |       name       | type  |    owner    

--- a/test/sql/information_views.sql
+++ b/test/sql/information_views.sql
@@ -100,3 +100,26 @@ FROM timescaledb_information.chunks WHERE hypertable_name = 'test_table_int' ORD
 \x
 SELECT * FROM timescaledb_information.dimensions ORDER BY hypertable_name, dimension_number;
 \x
+
+CREATE OR REPLACE FUNCTION info_view_time_part(unixtime float8)
+RETURNS bigint LANGUAGE SQL IMMUTABLE AS 'SELECT unixtime::bigint';
+
+CREATE OR REPLACE FUNCTION info_view_hash_part(device text)
+RETURNS integer LANGUAGE SQL IMMUTABLE AS 'SELECT _timescaledb_functions.get_partition_hash(device)';
+
+CREATE TABLE info_view_custom_part(time float8, device text);
+SELECT create_hypertable('info_view_custom_part',
+                         'time',
+                         'device',
+                         2,
+                         chunk_time_interval => 1,
+                         time_partitioning_func => 'info_view_time_part',
+                         partitioning_func => 'info_view_hash_part');
+
+\pset format unaligned
+SELECT hypertable_name,
+       primary_dimension_partitioning_func,
+       secondary_dimension_partitioning_func
+FROM timescaledb_information.hypertables
+WHERE hypertable_name = 'info_view_custom_part';
+\pset format aligned

--- a/tsl/test/expected/columnstore_aliases.out
+++ b/tsl/test/expected/columnstore_aliases.out
@@ -92,7 +92,7 @@ ALTER TABLE test2 set (
       timescaledb.orderby = 'ts desc'
 );
 SELECT * FROM timescaledb_information.hypertables WHERE hypertable_name = 'test2';
- hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  
--------------------+-----------------+-------------------+----------------+------------+---------------------+-------------+-------------------+--------------------------
- public            | test2           | default_perm_user |              1 |          4 | t                   |             | ts                | timestamp with time zone
+ hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | tablespaces | primary_dimension |  primary_dimension_type  | primary_dimension_partitioning_func | secondary_dimension_partitioning_func 
+-------------------+-----------------+-------------------+----------------+------------+---------------------+-------------+-------------------+--------------------------+-------------------------------------+---------------------------------------
+ public            | test2           | default_perm_user |              1 |          4 | t                   |             | ts                | timestamp with time zone |                                     | 
 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -432,26 +432,30 @@ pg_size_pretty | 112 kB
 select * from timescaledb_information.hypertables
 where hypertable_name like 'foo' or hypertable_name like 'conditions'
 order by hypertable_name;
--[ RECORD 1 ]----------+-------------------------
-hypertable_schema      | public
-hypertable_name        | conditions
-owner                  | default_perm_user
-num_dimensions         | 1
-num_chunks             | 2
-compression_enabled    | t
-tablespaces            | 
-primary_dimension      | time
-primary_dimension_type | timestamp with time zone
--[ RECORD 2 ]----------+-------------------------
-hypertable_schema      | public
-hypertable_name        | foo
-owner                  | default_perm_user
-num_dimensions         | 1
-num_chunks             | 4
-compression_enabled    | t
-tablespaces            | 
-primary_dimension      | a
-primary_dimension_type | integer
+-[ RECORD 1 ]-------------------------+-------------------------
+hypertable_schema                     | public
+hypertable_name                       | conditions
+owner                                 | default_perm_user
+num_dimensions                        | 1
+num_chunks                            | 2
+compression_enabled                   | t
+tablespaces                           | 
+primary_dimension                     | time
+primary_dimension_type                | timestamp with time zone
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
+-[ RECORD 2 ]-------------------------+-------------------------
+hypertable_schema                     | public
+hypertable_name                       | foo
+owner                                 | default_perm_user
+num_dimensions                        | 1
+num_chunks                            | 4
+compression_enabled                   | t
+tablespaces                           | 
+primary_dimension                     | a
+primary_dimension_type                | integer
+primary_dimension_partitioning_func   | 
+secondary_dimension_partitioning_func | 
 
 \x
 SELECT count(decompress_chunk(ch)) FROM show_chunks('conditions') ch;


### PR DESCRIPTION
Expose the stored partitioning functions for the first and second dimensions in timescaledb_information.hypertables. Function names are schema-qualified and remain NULL when a dimension has no partitioning function.

- [x] Add CHANGELOG updates
- [ ] Needs documentation updates

Fixes #6295.

Tests: make -C /build/debug installcheck TESTS="information_views tablespace trusted_extension compression columnstore_aliases" TEST_INSTANCE_OPTS="--temp-instance=/tmp/pgdata --temp-config=/build/test/postgresql.conf"