### PR TITLE
Add skip_cagg_invalidation GUC for bulk loads

### DIFF
--- a/.unreleased/pr_9842
+++ b/.unreleased/pr_9842
@@ -1,0 +1,2 @@
+Implements: #9842 Suppress continuous aggregate invalidation tracking during bulk loads
+Setting: `skip_cagg_invalidation`: skip continuous aggregate invalidation tracking for DML and DDL in the current session/transaction. Off by default.

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4234,17 +4234,20 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 		 * The invalidation will allow the refresh command on a continuous
 		 * aggregate to see that this region was dropped and and will
 		 * therefore be able to refresh accordingly.*/
-		for (uint64 i = 0; i < num_chunks; i++)
+		if (!ts_guc_skip_cagg_invalidation)
 		{
-			if (osm_chunk_id == chunks[i].fd.id)
+			for (uint64 i = 0; i < num_chunks; i++)
 			{
-				// we do not rebuild continuous aggs if tiered data is dropped */
-				continue;
-			}
-			int64 start = ts_chunk_primary_dimension_start(&chunks[i]);
-			int64 end = ts_chunk_primary_dimension_end(&chunks[i]);
+				if (osm_chunk_id == chunks[i].fd.id)
+				{
+					// we do not rebuild continuous aggs if tiered data is dropped */
+					continue;
+				}
+				int64 start = ts_chunk_primary_dimension_start(&chunks[i]);
+				int64 end = ts_chunk_primary_dimension_end(&chunks[i]);
 
-			ts_cm_functions->continuous_agg_invalidate_raw_ht(ht, start, end);
+				ts_cm_functions->continuous_agg_invalidate_raw_ht(ht, start, end);
+			}
 		}
 	}
 

--- a/src/copy.c
+++ b/src/copy.c
@@ -55,6 +55,7 @@
 #include "copy.h"
 #include "cross_module_fn.h"
 #include "dimension.h"
+#include "guc.h"
 #include "hypertable.h"
 #include "indexing.h"
 #include "subspace_store.h"
@@ -286,7 +287,7 @@ TSCopyMultiInsertBufferInit(TSCopyMultiInsertInfo *miinfo, ChunkInsertState *cis
 												 ts_guc_direct_compress_copy_tuple_sort_limit,
 												 cis->created_compressed_chunk);
 
