### PR TITLE
Remove missed 2.27.0 unreleased files

### DIFF
--- a/.unreleased/bloom-int2
+++ b/.unreleased/bloom-int2
@@ -1,1 +1,0 @@
-Backward-Incompatible Change: #9579 The bloom filter sparse indexes on compressed int2 columns could lead to SELECT queries not returning the rows that actually match the WHERE condition. The upgrade is blocked for the affected databases, and the incorrect indexes have to be dropped manually before the upgrade.

--- a/.unreleased/filter-columnar
+++ b/.unreleased/filter-columnar
@@ -1,1 +1,0 @@
-Implements: #9443 Enable vectorized aggregation in some cases when the WHERE clause contains filters not handled through the "Vectorized Filters" facility. This includes e.g. filters on time_bucket().

--- a/.unreleased/in-any-chunk-exclusion
+++ b/.unreleased/in-any-chunk-exclusion
@@ -1,1 +1,0 @@
-Implements: #9398 Fix chunk exclusion for IN/ANY on open (time) dimensions

--- a/.unreleased/pr_8868
+++ b/.unreleased/pr_8868
@@ -1,2 +1,0 @@
-Implements: #8868 Use PG_MODULE_MAGIC_EXT for PG18
-Thanks: @fabriziomello for adding support for PG_MODULE_MAGIC_EXT

--- a/.unreleased/pr_8967
+++ b/.unreleased/pr_8967
@@ -1,2 +1,0 @@
-Implements: #8967 Rewriting queries with continuous aggregates exactly matching query aggregation
-Setting: `enable_cagg_rewrites`: enables rewriting queries with CAggs. Off by default. `cagg_rewrites_debug_info`: prints CAgg rewrites diagnostics. Off by default.

--- a/.unreleased/pr_9355
+++ b/.unreleased/pr_9355
@@ -1,1 +1,0 @@
-Implements: #9355 Defer segmentby default for direct compress

--- a/.unreleased/pr_9363
+++ b/.unreleased/pr_9363
@@ -1,1 +1,0 @@
-Fixes: #9363 Change compression job status when chunks could be compressed

--- a/.unreleased/pr_9374
+++ b/.unreleased/pr_9374
@@ -1,1 +1,0 @@
-Implements: #9374 Use bloom filters to eliminate decompression of unrelated compressed batches during UPSERTs.

--- a/.unreleased/pr_9396
+++ b/.unreleased/pr_9396
@@ -1,1 +1,0 @@
-Implements: #9396 Analyze and get segmentby during direct compress

--- a/.unreleased/pr_9399
+++ b/.unreleased/pr_9399
@@ -1,1 +1,0 @@
-Implements: #9399 Use bloom filters to reduce decompression during UPDATE/DELETE commands.

--- a/.unreleased/pr_9403
+++ b/.unreleased/pr_9403
@@ -1,1 +1,0 @@
-Implements: #9403 Set default segmentby during direct compress flush

--- a/.unreleased/pr_9413
+++ b/.unreleased/pr_9413
@@ -1,1 +1,0 @@
-Fixes: #9413 Fix incorrect decompress markers on full batch delete

--- a/.unreleased/pr_9414
+++ b/.unreleased/pr_9414
@@ -1,1 +1,0 @@
-Fixes: #9414 Fix NULL compression handling in estimate_uncompressed_size

--- a/.unreleased/pr_9417
+++ b/.unreleased/pr_9417
@@ -1,1 +1,0 @@
-Fixes: #9417 Fix segfault in bloom1_contains

--- a/.unreleased/pr_9437
+++ b/.unreleased/pr_9437
@@ -1,1 +1,0 @@
-Implements: #9437 Allow running compression as part of refresh policy for compressed continuous aggregates

--- a/.unreleased/pr_9458
+++ b/.unreleased/pr_9458
@@ -1,1 +1,0 @@
-Implements: #9458 Remove _timescaledb_functions.repair_relation_acls

--- a/.unreleased/pr_9475
+++ b/.unreleased/pr_9475
@@ -1,1 +1,0 @@
-Implements: #9475 Calculate hashes for bloom filter predicates at planning time.

