### PR TITLE
Include Postgres header in coccinelle

### DIFF
--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -15,6 +15,7 @@ jobs:
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         sudo apt-get update
         sudo apt-get -y install coccinelle postgresql-server-dev-all
 

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -17,7 +17,7 @@ jobs:
       run: |
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         sudo apt-get update
-        sudo apt-get -y install coccinelle postgresql-server-dev-all
+        sudo apt-get -y install --no-install-recommends coccinelle postgresql-server-dev-all
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -17,7 +17,7 @@ jobs:
       run: |
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         sudo apt-get update
-        sudo apt-get -y install --no-install-recommends coccinelle postgresql-server-dev-all
+        sudo apt-get -y install --no-install-recommends coccinelle postgresql-server-dev-18
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -9,16 +9,14 @@ name: Coccinelle
 jobs:
   coccinelle:
     name: Coccinelle
-    # coccinelle version in ubuntu-latest (20.04) is too old so we run
-    # this in jammy (22.04)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |
         sudo apt-get update
-        sudo apt-get -y install coccinelle
+        sudo apt-get -y install coccinelle postgresql-server-dev-all
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/coccinelle.sh
+++ b/scripts/coccinelle.sh
@@ -6,8 +6,14 @@ SCRIPT_DIR=$(dirname "${0}")
 FAILED=false
 true > coccinelle.diff
 
+PG_SERVER_INC=$(pg_config --includedir-server)
+
 for f in "${SCRIPT_DIR}"/../coccinelle/*.cocci; do
-  spatch --very-quiet --include-headers --sp-file "$f" --dir "${SCRIPT_DIR}"/.. | tee -a coccinelle.diff
+  spatch --very-quiet \
+        --all-includes --include-headers-for-types \
+        -I "${PG_SERVER_INC}" \
+        --sp-file "$f" --dir "${SCRIPT_DIR}"/.. --include-headers \
+    | tee -a coccinelle.diff
   rc=$?
   if [ $rc -ne 0 ]; then
     FAILED=true

--- a/scripts/coccinelle.sh
+++ b/scripts/coccinelle.sh
@@ -12,6 +12,8 @@ for f in "${SCRIPT_DIR}"/../coccinelle/*.cocci; do
   spatch --very-quiet \
         --all-includes --include-headers-for-types \
         -I "${PG_SERVER_INC}" \
+        -I "${SCRIPT_DIR}/../src" \
+        -I "${SCRIPT_DIR}/../tsl/src" \
         --sp-file "$f" --dir "${SCRIPT_DIR}"/.. --include-headers \
     | tee -a coccinelle.diff
   rc=$?

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -854,8 +854,8 @@ chunk_get_minmax(const Chunk *chunk, Oid col_type, const char *col_name, Datum *
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 (errmsg("could not get the min/max values for column \"%s\" of chunk \"%s.%s\"",
 						 col_name,
-						 chunk->fd.schema_name.data,
-						 chunk->fd.table_name.data))));
+						 NameStr(chunk->fd.schema_name.data),
+						 NameStr(chunk->fd.table_name.data)))));
 	}
 
 	pfree(command.data);

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -854,8 +854,8 @@ chunk_get_minmax(const Chunk *chunk, Oid col_type, const char *col_name, Datum *
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 (errmsg("could not get the min/max values for column \"%s\" of chunk \"%s.%s\"",
 						 col_name,
-						 NameStr(chunk->fd.schema_name.data),
-						 NameStr(chunk->fd.table_name.data)))));
+						 NameStr(chunk->fd.schema_name),
+						 NameStr(chunk->fd.table_name)))));
 	}
 
 	pfree(command.data);


### PR DESCRIPTION
When it doesn't see the headers, it can't understand what e.g. `Name` is, so some rules don't work.


Disable-check: force-changelog-file