### PR TITLE
Fix NULL derefencing in columnar_result_finalize

### DIFF
--- a/tsl/src/nodes/vector_agg/exec.c
+++ b/tsl/src/nodes/vector_agg/exec.c
@@ -237,6 +237,8 @@ columnar_result_finalize(ColumnarResult *columnar_result, DecompressBatchState c
 	}
 	else if (columnar_result->type == DT_ArrowText)
 	{
+		/* offset_buffer should be allocated for ArrowText type */
+		Assert(columnar_result->offset_buffer != NULL);
 		columnar_result->offset_buffer[nrows] = columnar_result->current_offset;
 
 		arrow_result = MemoryContextAllocZero(batch_state->per_batch_context,


### PR DESCRIPTION
Fix Coverity report issue: 

        >>>     CID 503639:           (FORWARD_NULL)
        >>>     Passing "&columnar_result" to "columnar_result_finalize", which dereferences null "columnar_result.offset_buffer".
        594     	return columnar_result_finalize(&columnar_result, batch_state);


Disable-check: force-changelog-file