### PR TITLE
Remove chunk_constraint catalog tracking for foreign keys

### DIFF
--- a/.unreleased/pr_9878
+++ b/.unreleased/pr_9878
@@ -1,0 +1,1 @@
+Implements: #9878 Remove chunk_constraint catalog tracking for foreign keys

--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -110,7 +110,35 @@ run_sql_file test/sql/updates/post.${TEST_VERSION}.sql updated > "${OUTPUT_DIR}/
 run_sql_file test/sql/updates/post.${TEST_VERSION}.sql restored > "${OUTPUT_DIR}/post.restored.log"
 
 sed -i -E -e 's!"*_ts_meta_v2_bl[0-9A-Za-z]+_([_0-9A-Za-z]+)"*!regress-test-bloom_\1!g' \
+    -e 's!(_timescaledb_internal\._hyper_[0-9]+_[0-9]+_chunk" CONSTRAINT ")[0-9]+_[0-9]+_!\1!g' \
     "${OUTPUT_DIR}"/post.*.log
+
+# Sort \d "Referenced by:" blocks: psql's conname-only sort leaves heap-scan
+# order as a tiebreaker, which differs between fresh and upgraded installs.
+for log in "${OUTPUT_DIR}"/post.*.log; do
+  python3 - "${log}" <<'PYEOF'
+import re, sys
+path = sys.argv[1]
+with open(path) as f:
+    lines = f.readlines()
+con_re = re.compile(r'CONSTRAINT "([^"]+)"')
+def sort_key(line):
+    m = con_re.search(line)
+    return (m.group(1) if m else "", line)
+out, buf = [], []
+for line in lines:
+    if line.startswith('    TABLE "'):
+        buf.append(line)
+    else:
+        if buf:
+            out.extend(sorted(buf, key=sort_key))
+            buf = []
+        out.append(line)
+out.extend(sorted(buf, key=sort_key))
+with open(path, "w") as f:
+    f.writelines(out)
+PYEOF
+done
 
 if [ "${TEST_REPAIR}" = "true" ]; then
   echo "Creating repair database"

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,7 +1,5 @@
--- Inherited CHECK constraints on OSM chunks are no longer tracked in
--- _timescaledb_catalog.chunk_constraint. PostgreSQL inheritance handles
--- propagation, so the rows are redundant. Remove any rows left over from
--- earlier versions.
+-- Drop obsolete chunk_constraint rows for inherited CHECK constraints on
+-- OSM chunks; PG inheritance handles propagation now.
 DELETE FROM _timescaledb_catalog.chunk_constraint cc
 USING _timescaledb_catalog.chunk c
 WHERE cc.chunk_id = c.id
@@ -9,4 +7,71 @@ WHERE cc.chunk_id = c.id
   AND cc.dimension_slice_id IS NULL
   AND cc.hypertable_constraint_name IS NOT NULL
   AND cc.constraint_name = cc.hypertable_constraint_name;
+
+-- Rename legacy <chunk_id>_<seq>_<parent> chunk-side FKs to the parent name
+-- so the pg_depend backfill below can match them.
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT pg_catalog.format('%I.%I', c.schema_name, c.table_name) AS chunk_table,
+               cc.constraint_name AS old_name,
+               cc.hypertable_constraint_name AS new_name
+        FROM _timescaledb_catalog.chunk_constraint cc
+        JOIN _timescaledb_catalog.chunk c ON c.id = cc.chunk_id
+        JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
+        JOIN pg_constraint parent
+            ON parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
+            AND parent.conname = cc.hypertable_constraint_name
+            AND parent.contype = 'f'
+        WHERE cc.dimension_slice_id IS NULL
+          AND cc.hypertable_constraint_name IS NOT NULL
+          AND cc.constraint_name <> cc.hypertable_constraint_name
+    LOOP
+        EXECUTE pg_catalog.format('ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
+                                  r.chunk_table, r.old_name, r.new_name);
+    END LOOP;
+END
+$$;
+
+-- Backfill DEPENDENCY_AUTO edge so DROP/RENAME cascade to chunks, then
+-- drop the obsolete chunk_constraint rows.
+INSERT INTO pg_catalog.pg_depend
+    (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT 'pg_constraint'::regclass, child.oid, 0,
+       'pg_constraint'::regclass, parent.oid, 0, 'a'
+FROM _timescaledb_catalog.chunk_constraint cc
+JOIN _timescaledb_catalog.chunk c ON c.id = cc.chunk_id
+JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
+JOIN pg_constraint parent
+    ON parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
+    AND parent.conname = cc.hypertable_constraint_name
+    AND parent.contype = 'f'
+JOIN pg_constraint child
+    ON child.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
+    AND child.conname = cc.hypertable_constraint_name
+    AND child.contype = 'f'
+WHERE cc.dimension_slice_id IS NULL
+  AND cc.hypertable_constraint_name IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM pg_depend d
+      WHERE d.classid = 'pg_constraint'::regclass
+        AND d.objid = child.oid
+        AND d.refclassid = 'pg_constraint'::regclass
+        AND d.refobjid = parent.oid
+        AND d.deptype = 'a'
+  );
+
+DELETE FROM _timescaledb_catalog.chunk_constraint cc
+USING _timescaledb_catalog.chunk c,
+      _timescaledb_catalog.hypertable ht,
+      pg_constraint parent
+WHERE cc.chunk_id = c.id
+  AND ht.id = c.hypertable_id
+  AND parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
+  AND parent.conname = cc.hypertable_constraint_name
+  AND parent.contype = 'f'
+  AND cc.dimension_slice_id IS NULL
+  AND cc.hypertable_constraint_name IS NOT NULL;
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,19 +1,49 @@
--- Restore tracking rows for inherited CHECK constraints on OSM chunks.
--- Earlier versions expected one chunk_constraint row per CHECK constraint
--- inherited from the hypertable on each foreign-table chunk.
+-- Restore chunk_constraint rows for CHECK constraints on OSM chunks.
 INSERT INTO _timescaledb_catalog.chunk_constraint
     (chunk_id, dimension_slice_id, constraint_name, hypertable_constraint_name)
 SELECT c.id, NULL, con.conname, con.conname
 FROM _timescaledb_catalog.chunk c
 JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
-JOIN pg_class ht_class
-    ON ht_class.relname = ht.table_name
-JOIN pg_namespace ht_ns
-    ON ht_ns.oid = ht_class.relnamespace
-    AND ht_ns.nspname = ht.schema_name
 JOIN pg_constraint con
-    ON con.conrelid = ht_class.oid
+    ON con.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
     AND con.contype = 'c'
 WHERE c.osm_chunk
 ON CONFLICT DO NOTHING;
+
+-- Restore chunk_constraint rows for outbound FKs, derived from the
+-- DEPENDENCY_AUTO edge that replaced them.
+INSERT INTO _timescaledb_catalog.chunk_constraint
+    (chunk_id, dimension_slice_id, constraint_name, hypertable_constraint_name)
+SELECT c.id, NULL, child.conname, parent.conname
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
+JOIN pg_constraint child
+    ON child.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
+    AND child.contype = 'f'
+JOIN pg_depend d
+    ON d.classid = 'pg_constraint'::regclass
+    AND d.objid = child.oid
+    AND d.refclassid = 'pg_constraint'::regclass
+    AND d.deptype = 'a'
+JOIN pg_constraint parent
+    ON parent.oid = d.refobjid
+    AND parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
+    AND parent.contype = 'f'
+ON CONFLICT DO NOTHING;
+
+DELETE FROM pg_catalog.pg_depend d
+USING pg_constraint child,
+      pg_constraint parent,
+      _timescaledb_catalog.chunk c,
+      _timescaledb_catalog.hypertable ht
+WHERE d.classid = 'pg_constraint'::regclass
+  AND d.objid = child.oid
+  AND d.refclassid = 'pg_constraint'::regclass
+  AND d.refobjid = parent.oid
+  AND d.deptype = 'a'
+  AND child.contype = 'f'
+  AND parent.contype = 'f'
+  AND ht.id = c.hypertable_id
+  AND child.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
+  AND parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass;
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1049,6 +1049,7 @@ chunk_create_table_constraints(const Hypertable *ht, const Chunk *chunk)
 	/* Copy FK constraints after indexes are created, since FK validation
 	 * requires the supporting unique index to exist on the chunk. */
 	ts_chunk_copy_referencing_fk(ht, chunk);
