### PR TITLE
Cap refresh start when hypertable has tiered data

### DIFF
--- a/.unreleased/pr_9811
+++ b/.unreleased/pr_9811
@@ -1,0 +1,1 @@
+Fixes: #9811 Cap refresh start when hypertable has tiered data

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -239,7 +239,7 @@ extern TM_Result ts_chunk_lock_for_creating_compressed_chunk(Chunk *chunk);
 extern ScanIterator ts_chunk_scan_iterator_create(MemoryContext result_mcxt);
 extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);
-int ts_chunk_get_osm_chunk_id(int hypertable_id);
+extern TSDLLEXPORT int ts_chunk_get_osm_chunk_id(int hypertable_id);
 extern TSDLLEXPORT void ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk *chunk,
 													const Chunk *merge_chunk, int32 dimension_id);
 extern TSDLLEXPORT void ts_chunk_detach_by_relid(Oid relid);

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -1192,6 +1192,8 @@ dimension_slice_earliest_non_osm_found(TupleInfo *ti, void *data)
 
 	if (IS_OSM_CHUNK(chunk))
 	{
+		// Explicitly set slice to NULL to handle the scenario where all chunks are tiered
+		*slice = NULL;
 		return SCAN_CONTINUE;
 	}
 

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -1181,6 +1181,53 @@ ts_dimension_slice_nth_earliest_slice(int32 dimension_id, int n)
 	return ret;
 }
 
+static ScanTupleResult
+dimension_slice_earliest_non_osm_found(TupleInfo *ti, void *data)
+{
+	DimensionSlice **slice = (DimensionSlice **) data;
+	MemoryContext old = MemoryContextSwitchTo(ti->mctx);
+	*slice = dimension_slice_from_slot(ti->slot);
+	MemoryContextSwitchTo(old);
+	Chunk *chunk = ts_chunk_get_by_id((*slice)->fd.chunk_id, true);
+
+	if (IS_OSM_CHUNK(chunk))
+	{
+		return SCAN_CONTINUE;
+	}
+
+	return SCAN_DONE;
+}
+
+/*
+ * Return the earliest dimension slice not belonging to an OSM chunk.
+ */
+DimensionSlice *
+ts_dimension_slice_earliest_non_osm_slice(int32 dimension_id)
+{
+	ScanKeyData scankey[1];
+	DimensionSlice *ret = NULL;
+
+	ScanKeyInit(&scankey[0],
+				Anum_dimension_slice_dimension_id_range_start_range_end_idx_dimension_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(dimension_id));
+
+	dimension_slice_scan_limit_direction_internal(
+		DIMENSION_SLICE_DIMENSION_ID_RANGE_START_RANGE_END_IDX,
+		scankey,
+		1,
+		dimension_slice_earliest_non_osm_found,
+		(void *) &ret,
+		0,
+		ForwardScanDirection,
+		AccessShareLock,
+		NULL,
+		CurrentMemoryContext);
+
+	return ret;
+}
+
 typedef struct ReorderBoundaryState
 {
 	int target;

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -83,6 +83,7 @@ extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 
 
 extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_nth_latest_slice(int32 dimension_id, int n);
 extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_nth_earliest_slice(int32 dimension_id, int n);
+extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_earliest_non_osm_slice(int32 dimension_id);
 extern TSDLLEXPORT int32 ts_dimension_slice_oldest_valid_chunk_for_reorder(
 	int32 job_id, int32 dimension_id, int skip_newest_distinct_buckets);
 extern TSDLLEXPORT List *ts_dimension_slice_get_chunkids_to_compress(

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -33,6 +33,8 @@
 #include "cache.h"
 #include "continuous_aggs/invalidation_threshold.h"
 #include "continuous_aggs/materialize.h"
+#include "dimension.h"
+#include "dimension_slice.h"
 #include "guc.h"
 #include "invalidation.h"
 #include "refresh.h"
@@ -1286,6 +1288,30 @@ invalidation_cagg_has_pending_mat_ranges(ContinuousAgg *cagg)
 	return found;
 }
 
+/*
+ * Return the range_start of the earliest dimension slice (chunk) for the
+ * given raw hypertable, or INVAL_NEG_INFINITY when no chunks exist.
+ *
+ * This is used to ignore invalidation entries that lie entirely before any
+ * chunk — such entries cannot affect materialized data and should be
+ * preserved for future use rather than treated as pending work.
+ */
+int64
+invalidation_get_earliest_chunk_start(int32 raw_hypertable_id)
+{
+	Hypertable *raw_ht = cagg_get_hypertable_or_fail(raw_hypertable_id);
+	const Dimension *time_dim = hyperspace_get_open_dimension(raw_ht->space, 0);
+	Assert(time_dim != NULL);
+
+	DimensionSlice *slice = ts_dimension_slice_nth_earliest_slice(time_dim->fd.id, 1);
+	if (slice != NULL)
+	{
+		return slice->fd.range_start;
+	}
+
+	return INVAL_NEG_INFINITY;
+}
+
 bool
 invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
 {
@@ -1299,6 +1325,26 @@ invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
 											   PG_INT64_MAX);
 
 	int64 watermark = ts_cagg_watermark_get(cagg_hyper_id);
+
+	/*
+	 * Expand the earliest chunk boundary to the end of its containing
+	 * bucket. Invalidation entries are also bucket-expanded, so both
+	 * sides of the comparison use consistent bucket-aligned values.
+	 * Any entry whose expanded greatest_modified_value falls within this
+	 * bucket or earlier lies entirely before the first data and can be
+	 * ignored.
+	 */
+	int64 earliest_start = invalidation_get_earliest_chunk_start(cagg->data.raw_hypertable_id);
+	if (earliest_start != INVAL_NEG_INFINITY)
+	{
+		Invalidation boundary = { .lowest_modified_value = earliest_start,
+								  .greatest_modified_value = earliest_start };
+		invalidation_expand_to_bucket_boundaries(&boundary,
+												 cagg->partition_type,
+												 cagg->bucket_function);
+		earliest_start = boundary.greatest_modified_value;
+	}
+
 	ts_scanner_foreach(&iterator)
 	{
 		TupleInfo *ti;
@@ -1310,9 +1356,11 @@ invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
 													  ti,
 													  cagg->partition_type,
 													  cagg->bucket_function);
+
 		/* Entries which cannot be invalidations */
 		if (logentry.greatest_modified_value == INVAL_NEG_INFINITY ||
-			logentry.lowest_modified_value >= watermark)
+			logentry.lowest_modified_value >= watermark ||
+			logentry.greatest_modified_value <= earliest_start)
 		{
 			continue;
 		}

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1342,7 +1342,7 @@ invalidation_cagg_has_invalidations(ContinuousAgg *cagg)
 		invalidation_expand_to_bucket_boundaries(&boundary,
 												 cagg->partition_type,
 												 cagg->bucket_function);
