### PR TITLE
Allow subquery results which are exec params as gapfill arguments

### DIFF
--- a/.unreleased/pr_9821
+++ b/.unreleased/pr_9821
@@ -1,0 +1,2 @@
+Implements: #9821 Allow subquery results which are exec params as gapfill arguments
+Thanks: @scimad and @Nosfistis for suggesting expanding coverage for gapfill arguments

--- a/tsl/src/nodes/gapfill/gapfill_exec.c
+++ b/tsl/src/nodes/gapfill/gapfill_exec.c
@@ -319,7 +319,8 @@ is_simple_expr_walker(Node *node, void *context)
 		case T_CaseWhen:
 			break;
 		case T_Param:
-			if (castNode(Param, node)->paramkind != PARAM_EXTERN)
+			if (castNode(Param, node)->paramkind != PARAM_EXTERN &&
+				castNode(Param, node)->paramkind != PARAM_EXEC)
 			{
 				return true;
 			}
@@ -799,29 +800,11 @@ gapfill_advance_timestamp(GapFillState *state)
 	}
 }
 
-/*
- * Initialize the scan state
- */
 static void
-gapfill_begin(CustomScanState *node, EState *estate, int eflags)
+gapfill_initialize_arguments(GapFillState *state)
 {
-	GapFillState *state = (GapFillState *) node;
-	CustomScan *cscan = castNode(CustomScan, state->csstate.ss.ps.plan);
-
-	/*
-	 * this is the time_bucket_gapfill call from the plan which is used to
-	 * extract arguments and to align gapfill_start
-	 */
-	FuncExpr *func = list_nth(cscan->custom_private, GFP_GapfillFunc);
-	TupleDesc tupledesc = state->csstate.ss.ps.ps_ResultTupleSlot->tts_tupleDescriptor;
-	List *targetlist = copyObject(state->csstate.ss.ps.plan->targetlist);
 	bool isnull;
 	Datum arg_value;
-
-	state->gapfill_typid = func->funcresulttype;
-	state->state = FETCHED_NONE;
-	state->subslot = MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual);
-	state->scanslot = MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual);
 
 	/* bucket_width */
 	if (!is_simple_expr(linitial(state->args)))
@@ -840,7 +823,7 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 				 errmsg("invalid time_bucket_gapfill argument: bucket_width cannot be NULL")));
 	}
 
-	state->gapfill_period = gapfill_period_get_internal(func->funcresulttype,
+	state->gapfill_period = gapfill_period_get_internal(state->gapfill_typid,
 														exprType(linitial(state->args)),
 														arg_value,
 														&state->gapfill_interval);
@@ -907,8 +890,31 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 					 errhint("Specify start and finish as arguments or in the WHERE clause.")));
 		}
 
-		state->gapfill_end = gapfill_datum_get_internal(arg_value, func->funcresulttype);
+		state->gapfill_end = gapfill_datum_get_internal(arg_value, state->gapfill_typid);
 	}
+}
+
+/*
+ * Initialize the scan state
+ */
+static void
+gapfill_begin(CustomScanState *node, EState *estate, int eflags)
+{
+	GapFillState *state = (GapFillState *) node;
+	CustomScan *cscan = castNode(CustomScan, state->csstate.ss.ps.plan);
+
+	/*
+	 * this is the time_bucket_gapfill call from the plan which is used to
+	 * extract arguments and to align gapfill_start
+	 */
+	FuncExpr *func = list_nth(cscan->custom_private, GFP_GapfillFunc);
+	TupleDesc tupledesc = state->csstate.ss.ps.ps_ResultTupleSlot->tts_tupleDescriptor;
+	List *targetlist = copyObject(state->csstate.ss.ps.plan->targetlist);
+
+	state->gapfill_typid = func->funcresulttype;
+	state->state = PREFETCH;
+	state->subslot = MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual);
+	state->scanslot = MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual);
 
 	gapfill_state_initialize_columns(state, targetlist);
 