-			if (miinfo->has_continuous_aggregate)
+			if (miinfo->has_continuous_aggregate && !ts_guc_skip_cagg_invalidation)
 			{
 				ts_cm_functions->compressor_set_invalidation(buffer->compressor,
 															 miinfo->ht,
@@ -506,7 +507,7 @@ TSCopyMultiInsertBufferFlush(TSCopyMultiInsertInfo *miinfo, TSCopyMultiInsertBuf
 								 NULL /* transition capture */);
 		}
 
-		if (miinfo->has_continuous_aggregate)
+		if (miinfo->has_continuous_aggregate && !ts_guc_skip_cagg_invalidation)
 		{
 			bool should_free;
 			HeapTuple tuple = ExecFetchSlotHeapTuple(slots[i], false, &should_free);

--- a/src/guc.c
+++ b/src/guc.c
@@ -91,6 +91,7 @@ TSDLLEXPORT bool ts_guc_enable_columnar_scan_filter_pushdown = true;
 bool ts_guc_enable_qual_filtering = true;
 bool ts_guc_enable_cagg_reorder_groupby = true;
 TSDLLEXPORT bool ts_guc_enable_cagg_window_functions = false;
+TSDLLEXPORT bool ts_guc_skip_cagg_invalidation = false;
 bool ts_guc_enable_now_constify = true;
 bool ts_guc_enable_foreign_key_propagation = true;
 #if PG16_GE
@@ -1004,6 +1005,25 @@ _guc_init(void)
 							 "Enable window functions in continuous aggregates",
 							 "Allow window functions in continuous aggregate views",
 							 &ts_guc_enable_cagg_window_functions,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("skip_cagg_invalidation"),
+							 "Skip continuous aggregate invalidation tracking",
+							 "When enabled, DML (INSERT/UPDATE/DELETE/COPY) and DDL "
+							 "(DROP CHUNK, drop_chunks, TRUNCATE) on hypertables with "
+							 "continuous aggregates will not record invalidation entries "
+							 "for the duration of the session or transaction. The caller "
+							 "must explicitly refresh affected continuous aggregates with "
+							 "force => true after the operation. Intended for bulk-migration "
+							 "tools; use with SET LOCAL inside a transaction. Misuse will "
+							 "leave continuous aggregate state out of sync with the "
+							 "underlying hypertable.",
+							 &ts_guc_skip_cagg_invalidation,
 							 false,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -29,6 +29,7 @@ extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;
 extern TSDLLEXPORT bool ts_guc_enable_cagg_window_functions;
+extern TSDLLEXPORT bool ts_guc_skip_cagg_invalidation;
 extern TSDLLEXPORT int ts_guc_cagg_max_individual_materializations;
 extern bool ts_guc_enable_now_constify;
 extern bool ts_guc_enable_foreign_key_propagation;

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -945,7 +945,7 @@ ExecInsert(ModifyTableContext *context,
 		}
 	}
 
-	if (context->ht_state->has_continuous_aggregate)
+	if (context->ht_state->has_continuous_aggregate && !ts_guc_skip_cagg_invalidation)
 	{
 		bool should_free;
 		HeapTuple tuple = ExecFetchSlotHeapTuple(slot, false, &should_free);
@@ -1446,7 +1446,7 @@ ldelete:
 		 */
 	}
 
-	if (context->ht_state->has_continuous_aggregate)
+	if (context->ht_state->has_continuous_aggregate && !ts_guc_skip_cagg_invalidation)
 	{
 		bool should_free;
 		TupleTableSlot *cagg_slot = table_slot_create(resultRelationDesc, NULL);
@@ -1986,7 +1986,7 @@ redo_act:
 	ExecUpdateEpilogue(context, &updateCxt, resultRelInfo, tupleid, oldtuple,
 					   slot);
 
-	if (context->ht_state->has_continuous_aggregate)
+	if (context->ht_state->has_continuous_aggregate && !ts_guc_skip_cagg_invalidation)
 	{
 		TupleTableSlot *invalidation_slot = NULL;
 		bool should_free_old = false, should_free_new = false;
@@ -2506,7 +2506,7 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 														 ctr->cis->created_compressed_chunk);
 					ht_state->compressor_relid = RelationGetRelid(ctr->cis->rel);
 
-					if (ht_state->has_continuous_aggregate)
+					if (ht_state->has_continuous_aggregate && !ts_guc_skip_cagg_invalidation)
 					{
 						ts_cm_functions->compressor_set_invalidation(ht_state->compressor, ctr->hypertable, RelationGetRelid(ctr->cis->rel));
 					}

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -72,6 +72,7 @@
 #include "extension.h"
 #include "extension_constants.h"
 #include "foreign_key.h"
+#include "guc.h"
 #include "hypercube.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
@@ -1453,10 +1454,13 @@ process_truncate(ProcessUtilityArgs *args)
 						 * longer has any data */
 						raw_ht = ts_hypertable_get_by_id(cagg->data.raw_hypertable_id);
 						Assert(raw_ht != NULL);
-						ts_cm_functions->continuous_agg_invalidate_mat_ht(raw_ht,
-																		  mat_ht,
-																		  TS_TIME_NOBEGIN,
-																		  TS_TIME_NOEND);
+						if (!ts_guc_skip_cagg_invalidation)
+						{
+							ts_cm_functions->continuous_agg_invalidate_mat_ht(raw_ht,
+																			  mat_ht,
+																			  TS_TIME_NOBEGIN,
+																			  TS_TIME_NOEND);
+						}
 
 						/* Additionally, this cagg's materialization hypertable could be the
 						 * underlying hypertable for other caggs defined on top of it, in that case
@@ -1464,7 +1468,7 @@ process_truncate(ProcessUtilityArgs *args)
 						ContinuousAggHypertableStatus agg_status;
 
 						agg_status = ts_continuous_agg_hypertable_status(mat_ht->fd.id);
-						if (agg_status & HypertableIsRawTable)
+						if ((agg_status & HypertableIsRawTable) && !ts_guc_skip_cagg_invalidation)
 						{
 							ts_cm_functions->continuous_agg_invalidate_raw_ht(mat_ht,
 																			  TS_TIME_NOBEGIN,
@@ -1509,7 +1513,7 @@ process_truncate(ProcessUtilityArgs *args)
 									 errhint("TRUNCATE the continuous aggregate instead.")));
 						}
 
-						if (agg_status == HypertableIsRawTable)
+						if (agg_status == HypertableIsRawTable && !ts_guc_skip_cagg_invalidation)
 						{
 							/* The truncation invalidates all associated continuous aggregates */
 							ts_cm_functions->continuous_agg_invalidate_raw_ht(ht,
@@ -1553,7 +1557,9 @@ process_truncate(ProcessUtilityArgs *args)
 
 						/* If the hypertable has continuous aggregates, then invalidate
 						 * the truncated region. */
-						if (ts_continuous_agg_hypertable_status(ht->fd.id) == HypertableIsRawTable)
+						if (ts_continuous_agg_hypertable_status(ht->fd.id) ==
+								HypertableIsRawTable &&
+							!ts_guc_skip_cagg_invalidation)
 						{
 							ts_continuous_agg_invalidate_chunk(ht, chunk);
 						}
@@ -1736,7 +1742,8 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 
 			/* If the hypertable has continuous aggregates, then invalidate
 			 * the dropped region. */
-			if (ts_continuous_agg_hypertable_status(ht->fd.id) == HypertableIsRawTable)
+			if (ts_continuous_agg_hypertable_status(ht->fd.id) == HypertableIsRawTable &&
+				!ts_guc_skip_cagg_invalidation)
 			{
 				ts_continuous_agg_invalidate_chunk(ht, chunk);
 			}

--- a/tsl/test/expected/cagg_skip_invalidation.out
+++ b/tsl/test/expected/cagg_skip_invalidation.out
@@ -1,0 +1,354 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_functions.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+CREATE TABLE skip_inv (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv', 'ts', chunk_time_interval => '1 day'::interval);
+   create_hypertable   
+-----------------------
+ (1,public,skip_inv,t)
+
+INSERT INTO skip_inv VALUES ('2030-01-15 00:00', 0);
+CREATE MATERIALIZED VIEW skip_inv_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n, sum(v) AS s
+FROM skip_inv
+GROUP BY 1
+WITH NO DATA;
+-- Advance the invalidation threshold so inserts below it write to the
+-- hypertable_invalidation_log.
+CALL refresh_continuous_aggregate('skip_inv_1h', NULL, '2030-01-16');
+SELECT format('%I.%I', chunk_schema, chunk_name) AS skip_inv_chunk
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'skip_inv' \gset
+-- Case 1: GUC defaults to off; INSERT writes to the log.
+INSERT INTO skip_inv VALUES ('2030-01-15 01:00', 1);
+SELECT count(*) AS after_baseline_insert
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_baseline_insert 
+-----------------------
+                     1
+
+-- Clear the log between cases.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Case 2: All four DML paths under SET LOCAL skip_cagg_invalidation = on.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv VALUES ('2030-01-15 02:00', 2);
+COPY skip_inv FROM STDIN;
+UPDATE skip_inv SET v = v * 10 WHERE ts = '2030-01-15 02:00';
+DELETE FROM skip_inv WHERE ts = '2030-01-15 02:30';
+COMMIT;
+SELECT count(*) AS after_skipped_dml
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_dml 
+-------------------
+                 0
+
+-- Case 3: Direct chunk write. ModifyHypertable wraps chunk INSERT/COPY too.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT format('INSERT INTO %s VALUES (''2030-01-15 03:00'', 5)', :'skip_inv_chunk') \gexec
+INSERT INTO _timescaledb_internal._hyper_1_1_chunk VALUES ('2030-01-15 03:00', 5)
+SELECT format('COPY %s FROM STDIN', :'skip_inv_chunk') \gexec
+COPY _timescaledb_internal._hyper_1_1_chunk FROM STDIN
+COMMIT;
+SELECT count(*) AS after_skipped_direct_chunk
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_direct_chunk 
+----------------------------
+                          0
+
+-- Case 4: SET LOCAL must not leak past COMMIT.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv VALUES ('2030-01-15 04:00', 7);
+COMMIT;
+SHOW timescaledb.skip_cagg_invalidation;
+ timescaledb.skip_cagg_invalidation 
+------------------------------------
+ off
+
+INSERT INTO skip_inv VALUES ('2030-01-15 04:30', 8);
+SELECT count(*) AS after_scope_check
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_scope_check 
+-------------------
+                 1
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Case 5: After a skipped load, an explicit forced refresh picks up the new rows.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv
+SELECT '2030-01-15 05:00'::timestamptz + (i || ' minutes')::interval, i
+FROM generate_series(1, 60) i;
+COMMIT;
+SELECT count(*) AS after_bulk_load_log
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_bulk_load_log 
+---------------------
+                   0
+
+SELECT count(*) AS hourly_rows_before_refresh FROM skip_inv_1h
+WHERE bucket >= '2030-01-15 05:00' AND bucket < '2030-01-15 07:00';
+ hourly_rows_before_refresh 
+----------------------------
+                          0
+
+CALL refresh_continuous_aggregate('skip_inv_1h', '2030-01-15 05:00', '2030-01-15 07:00', force => true);
+SELECT bucket, n, s FROM skip_inv_1h
+WHERE bucket >= '2030-01-15 05:00' AND bucket < '2030-01-15 07:00'
+ORDER BY bucket;
+         bucket         | n  |  s   
+------------------------+----+------
+ 2030-01-15 05:00:00+00 | 59 | 1770
+ 2030-01-15 06:00:00+00 |  1 |   60
+
+DROP MATERIALIZED VIEW skip_inv_1h;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+DROP TABLE skip_inv;
+-- Case 6: Direct-compress INSERT/COPY paths. Exercises the
+-- compressor_set_invalidation gates in copy.c and modify_hypertable_exec.c.
+CREATE TABLE skip_inv_dc (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv_dc', 'ts', chunk_time_interval => '1 day'::interval);
+    create_hypertable     
+--------------------------
+ (3,public,skip_inv_dc,t)
+
+ALTER TABLE skip_inv_dc SET (timescaledb.compress, timescaledb.compress_segmentby = '');
+INSERT INTO skip_inv_dc VALUES ('2030-02-15 00:00', 0);
+SELECT compress_chunk(c) IS NOT NULL AS compressed
+  FROM show_chunks('skip_inv_dc') c;
+ compressed 
+------------
+ t
+
+CREATE MATERIALIZED VIEW skip_inv_dc_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n
+FROM skip_inv_dc
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_dc_1h', NULL, '2030-02-16');
+-- Direct-compress INSERT requires the planner to estimate >= 10 rows, so use
+-- generate_series. Direct-compress COPY has no row threshold.
+BEGIN;
+SET LOCAL timescaledb.enable_direct_compress_copy = on;
+SET LOCAL timescaledb.enable_direct_compress_insert = on;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv_dc
+SELECT '2030-02-15 01:00'::timestamptz + (i || ' seconds')::interval, i
+FROM generate_series(1, 20) i;
+COPY skip_inv_dc FROM STDIN;
+COMMIT;
+SELECT count(*) AS after_skipped_direct_compress
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_direct_compress 
+-------------------------------
+                             0
+
+DROP MATERIALIZED VIEW skip_inv_dc_1h;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_5_chunk
+DROP TABLE skip_inv_dc;
+-- Case 7: DDL paths (drop_chunks, DROP TABLE chunk, TRUNCATE chunk,
+-- TRUNCATE hypertable) under the GUC. Verifies the DDL invalidation
+-- sites in process_utility.c and chunk.c are gated.
+CREATE TABLE skip_inv_ddl (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv_ddl', 'ts', chunk_time_interval => '1 day'::interval);
+     create_hypertable     
+---------------------------
+ (6,public,skip_inv_ddl,t)
+
+INSERT INTO skip_inv_ddl
+SELECT ts, 1 FROM generate_series('2030-03-01'::timestamptz, '2030-03-05', '6 hours') ts;
+CREATE MATERIALIZED VIEW skip_inv_ddl_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n
+FROM skip_inv_ddl
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_ddl_1h', NULL, '2030-03-06');
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- 7a) Baseline: drop_chunks WITHOUT the GUC records invalidations.
+SELECT drop_chunks('skip_inv_ddl', older_than => '2030-03-02'::timestamptz) IS NOT NULL AS dropped;
+ dropped 
+---------
+ t
+
+SELECT count(*) > 0 AS ddl_baseline_recorded
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ ddl_baseline_recorded 
+-----------------------
+ t
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- 7b) drop_chunks UNDER the GUC: no invalidations recorded.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT drop_chunks('skip_inv_ddl', older_than => '2030-03-03'::timestamptz) IS NOT NULL AS dropped;
+ dropped 
+---------
+ t
+
+COMMIT;
+SELECT count(*) AS after_skipped_drop_chunks
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_drop_chunks 
+---------------------------
+                         0
+
+-- 7c) TRUNCATE chunk UNDER the GUC.
+SELECT format('%I.%I', chunk_schema, chunk_name) AS skip_inv_ddl_chunk
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'skip_inv_ddl'
+  ORDER BY range_start
+  LIMIT 1 \gset
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT format('TRUNCATE TABLE %s', :'skip_inv_ddl_chunk') \gexec
+TRUNCATE TABLE _timescaledb_internal._hyper_6_8_chunk
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_chunk
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_truncate_chunk 
+------------------------------
+                            0
+
+-- 7d) TRUNCATE hypertable UNDER the GUC.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+TRUNCATE TABLE skip_inv_ddl;
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_ht
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_truncate_ht 
+---------------------------
+                         0
+
+-- 7e) DROP TABLE chunk UNDER the GUC. Reload data first since 7d cleared it,
+-- and clear the log afterwards so it only reflects the DROP.
+INSERT INTO skip_inv_ddl
+SELECT ts, 1 FROM generate_series('2030-03-01'::timestamptz, '2030-03-05', '6 hours') ts;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SELECT format('%I.%I', chunk_schema, chunk_name) AS skip_inv_ddl_chunk2
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'skip_inv_ddl'
+  ORDER BY range_start
+  LIMIT 1 \gset
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT format('DROP TABLE %s', :'skip_inv_ddl_chunk2') \gexec
+DROP TABLE _timescaledb_internal._hyper_6_12_chunk
+COMMIT;
+SELECT count(*) AS after_skipped_drop_table_chunk
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_drop_table_chunk 
+--------------------------------
+                              0
+
+-- 7f) TRUNCATE cagg view UNDER the GUC. Records to the materialization
+-- invalidation log, not the hypertable log; assert both stay empty.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+TRUNCATE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+TRUNCATE TABLE skip_inv_ddl_1h;
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_cagg_hyper
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_truncate_cagg_hyper 
+-----------------------------------
+                                 0
+
+SELECT count(*) AS after_skipped_truncate_cagg_mat
+  FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+ after_skipped_truncate_cagg_mat 
+---------------------------------
+                               0
+
+DROP MATERIALIZED VIEW skip_inv_ddl_1h;
+DROP TABLE skip_inv_ddl;
+-- 7g) Hierarchical cagg cascade: TRUNCATE on an intermediate cagg that is
+-- itself the raw hypertable for another cagg. Exercises the second gate in
+-- process_utility.c that fires when agg_status has HypertableIsRawTable.
+CREATE TABLE skip_inv_hier (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv_hier', 'ts', chunk_time_interval => '1 day'::interval);
+     create_hypertable      
+----------------------------
+ (8,public,skip_inv_hier,t)
+
+INSERT INTO skip_inv_hier
+SELECT ts, 1 FROM generate_series('2030-04-01'::timestamptz, '2030-04-03', '1 hour') ts;
+CREATE MATERIALIZED VIEW skip_inv_hier_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n
+FROM skip_inv_hier
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_hier_1h', NULL, '2030-04-04');
+CREATE MATERIALIZED VIEW skip_inv_hier_1d
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', bucket) AS bucket, sum(n) AS n
+FROM skip_inv_hier_1h
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_hier_1d', NULL, '2030-04-04');
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+TRUNCATE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+TRUNCATE TABLE skip_inv_hier_1h;
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_hier_hyper
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ after_skipped_truncate_hier_hyper 
+-----------------------------------
+                                 0
+
+SELECT count(*) AS after_skipped_truncate_hier_mat
+  FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+ after_skipped_truncate_hier_mat 
+---------------------------------
+                               0
+
+DROP MATERIALIZED VIEW skip_inv_hier_1d;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_21_chunk
+DROP MATERIALIZED VIEW skip_inv_hier_1h;
+DROP TABLE skip_inv_hier;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_FILES
     cagg_policy.sql
     cagg_refresh_using_trigger.sql
     cagg_refresh_using_merge.sql
+    cagg_skip_invalidation.sql
     cagg_utils.sql
     cagg_watermark.sql
     chunk_publication_compression.sql

--- a/tsl/test/sql/cagg_skip_invalidation.sql
+++ b/tsl/test/sql/cagg_skip_invalidation.sql
@@ -1,0 +1,288 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_functions.stop_background_workers();
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+
+CREATE TABLE skip_inv (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv', 'ts', chunk_time_interval => '1 day'::interval);
+
+INSERT INTO skip_inv VALUES ('2030-01-15 00:00', 0);
+
+CREATE MATERIALIZED VIEW skip_inv_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n, sum(v) AS s
+FROM skip_inv
+GROUP BY 1
+WITH NO DATA;
+
+-- Advance the invalidation threshold so inserts below it write to the
+-- hypertable_invalidation_log.
+CALL refresh_continuous_aggregate('skip_inv_1h', NULL, '2030-01-16');
+
+SELECT format('%I.%I', chunk_schema, chunk_name) AS skip_inv_chunk
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'skip_inv' \gset
+
+-- Case 1: GUC defaults to off; INSERT writes to the log.
+INSERT INTO skip_inv VALUES ('2030-01-15 01:00', 1);
+SELECT count(*) AS after_baseline_insert
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- Clear the log between cases.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+-- Case 2: All four DML paths under SET LOCAL skip_cagg_invalidation = on.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv VALUES ('2030-01-15 02:00', 2);
+COPY skip_inv FROM STDIN;
+2030-01-15 02:30	3
+2030-01-15 02:45	4
+\.
+UPDATE skip_inv SET v = v * 10 WHERE ts = '2030-01-15 02:00';
+DELETE FROM skip_inv WHERE ts = '2030-01-15 02:30';
+COMMIT;
+SELECT count(*) AS after_skipped_dml
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- Case 3: Direct chunk write. ModifyHypertable wraps chunk INSERT/COPY too.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT format('INSERT INTO %s VALUES (''2030-01-15 03:00'', 5)', :'skip_inv_chunk') \gexec
+SELECT format('COPY %s FROM STDIN', :'skip_inv_chunk') \gexec
+2030-01-15 03:30	6
+\.
+COMMIT;
+SELECT count(*) AS after_skipped_direct_chunk
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- Case 4: SET LOCAL must not leak past COMMIT.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv VALUES ('2030-01-15 04:00', 7);
+COMMIT;
+SHOW timescaledb.skip_cagg_invalidation;
+INSERT INTO skip_inv VALUES ('2030-01-15 04:30', 8);
+SELECT count(*) AS after_scope_check
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+-- Case 5: After a skipped load, an explicit forced refresh picks up the new rows.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv
+SELECT '2030-01-15 05:00'::timestamptz + (i || ' minutes')::interval, i
+FROM generate_series(1, 60) i;
+COMMIT;
+SELECT count(*) AS after_bulk_load_log
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+SELECT count(*) AS hourly_rows_before_refresh FROM skip_inv_1h
+WHERE bucket >= '2030-01-15 05:00' AND bucket < '2030-01-15 07:00';
+
+CALL refresh_continuous_aggregate('skip_inv_1h', '2030-01-15 05:00', '2030-01-15 07:00', force => true);
+
+SELECT bucket, n, s FROM skip_inv_1h
+WHERE bucket >= '2030-01-15 05:00' AND bucket < '2030-01-15 07:00'
+ORDER BY bucket;
+
+DROP MATERIALIZED VIEW skip_inv_1h;
+DROP TABLE skip_inv;
+
+-- Case 6: Direct-compress INSERT/COPY paths. Exercises the
+-- compressor_set_invalidation gates in copy.c and modify_hypertable_exec.c.
+CREATE TABLE skip_inv_dc (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv_dc', 'ts', chunk_time_interval => '1 day'::interval);
+ALTER TABLE skip_inv_dc SET (timescaledb.compress, timescaledb.compress_segmentby = '');
+INSERT INTO skip_inv_dc VALUES ('2030-02-15 00:00', 0);
+SELECT compress_chunk(c) IS NOT NULL AS compressed
+  FROM show_chunks('skip_inv_dc') c;
+
+CREATE MATERIALIZED VIEW skip_inv_dc_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n
+FROM skip_inv_dc
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_dc_1h', NULL, '2030-02-16');
+
+-- Direct-compress INSERT requires the planner to estimate >= 10 rows, so use
+-- generate_series. Direct-compress COPY has no row threshold.
+BEGIN;
+SET LOCAL timescaledb.enable_direct_compress_copy = on;
+SET LOCAL timescaledb.enable_direct_compress_insert = on;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+INSERT INTO skip_inv_dc
+SELECT '2030-02-15 01:00'::timestamptz + (i || ' seconds')::interval, i
+FROM generate_series(1, 20) i;
+COPY skip_inv_dc FROM STDIN;
+2030-02-15 02:00	100
+2030-02-15 03:00	101
+\.
+COMMIT;
+SELECT count(*) AS after_skipped_direct_compress
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+DROP MATERIALIZED VIEW skip_inv_dc_1h;
+DROP TABLE skip_inv_dc;
+
+-- Case 7: DDL paths (drop_chunks, DROP TABLE chunk, TRUNCATE chunk,
+-- TRUNCATE hypertable) under the GUC. Verifies the DDL invalidation
+-- sites in process_utility.c and chunk.c are gated.
+CREATE TABLE skip_inv_ddl (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv_ddl', 'ts', chunk_time_interval => '1 day'::interval);
+INSERT INTO skip_inv_ddl
+SELECT ts, 1 FROM generate_series('2030-03-01'::timestamptz, '2030-03-05', '6 hours') ts;
+
+CREATE MATERIALIZED VIEW skip_inv_ddl_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n
+FROM skip_inv_ddl
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_ddl_1h', NULL, '2030-03-06');
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+-- 7a) Baseline: drop_chunks WITHOUT the GUC records invalidations.
+SELECT drop_chunks('skip_inv_ddl', older_than => '2030-03-02'::timestamptz) IS NOT NULL AS dropped;
+SELECT count(*) > 0 AS ddl_baseline_recorded
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+-- 7b) drop_chunks UNDER the GUC: no invalidations recorded.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT drop_chunks('skip_inv_ddl', older_than => '2030-03-03'::timestamptz) IS NOT NULL AS dropped;
+COMMIT;
+SELECT count(*) AS after_skipped_drop_chunks
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- 7c) TRUNCATE chunk UNDER the GUC.
+SELECT format('%I.%I', chunk_schema, chunk_name) AS skip_inv_ddl_chunk
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'skip_inv_ddl'
+  ORDER BY range_start
+  LIMIT 1 \gset
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT format('TRUNCATE TABLE %s', :'skip_inv_ddl_chunk') \gexec
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_chunk
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- 7d) TRUNCATE hypertable UNDER the GUC.
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+TRUNCATE TABLE skip_inv_ddl;
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_ht
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- 7e) DROP TABLE chunk UNDER the GUC. Reload data first since 7d cleared it,
+-- and clear the log afterwards so it only reflects the DROP.
+INSERT INTO skip_inv_ddl
+SELECT ts, 1 FROM generate_series('2030-03-01'::timestamptz, '2030-03-05', '6 hours') ts;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SELECT format('%I.%I', chunk_schema, chunk_name) AS skip_inv_ddl_chunk2
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name = 'skip_inv_ddl'
+  ORDER BY range_start
+  LIMIT 1 \gset
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+SELECT format('DROP TABLE %s', :'skip_inv_ddl_chunk2') \gexec
+COMMIT;
+SELECT count(*) AS after_skipped_drop_table_chunk
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+-- 7f) TRUNCATE cagg view UNDER the GUC. Records to the materialization
+-- invalidation log, not the hypertable log; assert both stay empty.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+TRUNCATE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+TRUNCATE TABLE skip_inv_ddl_1h;
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_cagg_hyper
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SELECT count(*) AS after_skipped_truncate_cagg_mat
+  FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+
+DROP MATERIALIZED VIEW skip_inv_ddl_1h;
+DROP TABLE skip_inv_ddl;
+
+-- 7g) Hierarchical cagg cascade: TRUNCATE on an intermediate cagg that is
+-- itself the raw hypertable for another cagg. Exercises the second gate in
+-- process_utility.c that fires when agg_status has HypertableIsRawTable.
+CREATE TABLE skip_inv_hier (ts timestamptz NOT NULL, v int);
+SELECT create_hypertable('skip_inv_hier', 'ts', chunk_time_interval => '1 day'::interval);
+INSERT INTO skip_inv_hier
+SELECT ts, 1 FROM generate_series('2030-04-01'::timestamptz, '2030-04-03', '1 hour') ts;
+
+CREATE MATERIALIZED VIEW skip_inv_hier_1h
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', ts) AS bucket, count(*) AS n
+FROM skip_inv_hier
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_hier_1h', NULL, '2030-04-04');
+
+CREATE MATERIALIZED VIEW skip_inv_hier_1d
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', bucket) AS bucket, sum(n) AS n
+FROM skip_inv_hier_1h
+GROUP BY 1
+WITH NO DATA;
+CALL refresh_continuous_aggregate('skip_inv_hier_1d', NULL, '2030-04-04');
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET timezone TO 'UTC';
+SET datestyle TO 'ISO, YMD';
+TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+TRUNCATE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+BEGIN;
+SET LOCAL timescaledb.skip_cagg_invalidation = on;
+TRUNCATE TABLE skip_inv_hier_1h;
+COMMIT;
+SELECT count(*) AS after_skipped_truncate_hier_hyper
+  FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+SELECT count(*) AS after_skipped_truncate_hier_mat
+  FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+
+DROP MATERIALIZED VIEW skip_inv_hier_1d;
+DROP MATERIALIZED VIEW skip_inv_hier_1h;
+DROP TABLE skip_inv_hier;