+	ts_chunk_inherit_outbound_fk(ht, chunk);
 }
 
 static Oid

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -752,7 +752,10 @@ ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkCo
 static bool
 chunk_constraint_need_on_chunk(Form_pg_constraint conform)
 {
-	if (conform->contype == CONSTRAINT_CHECK
+	/* CHECK and NOT NULL propagate via PG inheritance; FKs are linked via
+	 * pg_depend (see ts_chunk_inherit_outbound_fk_by_oid). */
+	if (conform->contype == CONSTRAINT_CHECK ||
+		conform->contype == CONSTRAINT_FOREIGN
 #if PG18_GE
 		/* Avoid NOT NULL constraints
 		 * https://github.com/postgres/postgres/commit/b0e96f31
@@ -760,25 +763,6 @@ chunk_constraint_need_on_chunk(Form_pg_constraint conform)
 		|| conform->contype == CONSTRAINT_NOTNULL
 #endif
 	)
-	{
-		/*
-		 * check and not null constraints handled by regular inheritance (from
-		 * docs): All check constraints and not-null constraints on a parent
-		 * table are automatically inherited by its children, unless
-		 * explicitly specified otherwise with NO INHERIT clauses. Other types
-		 * of constraints (unique, primary key, and foreign key constraints)
-		 * are not inherited."
-		 */
-		return false;
-	}
-	/*
-	   Check if the foreign key constraint references a partition in a partitioned
-	   table. In that case, we shouldn't include this constraint as we will end up
-	   checking the foreign key constraint once for every partition, which obviously
-	   leads to foreign key constraint violation. Instead, we only include constraints
-	   referencing the parent table of the partitioned table.
-	*/
-	if (conform->contype == CONSTRAINT_FOREIGN && OidIsValid(conform->conparentid))
 	{
 		return false;
 	}
@@ -907,20 +891,27 @@ ts_chunk_constraint_create_on_chunk(const Hypertable *ht, const Chunk *chunk, Oi
 
 	con = (Form_pg_constraint) GETSTRUCT(tuple);
 
-	if (chunk->relkind != RELKIND_FOREIGN_TABLE && chunk_constraint_need_on_chunk(con))
+	if (chunk->relkind != RELKIND_FOREIGN_TABLE)
 	{
-		ChunkConstraint *cc = ts_chunk_constraints_add(chunk->constraints,
-													   chunk->fd.id,
-													   0,
-													   NULL,
-													   NameStr(con->conname));
+		if (con->contype == CONSTRAINT_FOREIGN && !OidIsValid(con->conparentid))
+		{
+			ts_chunk_inherit_outbound_fk_by_oid(chunk, constraint_oid);
+		}
+		else if (chunk_constraint_need_on_chunk(con))
+		{
+			ChunkConstraint *cc = ts_chunk_constraints_add(chunk->constraints,
+														   chunk->fd.id,
+														   0,
+														   NULL,
+														   NameStr(con->conname));
 
-		ts_chunk_constraint_insert(cc);
-		create_non_dimensional_constraint(cc,
-										  chunk->table_id,
-										  chunk->fd.id,
-										  ht->main_table_relid,
-										  ht->fd.id);
+			ts_chunk_constraint_insert(cc);
+			create_non_dimensional_constraint(cc,
+											  chunk->table_id,
+											  chunk->fd.id,
+											  ht->main_table_relid,
+											  ht->fd.id);
+		}
 	}
 
 	ReleaseSysCache(tuple);
@@ -1300,6 +1291,12 @@ ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid,
 		ts_scan_iterator_close(&iterator);
 
 		return name;
+	}
+
+	/* FKs aren't in chunk_constraint; chunk-side name matches parent. */
+	if (OidIsValid(get_relation_constraint_oid(chunk_relid, hypertable_constraint_name, true)))
+	{
+		return pstrdup(hypertable_constraint_name);
 	}
 	return NULL;
 }

--- a/src/foreign_key.c
+++ b/src/foreign_key.c
@@ -15,15 +15,26 @@
 
 #include <postgres.h>
 #include "access/attmap.h"
+#include "access/genam.h"
+#include "access/htup_details.h"
+#include "access/table.h"
+#include "catalog/dependency.h"
+#include "catalog/indexing.h"
+#include "catalog/pg_depend.h"
 #include "catalog/pg_trigger.h"
 #include "commands/trigger.h"
 #include "parser/parser.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
 
 #include "compat/compat.h"
 #include "chunk.h"
 #include "chunk_constraint.h"
 #include "foreign_key.h"
 #include "hypertable.h"
+#include "process_utility.h"
+#include "ts_catalog/catalog.h"
 
 static HeapTuple relation_get_fk_constraint(Oid conrelid, Oid confrelid);
 static List *relation_get_referencing_fk(Oid reloid);
@@ -602,5 +613,191 @@ ts_chunk_drop_referencing_fk_by_chunk_id(Oid chunk_id)
 	{
 		HeapTuple fk_tuple = lfirst(lc);
 		ts_chunk_constraint_drop_from_tuple(fk_tuple);
+	}
+}
+
+/*
+ * Clone an outbound FK from the hypertable onto a chunk under the parent's
+ * name and link it with DEPENDENCY_AUTO so DROP CONSTRAINT cascades.
+ */
+void
+ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
+{
+	char *parent_name;
+	Oid child_oid;
+	ObjectAddress child_addr;
+	ObjectAddress parent_addr;
+
+	if (chunk->relkind == RELKIND_FOREIGN_TABLE || IS_OSM_CHUNK(chunk))
+	{
+		return;
+	}
+
+	parent_name = get_constraint_name(parent_fk_oid);
+	if (parent_name == NULL)
+	{
+		elog(ERROR, "cache lookup failed for constraint %u", parent_fk_oid);
+	}
+
+	child_oid = get_relation_constraint_oid(chunk->table_id, parent_name, true);
+	if (OidIsValid(child_oid))
+	{
+		/* Only adopt an existing constraint if it's a FK to the same target;
+		 * otherwise the AUTO edge would later cascade-drop an unrelated
+		 * constraint. */
+		HeapTuple parent_tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(parent_fk_oid));
+		HeapTuple child_tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(child_oid));
+		Oid parent_confrelid;
+		Form_pg_constraint child_con;
+
+		if (!HeapTupleIsValid(parent_tup) || !HeapTupleIsValid(child_tup))
+		{
+			elog(ERROR, "cache lookup failed for constraint");
+		}
+
+		parent_confrelid = ((Form_pg_constraint) GETSTRUCT(parent_tup))->confrelid;
+		child_con = (Form_pg_constraint) GETSTRUCT(child_tup);
+
+		if (child_con->contype != CONSTRAINT_FOREIGN || child_con->confrelid != parent_confrelid)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_OBJECT),
+					 errmsg("cannot inherit foreign key \"%s\" onto chunk \"%s\"",
+							parent_name,
+							get_rel_name(chunk->table_id)),
+					 errdetail("A constraint with that name already exists on the chunk "
+							   "and does not match the hypertable's foreign key.")));
+		}
+
+		ReleaseSysCache(child_tup);
+		ReleaseSysCache(parent_tup);
+	}
+	else
+	{
+		CatalogSecurityContext sec_ctx;
+
+		/* Become DB owner so the ALTER TABLE in constraint_clone succeeds
+		 * when the calling user doesn't own the chunk. */
+		ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+		ts_process_utility_set_expect_chunk_modification(true);
+		CatalogInternalCall2(DDL_CONSTRAINT_CLONE,
+							 ObjectIdGetDatum(parent_fk_oid),
+							 ObjectIdGetDatum(chunk->table_id));
+		ts_process_utility_set_expect_chunk_modification(false);
+		ts_catalog_restore_user(&sec_ctx);
+		CommandCounterIncrement();
+		child_oid = get_relation_constraint_oid(chunk->table_id, parent_name, false);
+	}
+
+	/* Drop any prior edge so re-attach doesn't accumulate duplicates. */
+	deleteDependencyRecordsForClass(ConstraintRelationId,
+									child_oid,
+									ConstraintRelationId,
+									DEPENDENCY_AUTO);
+	ObjectAddressSet(child_addr, ConstraintRelationId, child_oid);
+	ObjectAddressSet(parent_addr, ConstraintRelationId, parent_fk_oid);
+	recordDependencyOn(&child_addr, &parent_addr, DEPENDENCY_AUTO);
+}
+
+/*
+ * Find the chunk-side FK linked to parent_fk_oid via DEPENDENCY_AUTO.
+ * Needed because chunks created before 2.28 use the legacy
+ * <ht_id>_<chunk_id>_<parent> name, so we can't look up by name.
+ */
+Oid
+ts_chunk_find_outbound_fk_by_parent(Oid chunk_relid, Oid parent_fk_oid)
+{
+	Relation chunk_rel = table_open(chunk_relid, AccessShareLock);
+	Relation depRel = table_open(DependRelationId, AccessShareLock);
+	Oid result = InvalidOid;
+	ListCell *lc;
+
+	foreach (lc, RelationGetFKeyList(chunk_rel))
+	{
+		Oid child_oid = ((ForeignKeyCacheInfo *) lfirst(lc))->conoid;
+		ScanKeyData key[2];
+		SysScanDesc scan;
+		HeapTuple tup;
+
+		ScanKeyInit(&key[0],
+					Anum_pg_depend_classid,
+					BTEqualStrategyNumber,
+					F_OIDEQ,
+					ObjectIdGetDatum(ConstraintRelationId));
+		ScanKeyInit(&key[1],
+					Anum_pg_depend_objid,
+					BTEqualStrategyNumber,
+					F_OIDEQ,
+					ObjectIdGetDatum(child_oid));
+
+		scan = systable_beginscan(depRel, DependDependerIndexId, true, NULL, 2, key);
+
+		while (HeapTupleIsValid(tup = systable_getnext(scan)))
+		{
+			Form_pg_depend dep = (Form_pg_depend) GETSTRUCT(tup);
+
+			if (dep->refclassid == ConstraintRelationId && dep->refobjid == parent_fk_oid &&
+				dep->deptype == DEPENDENCY_AUTO)
+			{
+				result = child_oid;
+				break;
+			}
+		}
+
+		systable_endscan(scan);
+
+		if (OidIsValid(result))
+		{
+			break;
+		}
+	}
+
+	table_close(depRel, AccessShareLock);
+	table_close(chunk_rel, AccessShareLock);
+	return result;
+}
+
+/*
+ * Clone every outbound FK from the hypertable onto a chunk. Skips constraints
+ * whose conparentid is set, since PG already propagates those.
+ *
+ * FK OIDs are snapshotted first: RelationGetFKeyList returns a relcache-owned
+ * list that the clone path can invalidate.
+ */
+void
+ts_chunk_inherit_outbound_fk(const Hypertable *ht, const Chunk *chunk)
+{
+	Relation ht_rel;
+	List *fk_oids = NIL;
+	ListCell *lc;
+
+	if (chunk->relkind == RELKIND_FOREIGN_TABLE || IS_OSM_CHUNK(chunk))
+	{
+		return;
+	}
+
+	ht_rel = table_open(ht->main_table_relid, AccessShareLock);
+	foreach (lc, RelationGetFKeyList(ht_rel))
+	{
+		Oid conoid = ((ForeignKeyCacheInfo *) lfirst(lc))->conoid;
+		HeapTuple tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(conoid));
+		bool has_parent;
+
+		if (!HeapTupleIsValid(tup))
+		{
+			continue;
+		}
+		has_parent = OidIsValid(((Form_pg_constraint) GETSTRUCT(tup))->conparentid);
+		ReleaseSysCache(tup);
+		if (!has_parent)
+		{
+			fk_oids = lappend_oid(fk_oids, conoid);
+		}
+	}
+	table_close(ht_rel, AccessShareLock);
+
+	foreach (lc, fk_oids)
+	{
+		ts_chunk_inherit_outbound_fk_by_oid(chunk, lfirst_oid(lc));
 	}
 }

