### PR TITLE
Check hypertable ownership before recompression

### DIFF
--- a/.unreleased/pr_9800
+++ b/.unreleased/pr_9800
@@ -1,0 +1,1 @@
+Fixes: #9800 Check hypertable ownership before recompression

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -885,6 +885,7 @@ tsl_compress_chunk(PG_FUNCTION_ARGS)
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 
 	uncompressed_chunk_id = tsl_compress_chunk_wrapper(chunk, if_not_compressed, recompress);
 
@@ -1028,6 +1029,7 @@ tsl_rebuild_columnstore(PG_FUNCTION_ARGS)
 	}
 
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 
 	if (!ts_chunk_is_compressed(chunk) || ts_chunk_is_frozen(chunk))
 	{

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -6,6 +6,7 @@
 
 #include <postgres.h>
 #include "debug_point.h"
+#include <miscadmin.h>
 #include <parser/parse_coerce.h>
 #include <parser/parse_relation.h>
 #include <utils/inval.h>
@@ -22,6 +23,7 @@
 #include "create.h"
 #include "debug_assert.h"
 #include "guc.h"
+#include "hypertable.h"
 #include "indexing.h"
 #include "recompress.h"
 #include "ts_catalog/array_utils.h"
@@ -82,6 +84,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 
 	if (!ts_chunk_is_partial(chunk))
 	{

--- a/tsl/test/expected/compression_permissions-15.out
+++ b/tsl/test/expected/compression_permissions-15.out
@@ -59,7 +59,14 @@ ERROR:  must be owner of table conditions
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 SELECT compress_chunk(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
+SELECT compress_chunk(show_chunks('conditions'), recompress => true);
+ERROR:  must be owner of hypertable "conditions"
 SELECT decompress_chunk(show_chunks('conditions'));
+ERROR:  must be owner of hypertable "conditions"
+SELECT show_chunks('conditions') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+ERROR:  must be owner of hypertable "conditions"
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
 select add_compression_policy('conditions', '1day'::interval);
 ERROR:  must be owner of hypertable "conditions"

--- a/tsl/test/expected/compression_permissions-16.out
+++ b/tsl/test/expected/compression_permissions-16.out
@@ -59,7 +59,14 @@ ERROR:  must be owner of table conditions
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 SELECT compress_chunk(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
+SELECT compress_chunk(show_chunks('conditions'), recompress => true);
+ERROR:  must be owner of hypertable "conditions"
 SELECT decompress_chunk(show_chunks('conditions'));
+ERROR:  must be owner of hypertable "conditions"
+SELECT show_chunks('conditions') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+ERROR:  must be owner of hypertable "conditions"
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
 select add_compression_policy('conditions', '1day'::interval);
 ERROR:  must be owner of hypertable "conditions"

--- a/tsl/test/expected/compression_permissions-17.out
+++ b/tsl/test/expected/compression_permissions-17.out
@@ -59,7 +59,14 @@ ERROR:  must be owner of table conditions
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 SELECT compress_chunk(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
+SELECT compress_chunk(show_chunks('conditions'), recompress => true);
+ERROR:  must be owner of hypertable "conditions"
 SELECT decompress_chunk(show_chunks('conditions'));
+ERROR:  must be owner of hypertable "conditions"
+SELECT show_chunks('conditions') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+ERROR:  must be owner of hypertable "conditions"
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
 select add_compression_policy('conditions', '1day'::interval);
 ERROR:  must be owner of hypertable "conditions"

--- a/tsl/test/expected/compression_permissions-18.out
+++ b/tsl/test/expected/compression_permissions-18.out
@@ -59,7 +59,14 @@ ERROR:  must be owner of table conditions
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 SELECT compress_chunk(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
+SELECT compress_chunk(show_chunks('conditions'), recompress => true);
+ERROR:  must be owner of hypertable "conditions"
 SELECT decompress_chunk(show_chunks('conditions'));
+ERROR:  must be owner of hypertable "conditions"
+SELECT show_chunks('conditions') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+ERROR:  must be owner of hypertable "conditions"
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(show_chunks('conditions'));
 ERROR:  must be owner of hypertable "conditions"
 select add_compression_policy('conditions', '1day'::interval);
 ERROR:  must be owner of hypertable "conditions"

--- a/tsl/test/sql/compression_permissions.sql.in
+++ b/tsl/test/sql/compression_permissions.sql.in
@@ -60,7 +60,11 @@ alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby
 --- compress_chunks and decompress_chunks fail without correct perm --
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 SELECT compress_chunk(show_chunks('conditions'));
+SELECT compress_chunk(show_chunks('conditions'), recompress => true);
 SELECT decompress_chunk(show_chunks('conditions'));
+SELECT show_chunks('conditions') AS chunk LIMIT 1 \gset
+CALL _timescaledb_functions.rebuild_columnstore(:'chunk'::regclass);
+SELECT _timescaledb_functions.recompress_chunk_segmentwise(show_chunks('conditions'));
 select add_compression_policy('conditions', '1day'::interval);
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER


### PR DESCRIPTION
The SQL functions for compressing and rebuilding chunks did not
verify that the caller owned the hypertable. The first-time
compression path was protected by a check inside a shared helper,
but the recompression paths skipped it. Any user who could read a
chunk OID from the catalog could trigger a recompression on chunks
owned by someone else.

Add the ownership check at the entry of each affected function.

Disable-check: force-changelog-file