### PR DESCRIPTION
## Summary

Adds `timescaledb.skip_cagg_invalidation`, a session/transaction-scoped `PGC_USERSET` boolean GUC (default `off`) that suppresses continuous-aggregate invalidation tracking for both DML and DDL on hypertables.

## Motivation

Bulk-migration tools such as **live-sync** (the Postgres connector), **timescaledb-backfill**, and similar copy both the raw hypertable data and the cagg's materialized hypertable data from source to target. Once both are copied the cagg is already consistent with the underlying data on the target, so the invalidation entries produced as a side effect of the bulk INSERT/COPY are pure overhead — they only cause an unnecessary re-materialization of ranges that are already materialized.

Before 2.23.0 these tools handled it by dropping `ts_cagg_invalidation_trigger` around the load. That trigger was removed in 2.23.0 and invalidation now lives in the executor, so there is no supported opt-out. Workarounds that exist today are inadequate:

- Writing directly to a chunk still records invalidations (planner wraps chunk INSERT/COPY in `ModifyHypertable`).
- `timescaledb.restoring=on` breaks routing — rows land in the empty parent table, invisible to chunk queries and caggs.
- Clearing `continuous_aggs_hypertable_invalidation_log` after the load races with concurrent writers.

This GUC provides a supported, non-destructive opt-out for bulk-load tools that own the refresh lifecycle.