--- a/src/foreign_key.h
+++ b/src/foreign_key.h
@@ -15,3 +15,6 @@
 extern TSDLLEXPORT void ts_fk_propagate(Oid conrelid, Hypertable *ht);
 extern TSDLLEXPORT void ts_chunk_copy_referencing_fk(const Hypertable *ht, const Chunk *chunk);
 extern TSDLLEXPORT void ts_chunk_drop_referencing_fk_by_chunk_id(Oid chunk_id);
+extern TSDLLEXPORT void ts_chunk_inherit_outbound_fk(const Hypertable *ht, const Chunk *chunk);
+extern TSDLLEXPORT void ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid);
+extern TSDLLEXPORT Oid ts_chunk_find_outbound_fk_by_parent(Oid chunk_relid, Oid parent_fk_oid);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2683,8 +2683,36 @@ rename_hypertable_constraint(Hypertable *ht, Oid chunk_relid, void *arg)
 {
 	RenameStmt *stmt = (RenameStmt *) arg;
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	Oid chunk_con_oid;
+	Oid parent_con_oid;
 
 	ts_chunk_constraint_rename_hypertable_constraint(chunk->fd.id, stmt->subname, stmt->newname);
+
+	/* Inherited FKs aren't in chunk_constraint; locate the chunk-side
+	 * constraint via the pg_depend edge to handle legacy names. */
+	chunk_con_oid = InvalidOid;
+	parent_con_oid = get_relation_constraint_oid(ht->main_table_relid, stmt->subname, true);
+	if (OidIsValid(parent_con_oid))
+	{
+		chunk_con_oid = ts_chunk_find_outbound_fk_by_parent(chunk_relid, parent_con_oid);
+	}
+	if (OidIsValid(chunk_con_oid))
+	{
+		char *old_name = get_constraint_name(chunk_con_oid);
+
+		if (old_name != NULL && strcmp(old_name, stmt->newname) != 0)
+		{
+			RenameStmt rename = {
+				.type = T_RenameStmt,
+				.renameType = OBJECT_TABCONSTRAINT,
+				.relation =
+					makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0),
+				.subname = old_name,
+				.newname = stmt->newname,
+			};
+			RenameConstraint(&rename);
+		}
+	}
 }
 
 static void
@@ -2714,7 +2742,17 @@ alter_hypertable_constraint(Hypertable *ht, Oid chunk_relid, void *arg)
 		ts_chunk_constraint_get_name_from_hypertable_constraint(chunk_relid,
 																hypertable_constraint_name);
 