-		earliest_start = boundary.greatest_modified_value;
+		earliest_start = boundary.lowest_modified_value;
 	}
 
 	ts_scanner_foreach(&iterator)

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1303,7 +1303,7 @@ invalidation_get_earliest_chunk_start(int32 raw_hypertable_id)
 	const Dimension *time_dim = hyperspace_get_open_dimension(raw_ht->space, 0);
 	Assert(time_dim != NULL);
 
-	DimensionSlice *slice = ts_dimension_slice_nth_earliest_slice(time_dim->fd.id, 1);
+	DimensionSlice *slice = ts_dimension_slice_earliest_non_osm_slice(time_dim->fd.id);
 	if (slice != NULL)
 	{
 		return slice->fd.range_start;

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -58,3 +58,4 @@ extern HeapTuple create_invalidation_tup(const TupleDesc tupdesc, int32 cagg_hyp
 extern bool invalidation_hypertable_has_invalidations(int32 hyper_id);
 extern bool invalidation_cagg_has_invalidations(ContinuousAgg *cagg);
 extern bool invalidation_cagg_has_pending_mat_ranges(ContinuousAgg *cagg);
+extern int64 invalidation_get_earliest_chunk_start(int32 raw_hypertable_id);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -21,6 +21,7 @@
 #include <utils/tuplestore.h>
 
 #include "bgw_policy/policies_v2.h"
+#include "chunk.h"
 #include "debug_point.h"
 #include "dimension.h"
 #include "dimension_slice.h"
@@ -58,7 +59,6 @@ typedef struct CaggRefreshSpiContext
 	int save_nestlevel;
 } CaggRefreshSpiContext;
 
-static Hypertable *cagg_get_hypertable_or_fail(int32 hypertable_id);
 static InternalTimeRange get_largest_bucketed_window(Oid timetype, int64 bucket_width);
 static InternalTimeRange
 compute_inscribed_bucketed_refresh_window(const InternalTimeRange *const refresh_window,
@@ -84,7 +84,7 @@ static bool process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 												   const InternalTimeRange *refresh_window,
 												   const ContinuousAggRefreshContext context,
 												   bool bucketing_refresh_window);
-static Hypertable *
+Hypertable *
 cagg_get_hypertable_or_fail(int32 hypertable_id)
 {
 	Hypertable *ht = ts_hypertable_get_by_id(hypertable_id);
@@ -1141,6 +1141,37 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg,
 		if (refresh_window.end > computed_invalidation_threshold_for_cagg)
 		{
 			refresh_window.end = computed_invalidation_threshold_for_cagg;
+		}
+
+		/*
+		 * Cap the refresh window start at the earliest chunk when the
+		 * hypertable has tiered data but reads are disabled.
+		 *
+		 * Without this cap the refresh window may begin before the
+		 * earliest chunk, causing invalidations in that range to be
+		 * processed and removed. By raising the start to the earliest
+		 * chunk boundary we preserve those earlier invalidations so
+		 * they can be processed later when tiered reads are re-enabled.
+		 *
+		 * We only apply the cap when tiered data exists but reads are
+		 * off, because in that case the refresh cannot see the tiered
+		 * data and would still consume the invalidations. When tiered
+		 * reads are on (or there is no tiered data), no cap is needed.
+		 */
+		if (!ts_guc_enable_osm_reads)
+		{
+			int32 osm_chunk_id = ts_chunk_get_osm_chunk_id(cagg->data.raw_hypertable_id);
+
+			if (osm_chunk_id != INVALID_CHUNK_ID)
+			{
+				int64 earliest_start =
+					invalidation_get_earliest_chunk_start(cagg->data.raw_hypertable_id);
+
+				if (earliest_start > refresh_window.start)
+				{
+					refresh_window.start = earliest_start;
+				}
+			}
 		}
 
 		/* Capping the end might have made the window 0, or negative, so nothing to refresh in that

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -1289,7 +1289,17 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 	if (refresh_window.start_isnull)
 	{
 		debug_refresh_window(cagg, &refresh_window, "START IS NULL");
-		DimensionSlice *slice = ts_dimension_slice_nth_earliest_slice(time_dim->fd.id, 1);
+		DimensionSlice *slice;
+		// If tiered reads are disabled, we cap the refresh window to the start of the hypertable
+		// Get the earliest *non-osm* slice in this scenario.
+		if (!ts_guc_enable_osm_reads)
+		{
+			slice = ts_dimension_slice_earliest_non_osm_slice(time_dim->fd.id);
+		}
+		else
+		{
+			slice = ts_dimension_slice_nth_earliest_slice(time_dim->fd.id, 1);
+		}
 
 		/* If still there's no MIN slice range start then return no batches */
 		if (NULL == slice || TS_TIME_IS_MIN(slice->fd.range_start, refresh_window.type) ||

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -17,6 +17,7 @@
 /* Default refresh newest first */
 #define DEFAULT_REFRESH_NEWEST_FIRST true
 
+Hypertable *cagg_get_hypertable_or_fail(int32 hypertable_id);
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void continuous_agg_refresh_batched(ContinuousAgg *cagg, InternalTimeRange *refresh_window,
 										   ContinuousAggRefreshContext context,

--- a/tsl/test/expected/cagg_refresh_tiered.out
+++ b/tsl/test/expected/cagg_refresh_tiered.out
@@ -227,8 +227,7 @@ SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
 
 ----------------------------------------------------------------------
 -- Test 5: When the OSM chunk's range is updated to precede the
--- earliest real chunk, the wrong dimension slice is picked up
--- and the refresh is not capped correctly.
+-- earliest real chunk the refresh should be capped correctly.
 ----------------------------------------------------------------------
 -- Update the OSM chunk range so it sorts before all real chunks
 SELECT _timescaledb_functions.hypertable_osm_range_update('conditions2', -10::bigint, 10::bigint);

--- a/tsl/test/expected/cagg_refresh_tiered.out
+++ b/tsl/test/expected/cagg_refresh_tiered.out
@@ -226,6 +226,46 @@ SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
                    80 | 9223372036854775807
 
 ----------------------------------------------------------------------
+-- Test 5: When the OSM chunk's range is updated to precede the
+-- earliest real chunk, the wrong dimension slice is picked up
+-- and the refresh is not capped correctly.
+----------------------------------------------------------------------
+-- Update the OSM chunk range so it sorts before all real chunks
+SELECT _timescaledb_functions.hypertable_osm_range_update('conditions2', -10::bigint, 10::bigint);
+ hypertable_osm_range_update 
+-----------------------------
+ f
+
+-- Verify the OSM chunk now has a range that precedes the real data
+SELECT ds.range_start, ds.range_end, c.osm_chunk
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE c.hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions2')
+ORDER BY ds.range_start;
+ range_start | range_end | osm_chunk 
+-------------+-----------+-----------
+         -10 |        10 | t
+          20 |        30 | f
+          30 |        40 | f
+          40 |        50 | f
+          50 |        60 | f
+          60 |        70 | f
+          70 |        80 | f
+
+-- Insert to create a new invalidation
+INSERT INTO conditions2 VALUES (55, 1, 99.0);
+SET timescaledb.enable_tiered_reads = false;
+CALL refresh_continuous_aggregate('cond2_10', NULL, NULL);
+-- The expected entry should be (-INF, 19) and NOT (-INF, -11)
+-- The capping is incorrect
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+        start         |         end         
+----------------------+---------------------
+ -9223372036854775808 |                 -11
+                   80 | 9223372036854775807
+
+----------------------------------------------------------------------
 -- Cleanup
 ----------------------------------------------------------------------
 SET timescaledb.enable_tiered_reads = true;

--- a/tsl/test/expected/cagg_refresh_tiered.out
+++ b/tsl/test/expected/cagg_refresh_tiered.out
@@ -1,0 +1,240 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test that continuous aggregate refresh with NULL start caps the
+-- refresh window at the earliest chunk when tiered data is present
+-- and tiered reads are disabled.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+
+SET datestyle TO 'ISO, YMD';
+SET timezone TO 'UTC';
+----------------------------------------------------------------------
+-- Set up postgres_fdw for creating a real OSM chunk
+----------------------------------------------------------------------
+CREATE DATABASE osm_fdw_db;
+GRANT ALL PRIVILEGES ON DATABASE osm_fdw_db TO :ROLE_4;
+\c osm_fdw_db :ROLE_4
+CREATE TABLE osm_data (time bigint NOT NULL, device int, temp float);
+-- This represents tiered data that lives in object storage
+INSERT INTO osm_data VALUES (-5, 1, 10.0), (-3, 2, 20.0);
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT current_setting('port') AS "PORTNO" \gset
+CREATE EXTENSION postgres_fdw;
+CREATE SERVER osm_server FOREIGN DATA WRAPPER postgres_fdw
+OPTIONS (dbname 'osm_fdw_db', port :'PORTNO');
+GRANT USAGE ON FOREIGN SERVER osm_server TO :ROLE_4;
+CREATE USER MAPPING FOR :ROLE_4 SERVER osm_server
+OPTIONS (user :'ROLE_4', password :'ROLE_4_PASS');
+ALTER USER MAPPING FOR :ROLE_4 SERVER osm_server
+OPTIONS (ADD password_required 'false');
+\c :TEST_DBNAME :ROLE_4
+CREATE FOREIGN TABLE osm_fdw_chunk (time bigint NOT NULL, device int, temp float)
+SERVER osm_server OPTIONS (schema_name 'public', table_name 'osm_data');
+----------------------------------------------------------------------
+-- Create hypertable and continuous aggregate
+----------------------------------------------------------------------
+CREATE TABLE conditions (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+
+CREATE OR REPLACE FUNCTION bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS $$
+  SELECT coalesce(max(time), 0) FROM conditions
+$$;
+SELECT set_integer_now_func('conditions', 'bigint_now');
+ set_integer_now_func 
+----------------------
+ 
+
+-- Insert data from 0 to 99
+INSERT INTO conditions
+SELECT t, (t % 4) + 1, (t * 7) % 40
+FROM generate_series(0, 99, 1) t;
+CREATE MATERIALIZED VIEW cond_10
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH NO DATA;
+-- Invalidation log view
+CREATE VIEW cagg_invals AS
+SELECT materialization_id AS "cagg_id",
+       lowest_modified_value AS "start",
+       greatest_modified_value AS "end"
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+ORDER BY 1,2,3;
+-- Refresh to populate the cagg and establish the invalidation threshold
+CALL refresh_continuous_aggregate('cond_10', 0, 100);
+SELECT mat_hypertable_id AS cond_10_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond_10' \gset
+-- After refresh [0,100), the cagg log has sentinel entries for
+-- the regions before and after the refreshed window.
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond_10_id;
+        start         |         end         
+----------------------+---------------------
+ -9223372036854775808 |                  -1
+                  100 | 9223372036854775807
+
+----------------------------------------------------------------------
+-- Attach OSM chunk to simulate tiered data
+----------------------------------------------------------------------
+SELECT _timescaledb_functions.attach_osm_table_chunk('conditions', 'osm_fdw_chunk');
+ attach_osm_table_chunk 
+------------------------
+ t
+
+-- Verify the hypertable now has OSM status
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions';
+ status 
+--------
+      3
+
+-- Verify earliest non-OSM chunk starts at 0
+SELECT min(ds.range_start) AS earliest_start
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE c.hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions')
+  AND c.osm_chunk = false;
+ earliest_start 
+----------------
+              0
+
+----------------------------------------------------------------------
+-- Test 1: With tiered reads disabled and OSM chunk present, a
+-- NULL-start refresh caps at the earliest chunk. The sentinel entry
+-- (-INF, -1) is preserved because it falls entirely before the cap.
+----------------------------------------------------------------------
+-- Insert data to create invalidations that will trigger the refresh
+INSERT INTO conditions VALUES (15, 1, 99.0), (25, 2, 99.0);
+SET timescaledb.enable_tiered_reads = false;
+CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
+-- The (-INF, -1) entry should be preserved
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond_10_id;
+        start         |         end         
+----------------------+---------------------
+ -9223372036854775808 |                  -1
+                  100 | 9223372036854775807
+
+----------------------------------------------------------------------
+-- Test 2: With tiered reads enabled, the cap is NOT applied.
+-- The full refresh window is used.
+----------------------------------------------------------------------
+SET timescaledb.enable_tiered_reads = true;
+-- Insert to create a new invalidation so the refresh has work to do
+INSERT INTO conditions VALUES (35, 3, 99.0);
+CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
+-- The (-INF, -1) entry should now be consumed
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond_10_id;
+ start |         end         
+-------+---------------------
+   100 | 9223372036854775807
+
+----------------------------------------------------------------------
+-- Test 3: Verify the cap preserves pre-chunk invalidations for a
+-- hypertable whose data does not start at 0.
+----------------------------------------------------------------------
+DROP MATERIALIZED VIEW cond_10;
+NOTICE:  drop cascades to 2 other objects
+DROP TABLE conditions CASCADE;
+-- Create a fresh hypertable with data starting at 20
+CREATE TABLE conditions2 (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions2', 'time', chunk_time_interval => 10);
+    create_hypertable     
+--------------------------
+ (3,public,conditions2,t)
+
+CREATE OR REPLACE FUNCTION bigint_now2()
+RETURNS bigint LANGUAGE SQL STABLE AS $$
+  SELECT coalesce(max(time), 0) FROM conditions2
+$$;
+SELECT set_integer_now_func('conditions2', 'bigint_now2');
+ set_integer_now_func 
+----------------------
+ 
+
+INSERT INTO conditions2
+SELECT t, (t % 4) + 1, (t * 7) % 40
+FROM generate_series(20, 79, 1) t;
+CREATE MATERIALIZED VIEW cond2_10
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions2
+GROUP BY 1,2 WITH NO DATA;
+CALL refresh_continuous_aggregate('cond2_10', 20, 80);
+SELECT mat_hypertable_id AS cond2_10_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond2_10' \gset
+-- The invalidation log should have entries for before 20 and after 80
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+        start         |         end         
+----------------------+---------------------
+ -9223372036854775808 |                  19
+                   80 | 9223372036854775807
+
+-- Attach a new OSM chunk for this hypertable
+CREATE FOREIGN TABLE osm_fdw_chunk2 (time bigint NOT NULL, device int, temp float)
+SERVER osm_server OPTIONS (schema_name 'public', table_name 'osm_data');
+SELECT _timescaledb_functions.attach_osm_table_chunk('conditions2', 'osm_fdw_chunk2');
+ attach_osm_table_chunk 
+------------------------
+ t
+
+-- Verify earliest non-OSM chunk starts at 20
+SELECT min(ds.range_start) AS earliest_start
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE c.hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions2')
+  AND c.osm_chunk = false;
+ earliest_start 
+----------------
+             20
+
+-- Insert to create invalidation
+INSERT INTO conditions2 VALUES (35, 3, 99.0);
+SET timescaledb.enable_tiered_reads = false;
+CALL refresh_continuous_aggregate('cond2_10', NULL, NULL);
+-- The (-INF, 19) entry should be preserved because the cap is at 20
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+        start         |         end         
+----------------------+---------------------
+ -9223372036854775808 |                  19
+                   80 | 9223372036854775807
+
+----------------------------------------------------------------------
+-- Test 4: The cap also applies when an explicit start is given that
+-- falls before the earliest chunk. A refresh with start=0 should
+-- still be capped at 20 when tiered reads are disabled.
+----------------------------------------------------------------------
+-- Insert to create a new invalidation
+INSERT INTO conditions2 VALUES (45, 2, 99.0);
+-- Explicit start of 0, which is before the earliest chunk at 20
+CALL refresh_continuous_aggregate('cond2_10', 0, 80);
+-- The (-INF, 19) entry should still be preserved because the cap
+-- raises the effective start from 0 to 20
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+        start         |         end         
+----------------------+---------------------
+ -9223372036854775808 |                  19
+                   80 | 9223372036854775807
+
+----------------------------------------------------------------------
+-- Cleanup
+----------------------------------------------------------------------
+SET timescaledb.enable_tiered_reads = true;
+DROP MATERIALIZED VIEW cond2_10;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_20_chunk
+DROP TABLE conditions2 CASCADE;
+DROP VIEW cagg_invals;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP SERVER osm_server CASCADE;
+NOTICE:  drop cascades to user mapping for test_role_4 on server osm_server
+DROP EXTENSION postgres_fdw;
+DROP DATABASE osm_fdw_db;

--- a/tsl/test/expected/cagg_refresh_tiered.out
+++ b/tsl/test/expected/cagg_refresh_tiered.out
@@ -257,12 +257,11 @@ ORDER BY ds.range_start;
 INSERT INTO conditions2 VALUES (55, 1, 99.0);
 SET timescaledb.enable_tiered_reads = false;
 CALL refresh_continuous_aggregate('cond2_10', NULL, NULL);
--- The expected entry should be (-INF, 19) and NOT (-INF, -11)
--- The capping is incorrect
+-- The refresh cap skips the OSM chunk entry and caps at the earliest hypertable entry
 SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
         start         |         end         
 ----------------------+---------------------
- -9223372036854775808 |                 -11
+ -9223372036854775808 |                  19
                    80 | 9223372036854775807
 
 ----------------------------------------------------------------------

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -721,6 +721,7 @@ SELECT * FROM ht_try_weekly;
 
 SET timescaledb.enable_tiered_reads=false;
 CALL refresh_continuous_aggregate('ht_try_weekly', '2019-12-29', '2020-01-10', force=>false);
+NOTICE:  continuous aggregate "ht_try_weekly" is already up-to-date
 SELECT * FROM ht_try_weekly;
  ts_bucket | avg 
 -----------+-----

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -137,6 +137,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     cagg_policy_incremental.sql
     cagg_refresh_cleanup.sql
     cagg_refresh_incremental.sql
+    cagg_refresh_tiered.sql
     chunk_column_stats.sql
     compress_bgw_reorder_drop_chunks.sql
     compress_bloom_legacy_v1.sql

--- a/tsl/test/sql/cagg_refresh_tiered.sql
+++ b/tsl/test/sql/cagg_refresh_tiered.sql
@@ -227,8 +227,7 @@ INSERT INTO conditions2 VALUES (55, 1, 99.0);
 SET timescaledb.enable_tiered_reads = false;
 CALL refresh_continuous_aggregate('cond2_10', NULL, NULL);
 
--- The expected entry should be (-INF, 19) and NOT (-INF, -11)
--- The capping is incorrect
+-- The refresh cap skips the OSM chunk entry and caps at the earliest hypertable entry
 SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
 
 ----------------------------------------------------------------------

--- a/tsl/test/sql/cagg_refresh_tiered.sql
+++ b/tsl/test/sql/cagg_refresh_tiered.sql
@@ -1,0 +1,218 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test that continuous aggregate refresh with NULL start caps the
+-- refresh window at the earliest chunk when tiered data is present
+-- and tiered reads are disabled.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_functions.stop_background_workers();
+SET datestyle TO 'ISO, YMD';
+SET timezone TO 'UTC';
+
+----------------------------------------------------------------------
+-- Set up postgres_fdw for creating a real OSM chunk
+----------------------------------------------------------------------
+CREATE DATABASE osm_fdw_db;
+GRANT ALL PRIVILEGES ON DATABASE osm_fdw_db TO :ROLE_4;
+
+\c osm_fdw_db :ROLE_4
+CREATE TABLE osm_data (time bigint NOT NULL, device int, temp float);
+-- This represents tiered data that lives in object storage
+INSERT INTO osm_data VALUES (-5, 1, 10.0), (-3, 2, 20.0);
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+SELECT current_setting('port') AS "PORTNO" \gset
+
+CREATE EXTENSION postgres_fdw;
+CREATE SERVER osm_server FOREIGN DATA WRAPPER postgres_fdw
+OPTIONS (dbname 'osm_fdw_db', port :'PORTNO');
+GRANT USAGE ON FOREIGN SERVER osm_server TO :ROLE_4;
+
+CREATE USER MAPPING FOR :ROLE_4 SERVER osm_server
+OPTIONS (user :'ROLE_4', password :'ROLE_4_PASS');
+
+ALTER USER MAPPING FOR :ROLE_4 SERVER osm_server
+OPTIONS (ADD password_required 'false');
+
+\c :TEST_DBNAME :ROLE_4
+
+CREATE FOREIGN TABLE osm_fdw_chunk (time bigint NOT NULL, device int, temp float)
+SERVER osm_server OPTIONS (schema_name 'public', table_name 'osm_data');
+
+----------------------------------------------------------------------
+-- Create hypertable and continuous aggregate
+----------------------------------------------------------------------
+CREATE TABLE conditions (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
+
+CREATE OR REPLACE FUNCTION bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS $$
+  SELECT coalesce(max(time), 0) FROM conditions
+$$;
+SELECT set_integer_now_func('conditions', 'bigint_now');
+
+-- Insert data from 0 to 99
+INSERT INTO conditions
+SELECT t, (t % 4) + 1, (t * 7) % 40
+FROM generate_series(0, 99, 1) t;
+
+CREATE MATERIALIZED VIEW cond_10
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH NO DATA;
+
+-- Invalidation log view
+CREATE VIEW cagg_invals AS
+SELECT materialization_id AS "cagg_id",
+       lowest_modified_value AS "start",
+       greatest_modified_value AS "end"
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+ORDER BY 1,2,3;
+
+-- Refresh to populate the cagg and establish the invalidation threshold
+CALL refresh_continuous_aggregate('cond_10', 0, 100);
+
+SELECT mat_hypertable_id AS cond_10_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond_10' \gset
+
+-- After refresh [0,100), the cagg log has sentinel entries for
+-- the regions before and after the refreshed window.
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond_10_id;
+
+----------------------------------------------------------------------
+-- Attach OSM chunk to simulate tiered data
+----------------------------------------------------------------------
+SELECT _timescaledb_functions.attach_osm_table_chunk('conditions', 'osm_fdw_chunk');
+
+-- Verify the hypertable now has OSM status
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions';
+
+-- Verify earliest non-OSM chunk starts at 0
+SELECT min(ds.range_start) AS earliest_start
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE c.hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions')
+  AND c.osm_chunk = false;
+
+----------------------------------------------------------------------
+-- Test 1: With tiered reads disabled and OSM chunk present, a
+-- NULL-start refresh caps at the earliest chunk. The sentinel entry
+-- (-INF, -1) is preserved because it falls entirely before the cap.
+----------------------------------------------------------------------
+
+-- Insert data to create invalidations that will trigger the refresh
+INSERT INTO conditions VALUES (15, 1, 99.0), (25, 2, 99.0);
+
+SET timescaledb.enable_tiered_reads = false;
+CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
+
+-- The (-INF, -1) entry should be preserved
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond_10_id;
+
+----------------------------------------------------------------------
+-- Test 2: With tiered reads enabled, the cap is NOT applied.
+-- The full refresh window is used.
+----------------------------------------------------------------------
+SET timescaledb.enable_tiered_reads = true;
+
+-- Insert to create a new invalidation so the refresh has work to do
+INSERT INTO conditions VALUES (35, 3, 99.0);
+
+CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
+
+-- The (-INF, -1) entry should now be consumed
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond_10_id;
+
+----------------------------------------------------------------------
+-- Test 3: Verify the cap preserves pre-chunk invalidations for a
+-- hypertable whose data does not start at 0.
+----------------------------------------------------------------------
+DROP MATERIALIZED VIEW cond_10;
+DROP TABLE conditions CASCADE;
+
+-- Create a fresh hypertable with data starting at 20
+CREATE TABLE conditions2 (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions2', 'time', chunk_time_interval => 10);
+
+CREATE OR REPLACE FUNCTION bigint_now2()
+RETURNS bigint LANGUAGE SQL STABLE AS $$
+  SELECT coalesce(max(time), 0) FROM conditions2
+$$;
+SELECT set_integer_now_func('conditions2', 'bigint_now2');
+
+INSERT INTO conditions2
+SELECT t, (t % 4) + 1, (t * 7) % 40
+FROM generate_series(20, 79, 1) t;
+
+CREATE MATERIALIZED VIEW cond2_10
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions2
+GROUP BY 1,2 WITH NO DATA;
+
+CALL refresh_continuous_aggregate('cond2_10', 20, 80);
+
+SELECT mat_hypertable_id AS cond2_10_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond2_10' \gset
+
+-- The invalidation log should have entries for before 20 and after 80
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+
+-- Attach a new OSM chunk for this hypertable
+CREATE FOREIGN TABLE osm_fdw_chunk2 (time bigint NOT NULL, device int, temp float)
+SERVER osm_server OPTIONS (schema_name 'public', table_name 'osm_data');
+
+SELECT _timescaledb_functions.attach_osm_table_chunk('conditions2', 'osm_fdw_chunk2');
+
+-- Verify earliest non-OSM chunk starts at 20
+SELECT min(ds.range_start) AS earliest_start
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE c.hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions2')
+  AND c.osm_chunk = false;
+
+-- Insert to create invalidation
+INSERT INTO conditions2 VALUES (35, 3, 99.0);
+
+SET timescaledb.enable_tiered_reads = false;
+CALL refresh_continuous_aggregate('cond2_10', NULL, NULL);
+
+-- The (-INF, 19) entry should be preserved because the cap is at 20
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+
+----------------------------------------------------------------------
+-- Test 4: The cap also applies when an explicit start is given that
+-- falls before the earliest chunk. A refresh with start=0 should
+-- still be capped at 20 when tiered reads are disabled.
+----------------------------------------------------------------------
+
+-- Insert to create a new invalidation
+INSERT INTO conditions2 VALUES (45, 2, 99.0);
+
+-- Explicit start of 0, which is before the earliest chunk at 20
+CALL refresh_continuous_aggregate('cond2_10', 0, 80);
+
+-- The (-INF, 19) entry should still be preserved because the cap
+-- raises the effective start from 0 to 20
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+
+----------------------------------------------------------------------
+-- Cleanup
+----------------------------------------------------------------------
+SET timescaledb.enable_tiered_reads = true;
+DROP MATERIALIZED VIEW cond2_10;
+DROP TABLE conditions2 CASCADE;
+DROP VIEW cagg_invals;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP SERVER osm_server CASCADE;
+DROP EXTENSION postgres_fdw;
+DROP DATABASE osm_fdw_db;

--- a/tsl/test/sql/cagg_refresh_tiered.sql
+++ b/tsl/test/sql/cagg_refresh_tiered.sql
@@ -206,8 +206,7 @@ SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
 
 ----------------------------------------------------------------------
 -- Test 5: When the OSM chunk's range is updated to precede the
--- earliest real chunk, the wrong dimension slice is picked up
--- and the refresh is not capped correctly.
+-- earliest real chunk the refresh should be capped correctly.
 ----------------------------------------------------------------------
 
 -- Update the OSM chunk range so it sorts before all real chunks

--- a/tsl/test/sql/cagg_refresh_tiered.sql
+++ b/tsl/test/sql/cagg_refresh_tiered.sql
@@ -205,6 +205,33 @@ CALL refresh_continuous_aggregate('cond2_10', 0, 80);
 SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
 
 ----------------------------------------------------------------------
+-- Test 5: When the OSM chunk's range is updated to precede the
+-- earliest real chunk, the wrong dimension slice is picked up
+-- and the refresh is not capped correctly.
+----------------------------------------------------------------------
+
+-- Update the OSM chunk range so it sorts before all real chunks
+SELECT _timescaledb_functions.hypertable_osm_range_update('conditions2', -10::bigint, 10::bigint);
+
+-- Verify the OSM chunk now has a range that precedes the real data
+SELECT ds.range_start, ds.range_end, c.osm_chunk
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+JOIN _timescaledb_catalog.dimension_slice ds ON ds.id = cc.dimension_slice_id
+WHERE c.hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions2')
+ORDER BY ds.range_start;
+
+-- Insert to create a new invalidation
+INSERT INTO conditions2 VALUES (55, 1, 99.0);
+
+SET timescaledb.enable_tiered_reads = false;
+CALL refresh_continuous_aggregate('cond2_10', NULL, NULL);
+
+-- The expected entry should be (-INF, 19) and NOT (-INF, -11)
+-- The capping is incorrect
+SELECT "start", "end" FROM cagg_invals WHERE cagg_id = :cond2_10_id;
+
+----------------------------------------------------------------------
 -- Cleanup
 ----------------------------------------------------------------------
 SET timescaledb.enable_tiered_reads = true;


### PR DESCRIPTION
Currently during a refresh, we process the ranges before the earliest chunk in the hypertable as well. This can lead to potential missing data when tiered data is present but tiered reads are disabled during the refresh.

By capping the refresh range at the start of the earliest chunk, any invalidations before the earliest chunk are no longer processed and removed. Thus, in a subsequent refresh, if tiered data reads are enabled, that data would be materialized in the CAgg.

We only need to do this when the hypertable has tiered data. Any new tiered data will either have been processed before tiering (since it exists in some chunk) or will be inserted after this refresh (which will generate invalidations).

We also cap the refresh start when generating batches for an incremental refresh.