--- a/.unreleased/pr_9479
+++ b/.unreleased/pr_9479
@@ -1,1 +1,0 @@
-Fixes: #9479 Disallow sub-day offset for time-bucket on Date

--- a/.unreleased/pr_9482
+++ b/.unreleased/pr_9482
@@ -1,1 +1,0 @@
-Fixes: #9482 Forbid Batch Sort Merge on nullable orderby columns

--- a/.unreleased/pr_9490
+++ b/.unreleased/pr_9490
@@ -1,1 +1,0 @@
-Fixes: #9490 Disallow negative interval as chunk_interval

--- a/.unreleased/pr_9500
+++ b/.unreleased/pr_9500
@@ -1,1 +1,0 @@
-Fixes: #9500 Fix off-by-one error when building object name

--- a/.unreleased/pr_9504
+++ b/.unreleased/pr_9504
@@ -1,1 +1,0 @@
-Implements: #9504 Allow ALTER TABLE RESET on materialization hypertables

--- a/.unreleased/pr_9519
+++ b/.unreleased/pr_9519
@@ -1,1 +1,0 @@
-Fixes: #9519 Remove self-referential FOREIGN KEY constraints from catalog

--- a/.unreleased/pr_9521
+++ b/.unreleased/pr_9521
@@ -1,2 +1,0 @@
-Implements: #9521 Add support for reporting index creation progress
-Thanks: @maltalex for reporting an issue with index creation progress reporting

--- a/.unreleased/pr_9559
+++ b/.unreleased/pr_9559
@@ -1,1 +1,0 @@
-Implements: #9559 Notice on compression settings change

--- a/.unreleased/pr_9561
+++ b/.unreleased/pr_9561
@@ -1,1 +1,0 @@
-Fixes: #9561 Simplify job history retention by replacing binary search and temp table

--- a/.unreleased/pr_9569
+++ b/.unreleased/pr_9569
@@ -1,1 +1,0 @@
-Implements: #9569 For nullable orderby columns do segmentwise decompress-compress instead of segmentwise recompress.

--- a/.unreleased/pr_9583
+++ b/.unreleased/pr_9583
@@ -1,1 +1,0 @@
-Implements: #9583 Drop existing sparse indexes when dropping columns

--- a/.unreleased/pr_9590
+++ b/.unreleased/pr_9590
@@ -1,1 +1,0 @@
-Fixes: #9590 Fix policy skipping uncompressed chunks

--- a/.unreleased/pr_9596
+++ b/.unreleased/pr_9596
@@ -1,1 +1,0 @@
-Fixes: #9596 Remove unused process_hypertable_invalidations policy code

--- a/.unreleased/pr_9604
+++ b/.unreleased/pr_9604
@@ -1,1 +1,0 @@
-Fixes: #9604 Remove dead post_parse_analyze_hook capture in loader

--- a/.unreleased/pr_9610
+++ b/.unreleased/pr_9610
@@ -1,1 +1,0 @@
-Fixes: #9610 Fix use-after-free crash in cache_destroy during transaction abort

--- a/.unreleased/pr_9632
+++ b/.unreleased/pr_9632
@@ -1,1 +1,0 @@
-Fixes: #9632 Preserve chunk settings during recompress

--- a/.unreleased/pr_9640
+++ b/.unreleased/pr_9640
@@ -1,1 +1,0 @@
-Fixes: #9640 Fix NULL datumCopy crash in segmentby analysis

--- a/.unreleased/pr_9648
+++ b/.unreleased/pr_9648
@@ -1,1 +1,0 @@
-Implements: #9648 Support ENABLE/DISABLE TRIGGER on hypertables

--- a/.unreleased/pr_9680
+++ b/.unreleased/pr_9680
@@ -1,1 +1,0 @@
-Fixes: #9680 Fix segfault in direct compress insert on hypertable with dropped column

--- a/.unreleased/pr_9692
+++ b/.unreleased/pr_9692
@@ -1,1 +1,0 @@
-Fixes: #9692 Fix internal "invalid perminfoindex 0 in RTE" error on MERGE NOT MATCHED INSERT into a hypertable