-	AlterTableInternal(chunk_relid, list_make1(cmd), false);
+	if (cmd_constraint->conname != NULL)
+	{
+		AlterTableInternal(chunk_relid, list_make1(cmd), false);
+	}
+	else
+	{
+		elog(DEBUG1,
+			 "skipping ALTER CONSTRAINT \"%s\" on chunk \"%s\": no matching constraint",
+			 hypertable_constraint_name,
+			 get_rel_name(chunk_relid));
+	}
 
 	/* Restore for next iteration */
 	cmd_constraint->conname = hypertable_constraint_name;

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -852,3 +852,48 @@ CREATE TABLE i9132(time timestamptz) WITH (tsdb.hypertable);
 NOTICE:  using column "time" as partitioning column
 INSERT INTO i9132 VALUES ('2024-01-01'), ('2024-02-02');
 ALTER TABLE i9132 ADD COLUMN id serial, ADD CONSTRAINT implicit_pk PRIMARY KEY (id, time);
+-- Renaming an outbound foreign key on the hypertable should rename the
+-- inherited foreign key on every chunk.
+CREATE TABLE fk_ref(id INTEGER PRIMARY KEY);
+INSERT INTO fk_ref VALUES (1), (2);
+CREATE TABLE fk_ht(
+    time TIMESTAMPTZ NOT NULL,
+    ref_id INTEGER,
+    CONSTRAINT fk_ht_ref_fkey FOREIGN KEY (ref_id) REFERENCES fk_ref(id)
+) WITH (tsdb.hypertable, tsdb.partition_column = 'time');
+INSERT INTO fk_ht VALUES ('2024-01-01', 1), ('2024-03-01', 2);
+-- Inherited FKs on chunks initially carry the hypertable constraint name.
+SELECT count(*) AS chunk_fks_fkey
+FROM pg_constraint pc
+JOIN pg_class c ON c.oid = pc.conrelid
+WHERE c.relname LIKE '_hyper%' AND pc.contype = 'f' AND pc.conname LIKE '%fk_ht_ref_fkey%';
+ chunk_fks_fkey 
+----------------
+              2
+
+ALTER TABLE fk_ht RENAME CONSTRAINT fk_ht_ref_fkey TO fk_ht_ref_renamed;
+-- After the rename all chunk-side FKs must reference the new name and none
+-- of the old name should remain.
+SELECT count(*) AS chunk_fks_renamed
+FROM pg_constraint pc
+JOIN pg_class c ON c.oid = pc.conrelid
+WHERE c.relname LIKE '_hyper%' AND pc.contype = 'f' AND pc.conname LIKE '%fk_ht_ref_renamed%';
+ chunk_fks_renamed 
+-------------------
+                 2
+
+SELECT count(*) AS chunk_fks_old
+FROM pg_constraint pc
+JOIN pg_class c ON c.oid = pc.conrelid
+WHERE c.relname LIKE '_hyper%' AND pc.contype = 'f' AND pc.conname LIKE '%fk_ht_ref_fkey%';
+ chunk_fks_old 
+---------------
+             0
+
+-- The FK is still enforced.
+\set ON_ERROR_STOP 0
+INSERT INTO fk_ht VALUES ('2024-02-01', 999);
+ERROR:  insert or update on table "_hyper_18_39_chunk" violates foreign key constraint "fk_ht_ref_renamed"
+\set ON_ERROR_STOP 1
+DROP TABLE fk_ht;
+DROP TABLE fk_ref;

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -365,7 +365,7 @@ SELECT * FROM create_hypertable('hyper_fk', 'time', chunk_time_interval => 10);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  insert or update on table "_hyper_4_7_chunk" violates foreign key constraint "7_17_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_7_chunk" violates foreign key constraint "hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 INSERT INTO devices VALUES ('dev2');
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
@@ -400,37 +400,36 @@ FOREIGN KEY (device_id) REFERENCES devices(device_id);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000002, 'dev3', 11);
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_22_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_4_8_chunk');
-          Constraint          | Type |   Columns   |                   Index                    |                                           Expr                                           | Deferrable | Deferred | Validated 
-------------------------------+------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------+------------+----------+-----------
- 8_20_hyper_fk_pkey           | p    | {time}      | _timescaledb_internal."8_20_hyper_fk_pkey" |                                                                                          | f          | f        | t
- 8_22_hyper_fk_device_id_fkey | f    | {device_id} | devices_pkey                               |                                                                                          | f          | f        | t
- constraint_8                 | c    | {time}      | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint)) | f          | f        | t
- hyper_fk_sensor_1_check      | c    | {sensor_1}  | -                                          | (sensor_1 > (10)::numeric)                                                               | f          | f        | t
+       Constraint        | Type |   Columns   |                   Index                    |                                           Expr                                           | Deferrable | Deferred | Validated 
+-------------------------+------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------+------------+----------+-----------
+ 8_18_hyper_fk_pkey      | p    | {time}      | _timescaledb_internal."8_18_hyper_fk_pkey" |                                                                                          | f          | f        | t
+ constraint_8            | c    | {time}      | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint)) | f          | f        | t
+ hyper_fk_device_id_fkey | f    | {device_id} | devices_pkey                               |                                                                                          | f          | f        | t
+ hyper_fk_sensor_1_check | c    | {sensor_1}  | -                                          | (sensor_1 > (10)::numeric)                                                               | f          | f        | t
 
 SELECT * FROM _timescaledb_catalog.chunk_constraint;
- chunk_id | dimension_slice_id |       constraint_name        | hypertable_constraint_name 
-----------+--------------------+------------------------------+----------------------------
-        3 |                  3 | constraint_3                 | 
-        4 |                  4 | constraint_4                 | 
-        5 |                  5 | constraint_5                 | 
-        4 |                    | 4_10_new_name2               | new_name2
-        5 |                    | 5_11_new_name2               | new_name2
-        6 |                  6 | constraint_6                 | 
-        6 |                    | 6_16_hyper_pk_pkey           | hyper_pk_pkey
-        8 |                  8 | constraint_8                 | 
-        8 |                    | 8_20_hyper_fk_pkey           | hyper_fk_pkey
-        8 |                    | 8_22_hyper_fk_device_id_fkey | hyper_fk_device_id_fkey
+ chunk_id | dimension_slice_id |  constraint_name   | hypertable_constraint_name 
+----------+--------------------+--------------------+----------------------------
+        3 |                  3 | constraint_3       | 
+        4 |                  4 | constraint_4       | 
+        5 |                  5 | constraint_5       | 
+        4 |                    | 4_10_new_name2     | new_name2
+        5 |                    | 5_11_new_name2     | new_name2
+        6 |                  6 | constraint_6       | 
+        6 |                    | 6_16_hyper_pk_pkey | hyper_pk_pkey
+        8 |                  8 | constraint_8       | 
+        8 |                    | 8_18_hyper_fk_pkey | hyper_fk_pkey
 
 --test CASCADE drop behavior
 DROP TABLE devices CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to constraint hyper_fk_device_id_fkey on table hyper_fk
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_4_8_chunk');
        Constraint        | Type |  Columns   |                   Index                    |                                           Expr                                           | Deferrable | Deferred | Validated 
 -------------------------+------+------------+--------------------------------------------+------------------------------------------------------------------------------------------+------------+----------+-----------
- 8_20_hyper_fk_pkey      | p    | {time}     | _timescaledb_internal."8_20_hyper_fk_pkey" |                                                                                          | f          | f        | t
+ 8_18_hyper_fk_pkey      | p    | {time}     | _timescaledb_internal."8_18_hyper_fk_pkey" |                                                                                          | f          | f        | t
  constraint_8            | c    | {time}     | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint)) | f          | f        | t
  hyper_fk_sensor_1_check | c    | {sensor_1} | -                                          | (sensor_1 > (10)::numeric)                                                               | f          | f        | t
 
@@ -445,7 +444,7 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
         6 |                  6 | constraint_6       | 
         6 |                    | 6_16_hyper_pk_pkey | hyper_pk_pkey
         8 |                  8 | constraint_8       | 
