### PR TITLE
Fix body_buffer overflow for int2 in columnar_result_set_row

### DIFF
--- a/tsl/src/nodes/vector_agg/exec.c
+++ b/tsl/src/nodes/vector_agg/exec.c
@@ -123,7 +123,7 @@ columnar_result_init_for_type(ColumnarResult *columnar_result,
 	{
 		Assert(columnar_result->type > 0);
 		columnar_result->allocated_body_bytes =
-			pad_to_multiple(64, 1 + columnar_result->type * nrows);
+			pad_to_multiple(64, sizeof(Datum) + columnar_result->type * nrows);
 	}
 
 	columnar_result->body_buffer = MemoryContextAllocZero(batch_state->per_batch_context,

--- a/tsl/test/expected/vector_agg_memory.out
+++ b/tsl/test/expected/vector_agg_memory.out
@@ -115,4 +115,39 @@ select * from log where (
  n | bytes | a | b | c | d | e | f 
 ---+-------+---+---+---+---+---+---
 
+-- Test body_buffer overflow for int2 type, it was flagged by LLM Fuzzer.
+CREATE TABLE t_int2_repro (
+    time timestamptz NOT NULL,
+    a int2 NOT NULL,
+    b int2 NOT NULL
+);
+SELECT table_name FROM create_hypertable('t_int2_repro', 'time', chunk_time_interval => interval '1 year');
+  table_name  
+--------------
+ t_int2_repro
+
+-- Insert exactly 30 rows into a single chunk, body_buffer will be set to 30*2 + 8(size of Datum) padded to 64 bytes.
+INSERT INTO t_int2_repro
+SELECT '2020-01-01'::timestamptz + i * '1 hour'::interval,
+       (i % 100)::int2,
+       (i % 50)::int2
+FROM generate_series(1, 30) i;
+ALTER TABLE t_int2_repro SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time'
+);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_int2_repro') c;
+ count 
+-------
+     1
+
+-- This triggers vector_slot_evaluate_function with int2pl (int2 + int2 -> int2),
+-- which calls columnar_result_set_row with type=2.
+-- Should not see warning on memcpy overflow.
+SELECT sum(a + b) FROM t_int2_repro;
+ sum 
+-----
+ 930
+
+drop table t_int2_repro cascade;
 reset max_parallel_workers_per_gather;

--- a/tsl/test/sql/vector_agg_memory.sql
+++ b/tsl/test/sql/vector_agg_memory.sql
@@ -126,4 +126,32 @@ select * from log where (
     select regr_slope(bytes, n) > 0.01 from log
 );
 
+-- Test body_buffer overflow for int2 type, it was flagged by LLM Fuzzer.
+CREATE TABLE t_int2_repro (
+    time timestamptz NOT NULL,
+    a int2 NOT NULL,
+    b int2 NOT NULL
+);
+SELECT table_name FROM create_hypertable('t_int2_repro', 'time', chunk_time_interval => interval '1 year');
+
+-- Insert exactly 30 rows into a single chunk, body_buffer will be set to 30*2 + 8(size of Datum) padded to 64 bytes.
+INSERT INTO t_int2_repro
+SELECT '2020-01-01'::timestamptz + i * '1 hour'::interval,
+       (i % 100)::int2,
+       (i % 50)::int2
+FROM generate_series(1, 30) i;
+
+ALTER TABLE t_int2_repro SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time'
+);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_int2_repro') c;
+
+-- This triggers vector_slot_evaluate_function with int2pl (int2 + int2 -> int2),
+-- which calls columnar_result_set_row with type=2.
+-- Should not see warning on memcpy overflow.
+SELECT sum(a + b) FROM t_int2_repro;
+
+drop table t_int2_repro cascade;
+
 reset max_parallel_workers_per_gather;


### PR DESCRIPTION
Flagged by LLM Fuzzer: https://github.com/timescale/timescaledb/actions/runs/25680328237

Disable-check: force-changelog-file