@@ -938,6 +944,12 @@ gapfill_exec(CustomScanState *node)
 	while (true)
 	{
 		CHECK_FOR_INTERRUPTS();
+
+		if (PREFETCH == state->state)
+		{
+			gapfill_initialize_arguments(state);
+			state->state = FETCHED_NONE;
+		}
 
 		/* fetch next tuple from subplan */
 		if (FETCHED_NONE == state->state)
@@ -1043,6 +1055,7 @@ gapfill_rescan(CustomScanState *node)
 		ExecReScan(linitial(node->custom_ps));
 	}
 
+	gapfill_initialize_arguments(state);
 	state->state = FETCHED_NONE;
 	state->next_timestamp = state->gapfill_start;
 	state->next_offset = state->gapfill_interval;

--- a/tsl/src/nodes/gapfill/gapfill_internal.h
+++ b/tsl/src/nodes/gapfill/gapfill_internal.h
@@ -46,6 +46,7 @@
  */
 typedef enum GapFillFetchState
 {
+	PREFETCH,
 	FETCHED_NONE,
 	FETCHED_ONE,
 	FETCHED_NEXT_GROUP,

--- a/tsl/test/shared/expected/gapfill-15.out
+++ b/tsl/test/shared/expected/gapfill-15.out
@@ -1126,21 +1126,26 @@ SELECT
 FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
 GROUP BY 1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
--- test subqueries as interval, start and stop (not supported atm)
+-- nonsimple expression (var) as gapfill bucket width, start and finish
 SELECT
-  time_bucket_gapfill((SELECT 1),time,1,11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(polling_interval,time),
+  m1.device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1, (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,(SELECT 1),11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, time - 10, 100),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: start must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,1,(SELECT 11))
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, -100, time + 10),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: finish must be a simple expression
 \set ON_ERROR_STOP 1
 -- test time_bucket_gapfill without aggregation
@@ -3448,3 +3453,301 @@ EXECUTE coalesce_tz_test(NULL);
 DEALLOCATE coalesce_tz_test;
 RESET plan_cache_mode;
 DROP TABLE gf_tz_test;
+-- test subqueries as bucket width, start and stop
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+-- Fill gaps between min and max time in the table
+SELECT
+  time_bucket_gapfill('10m'::interval,time),
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1 ORDER BY 1;
+     time_bucket_gapfill      | locf 
+------------------------------+------
+ Mon Jan 01 05:00:00 2018 PST |  0.7
+ Mon Jan 01 05:10:00 2018 PST |  0.7
+ Mon Jan 01 05:20:00 2018 PST |  0.7
+ Mon Jan 01 05:30:00 2018 PST |  0.7
+ Mon Jan 01 05:40:00 2018 PST |  0.7
+ Mon Jan 01 05:50:00 2018 PST |  0.7
+ Mon Jan 01 06:00:00 2018 PST |  0.7
+ Mon Jan 01 06:10:00 2018 PST |  0.7
+ Mon Jan 01 06:20:00 2018 PST |  0.7
+ Mon Jan 01 06:30:00 2018 PST |  0.7
+ Mon Jan 01 06:40:00 2018 PST |  0.7
+ Mon Jan 01 06:50:00 2018 PST |  0.7
+
+-- Fill gaps between min and max time in the table for each device
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+     time_bucket_gapfill      | device_id | locf 
+------------------------------+-----------+------
+ Mon Jan 01 05:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:40:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:40:00 2018 PST |         3 |  0.9
+
+-- Fill gaps with individual bucket width for each device
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.5
+         2 | Mon Jan 01 05:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:40:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:40:00 2018 PST |   0.7
+         3 | Mon Jan 01 05:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 05:30:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:30:00 2018 PST |   0.9
+
+-- See that EXPLAIN shows nested loop.
+set enable_indexscan = 0;
+set enable_bitmapscan = 0;
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 1 (returns $2)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2
+               InitPlan 2 (returns $4)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_1
+               ->  GroupAggregate
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone)), m1.device_id
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= $2) AND ("time" < $4) AND (device_id = "*VALUES*".column1))
+
+-- Same as above with correlated subquery in locf
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.3
+         2 | Mon Jan 01 05:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:40:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:40:00 2018 PST |  1.35
+         3 | Mon Jan 01 05:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 05:30:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:30:00 2018 PST |   1.2
+
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 2 (returns $3)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_2
+               InitPlan 3 (returns $5)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_3
+               ->  Group
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone)), m1.device_id
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= $3) AND ("time" < $5) AND (device_id = "*VALUES*".column1))
+                     SubPlan 1
+                       ->  Aggregate
+                             ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                   ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                         Filter: (m1.device_id = device_id)
+
+-- Cannot infer start boundary as it's a SubPlan for correlated subquery
+:PREFIX SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   InitPlan 2 (returns $3)
+     ->  Aggregate
+           ->  Seq Scan on _hyper_X_X_chunk m2_2
+   ->  GroupAggregate
+         Group Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Sort
+               Sort Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Result
+                     ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                           ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                 Filter: (("time" < $3) AND ("time" >= (SubPlan 1)))
+                                 SubPlan 1
+                                   ->  Aggregate
+                                         ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                               ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                                     Filter: (device_id = m1_1.device_id)
+
+\set ON_ERROR_STOP 0
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+ERROR:  missing time_bucket_gapfill argument: could not infer start from WHERE clause
+HINT:  Specify start and finish as arguments or in the WHERE clause.
+\set ON_ERROR_STOP 1
+reset enable_indexscan;
+reset enable_bitmapscan;

