### PR TITLE
Don't install unneeded Postgres component in Windows tests

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -188,7 +188,7 @@ jobs:
       id: cache-postgresql
       with:
         path: C:\Progra~1\PostgreSQL\${{ matrix.versions.pg }}
-        key: "${{ runner.os }}-build-pg${{ matrix.pg_version }}\
+        key: "${{ runner.os }}-build-pg${{ matrix.versions.pg_version }}\
           -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
 
     - name: Install PostgreSQL ${{ matrix.versions.pg }} (using ${{ matrix.versions.pg_version }})

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -196,17 +196,17 @@ jobs:
       run: |
         $version = ${{ matrix.versions.pg_version }}
         $version = $version.Replace('"', '') + "-1"
-        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} \
-          --force --accept-source-agreements --accept-package-agreements --disable-interactivity \
-          --custom "--disable-components pgAdmin,stackbuilder" \
+        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} `
+          --force --accept-source-agreements --accept-package-agreements --disable-interactivity `
+          --custom "--disable-components pgAdmin,stackbuilder" `
           --version $version
 
     # This is for nightly builds. Here we pick the latest version of the package.
     - name: Install PostgreSQL ${{ matrix.versions.pg }}
       if: github.event_name == 'schedule' && steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} \
-          --force --accept-source-agreements --accept-package-agreements --disable-interactivity \
+        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} `
+          --force --accept-source-agreements --accept-package-agreements --disable-interactivity `
           --custom "--disable-components pgAdmin,stackbuilder"
 
     - name: Configure TimescaleDB

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -188,7 +188,7 @@ jobs:
       id: cache-postgresql
       with:
         path: C:\Progra~1\PostgreSQL\${{ matrix.versions.pg }}
-        key: "${{ runner.os }}-build-pg${{ matrix.pkg_version }}\
+        key: "${{ runner.os }}-build-pg${{ matrix.pg_version }}\
           -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
 
     - name: Install PostgreSQL ${{ matrix.versions.pg }} (using ${{ matrix.versions.pg_version }})
@@ -196,13 +196,18 @@ jobs:
       run: |
         $version = ${{ matrix.versions.pg_version }}
         $version = $version.Replace('"', '') + "-1"
-        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} --version $version --force --accept-source-agreements --accept-package-agreements --disable-interactivity
+        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} \
+          --force --accept-source-agreements --accept-package-agreements --disable-interactivity \
+          --custom "--disable-components pgAdmin,stackbuilder" \
+          --version $version
 
     # This is for nightly builds. Here we pick the latest version of the package.
     - name: Install PostgreSQL ${{ matrix.versions.pg }}
       if: github.event_name == 'schedule' && steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} --force --accept-source-agreements --accept-package-agreements --disable-interactivity
+        winget install --id PostgreSQL.PostgreSQL.${{ matrix.versions.pg }} \
+          --force --accept-source-agreements --accept-package-agreements --disable-interactivity \
+          --custom "--disable-components pgAdmin,stackbuilder"
 
     - name: Configure TimescaleDB
       run: cmake -B build_win -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `


### PR DESCRIPTION
This saves some space in GitHub Actions cache.

Also fix a typo in the cache key.