### PR TITLE
Add advisory_lock test to flaky upstream tests

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -21,6 +21,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testtablespace)
 
 # Tests to ignore
 set(PG_IGNORE_TESTS
+    advisory_lock
     amutils
     database
     event_trigger


### PR DESCRIPTION
- **Add advisory_lock test to flaky upstream tests**

Disable-check: force-changelog-file
Disable-check: approval-count