-        8 |                    | 8_20_hyper_fk_pkey | hyper_fk_pkey
+        8 |                    | 8_18_hyper_fk_pkey | hyper_fk_pkey
 
 --the fk went away.
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
@@ -468,7 +467,7 @@ BEGIN;
         1
 
 COMMIT;
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_23_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_fk ALTER CONSTRAINT hyper_fk_device_id_fkey NOT DEFERRABLE;
 \set ON_ERROR_STOP 0
@@ -476,7 +475,7 @@ BEGIN;
   --error detected right away
   INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
   (1257987700000000003, 'dev4', 11);
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_23_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "hyper_fk_device_id_fkey"
   SELECT 1;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
@@ -586,7 +585,7 @@ INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "11_25_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "11_19_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_ex DROP CONSTRAINT hyper_ex_time_device_id_excl;
 --can now add
@@ -599,7 +598,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
         time WITH =, device_id WITH =
     ) WHERE (not canceled)
 ;
-ERROR:  could not create exclusion constraint "11_26_hyper_ex_time_device_id_excl"
+ERROR:  could not create exclusion constraint "11_20_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_ex WHERE sensor_1 = 12;
 ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
@@ -618,7 +617,7 @@ BEGIN;
         1
 
 COMMIT;
-ERROR:  conflicting key value violates exclusion constraint "11_27_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "11_21_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 --cannot add exclusion constraint without partition key.
 CREATE TABLE hyper_ex_invalid (
@@ -682,7 +681,7 @@ BEGIN;
         1
 
 COMMIT;
-ERROR:  duplicate key value violates unique constraint "12_28_hyper_unique_deferred_time_key"
+ERROR:  duplicate key value violates unique constraint "12_22_hyper_unique_deferred_time_key"
 \set ON_ERROR_STOP 1
 --test deferred on create table
 CREATE TABLE hyper_pk_deferred (
@@ -706,7 +705,7 @@ BEGIN;
         1
 
 COMMIT;
-ERROR:  duplicate key value violates unique constraint "13_29_hyper_pk_deferred_pkey"
+ERROR:  duplicate key value violates unique constraint "13_23_hyper_pk_deferred_pkey"
 \set ON_ERROR_STOP 1
 --test that deferred works on create table too
 CREATE TABLE hyper_fk_deferred (
@@ -729,7 +728,7 @@ BEGIN;
         1
 
 COMMIT;
-ERROR:  insert or update on table "_hyper_12_14_chunk" violates foreign key constraint "14_30_hyper_fk_deferred_device_id_fkey"
+ERROR:  insert or update on table "_hyper_12_14_chunk" violates foreign key constraint "hyper_fk_deferred_device_id_fkey"
 \set ON_ERROR_STOP 1
 CREATE TABLE hyper_ex_deferred (
     time BIGINT,
@@ -756,7 +755,7 @@ BEGIN;
         1
 
 COMMIT;
-ERROR:  conflicting key value violates exclusion constraint "15_33_hyper_ex_deferred_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "15_25_hyper_ex_deferred_time_device_id_excl"
 \set ON_ERROR_STOP 1
 -- Make sure renaming schemas won't break dropping constraints
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -74,9 +74,9 @@ INSERT INTO "meta" ("id") values (1);
 COPY hyper (time, meta_id, value) FROM STDIN DELIMITER ',';
 \set ON_ERROR_STOP 0
 \copy hyper (time, meta_id, value) FROM STDIN DELIMITER ',';
-ERROR:  insert or update on table "_hyper_2_6_chunk" violates foreign key constraint "6_1_hyper_meta_id_fkey"
+ERROR:  insert or update on table "_hyper_2_6_chunk" violates foreign key constraint "hyper_meta_id_fkey"
 COPY hyper (time, meta_id, value) FROM STDIN DELIMITER ',';
-ERROR:  insert or update on table "_hyper_2_6_chunk" violates foreign key constraint "6_1_hyper_meta_id_fkey"
+ERROR:  insert or update on table "_hyper_2_6_chunk" violates foreign key constraint "hyper_meta_id_fkey"
 \set ON_ERROR_STOP 1
 COPY (SELECT * FROM hyper ORDER BY time, meta_id) TO STDOUT;
 1	1	1

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -804,17 +804,17 @@ SELECT SHOW_CHUNKS('timescale');
 \set ON_ERROR_STOP 0
 -- record goes into chunk1 violating FK constraint as value 1001 is not present in regular table
 INSERT INTO timescale SELECT now(), 1001, 43;
-ERROR:  insert or update on table "_hyper_19_15_chunk" violates foreign key constraint "15_1_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_19_15_chunk" violates foreign key constraint "timescale_id_fkey"
 -- record goes into chunk2 violating FK constraint as value 1002 is not present in regular table
 INSERT INTO timescale SELECT now() + interval '20' day, 1002, 43;
-ERROR:  insert or update on table "_hyper_19_16_chunk" violates foreign key constraint "16_2_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_19_16_chunk" violates foreign key constraint "timescale_id_fkey"
 -- record goes into chunk3 violating FK constraint as value 1003 is not present in regular table
 INSERT INTO timescale SELECT now() + interval '40' day, 1003, 43;
-ERROR:  insert or update on table "_hyper_19_17_chunk" violates foreign key constraint "17_3_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_19_17_chunk" violates foreign key constraint "timescale_id_fkey"
 \set ON_ERROR_STOP 1
 -- cleanup
 DROP TABLE regular cascade;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to constraint timescale_id_fkey on table timescale
 DROP TABLE timescale cascade;
 -- test PARTITION BY RANGE
 CREATE TABLE regular(
@@ -859,17 +859,17 @@ SELECT SHOW_CHUNKS('timescale');
 \set ON_ERROR_STOP 0
 -- FK constraint violation as value 801 is not present in regular table
 INSERT INTO timescale SELECT now(), 801, 43;
-ERROR:  insert or update on table "_hyper_20_18_chunk" violates foreign key constraint "18_4_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_20_18_chunk" violates foreign key constraint "timescale_id_fkey"
 -- FK constraint violation as value 902 is not present in regular table
 INSERT INTO timescale SELECT now() + interval '20' day, 902, 43;
-ERROR:  insert or update on table "_hyper_20_19_chunk" violates foreign key constraint "19_5_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_20_19_chunk" violates foreign key constraint "timescale_id_fkey"
 -- FK constraint violation as value 1003 is not present in regular table
 INSERT INTO timescale SELECT now() + interval '40' day, 1003, 43;
-ERROR:  insert or update on table "_hyper_20_20_chunk" violates foreign key constraint "20_6_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_20_20_chunk" violates foreign key constraint "timescale_id_fkey"
 \set ON_ERROR_STOP 1
 -- cleanup
 DROP TABLE regular cascade;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to constraint timescale_id_fkey on table timescale
 DROP TABLE timescale cascade;
 -- test PARTITION BY LIST
 CREATE TABLE regular(
@@ -906,17 +906,17 @@ insert into timescale values (now(), 8,2);
 \set ON_ERROR_STOP 0
 -- FK constraint violation as value 9 is not present in regular table
 insert into timescale values (now(), 9,2);
-ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key constraint "21_7_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key constraint "timescale_id_fkey"
 -- FK constraint violation as value 10 is not present in regular table
 insert into timescale values (now(), 10,2);
-ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key constraint "21_7_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key constraint "timescale_id_fkey"
 -- FK constraint violation as value 111 is not present in regular table
 insert into timescale values (now(), 111,2);
-ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key constraint "21_7_timescale_id_fkey"
+ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key constraint "timescale_id_fkey"
 \set ON_ERROR_STOP 1
 -- cleanup
 DROP TABLE regular cascade;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to constraint timescale_id_fkey on table timescale
 DROP TABLE timescale cascade;
 -- github issue 4872
 -- If subplan of ChunkAppend is TidRangeScan, then SELECT on

--- a/test/expected/rowsecurity-15.out
+++ b/test/expected/rowsecurity-15.out
@@ -528,7 +528,7 @@ INSERT INTO document VALUES (11, 33, 1, current_user, 'hoge');
 -- UNIQUE or PRIMARY KEY constraint violation DOES reveal presence of row
 SET SESSION AUTHORIZATION regress_rls_bob;
 INSERT INTO document VALUES (8, 44, 1, 'regress_rls_bob', 'my third manga'); -- Must fail with unique violation, revealing presence of did we can't see
-ERROR:  duplicate key value violates unique constraint "5_10_document_pkey"
+ERROR:  duplicate key value violates unique constraint "5_5_document_pkey"
 DETAIL:  Key (did)=(8) already exists.
 SELECT * FROM document WHERE did = 8; -- and confirm we can't see it
  did | cid | dlevel | dauthor | dtitle 

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -528,7 +528,7 @@ INSERT INTO document VALUES (11, 33, 1, current_user, 'hoge');
 -- UNIQUE or PRIMARY KEY constraint violation DOES reveal presence of row
 SET SESSION AUTHORIZATION regress_rls_bob;
 INSERT INTO document VALUES (8, 44, 1, 'regress_rls_bob', 'my third manga'); -- Must fail with unique violation, revealing presence of did we can't see
-ERROR:  duplicate key value violates unique constraint "5_10_document_pkey"
+ERROR:  duplicate key value violates unique constraint "5_5_document_pkey"
 DETAIL:  Key (did)=(8) already exists.
 SELECT * FROM document WHERE did = 8; -- and confirm we can't see it
  did | cid | dlevel | dauthor | dtitle 

--- a/test/expected/rowsecurity-17.out
+++ b/test/expected/rowsecurity-17.out
@@ -528,7 +528,7 @@ INSERT INTO document VALUES (11, 33, 1, current_user, 'hoge');
 -- UNIQUE or PRIMARY KEY constraint violation DOES reveal presence of row
 SET SESSION AUTHORIZATION regress_rls_bob;
 INSERT INTO document VALUES (8, 44, 1, 'regress_rls_bob', 'my third manga'); -- Must fail with unique violation, revealing presence of did we can't see
-ERROR:  duplicate key value violates unique constraint "5_10_document_pkey"
+ERROR:  duplicate key value violates unique constraint "5_5_document_pkey"
 DETAIL:  Key (did)=(8) already exists.
 SELECT * FROM document WHERE did = 8; -- and confirm we can't see it
  did | cid | dlevel | dauthor | dtitle 

--- a/test/expected/rowsecurity-18.out
+++ b/test/expected/rowsecurity-18.out
@@ -527,7 +527,7 @@ INSERT INTO document VALUES (11, 33, 1, current_user, 'hoge');
 -- UNIQUE or PRIMARY KEY constraint violation DOES reveal presence of row
 SET SESSION AUTHORIZATION regress_rls_bob;
 INSERT INTO document VALUES (8, 44, 1, 'regress_rls_bob', 'my third manga'); -- Must fail with unique violation, revealing presence of did we can't see
-ERROR:  duplicate key value violates unique constraint "5_10_document_pkey"
+ERROR:  duplicate key value violates unique constraint "5_5_document_pkey"
 DETAIL:  Key (did)=(8) already exists.
 SELECT * FROM document WHERE did = 8; -- and confirm we can't see it
  did | cid | dlevel | dauthor | dtitle 

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -529,3 +529,42 @@ CREATE TABLE i9132(time timestamptz) WITH (tsdb.hypertable);
 INSERT INTO i9132 VALUES ('2024-01-01'), ('2024-02-02');
 ALTER TABLE i9132 ADD COLUMN id serial, ADD CONSTRAINT implicit_pk PRIMARY KEY (id, time);
 
+-- Renaming an outbound foreign key on the hypertable should rename the
+-- inherited foreign key on every chunk.
+CREATE TABLE fk_ref(id INTEGER PRIMARY KEY);
+INSERT INTO fk_ref VALUES (1), (2);
+CREATE TABLE fk_ht(
+    time TIMESTAMPTZ NOT NULL,
+    ref_id INTEGER,
+    CONSTRAINT fk_ht_ref_fkey FOREIGN KEY (ref_id) REFERENCES fk_ref(id)
+) WITH (tsdb.hypertable, tsdb.partition_column = 'time');
+INSERT INTO fk_ht VALUES ('2024-01-01', 1), ('2024-03-01', 2);
+
+-- Inherited FKs on chunks initially carry the hypertable constraint name.
+SELECT count(*) AS chunk_fks_fkey
+FROM pg_constraint pc
+JOIN pg_class c ON c.oid = pc.conrelid
+WHERE c.relname LIKE '_hyper%' AND pc.contype = 'f' AND pc.conname LIKE '%fk_ht_ref_fkey%';
+
+ALTER TABLE fk_ht RENAME CONSTRAINT fk_ht_ref_fkey TO fk_ht_ref_renamed;
+
+-- After the rename all chunk-side FKs must reference the new name and none
+-- of the old name should remain.
+SELECT count(*) AS chunk_fks_renamed
+FROM pg_constraint pc
+JOIN pg_class c ON c.oid = pc.conrelid
+WHERE c.relname LIKE '_hyper%' AND pc.contype = 'f' AND pc.conname LIKE '%fk_ht_ref_renamed%';
+
+SELECT count(*) AS chunk_fks_old
+FROM pg_constraint pc
+JOIN pg_class c ON c.oid = pc.conrelid
+WHERE c.relname LIKE '_hyper%' AND pc.contype = 'f' AND pc.conname LIKE '%fk_ht_ref_fkey%';
+
+-- The FK is still enforced.
+\set ON_ERROR_STOP 0
+INSERT INTO fk_ht VALUES ('2024-02-01', 999);
+\set ON_ERROR_STOP 1
+
+DROP TABLE fk_ht;
+DROP TABLE fk_ref;
+

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -152,9 +152,14 @@ FROM  _timescaledb_catalog.chunk c
 INNER JOIN pg_class cl ON (cl.oid=format('%I.%I', schema_name, table_name)::regclass)
 ORDER BY c.id, c.hypertable_id;
 
-SELECT chunk_constraint.* FROM _timescaledb_catalog.chunk_constraint
+-- Strip the legacy <chunk_id>_<seq>_ prefix so old and new naming compare equal.
+SELECT chunk_constraint.chunk_id,
+       chunk_constraint.dimension_slice_id,
+       regexp_replace(chunk_constraint.constraint_name, '^[0-9]+_[0-9]+_', '') AS constraint_name,
+       chunk_constraint.hypertable_constraint_name
+FROM _timescaledb_catalog.chunk_constraint
 JOIN _timescaledb_catalog.chunk ON chunk.id = chunk_constraint.chunk_id
-ORDER BY chunk_constraint.chunk_id, chunk_constraint.dimension_slice_id, chunk_constraint.constraint_name;
+ORDER BY chunk_constraint.chunk_id, chunk_constraint.dimension_slice_id, 3;
 
 -- Show attnum of all regclass objects belonging to our extension
 -- if those are not the same between fresh install/update our update scripts are broken
@@ -168,8 +173,10 @@ FROM pg_depend dep
 WHERE classid='pg_class'::regclass
 ORDER BY attrelid::regclass::text,att.attnum;
 
--- Show constraints
-SELECT conrelid::regclass::text, conname, pg_get_constraintdef(oid)
+-- Show constraints, stripping the legacy <chunk_id>_<seq>_ prefix.
+SELECT conrelid::regclass::text,
+       regexp_replace(conname, '^[0-9]+_[0-9]+_', '') AS conname,
+       pg_get_constraintdef(oid)
 FROM pg_constraint
 WHERE conrelid::regclass::text ~ '^_timescaledb_'
 \if :PG_UPGRADE_TEST

--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -22,7 +22,7 @@ BEGIN
     FOR constraint_row IN
     SELECT c.conname, h.id AS hypertable_id FROM _timescaledb_catalog.hypertable h INNER JOIN
            pg_constraint c ON (c.conrelid = format('%I.%I', h.schema_name, h.table_name)::regclass)
-        WHERE c.contype NOT IN ('c','n')
+        WHERE c.contype NOT IN ('c','n','f')
     LOOP
         SELECT count(*) FROM _timescaledb_catalog.chunk c
         WHERE c.hypertable_id = constraint_row.hypertable_id

--- a/test/sql/updates/post.sequences.sql
+++ b/test/sql/updates/post.sequences.sql
@@ -2,9 +2,11 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
--- check sequences did not get reset
+-- check sequences did not get reset. chunk_constraint_name's nextval varies
+-- across versions (FK/CHECK tracking was removed) and is excluded.
 SELECT seqrelid::regclass,
-  nextval(seqrelid),
+  CASE WHEN seqrelid::regclass::text = '_timescaledb_catalog.chunk_constraint_name'
+       THEN NULL ELSE nextval(seqrelid) END AS nextval,
   seqstart,
   seqincrement,
   seqmax,

--- a/tsl/test/expected/attach_chunk.out
+++ b/tsl/test/expected/attach_chunk.out
@@ -136,8 +136,7 @@ SELECT count(*) > 0 FROM pg_inherits WHERE inhrelid = :'CHUNK_NAME'::regclass::o
 SELECT * FROM _timescaledb_catalog.chunk_constraint WHERE chunk_id = :'CHUNK_ID';
  chunk_id | dimension_slice_id |        constraint_name         | hypertable_constraint_name 
 ----------+--------------------+--------------------------------+----------------------------
-        5 |                    | 1_2_attach_test_id_time_unique | attach_test_id_time_unique
-        5 |                    | 5_8_attach_test_device_fkey    | attach_test_device_fkey
+        5 |                    | 1_1_attach_test_id_time_unique | attach_test_id_time_unique
         5 |                  2 | constraint_2                   | 
         5 |                  7 | constraint_7                   | 
 

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -160,12 +160,12 @@ SELECT * FROM chunkapi ORDER BY 1,2,3;
 -- are specific to the chunk.  Currently, foreign key, unique, and
 -- primary key constraints are not inherited or auto-created.
 SELECT * FROM test.show_constraints(format('%I.%I', :'CHUNK_SCHEMA', :'CHUNK_NAME')::regclass);
-        Constraint        | Type | Columns  |                   Index                   |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
---------------------------+------+----------+-------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
- 5_5_chunkapi_device_fkey | f    | {device} | devices_pkey                              |                                                                                                                                                | f          | f        | t
- 5_6_chunkapi_pkey        | p    | {time}   | _timescaledb_internal."5_6_chunkapi_pkey" |                                                                                                                                                | f          | f        | t
- chunkapi_temp_check      | c    | {temp}   | -                                         | (temp > (0)::double precision)                                                                                                                 | f          | f        | t
- constraint_6             | c    | {time}   | -                                         | (("time" >= 'Wed Dec 27 16:00:00 2017 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 03 16:00:00 2018 PST'::timestamp with time zone)) | f          | f        | t
+      Constraint      | Type | Columns  |                   Index                   |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
+----------------------+------+----------+-------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
+ 5_3_chunkapi_pkey    | p    | {time}   | _timescaledb_internal."5_3_chunkapi_pkey" |                                                                                                                                                | f          | f        | t
+ chunkapi_device_fkey | f    | {device} | devices_pkey                              |                                                                                                                                                | f          | f        | t
+ chunkapi_temp_check  | c    | {temp}   | -                                         | (temp > (0)::double precision)                                                                                                                 | f          | f        | t
+ constraint_6         | c    | {time}   | -                                         | (("time" >= 'Wed Dec 27 16:00:00 2017 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 03 16:00:00 2018 PST'::timestamp with time zone)) | f          | f        | t
 
 TRUNCATE chunkapi;
 -- Create a table with extra columns

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1301,7 +1301,7 @@ _timescaledb_catalog.chunk c, _timescaledb_catalog.chunk_constraint cc WHERE c.h
 AND c.id = cc.chunk_id;
  id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk | chunk_id | dimension_slice_id |       constraint_name       | hypertable_constraint_name 
 ----+---------------+-----------------------+--------------------+---------------------+--------+-----------+----------+--------------------+-----------------------------+----------------------------
- 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     |      0 | f         |       31 |                    | 31_5_test_multicon_time_key | test_multicon_time_key
+ 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     |      0 | f         |       31 |                    | 31_2_test_multicon_time_key | test_multicon_time_key
  31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     |      0 | f         |       31 |                 28 | constraint_28               | 
 
 \c :TEST_DBNAME :ROLE_SUPERUSER ;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -946,9 +946,9 @@ SELECT constraint_schema, constraint_name, table_schema, table_name, constraint_
 FROM information_schema.table_constraints
 WHERE table_name = :'CHUNK_NAME' AND constraint_type = 'FOREIGN KEY'
 ORDER BY constraint_name;
-   constraint_schema   |      constraint_name      |     table_schema      |     table_name     | constraint_type 
------------------------+---------------------------+-----------------------+--------------------+-----------------
- _timescaledb_internal | 42_6_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
+   constraint_schema   |   constraint_name    |     table_schema      |     table_name     | constraint_type 
+-----------------------+----------------------+-----------------------+--------------------+-----------------
+ _timescaledb_internal | hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
 
 SELECT compress_chunk(:'CHUNK_FULL_NAME');
               compress_chunk              
@@ -959,9 +959,9 @@ SELECT constraint_schema, constraint_name, table_schema, table_name, constraint_
 FROM information_schema.table_constraints
 WHERE table_name = :'CHUNK_NAME' AND constraint_type = 'FOREIGN KEY'
 ORDER BY constraint_name;
-   constraint_schema   |      constraint_name      |     table_schema      |     table_name     | constraint_type 
------------------------+---------------------------+-----------------------+--------------------+-----------------
- _timescaledb_internal | 42_6_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
+   constraint_schema   |   constraint_name    |     table_schema      |     table_name     | constraint_type 
+-----------------------+----------------------+-----------------------+--------------------+-----------------
+ _timescaledb_internal | hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
 
 -- Delete data from compressed chunk directly fails
 \set ON_ERROR_STOP 0
@@ -994,9 +994,9 @@ SELECT constraint_schema, constraint_name, table_schema, table_name, constraint_
 FROM information_schema.table_constraints
 WHERE table_name = :'CHUNK_NAME' AND constraint_type = 'FOREIGN KEY'
 ORDER BY constraint_name;
-   constraint_schema   |      constraint_name      |     table_schema      |     table_name     | constraint_type 
------------------------+---------------------------+-----------------------+--------------------+-----------------
- _timescaledb_internal | 42_6_hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
+   constraint_schema   |   constraint_name    |     table_schema      |     table_name     | constraint_type 
+-----------------------+----------------------+-----------------------+--------------------+-----------------
+ _timescaledb_internal | hyper_device_id_fkey | _timescaledb_internal | _hyper_18_42_chunk | FOREIGN KEY
 
 -- create hypertable with 2 chunks
 CREATE TABLE ht5(time TIMESTAMPTZ NOT NULL);

--- a/tsl/test/expected/compression_constraints.out
+++ b/tsl/test/expected/compression_constraints.out
@@ -272,7 +272,7 @@ ALTER TABLE metrics ADD CONSTRAINT device_fk FOREIGN KEY(device) REFERENCES devi
 INSERT INTO metrics SELECT '2025-03-01','d2',0.3;
 \set ON_ERROR_STOP 0
 INSERT INTO metrics SELECT '2025-03-01','d3',0.3;
-ERROR:  insert or update on table "_hyper_5_25_chunk" violates foreign key constraint "25_11_device_fk"
+ERROR:  insert or update on table "_hyper_5_25_chunk" violates foreign key constraint "device_fk"
 \set ON_ERROR_STOP 1
 ROLLBACK;
 BEGIN;
@@ -302,7 +302,7 @@ ALTER TABLE metrics ADD CONSTRAINT device_fk FOREIGN KEY(device) REFERENCES devi
 INSERT INTO metrics SELECT '2025-03-01','d2',0.3;
 \set ON_ERROR_STOP 0
 INSERT INTO metrics SELECT '2025-03-01','d3',0.3;
-ERROR:  insert or update on table "_hyper_5_28_chunk" violates foreign key constraint "28_15_device_fk"
+ERROR:  insert or update on table "_hyper_5_28_chunk" violates foreign key constraint "device_fk"
 \set ON_ERROR_STOP 1
 ROLLBACK;
 BEGIN;

--- a/tsl/test/expected/compression_fks.out
+++ b/tsl/test/expected/compression_fks.out
@@ -14,7 +14,7 @@ ALTER TABLE ht_with_fk SET (timescaledb.compress,timescaledb.compress_segmentby=
 -- no keys added yet so any insert into ht_with_fk should fail
 \set ON_ERROR_STOP 0
 INSERT INTO ht_with_fk SELECT '2000-01-01';
-ERROR:  insert or update on table "_hyper_1_1_chunk" violates foreign key constraint "1_1_keys"
+ERROR:  insert or update on table "_hyper_1_1_chunk" violates foreign key constraint "keys"
 \set ON_ERROR_STOP 1
 -- create a key in the referenced table
 INSERT INTO keys SELECT '2000-01-01';
@@ -30,11 +30,11 @@ INSERT INTO ht_with_fk SELECT '2000-01-01';
 -- inserting key not present in keys should fail
 \set ON_ERROR_STOP 0
 INSERT INTO ht_with_fk SELECT '2000-01-01 0:00:01';
-ERROR:  insert or update on table "_hyper_1_2_chunk" violates foreign key constraint "2_2_keys"
+ERROR:  insert or update on table "_hyper_1_2_chunk" violates foreign key constraint "keys"
 \set ON_ERROR_STOP 1
 SELECT conrelid::regclass,conname,confrelid::regclass FROM pg_constraint WHERE contype = 'f' AND confrelid = 'keys'::regclass ORDER BY conrelid::regclass::text COLLATE "C",conname;
-                conrelid                | conname  | confrelid 
-----------------------------------------+----------+-----------
- _timescaledb_internal._hyper_1_2_chunk | 2_2_keys | keys
- ht_with_fk                             | keys     | keys
+                conrelid                | conname | confrelid 
+----------------------------------------+---------+-----------
+ _timescaledb_internal._hyper_1_2_chunk | keys    | keys
+ ht_with_fk                             | keys    | keys
 

--- a/tsl/test/expected/foreign_keys_test-15.out
+++ b/tsl/test/expected/foreign_keys_test-15.out
@@ -368,7 +368,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -406,7 +406,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -444,7 +444,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -533,7 +533,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -595,7 +595,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
@@ -1053,7 +1053,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -1091,7 +1091,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -1129,7 +1129,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -1218,7 +1218,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -1280,7 +1280,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');

--- a/tsl/test/expected/foreign_keys_test-16.out
+++ b/tsl/test/expected/foreign_keys_test-16.out
@@ -368,7 +368,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -406,7 +406,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -444,7 +444,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -533,7 +533,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -595,7 +595,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
@@ -1053,7 +1053,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -1091,7 +1091,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -1129,7 +1129,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -1218,7 +1218,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -1280,7 +1280,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');

--- a/tsl/test/expected/foreign_keys_test-17.out
+++ b/tsl/test/expected/foreign_keys_test-17.out
@@ -368,7 +368,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -406,7 +406,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -444,7 +444,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -533,7 +533,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -595,7 +595,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
@@ -1053,7 +1053,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -1091,7 +1091,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -1129,7 +1129,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -1218,7 +1218,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -1280,7 +1280,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');

--- a/tsl/test/expected/foreign_keys_test-18.out
+++ b/tsl/test/expected/foreign_keys_test-18.out
@@ -368,7 +368,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -406,7 +406,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -444,7 +444,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -533,7 +533,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -595,7 +595,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');
@@ -1053,7 +1053,7 @@ INSERT INTO ht(time) VALUES ('2020-01-01');
 -- NO ACTION
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_no_action) VALUES ('2020-01-01', 'fk_no_action');
-psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_14_ht_fk_no_action_fkey"
+psql:include/foreign_keys.sql:422: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_no_action_fkey"
 -- ON UPDATE NO ACTION
 BEGIN;
 INSERT INTO fk_no_action(fk_no_action) VALUES ('fk_no_action');
@@ -1091,7 +1091,7 @@ ROLLBACK;
 -- RESTRICT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_restrict) VALUES ('2020-01-01', 'fk_restrict');
-psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_15_ht_fk_restrict_fkey"
+psql:include/foreign_keys.sql:460: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_restrict_fkey"
 -- ON UPDATE RESTRICT
 BEGIN;
 INSERT INTO fk_restrict(fk_restrict) VALUES ('fk_restrict');
@@ -1129,7 +1129,7 @@ ROLLBACK;
 -- CASCADE
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_cascade) VALUES ('2020-01-01', 'fk_cascade');
-psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_13_ht_fk_cascade_fkey"
+psql:include/foreign_keys.sql:499: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_cascade_fkey"
 -- ON UPDATE CASCADE
 BEGIN;
 INSERT INTO fk_cascade(fk_cascade) VALUES ('fk_cascade');
@@ -1218,7 +1218,7 @@ ROLLBACK;
 -- SET NULL
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_null) VALUES ('2020-01-01', 'fk_set_null');
-psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_17_ht_fk_set_null_fkey"
+psql:include/foreign_keys.sql:599: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_null_fkey"
 -- ON UPDATE SET NULL
 BEGIN;
 INSERT INTO fk_set_null(fk_set_null) VALUES ('fk_set_null');
@@ -1280,7 +1280,7 @@ ROLLBACK;
 -- SET DEFAULT
 -- should fail with foreign key violation
 INSERT INTO ht(time, fk_set_default) VALUES ('2020-01-01', 'fk_set_default');
-psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "14_16_ht_fk_set_default_fkey"
+psql:include/foreign_keys.sql:667: ERROR:  insert or update on table "_hyper_13_14_chunk" violates foreign key constraint "ht_fk_set_default_fkey"
 -- ON UPDATE SET DEFAULT
 BEGIN;
 INSERT INTO fk_set_default(fk_set_default) VALUES ('fk_set_default');


### PR DESCRIPTION
Chunk-side foreign keys now share the parent's name and carry a
DEPENDENCY_AUTO edge in pg_depend instead of a chunk_constraint row.
Dropping the parent cascades to all chunks; renaming walks each
chunk and reuses PostgreSQL's RenameConstraint.

The update script renames any pre-existing chunk-side FK to match
the parent, backfills the pg_depend edge, and removes the obsolete
chunk_constraint rows.

Disable-check: force-changelog-file
