### PR TITLE
Release 2.27.1

### DIFF
--- a/.unreleased/pr_9795
+++ b/.unreleased/pr_9795
@@ -1,1 +1,0 @@
-Fixes: #9795 Delete orphaned compression_settings before migrating catalog table

--- a/.unreleased/pr_9799
+++ b/.unreleased/pr_9799
@@ -1,2 +1,0 @@
-Fixes: #9799 Fix job_errors view leaking failed jobs to non-owners
-Thanks: @homanp for reporting an information leak with the job_errors view

--- a/.unreleased/pr_9800
+++ b/.unreleased/pr_9800
@@ -1,1 +1,0 @@
-Fixes: #9800 Check hypertable ownership before recompression

--- a/.unreleased/pr_9801
+++ b/.unreleased/pr_9801
@@ -1,1 +1,0 @@
-Fixes: #9801 Fix information leak in policy_reorder_remove

--- a/.unreleased/pr_9824
+++ b/.unreleased/pr_9824
@@ -1,1 +1,0 @@
-Fixes: #9824 Adding migration scripts for composite bloom filters

--- a/.unreleased/pr_9828
+++ b/.unreleased/pr_9828
@@ -1,1 +1,0 @@
-Fixes: #9828 Skip columnar index scan when grouping by an expression

--- a/.unreleased/pr_9830
+++ b/.unreleased/pr_9830
@@ -1,1 +1,0 @@
-Fixes: #9830 Skip ColumnarIndexScan for GROUPING SETS / ROLLUP / CUBE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ This page lists all the latest features and updates to TimescaleDB. When
 you use psql to update your database, use the -X flag and prevent any .psqlrc
 commands from accidentally triggering the load of a previous DB version.**
 
+## 2.27.1 (2026-05-19)
+
+This release contains performance improvements and bug fixes since the 2.27.0 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.27.1**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* [#9828](https://github.com/timescale/timescaledb/pull/9828) Skip columnar index scan when grouping by an expression
+* [#9830](https://github.com/timescale/timescaledb/pull/9830) Skip ColumnarIndexScan for GROUPING SETS / ROLLUP / CUBE
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+
 ## 2.27.0 (2026-05-12)
 
 This release contains performance improvements and bug fixes since the 2.26.4 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ commands from accidentally triggering the load of a previous DB version.**
 This release contains performance improvements and bug fixes since the 2.27.0 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
-* [#9795](https://github.com/timescale/timescaledb/pull/9795) Delete orphaned compression_settings before migrating catalog table
+* [#9795](https://github.com/timescale/timescaledb/pull/9795) Delete orphaned `compression_settings` before migrating catalog table
 * [#9800](https://github.com/timescale/timescaledb/pull/9800) Check hypertable ownership before recompression
-* [#9801](https://github.com/timescale/timescaledb/pull/9801) Fix information leak in policy_reorder_remove
+* [#9801](https://github.com/timescale/timescaledb/pull/9801) Fix information leak in `policy_reorder_remove`
 * [#9828](https://github.com/timescale/timescaledb/pull/9828) Skip columnar index scan when grouping by an expression
-* [#9830](https://github.com/timescale/timescaledb/pull/9830) Skip ColumnarIndexScan for GROUPING SETS / ROLLUP / CUBE
+* [#9830](https://github.com/timescale/timescaledb/pull/9830) Skip `ColumnarIndexScan` for GROUPING SETS / ROLLUP / CUBE
 
 ## 2.27.0 (2026-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,12 @@ commands from accidentally triggering the load of a previous DB version.**
 
 This release contains performance improvements and bug fixes since the 2.27.0 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.27.1**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
-
 **Bugfixes**
+* [#9795](https://github.com/timescale/timescaledb/pull/9795) Delete orphaned compression_settings before migrating catalog table
+* [#9800](https://github.com/timescale/timescaledb/pull/9800) Check hypertable ownership before recompression
+* [#9801](https://github.com/timescale/timescaledb/pull/9801) Fix information leak in policy_reorder_remove
 * [#9828](https://github.com/timescale/timescaledb/pull/9828) Skip columnar index scan when grouping by an expression
 * [#9830](https://github.com/timescale/timescaledb/pull/9830) Skip ColumnarIndexScan for GROUPING SETS / ROLLUP / CUBE
-
-**New Settings**
-
-**GUCs**
-
-**Thanks**
 
 ## 2.27.0 (2026-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ This release contains performance improvements and bug fixes since the 2.27.0 re
 
 **Bugfixes**
 * [#9795](https://github.com/timescale/timescaledb/pull/9795) Delete orphaned `compression_settings` before migrating catalog table
+* [#9799](https://github.com/timescale/timescaledb/pull/9799) Fix `job_errors` view leaking failed jobs to non-owners
 * [#9800](https://github.com/timescale/timescaledb/pull/9800) Check hypertable ownership before recompression
 * [#9801](https://github.com/timescale/timescaledb/pull/9801) Fix information leak in `policy_reorder_remove`
+* [#9824](https://github.com/timescale/timescaledb/pull/9824) Adding migration scripts for composite bloom filters
 * [#9828](https://github.com/timescale/timescaledb/pull/9828) Skip columnar index scan when grouping by an expression
 * [#9830](https://github.com/timescale/timescaledb/pull/9830) Skip `ColumnarIndexScan` for GROUPING SETS / ROLLUP / CUBE
+
+**Thanks**
+* @homanp for reporting an information leak with the job_errors view
 
 ## 2.27.0 (2026-05-12)
 


### PR DESCRIPTION
# TimescaleDB Changelog

**Please note: When updating your database, you should connect using
This page lists all the latest features and updates to TimescaleDB. When
you use psql to update your database, use the -X flag and prevent any .psqlrc
commands from accidentally triggering the load of a previous DB version.**

## 2.27.1 (2026-05-19)

This release contains performance improvements and bug fixes since the 2.27.0 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#9795](https://github.com/timescale/timescaledb/pull/9795) Delete orphaned `compression_settings` before migrating catalog table
* [#9799](https://github.com/timescale/timescaledb/pull/9799) Fix `job_errors` view leaking failed jobs to non-owners
* [#9800](https://github.com/timescale/timescaledb/pull/9800) Check hypertable ownership before recompression
* [#9801](https://github.com/timescale/timescaledb/pull/9801) Fix information leak in `policy_reorder_remove`
* [#9824](https://github.com/timescale/timescaledb/pull/9824) Adding migration scripts for composite bloom filters
* [#9828](https://github.com/timescale/timescaledb/pull/9828) Skip columnar index scan when grouping by an expression
* [#9830](https://github.com/timescale/timescaledb/pull/9830) Skip `ColumnarIndexScan` for GROUPING SETS / ROLLUP / CUBE

**Thanks**
* @homanp for reporting an information leak with the job_errors view