--- a/.unreleased/pr_9697
+++ b/.unreleased/pr_9697
@@ -1,1 +1,0 @@
-Implements: #9697 Improve pathkey handling for compressed sub-paths during sort transformation

--- a/.unreleased/pr_9702
+++ b/.unreleased/pr_9702
@@ -1,1 +1,0 @@
-Implements: #9702 Allow Batch Sorted Merge for unordered chunks with no segmentby or when all segmentby columns are pinned to a Const

--- a/.unreleased/pr_9705
+++ b/.unreleased/pr_9705
@@ -1,2 +1,0 @@
-Fixes: #9705 Only freeze compressed rows when truncating uncompressed chunk
-Fixes: #9705 Avoid double TOAST delete when DELETE-after-compression is enabled

--- a/.unreleased/pr_9706
+++ b/.unreleased/pr_9706
@@ -1,1 +1,0 @@
-Fixes: #9706 Use bigint in estimate_uncompressed_size calculations

--- a/.unreleased/pr_9707
+++ b/.unreleased/pr_9707
@@ -1,1 +1,0 @@
-Fixes: #9707 Fix policy name comparison in remove_policies

--- a/.unreleased/pr_9709
+++ b/.unreleased/pr_9709
@@ -1,1 +1,0 @@
-Fixes: #9709 Reject mismatched element type in bool/uuid decompression

--- a/.unreleased/pr_9710
+++ b/.unreleased/pr_9710
@@ -1,1 +1,0 @@
-Fixes: #9710 Return bigint from compressed_data_column_size

--- a/.unreleased/pr_9711
+++ b/.unreleased/pr_9711
@@ -1,1 +1,0 @@
-Fixes: #9711 Fix registration row leak when continuous aggregate refresh fails

--- a/.unreleased/pr_9717
+++ b/.unreleased/pr_9717
@@ -1,1 +1,0 @@
-Fixes: #9717 Reject non-positive time bucket width on cagg creation

--- a/.unreleased/pr_9733
+++ b/.unreleased/pr_9733
@@ -1,2 +1,0 @@
-Fixes: #9731 Avoid creating overlapping batches during recompression for multi orderby configurations
-Thanks: @h0rn3t for reporting issue with recompression creating overlapping batches

--- a/.unreleased/pr_9736
+++ b/.unreleased/pr_9736
@@ -1,1 +1,0 @@
-Fixes: #9736 Do logical sparse index comparison

--- a/.unreleased/pr_9743
+++ b/.unreleased/pr_9743
@@ -1,2 +1,0 @@
-Fixes: #9743 Fixes the composite bloom metadata column naming scheme
-Thanks: @pavanmanishd for the first version of the fix

--- a/.unreleased/pr_9744
+++ b/.unreleased/pr_9744
@@ -1,1 +1,0 @@
-Fixes: #9744 Use a fixed call string for the telemetry job in ts_stat_statements recording

--- a/.unreleased/pr_9747
+++ b/.unreleased/pr_9747
@@ -1,1 +1,0 @@
-Fixes: #9747 Reject inheriting from a hypertable

--- a/.unreleased/pr_9767
+++ b/.unreleased/pr_9767
@@ -1,1 +1,0 @@
-Fixes: #9767 Skip dropped chunks when trying to remove ts_cagg_invalidation_trigger

--- a/.unreleased/saop-pushdown
+++ b/.unreleased/saop-pushdown
@@ -1,2 +1,0 @@
-Implements: #9192 Push down scalar array operations into the columnar metadata scan by transforming them into an OR/AND clause.
-Setting: `enable_columnar_scan_filter_pushdown`: enables pushing the filters on columnar scan down to the compressed scan level. On by default.


### PR DESCRIPTION
At https://github.com/timescale/timescaledb/commit/a1861abdfabae3c874a679e7da68bc46776d4dd5, we missed
removing the unreleased files for PRs merged in 2.27.0 as part of
the normal post-release procedure.

Disable-check: force-changelog-file
Disable-check: approval-count