## What the GUC gates

**DML** (`src/copy.c`, `src/nodes/modify_hypertable_exec.c`): INSERT, UPDATE, DELETE, COPY, direct-compress INSERT, direct-compress COPY.

**DDL** (`src/process_utility.c`, `src/chunk.c`): DROP TABLE chunk, `drop_chunks()`, TRUNCATE chunk, TRUNCATE hypertable, TRUNCATE cagg (and hierarchical-cagg cascade).

## Intended usage

```sql
BEGIN;
  SET LOCAL timescaledb.skip_cagg_invalidation = on;
  -- bulk-load raw hypertable AND/OR the cagg's materialized hypertable
COMMIT;
```

Migration tools are responsible for ensuring the materialized hypertable is brought to the same state as the source. If the load covers only part of a range, an explicit `refresh_continuous_aggregate(cagg, low, high, force => true)` can finish the job.

## Test plan

New regress test `tsl/test/sql/cagg_skip_invalidation.sql` covers:

- [x] Baseline (GUC off) — INSERT writes to `continuous_aggs_hypertable_invalidation_log`.
- [x] All four DML paths under `SET LOCAL skip_cagg_invalidation = on` — log unchanged.
- [x] Direct chunk write under the GUC.
- [x] `SET LOCAL` scope — setting does not leak across transactions.
- [x] End-to-end refresh with `force => true` after a skipped load.
- [x] Direct-compress INSERT/COPY paths under the GUC.
- [x] DDL paths under the GUC: baseline shows `drop_chunks` records invalidations; under the GUC `drop_chunks`, TRUNCATE chunk, and TRUNCATE hypertable all leave the log empty.
- [x] No regressions in `cagg_invalidation`, `cagg_invalidation_variable_bucket`, `cagg_refresh_using_trigger`, `cagg_refresh_using_merge`, `cagg_refresh_cleanup`, `cagg_direct_compress`, `cagg_drop_chunks`, `cagg_bgw_drop_chunks`, `cagg_tableam` (all pass).