### PR TITLE
[2.24.x] Backport CVE-2026-29089: ensure search_path set before SQL scripts

### DIFF
--- a/.unreleased/pr_9331
+++ b/.unreleased/pr_9331
@@ -1,0 +1,1 @@
+Fixes: #9331 Ensure search_path is set before anything else in SQL scripts

--- a/cmake/GenerateScripts.cmake
+++ b/cmake/GenerateScripts.cmake
@@ -146,7 +146,7 @@ function(generate_downgrade_script)
   include(
     ${CMAKE_BINARY_DIR}/v${_downgrade_TARGET_VERSION}/cmake/ScriptFiles.cmake)
 
-  set(_downgrade_PRE_FILES ${PRE_DOWNGRADE_FILES})
+  set(_downgrade_PRE_FILES "header.sql;${PRE_DOWNGRADE_FILES}")
   set(_downgrade_POST_FILES "${PRE_INSTALL_FUNCTION_FILES};${SOURCE_FILES}" ${SET_POST_UPDATE_STAGE}
                             ${POST_UPDATE_FILES} ${UNSET_UPDATE_STAGE})
 

--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -10,7 +10,8 @@
 
 # Source files that define the schemas and tables for our metadata
 set(PRE_INSTALL_SOURCE_FILES
-    pre_install/schemas.sql # Must be first
+    header.sql # Must be first since it sets up the search path
+    pre_install/schemas.sql
     pre_install/types.pre.sql
     pre_install/types.functions.sql
     pre_install/types.post.sql # Must be before tables.sql

--- a/scripts/check_sql_script.py
+++ b/scripts/check_sql_script.py
@@ -64,6 +64,12 @@ class SQLVisitor(Visitor):
     def visit_CreateEventTrigStmt(self, _ancestors, _node):
         return Skip
 
+    def visit_VariableSetStmt(self, _ancestors, node):
+        if not node.is_local:
+            self.error(node, "Consider using SET LOCAL instead of SET")
+
+        return Skip
+
     def visit_CreateTrigStmt(self, _ancestors, node):
         if not node.replace:
             self.error(node, "Consider using CREATE OR REPLACE TRIGGER")

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -235,7 +235,7 @@ foreach(transition_mod_file ${MOD_FILES_LIST})
   endif()
 
   version_check_file("updates/version_check.sql" VERSION_CHECK_VERSIONED)
-  list(PREPEND PRE_FILES ${VERSION_CHECK_VERSIONED})
+  list(PREPEND PRE_FILES "header.sql;${VERSION_CHECK_VERSIONED}")
 
   # There might not have been any changes in the modfile, in which case the
   # modfile need not be present

--- a/sql/header.sql
+++ b/sql/header.sql
@@ -1,0 +1,6 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- This file is always prepended to all installation and upgrade/downgrade scripts.
+SET LOCAL search_path TO pg_catalog, pg_temp;


### PR DESCRIPTION
backport for CVE-2026-29089 onto `2.24.x`. the fix sets `search_path` before anything else in the SQL scripts, blocking search-path-shadowing class.

upstream commit: https://github.com/timescale/timescaledb/commit/9a8f7f8bdeb99e6abae0786ffe526791a8628ce3
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-29089

files touched are the build/CMake scripts and the SQL script generation. `git cherry-pick -x` applied cleanly. haven't run the full test suite locally.