### PR TITLE
fix(tsl): duplicated words in columnar_scan/planner, gorilla, and recompress comments

### DIFF
--- a/.unreleased/pr_9814
+++ b/.unreleased/pr_9814
@@ -1,0 +1,2 @@
+Thanks: @otjdiepluong for fixing spelling mistakes in timescaledb source code comments
+

--- a/tsl/src/compression/algorithms/gorilla.c
+++ b/tsl/src/compression/algorithms/gorilla.c
@@ -384,7 +384,7 @@ gorilla_compressor_append_value(GorillaCompressor *compressor, uint64 val)
 	{
 		/* leftmost/rightmost 1 is not well-defined when all the bits in the number
 		 * are 0; the C implementations of these functions will ERROR, while the
-		 * assembly versions may return any value. We special-case 0 to to use
+		 * assembly versions may return any value. We special-case 0 to use
 		 * values for leading and trailing-zeroes that we know will work.
 		 */
 		int leading_zeros = xor != 0 ? 63 - pg_leftmost_one_pos64(xor) : 63;

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -617,7 +617,7 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 			break;
 		}
 
-		/* Reset index scan if we are done with with this segment */
+		/* Reset index scan if we are done with this segment */
 		if (done_with_segment)
 		{
 			continue;

--- a/tsl/src/nodes/columnar_scan/planner.c
+++ b/tsl/src/nodes/columnar_scan/planner.c
@@ -1366,7 +1366,7 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 			}
 
 			/*
-			 * If the the compressed target list is not based on the layout of
+			 * If the compressed target list is not based on the layout of
 			 * the uncompressed chunk (see comment for physical_tlist above),
 			 * adjust the position of the attribute.
 			 */


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in source comments:
- `tsl/src/nodes/columnar_scan/planner.c` — "/* If the the compressed target list is not based on the layout of" → "/* If the compressed target list is not based on the layout of"
- `tsl/src/compression/algorithms/gorilla.c` — "* assembly versions may return any value. We special-case 0 to to use" → "...We special-case 0 to use"
- `tsl/src/compression/recompress.c` — "/* Reset index scan if we are done with with this segment */" → "/* Reset index scan if we are done with this segment */"

No code/behavior change.

Disable-check: force-changelog-file