### PR TITLE
Fix job_errors view leaking failed jobs to non-owners

### DIFF
--- a/.unreleased/pr_9799
+++ b/.unreleased/pr_9799
@@ -1,0 +1,2 @@
+Fixes: #9799 Fix job_errors view leaking failed jobs to non-owners
+Thanks: @homanp for reporting an information leak with the job_errors view

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -323,8 +323,7 @@ FROM
 LEFT JOIN
     _timescaledb_catalog.bgw_job j ON (j.id = h.job_id)
 WHERE
-    h.succeeded IS FALSE
-    OR h.succeeded IS NULL
+    (h.succeeded IS FALSE OR h.succeeded IS NULL)
     AND (pg_catalog.pg_has_role(current_user,
 			   (SELECT pg_catalog.pg_get_userbyid(datdba)
 			      FROM pg_catalog.pg_database

--- a/tsl/test/expected/bgw_job_stat_history_errors_permissions.out
+++ b/tsl/test/expected/bgw_job_stat_history_errors_permissions.out
@@ -82,12 +82,9 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
 FROM timescaledb_information.job_errors WHERE job_id >= 1000
 ORDER BY job_id;
- job_id | proc_schema |  proc_name   | sqlerrcode |                     err_message                     
---------+-------------+--------------+------------+-----------------------------------------------------
-   1000 | public      | job_fail     | P0001      | raising an exception
-   1002 | public      | custom_proc2 | 40001      | could not serialize access due to concurrent update
-  11111 |             |              |            | not an error
-  22222 |             |              |            | 
+ job_id | proc_schema | proc_name | sqlerrcode |     err_message      
+--------+-------------+-----------+------------+----------------------
+   1000 | public      | job_fail  | P0001      | raising an exception
 
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message
@@ -95,10 +92,7 @@ FROM timescaledb_information.job_errors WHERE job_id >= 1000
 ORDER BY job_id;
  job_id | proc_schema |  proc_name   | sqlerrcode |                     err_message                     
 --------+-------------+--------------+------------+-----------------------------------------------------
-   1000 | public      | job_fail     | P0001      | raising an exception
    1002 | public      | custom_proc2 | 40001      | could not serialize access due to concurrent update
-  11111 |             |              |            | not an error
-  22222 |             |              |            | 
 
 SET ROLE :ROLE_SUPERUSER;
 SELECT job_id, proc_schema, proc_name, sqlerrcode, err_message


### PR DESCRIPTION
A missing pair of parentheses made operator precedence apply the role
check only to crash rows. Failed jobs bypassed the check, so any user
could see error details from other users' jobs.