--- a/tsl/test/shared/expected/gapfill-16.out
+++ b/tsl/test/shared/expected/gapfill-16.out
@@ -1126,21 +1126,26 @@ SELECT
 FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
 GROUP BY 1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
--- test subqueries as interval, start and stop (not supported atm)
+-- nonsimple expression (var) as gapfill bucket width, start and finish
 SELECT
-  time_bucket_gapfill((SELECT 1),time,1,11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(polling_interval,time),
+  m1.device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1, (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,(SELECT 1),11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, time - 10, 100),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: start must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,1,(SELECT 11))
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, -100, time + 10),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: finish must be a simple expression
 \set ON_ERROR_STOP 1
 -- test time_bucket_gapfill without aggregation
@@ -3448,3 +3453,301 @@ EXECUTE coalesce_tz_test(NULL);
 DEALLOCATE coalesce_tz_test;
 RESET plan_cache_mode;
 DROP TABLE gf_tz_test;
+-- test subqueries as bucket width, start and stop
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+-- Fill gaps between min and max time in the table
+SELECT
+  time_bucket_gapfill('10m'::interval,time),
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1 ORDER BY 1;
+     time_bucket_gapfill      | locf 
+------------------------------+------
+ Mon Jan 01 05:00:00 2018 PST |  0.7
+ Mon Jan 01 05:10:00 2018 PST |  0.7
+ Mon Jan 01 05:20:00 2018 PST |  0.7
+ Mon Jan 01 05:30:00 2018 PST |  0.7
+ Mon Jan 01 05:40:00 2018 PST |  0.7
+ Mon Jan 01 05:50:00 2018 PST |  0.7
+ Mon Jan 01 06:00:00 2018 PST |  0.7
+ Mon Jan 01 06:10:00 2018 PST |  0.7
+ Mon Jan 01 06:20:00 2018 PST |  0.7
+ Mon Jan 01 06:30:00 2018 PST |  0.7
+ Mon Jan 01 06:40:00 2018 PST |  0.7
+ Mon Jan 01 06:50:00 2018 PST |  0.7
+
+-- Fill gaps between min and max time in the table for each device
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+     time_bucket_gapfill      | device_id | locf 
+------------------------------+-----------+------
+ Mon Jan 01 05:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:40:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:40:00 2018 PST |         3 |  0.9
+
+-- Fill gaps with individual bucket width for each device
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.5
+         2 | Mon Jan 01 05:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:40:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:40:00 2018 PST |   0.7
+         3 | Mon Jan 01 05:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 05:30:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:30:00 2018 PST |   0.9
+
+-- See that EXPLAIN shows nested loop.
+set enable_indexscan = 0;
+set enable_bitmapscan = 0;
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 1 (returns $2)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2
+               InitPlan 2 (returns $4)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_1
+               ->  GroupAggregate
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= $2) AND ("time" < $4) AND (device_id = "*VALUES*".column1))
+
+-- Same as above with correlated subquery in locf
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.3
+         2 | Mon Jan 01 05:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:40:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:40:00 2018 PST |  1.35
+         3 | Mon Jan 01 05:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 05:30:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:30:00 2018 PST |   1.2
+
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 2 (returns $3)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_2
+               InitPlan 3 (returns $5)
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_3
+               ->  Group
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= $3) AND ("time" < $5) AND (device_id = "*VALUES*".column1))
+                     SubPlan 1
+                       ->  Aggregate
+                             ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                   ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                         Filter: (m1.device_id = device_id)
+
+-- Cannot infer start boundary as it's a SubPlan for correlated subquery
+:PREFIX SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   InitPlan 2 (returns $3)
+     ->  Aggregate
+           ->  Seq Scan on _hyper_X_X_chunk m2_2
+   ->  GroupAggregate
+         Group Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Sort
+               Sort Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Result
+                     ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                           ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                 Filter: (("time" < $3) AND ("time" >= (SubPlan 1)))
+                                 SubPlan 1
+                                   ->  Aggregate
+                                         ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                               ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                                     Filter: (device_id = m1_1.device_id)
+
+\set ON_ERROR_STOP 0
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+ERROR:  missing time_bucket_gapfill argument: could not infer start from WHERE clause
+HINT:  Specify start and finish as arguments or in the WHERE clause.
+\set ON_ERROR_STOP 1
+reset enable_indexscan;
+reset enable_bitmapscan;

