### PR TITLE
Skip columnar index scan when grouping by an expression

### DIFF
--- a/.unreleased/pr_9828
+++ b/.unreleased/pr_9828
@@ -1,0 +1,1 @@
+Fixes: #9828 Skip columnar index scan when grouping by an expression

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
@@ -768,6 +768,19 @@ insert_columnar_index_scan(Plan *plan, void *context)
 		return plan;
 	}
 
+	/*
+	 * Every group-by column must reach the Agg as a bare Var.
+	 * Grouping by expression is currently not supported.
+	 */
+	for (int k = 0; k < agg->numCols; k++)
+	{
+		TargetEntry *tle = list_nth_node(TargetEntry, childplan->targetlist, agg->grpColIdx[k] - 1);
+		if (!IsA(tle->expr, Var))
+		{
+			return plan;
+		}
+	}
+
 	Plan *result = columnar_index_scan_plan_create(agg, cscan, rtable);
 	if (result == NULL)
 	{

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -2371,3 +2371,19 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 + on
  
   device | count 
+NOTICE:  using column "ts" as partitioning column
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: (_hyper_3_5_chunk.device_id)::text
+   ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk
+         ->  Seq Scan on compress_hyper_4_6_chunk
+
+ count 
+-------
+     1
+     1
+

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -2373,3 +2373,19 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 + on
  
   device | count 
+NOTICE:  using column "ts" as partitioning column
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: (_hyper_3_5_chunk.device_id)::text
+   ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk
+         ->  Seq Scan on compress_hyper_4_6_chunk
+
+ count 
+-------
+     1
+     1
+

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -2524,3 +2524,19 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 + on
  
   device | count 
+NOTICE:  using column "ts" as partitioning column
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: (_hyper_3_5_chunk.device_id)::text
+   ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk
+         ->  Seq Scan on compress_hyper_4_6_chunk
+
+ count 
+-------
+     1
+     1
+

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -2524,3 +2524,19 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 + on
  
   device | count 
+NOTICE:  using column "ts" as partitioning column
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+--- QUERY PLAN ---
+ HashAggregate
+   Group Key: (_hyper_3_5_chunk.device_id)::text
+   ->  Custom Scan (ColumnarScan) on _hyper_3_5_chunk
+         ->  Seq Scan on compress_hyper_4_6_chunk
+
+ count 
+-------
+     1
+     1
+

--- a/tsl/test/sql/columnar_index_scan.sql.in
+++ b/tsl/test/sql/columnar_index_scan.sql.in
@@ -132,3 +132,17 @@ SET timescaledb.enable_columnarindexscan = on;
 -- compare optimized vs non-optimized results
 :DIFF_CMD
 
+
+-- GROUP BY a cast of a segmentby column whose underlying type differs from the cast's output type
+CREATE TABLE cast_grp(ts timestamptz NOT NULL, device_id int) WITH (
+    tsdb.hypertable, tsdb.orderby='ts', tsdb.segmentby='device_id');
+INSERT INTO cast_grp VALUES ('2025-01-01', 1), ('2025-01-01', 2);
+SELECT compress_chunk(c) FROM show_chunks('cast_grp') c;
+
+SELECT format('%I.%I', chunk_schema, chunk_name) AS "CAST_CHUNK"
+FROM timescaledb_information.chunks WHERE hypertable_name = 'cast_grp' \gset
+
+SET timescaledb.enable_columnarindexscan = on;
+EXPLAIN (costs off) SELECT count(*) FROM :CAST_CHUNK GROUP BY (device_id)::text;
+SELECT count(*) FROM :CAST_CHUNK GROUP BY (device_id)::text ORDER BY 1;
+


### PR DESCRIPTION
The rewrite that swaps ColumnarScan for ColumnarIndexScan only emits
bare metadata columns. When the group-by column reaches the aggregate
through a cast or other wrapper, the rewrite drops the wrapper, leaving
the aggregate's hash and equality functions bound to the wrapper's
type and the actual data of a different type. This produced a crash
for queries like GROUP BY (segmentby_col)::text on a compressed chunk.

Bail out of the rewrite when any group-by column is not a bare column
in the child output.