### PR TITLE
Remove chunk_constraint catalog tracking for CHECK constraints

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,12 @@
+-- Inherited CHECK constraints on OSM chunks are no longer tracked in
+-- _timescaledb_catalog.chunk_constraint. PostgreSQL inheritance handles
+-- propagation, so the rows are redundant. Remove any rows left over from
+-- earlier versions.
+DELETE FROM _timescaledb_catalog.chunk_constraint cc
+USING _timescaledb_catalog.chunk c
+WHERE cc.chunk_id = c.id
+  AND c.osm_chunk
+  AND cc.dimension_slice_id IS NULL
+  AND cc.hypertable_constraint_name IS NOT NULL
+  AND cc.constraint_name = cc.hypertable_constraint_name;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,19 @@
+-- Restore tracking rows for inherited CHECK constraints on OSM chunks.
+-- Earlier versions expected one chunk_constraint row per CHECK constraint
+-- inherited from the hypertable on each foreign-table chunk.
+INSERT INTO _timescaledb_catalog.chunk_constraint
+    (chunk_id, dimension_slice_id, constraint_name, hypertable_constraint_name)
+SELECT c.id, NULL, con.conname, con.conname
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
+JOIN pg_class ht_class
+    ON ht_class.relname = ht.table_name
+JOIN pg_namespace ht_ns
+    ON ht_ns.oid = ht_class.relnamespace
+    AND ht_ns.nspname = ht.schema_name
+JOIN pg_constraint con
+    ON con.conrelid = ht_class.oid
+    AND con.contype = 'c'
+WHERE c.osm_chunk
+ON CONFLICT DO NOTHING;
+

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -5065,17 +5065,11 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	/* insert dimension slices if they do not exist.
 	 */
 	ts_dimension_slice_insert_multi(chunk->cube->slices, chunk->cube->num_slices);
-	/* check constraints are not automatically created for foreign tables.
-	 * See: ts_chunk_constraints_add_dimension_constraints.
-	 * Collect all the check constraints from the hypertable and add them to the
-	 * foreign table. Otherwise, cannot add as child of the hypertable (pg inheritance
-	 * code will error. Note that the name of the check constraint on the hypertable
-	 * and the foreign table chunk should match.
+	/* CHECK constraints are not inherited automatically by foreign tables, so
+	 * clone them from the hypertable onto the foreign chunk before running
+	 * ALTER TABLE ... INHERIT below.
 	 */
-	ts_chunk_constraints_add_inheritable_check_constraints(chunk->constraints,
-														   chunk->fd.id,
-														   chunk->relkind,
-														   chunk->hypertable_relid);
+	ts_chunk_clone_check_constraints(relid, chunk->hypertable_relid);
 	chunk_create_table_constraints(parent_ht, chunk);
 	/* Add dimension constraints for the chunk */
 	ts_chunk_constraints_add_dimension_constraints(chunk->constraints, chunk->fd.id, chunk->cube);

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -858,37 +858,38 @@ ts_chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 ch
 	return ts_constraint_process(hypertable_oid, chunk_constraint_add, &cc);
 }
 
-/* check constraints have the same name as the one on the hypertable */
 static ConstraintProcessStatus
-chunk_constraint_add_check(HeapTuple constraint_tuple, void *arg)
+clone_check_constraint(HeapTuple tuple, void *arg)
 {
-	ConstraintContext *cc = arg;
-	Form_pg_constraint constraint = (Form_pg_constraint) GETSTRUCT(constraint_tuple);
+	Form_pg_constraint con = (Form_pg_constraint) GETSTRUCT(tuple);
+	Oid chunk_relid = *(Oid *) arg;
 
-	if (constraint->contype == CONSTRAINT_CHECK)
+	if (con->contype != CONSTRAINT_CHECK)
 	{
-		ts_chunk_constraints_add(cc->ccs,
-								 cc->chunk_id,
-								 0,
-								 NameStr(constraint->conname),
-								 NameStr(constraint->conname));
-		return CONSTR_PROCESSED;
+		return CONSTR_IGNORED;
 	}
 
-	return CONSTR_IGNORED;
+	CatalogInternalCall2(DDL_CONSTRAINT_CLONE,
+						 ObjectIdGetDatum(con->oid),
+						 ObjectIdGetDatum(chunk_relid));
+	return CONSTR_PROCESSED;
 }
 