--- a/tsl/test/shared/expected/gapfill-17.out
+++ b/tsl/test/shared/expected/gapfill-17.out
@@ -1126,21 +1126,26 @@ SELECT
 FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
 GROUP BY 1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
--- test subqueries as interval, start and stop (not supported atm)
+-- nonsimple expression (var) as gapfill bucket width, start and finish
 SELECT
-  time_bucket_gapfill((SELECT 1),time,1,11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(polling_interval,time),
+  m1.device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1, (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,(SELECT 1),11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, time - 10, 100),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: start must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,1,(SELECT 11))
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, -100, time + 10),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: finish must be a simple expression
 \set ON_ERROR_STOP 1
 -- test time_bucket_gapfill without aggregation
@@ -3448,3 +3453,301 @@ EXECUTE coalesce_tz_test(NULL);
 DEALLOCATE coalesce_tz_test;
 RESET plan_cache_mode;
 DROP TABLE gf_tz_test;
+-- test subqueries as bucket width, start and stop
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+-- Fill gaps between min and max time in the table
+SELECT
+  time_bucket_gapfill('10m'::interval,time),
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1 ORDER BY 1;
+     time_bucket_gapfill      | locf 
+------------------------------+------
+ Mon Jan 01 05:00:00 2018 PST |  0.7
+ Mon Jan 01 05:10:00 2018 PST |  0.7
+ Mon Jan 01 05:20:00 2018 PST |  0.7
+ Mon Jan 01 05:30:00 2018 PST |  0.7
+ Mon Jan 01 05:40:00 2018 PST |  0.7
+ Mon Jan 01 05:50:00 2018 PST |  0.7
+ Mon Jan 01 06:00:00 2018 PST |  0.7
+ Mon Jan 01 06:10:00 2018 PST |  0.7
+ Mon Jan 01 06:20:00 2018 PST |  0.7
+ Mon Jan 01 06:30:00 2018 PST |  0.7
+ Mon Jan 01 06:40:00 2018 PST |  0.7
+ Mon Jan 01 06:50:00 2018 PST |  0.7
+
+-- Fill gaps between min and max time in the table for each device
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+     time_bucket_gapfill      | device_id | locf 
+------------------------------+-----------+------
+ Mon Jan 01 05:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:40:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:40:00 2018 PST |         3 |  0.9
+
+-- Fill gaps with individual bucket width for each device
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.5
+         2 | Mon Jan 01 05:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:40:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:40:00 2018 PST |   0.7
+         3 | Mon Jan 01 05:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 05:30:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:30:00 2018 PST |   0.9
+
+-- See that EXPLAIN shows nested loop.
+set enable_indexscan = 0;
+set enable_bitmapscan = 0;
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 1
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2
+               InitPlan 2
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_1
+               ->  GroupAggregate
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= (InitPlan 1).col1) AND ("time" < (InitPlan 2).col1) AND (device_id = "*VALUES*".column1))
+
+-- Same as above with correlated subquery in locf
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.3
+         2 | Mon Jan 01 05:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:40:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:40:00 2018 PST |  1.35
+         3 | Mon Jan 01 05:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 05:30:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:30:00 2018 PST |   1.2
+
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 2
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_2
+               InitPlan 3
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_3
+               ->  Group
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= (InitPlan 2).col1) AND ("time" < (InitPlan 3).col1) AND (device_id = "*VALUES*".column1))
+                     SubPlan 1
+                       ->  Aggregate
+                             ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                   ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                         Filter: (m1.device_id = device_id)
+
+-- Cannot infer start boundary as it's a SubPlan for correlated subquery
+:PREFIX SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   InitPlan 2
+     ->  Aggregate
+           ->  Seq Scan on _hyper_X_X_chunk m2_2
+   ->  GroupAggregate
+         Group Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Sort
+               Sort Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Result
+                     ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                           ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                 Filter: (("time" < (InitPlan 2).col1) AND ("time" >= (SubPlan 1)))
+                                 SubPlan 1
+                                   ->  Aggregate
+                                         ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                               ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                                     Filter: (device_id = m1_1.device_id)
+
+\set ON_ERROR_STOP 0
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+ERROR:  missing time_bucket_gapfill argument: could not infer start from WHERE clause
+HINT:  Specify start and finish as arguments or in the WHERE clause.
+\set ON_ERROR_STOP 1
+reset enable_indexscan;
+reset enable_bitmapscan;

--- a/tsl/test/shared/expected/gapfill-18.out
+++ b/tsl/test/shared/expected/gapfill-18.out
@@ -1126,21 +1126,26 @@ SELECT
 FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
 GROUP BY 1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
--- test subqueries as interval, start and stop (not supported atm)
+-- nonsimple expression (var) as gapfill bucket width, start and finish
 SELECT
-  time_bucket_gapfill((SELECT 1),time,1,11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(polling_interval,time),
+  m1.device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1, (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
 ERROR:  invalid time_bucket_gapfill argument: bucket_width must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,(SELECT 1),11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, time - 10, 100),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: start must be a simple expression
 SELECT
-  time_bucket_gapfill(1,time,1,(SELECT 11))
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, -100, time + 10),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 ERROR:  invalid time_bucket_gapfill argument: finish must be a simple expression
 \set ON_ERROR_STOP 1
 -- test time_bucket_gapfill without aggregation
@@ -3448,3 +3453,304 @@ EXECUTE coalesce_tz_test(NULL);
 DEALLOCATE coalesce_tz_test;
 RESET plan_cache_mode;
 DROP TABLE gf_tz_test;
+-- test subqueries as bucket width, start and stop
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill 
+---------------------
+                   1
+                   2
+                   3
+                   4
+                   5
+                   6
+                   7
+                   8
+                   9
+                  10
+
+-- Fill gaps between min and max time in the table
+SELECT
+  time_bucket_gapfill('10m'::interval,time),
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1 ORDER BY 1;
+     time_bucket_gapfill      | locf 
+------------------------------+------
+ Mon Jan 01 05:00:00 2018 PST |  0.7
+ Mon Jan 01 05:10:00 2018 PST |  0.7
+ Mon Jan 01 05:20:00 2018 PST |  0.7
+ Mon Jan 01 05:30:00 2018 PST |  0.7
+ Mon Jan 01 05:40:00 2018 PST |  0.7
+ Mon Jan 01 05:50:00 2018 PST |  0.7
+ Mon Jan 01 06:00:00 2018 PST |  0.7
+ Mon Jan 01 06:10:00 2018 PST |  0.7
+ Mon Jan 01 06:20:00 2018 PST |  0.7
+ Mon Jan 01 06:30:00 2018 PST |  0.7
+ Mon Jan 01 06:40:00 2018 PST |  0.7
+ Mon Jan 01 06:50:00 2018 PST |  0.7
+
+-- Fill gaps between min and max time in the table for each device
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+     time_bucket_gapfill      | device_id | locf 
+------------------------------+-----------+------
+ Mon Jan 01 05:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:00:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:20:00 2018 PST |         1 |  0.5
+ Mon Jan 01 06:40:00 2018 PST |         1 |  0.5
+ Mon Jan 01 05:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:00:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:20:00 2018 PST |         2 |  0.7
+ Mon Jan 01 06:40:00 2018 PST |         2 |  0.7
+ Mon Jan 01 05:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 05:40:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:00:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:20:00 2018 PST |         3 |  0.9
+ Mon Jan 01 06:40:00 2018 PST |         3 |  0.9
+
+-- Fill gaps with individual bucket width for each device
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.5
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.5
+         2 | Mon Jan 01 05:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 05:40:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:00:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:20:00 2018 PST |   0.7
+         2 | Mon Jan 01 06:40:00 2018 PST |   0.7
+         3 | Mon Jan 01 05:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 05:30:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:00:00 2018 PST |   0.9
+         3 | Mon Jan 01 06:30:00 2018 PST |   0.9
+
+-- See that EXPLAIN shows nested loop.
+set enable_indexscan = 0;
+set enable_bitmapscan = 0;
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 1
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2
+               InitPlan 2
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_1
+               ->  GroupAggregate
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= (InitPlan 1).col1) AND ("time" < (InitPlan 2).col1) AND (device_id = "*VALUES*".column1))
+
+-- Same as above with correlated subquery in locf
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+ device_id |            bucket            | value 
+-----------+------------------------------+-------
+         1 | Mon Jan 01 05:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 05:50:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:00:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:10:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:20:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:30:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:40:00 2018 PST |   0.3
+         1 | Mon Jan 01 06:50:00 2018 PST |   0.3
+         2 | Mon Jan 01 05:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 05:40:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:00:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:20:00 2018 PST |  1.35
+         2 | Mon Jan 01 06:40:00 2018 PST |  1.35
+         3 | Mon Jan 01 05:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 05:30:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:00:00 2018 PST |   1.2
+         3 | Mon Jan 01 06:30:00 2018 PST |   1.2
+
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m1.device_id, (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+   ->  Nested Loop
+         ->  Values Scan on "*VALUES*"
+         ->  Custom Scan (GapFill)
+               InitPlan 2
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_2
+               InitPlan 3
+                 ->  Aggregate
+                       ->  Seq Scan on _hyper_X_X_chunk m2_3
+               ->  Group
+                     Group Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill("*VALUES*".column2, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+                           ->  Result
+                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                                       ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                             Filter: (("time" >= (InitPlan 2).col1) AND ("time" < (InitPlan 3).col1) AND (device_id = "*VALUES*".column1))
+                     SubPlan 1
+                       ->  Aggregate
+                             ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                   ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                         Filter: (m1.device_id = device_id)
+
+-- Cannot infer start boundary as it's a SubPlan for correlated subquery
+:PREFIX SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   InitPlan 3
+     ->  Aggregate
+           ->  Seq Scan on _hyper_X_X_chunk m2_2
+   ->  GroupAggregate
+         Group Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Sort
+               Sort Key: m1.device_id, (time_bucket_gapfill('@ 20 mins'::interval, m1."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+               ->  Result
+                     ->  Custom Scan (ChunkAppend) on metrics_tstz m1
+                           ->  Seq Scan on _hyper_X_X_chunk m1_1
+                                 Filter: (("time" < (InitPlan 3).col1) AND ("time" >= (SubPlan 2)))
+                                 SubPlan 2
+                                   ->  Result
+                                         InitPlan 1
+                                           ->  Limit
+                                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                                       Order: m2."time"
+                                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_tstz_time_idx on _hyper_X_X_chunk m2_1
+                                                             Filter: (device_id = m1_1.device_id)
+
+\set ON_ERROR_STOP 0
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+ERROR:  missing time_bucket_gapfill argument: could not infer start from WHERE clause
+HINT:  Specify start and finish as arguments or in the WHERE clause.
+\set ON_ERROR_STOP 1
+reset enable_indexscan;
+reset enable_bitmapscan;

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -426,22 +426,26 @@ SELECT
 FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
 GROUP BY 1;
 
--- test subqueries as interval, start and stop (not supported atm)
+-- nonsimple expression (var) as gapfill bucket width, start and finish
 SELECT
-  time_bucket_gapfill((SELECT 1),time,1,11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(polling_interval,time),
+  m1.device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1, (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
 
 SELECT
-  time_bucket_gapfill(1,time,(SELECT 1),11)
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
+  time_bucket_gapfill(1, time, time - 10, 100),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 
 SELECT
-  time_bucket_gapfill(1,time,1,(SELECT 11))
-FROM (VALUES (1),(2)) v(time)
-GROUP BY 1;
-
+  time_bucket_gapfill(1, time, -100, time + 10),
+  locf(avg(value))
+FROM metrics_int m1
+GROUP BY 1 ORDER BY 1;
 
 \set ON_ERROR_STOP 1
 
@@ -1672,3 +1676,120 @@ RESET plan_cache_mode;
 
 DROP TABLE gf_tz_test;
 
+-- test subqueries as bucket width, start and stop
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+-- Fill gaps between min and max time in the table
+SELECT
+  time_bucket_gapfill('10m'::interval,time),
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1 ORDER BY 1;
+
+-- Fill gaps between min and max time in the table for each device
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+
+-- Fill gaps with individual bucket width for each device
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+
+-- See that EXPLAIN shows nested loop.
+set enable_indexscan = 0;
+set enable_bitmapscan = 0;
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(avg(v1)) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+
+-- Same as above with correlated subquery in locf
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+
+:PREFIX
+SELECT sq.device_id, bucket, value
+FROM (VALUES(1, '10m'::interval),(2, '20m'::interval), (3, '30m'::interval)) dev(device_id, polling_interval)
+INNER JOIN LATERAL (
+  SELECT
+  time_bucket_gapfill(dev.polling_interval,time) bucket,
+  m1.device_id,
+  locf(
+    (SELECT avg(v1 + v2/100.0) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id)
+  ) value
+  FROM metrics_tstz m1
+  WHERE m1.device_id = dev.device_id AND time >= (select min(time) from  metrics_tstz m2) AND time < (select max(time) from  metrics_tstz m2)
+  GROUP BY 1,2) sq ON (true)
+ORDER BY 1,2;
+
+-- Cannot infer start boundary as it's a SubPlan for correlated subquery
+:PREFIX SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+
+\set ON_ERROR_STOP 0
+SELECT
+  time_bucket_gapfill('20m'::interval,time),
+  device_id,
+  locf(avg(v1))
+FROM metrics_tstz m1
+WHERE time >= (select min(time) from  metrics_tstz m2 where m2.device_id = m1.device_id)
+AND time < (select max(time) from  metrics_tstz m2)
+GROUP BY 1,2 ORDER BY 2,1;
+\set ON_ERROR_STOP 1
+
+reset enable_indexscan;
+reset enable_bitmapscan;


### PR DESCRIPTION
Fixes #7605.
Fixes #8380 (as far as we can, they can do individual bucket widths for each group via LATERAL subquery).
Fixes #2595

We can allow Exec params as `time_bucket_gapfill` arguments if we move argument initialization from `gapfill_begin` into initial state of `gapfill_exec`.  We'll also reinitialize arguments on each rescan.