-/* Adds only inheritable check constraints */
-int
-ts_chunk_constraints_add_inheritable_check_constraints(ChunkConstraints *ccs, int32 chunk_id,
-													   const char chunk_relkind, Oid hypertable_oid)
+/*
+ * Clone CHECK constraints from a hypertable onto a foreign-table chunk.
+ *
+ * Foreign tables do not inherit CHECK constraints automatically, so we
+ * have to recreate the hypertable's CHECKs on the foreign chunk under
+ * the same name before running ALTER TABLE ... INHERIT. PostgreSQL will
+ * then merge the foreign chunk's CHECKs with the parent's and propagate
+ * subsequent renames or drops via normal inheritance.
+ */
+void
+ts_chunk_clone_check_constraints(Oid chunk_relid, Oid hypertable_oid)
 {
-	ConstraintContext cc = {
-		.chunk_relkind = chunk_relkind,
-		.ccs = ccs,
-		.chunk_id = chunk_id,
-	};
-	return ts_constraint_process(hypertable_oid, chunk_constraint_add_check, &cc);
+	ts_process_utility_set_expect_chunk_modification(true);
+	ts_constraint_process(hypertable_oid, clone_check_constraint, &chunk_relid);
+	ts_process_utility_set_expect_chunk_modification(false);
 }
 
 void

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -56,8 +56,7 @@ extern TSDLLEXPORT int ts_chunk_constraints_add_inheritable_constraints(ChunkCon
 																		const char chunk_relkind,
 																		Oid hypertable_oid,
 																		Oid table_id);
-extern TSDLLEXPORT int ts_chunk_constraints_add_inheritable_check_constraints(
-	ChunkConstraints *ccs, int32 chunk_id, const char chunk_relkind, Oid hypertable_oid);
+extern void ts_chunk_clone_check_constraints(Oid chunk_relid, Oid hypertable_oid);
 extern TSDLLEXPORT void ts_chunk_constraints_insert_metadata(const ChunkConstraints *ccs);
 extern TSDLLEXPORT Constraint *ts_chunk_constraint_dimensional_create(const Dimension *dim,
 																	  const DimensionSlice *slice,

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1021,6 +1021,16 @@ SELECT * FROM test.show_constraints('child_hyper_constr');
 -------------------------+------+---------+-------+---------------------------------+------------+----------+-----------
  hyper_constr_temp_check | c    | {temp}  | -     | (temp > (10)::double precision) | f          | f        | t
 
+-- inherited CHECK constraints on OSM chunks are not tracked in chunk_constraint
+SELECT cc.constraint_name, cc.hypertable_constraint_name, cc.dimension_slice_id
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+WHERE c.table_name = 'child_hyper_constr'
+ORDER BY cc.constraint_name;
+ constraint_name | hypertable_constraint_name | dimension_slice_id 
+-----------------+----------------------------+--------------------
+ constraint_19   |                            |                 19
+
 -- TEST foreign key trigger: deleting data from foreign table measure
 -- does not error out due to data in osm chunk
 \set ON_ERROR_STOP 0

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -641,6 +641,13 @@ SELECT * FROM hyper_constr WHERE time > 200 and time < 400 order by time;
 --TEST verify the check constraint exists on the OSM chunk
 SELECT * FROM test.show_constraints('child_hyper_constr');
 
+-- inherited CHECK constraints on OSM chunks are not tracked in chunk_constraint
+SELECT cc.constraint_name, cc.hypertable_constraint_name, cc.dimension_slice_id
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.chunk_constraint cc ON cc.chunk_id = c.id
+WHERE c.table_name = 'child_hyper_constr'
+ORDER BY cc.constraint_name;
+
 -- TEST foreign key trigger: deleting data from foreign table measure
 -- does not error out due to data in osm chunk
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
Removed chunk_constraint catalog tracking for inherited CHECK constraints
on OSM (foreign-table) chunks. CHECKs are still physically created on the
foreign chunk so ALTER TABLE ... INHERIT can merge them; from that point
on PostgreSQL's normal inheritance handles rename/drop propagation.

Disable-check: force-changelog-file