### PR TITLE
Fix variable batch cutting for incremental refresh

### DIFF
--- a/.unreleased/pr_9890
+++ b/.unreleased/pr_9890
@@ -1,0 +1,1 @@
+Fixes: #9890 Fix incremental refresh batch boundaries to align with variable-width buckets and start only where a chunk and an invalidation overlap

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -514,7 +514,7 @@ ts_dimension_slice_scan_list(int32 dimension_id, int64 coordinate, List **matchi
 										CurrentMemoryContext);
 }
 
-int
+TSDLLEXPORT int
 ts_dimension_slice_scan_iterator_set_range(ScanIterator *it, int32 dimension_id,
 										   StrategyNumber start_strategy, int64 start_value,
 										   StrategyNumber end_strategy, int64 end_value)
@@ -970,7 +970,7 @@ ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id, const ScanTupLo
 	return slice;
 }
 
-ScanIterator
+TSDLLEXPORT ScanIterator
 ts_dimension_slice_scan_iterator_create(const ScanTupLock *tuplock, MemoryContext result_mcxt)
 {
 	ScanIterator it = ts_scan_iterator_create(DIMENSION_SLICE, AccessShareLock, result_mcxt);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -98,15 +98,15 @@ extern TSDLLEXPORT List *ts_dimension_slice_get_chunkids_to_compress(
 	StrategyNumber end_strategy, int64 end_value, bool compress, bool recompress, int32 numchunks);
 
 extern DimensionSlice *ts_dimension_slice_from_tuple(TupleInfo *ti);
-extern ScanIterator ts_dimension_slice_scan_iterator_create(const ScanTupLock *tuplock,
-															MemoryContext result_mcxt);
+extern TSDLLEXPORT ScanIterator ts_dimension_slice_scan_iterator_create(const ScanTupLock *tuplock,
+																		MemoryContext result_mcxt);
 extern void ts_dimension_slice_scan_iterator_set_slice_id(ScanIterator *it, int32 slice_id);
 extern DimensionSlice *ts_dimension_slice_scan_iterator_get_by_id(ScanIterator *it, int32 slice_id);
 
-extern int ts_dimension_slice_scan_iterator_set_range(ScanIterator *it, int32 dimension_id,
-													  StrategyNumber start_strategy,
-													  int64 start_value,
-													  StrategyNumber end_strategy, int64 end_value);
+extern TSDLLEXPORT int
+ts_dimension_slice_scan_iterator_set_range(ScanIterator *it, int32 dimension_id,
+										   StrategyNumber start_strategy, int64 start_value,
+										   StrategyNumber end_strategy, int64 end_value);
 
 extern bool ts_osm_chunk_range_overlaps(int32 osm_dimension_slice_id, int32 dimension_id,
 										int64 range_start, int64 range_end);

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -445,11 +445,9 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 	ContinuousAggRefreshContext context = { .callctx = CAGG_REFRESH_POLICY, .job_id = job_id };
 
 	/* Try to split window range into a list of ranges */
-	List *refresh_window_list =
-		continuous_agg_split_refresh_window(policy_data.cagg,
-											&policy_data.refresh_window,
-											policy_data.buckets_per_batch,
-											policy_data.refresh_newest_first);
+	List *refresh_window_list = continuous_agg_split_refresh_window(policy_data.cagg,
+																	&policy_data.refresh_window,
+																	policy_data.buckets_per_batch);
 	if (refresh_window_list == NIL)
 	{
 		refresh_window_list = lappend(refresh_window_list, &policy_data.refresh_window);
@@ -461,11 +459,20 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 
 	context.number_of_batches = list_length(refresh_window_list);
 
-	ListCell *lc;
+	/*
+	 * The list is always built oldest-first. When refresh_newest_first is true we
+	 * iterate from the last element down to the first using index-based access so
+	 * that no reversal copy of the list is needed.
+	 */
 	int32 processing_batch = 0;
-	foreach (lc, refresh_window_list)
+	int32 nbatches = list_length(refresh_window_list);
+	int32 batch_start = policy_data.refresh_newest_first ? nbatches - 1 : 0;
+	int32 batch_end = policy_data.refresh_newest_first ? -1 : nbatches;
+	int32 batch_step = policy_data.refresh_newest_first ? -1 : 1;
+	for (int32 batch_idx = batch_start; batch_idx != batch_end; batch_idx += batch_step)
 	{
-		InternalTimeRange *refresh_window = (InternalTimeRange *) lfirst(lc);
+		InternalTimeRange *refresh_window =
+			(InternalTimeRange *) list_nth(refresh_window_list, batch_idx);
 		elog(DEBUG1,
 			 "refreshing continuous aggregate \"%s\" from %s to %s",
 			 NameStr(policy_data.cagg->data.user_view_name),
@@ -553,6 +560,7 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 			}
 
 			/* Process each chunk in its own transaction */
+			ListCell *lc;
 			foreach (lc, chunkid_lst)
 			{
 				PushActiveSnapshot(GetTransactionSnapshot());

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -7,6 +7,7 @@
 
 #include <access/xact.h>
 #include <executor/spi.h>
+#include <executor/tuptable.h>
 #include <fmgr.h>
 #include <miscadmin.h>
 #include <storage/lmgr.h>
@@ -17,6 +18,7 @@
 #include <utils/guc.h>
 #include <utils/lsyscache.h>
 #include <utils/snapmgr.h>
+#include <utils/tuplestore.h>
 
 #include "debug_point.h"
 #include "dimension.h"
@@ -1086,7 +1088,7 @@ debug_refresh_window(const ContinuousAgg *cagg, const InternalTimeRange *refresh
 
 List *
 continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *original_refresh_window,
-									int32 buckets_per_batch, bool refresh_newest_first)
+									int32 buckets_per_batch)
 {
 	/* Do not produce batches when the number of buckets per batch is zero (disabled) */
 	if (buckets_per_batch == 0)
@@ -1130,7 +1132,9 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 				 NameStr(cagg->data.user_view_name));
 			return NIL;
 		}
-		refresh_window.start = slice->fd.range_start;
+		refresh_window.start = cagg_current_bucket_start(slice->fd.range_start,
+														 refresh_window.type,
+														 cagg->bucket_function);
 		refresh_window.start_isnull = false;
 	}
 
@@ -1150,7 +1154,11 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 				 NameStr(cagg->data.user_view_name));
 			return NIL;
 		}
-		refresh_window.end = slice->fd.range_end;
+		/* range_end is exclusive; subtract 1 to get the last internal value in the chunk,
+		 * then find the end of the bucket that contains it. */
+		refresh_window.end = cagg_next_bucket_start(slice->fd.range_end - 1,
+													refresh_window.type,
+													cagg->bucket_function);
 		refresh_window.end_isnull = false;
 	}
 
@@ -1179,106 +1187,28 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 
 	debug_refresh_window(cagg, &refresh_window, "before produce batches");
 
-	/*
-	 * Produce the batches to be processed
-	 *
-	 * The refresh window is split into multiple batches of size `batch_size` each. The batches are
-	 * produced in reverse order so that the first range produced is the last range to be processed.
-	 *
-	 * The batches are produced in reverse order because the most recent data should be the first to
-	 * be processed and be visible for the users.
-	 *
-	 * It takes in account the invalidation logs (hypertable and materialization hypertable) to
-	 * avoid producing wholes that have no data to be processed.
-	 *
-	 * The logic is something like the following:
-	 * 1. Get dimension slices from the original hypertables
-	 * 2. Get either hypertable and materialization hypertable invalidation logs
-	 * 3. Produce the batches in reverse order
-	 * 4. Check if the produced batch overlaps either with dimension slices #1 and invalidation logs
-	 * #2
-	 * 5. If the batch overlaps with both then it's a valid batch to be processed
-	 * 6. If the batch overlaps with only one of them then it's not a valid batch to be processed
-	 * 7. If the batch does not overlap with any of them then it's not a valid batch to be processed
-	 */
-	const char *query_str_template = " \
-		WITH dimension_slices AS ( \
-			SELECT \
-				range_start AS start, \
-				range_end AS end \
-			FROM \
-				_timescaledb_catalog.dimension_slice \
-				JOIN _timescaledb_catalog.dimension ON dimension.id = dimension_slice.dimension_id \
-			WHERE \
-				hypertable_id = $1 \
-				AND dimension_id = $2 \
-				AND range_end >= range_start \
-			ORDER BY \
-				%s \
-		), \
-		invalidation_logs AS ( \
-			SELECT \
-				lowest_modified_value, \
-				greatest_modified_value \
-			FROM \
-				_timescaledb_catalog.continuous_aggs_materialization_invalidation_log \
-			WHERE \
-				materialization_id = $3 \
-				AND greatest_modified_value >= lowest_modified_value \
-			UNION ALL \
-			SELECT \
-				pg_catalog.min(lowest_modified_value) AS lowest_modified_value, \
-				pg_catalog.max(greatest_modified_value) AS greatest_modified_value \
-			FROM \
-				_timescaledb_catalog.continuous_aggs_hypertable_invalidation_log \
-			WHERE \
-				hypertable_id = $1 \
-				AND greatest_modified_value >= lowest_modified_value \
-		) \
-		SELECT \
-			refresh_start AS start, \
-			LEAST($6::numeric, refresh_start::numeric + $4::numeric)::bigint AS end \
-		FROM \
-			pg_catalog.generate_series($5, $6, $4) AS refresh_start \
-		WHERE \
-			EXISTS ( \
-			    SELECT FROM dimension_slices \
-				WHERE \
-					pg_catalog.int8range(refresh_start, LEAST($6::numeric, refresh_start::numeric + $4::numeric)::bigint) \
-					OPERATOR(pg_catalog.&&) \
-					pg_catalog.int8range(dimension_slices.start, dimension_slices.end) \
-			) \
-			AND EXISTS ( \
-				SELECT FROM \
-					invalidation_logs \
-				WHERE \
-					pg_catalog.int8range(refresh_start, LEAST($6::numeric, refresh_start::numeric + $4::numeric)::bigint) \
-					OPERATOR(pg_catalog.&&) \
-					pg_catalog.int8range(lowest_modified_value, greatest_modified_value) \
-					AND lowest_modified_value IS NOT NULL \
-					AND (greatest_modified_value IS NOT NULL AND greatest_modified_value != $7) \
-			) \
-		ORDER BY \
-			refresh_start %s;";
+	/* $3 = CAGG_INVALIDATION_WRONG_GREATEST_VALUE sentinel, $4/$5 = refresh window bounds */
+	static const char *inval_query =
+		"SELECT lowest_modified_value, greatest_modified_value FROM ("
+		"  SELECT lowest_modified_value, greatest_modified_value"
+		"    FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log"
+		"   WHERE materialization_id = $1"
+		"     AND greatest_modified_value >= lowest_modified_value"
+		"  UNION ALL"
+		"  SELECT pg_catalog.min(lowest_modified_value), pg_catalog.max(greatest_modified_value)"
+		"    FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log"
+		"   WHERE hypertable_id = $2"
+		"     AND greatest_modified_value >= lowest_modified_value"
+		") t"
+		" WHERE lowest_modified_value IS NOT NULL"
+		"   AND greatest_modified_value IS NOT NULL"
+		"   AND greatest_modified_value != $3"
+		"   AND greatest_modified_value >= $4"
+		"   AND lowest_modified_value < $5"
+		" ORDER BY 1 ASC";
 
-	const char *query_str = psprintf(query_str_template,
-									 refresh_newest_first ? "range_end DESC" : "range_start ASC",
-									 refresh_newest_first ? "DESC" : "ASC");
-
-	/* List of InternalTimeRange elements to be returned */
 	List *refresh_window_list = NIL;
-
-	/* Prepare for SPI call */
 	int res;
-	Oid types[] = { INT4OID, INT4OID, INT4OID, INT8OID, INT8OID, INT8OID, INT8OID };
-	Datum values[] = { Int32GetDatum(ht->fd.id),
-					   Int32GetDatum(time_dim->fd.id),
-					   Int32GetDatum(cagg->data.mat_hypertable_id),
-					   Int64GetDatum(batch_size),
-					   Int64GetDatum(refresh_window.start),
-					   Int64GetDatum(refresh_window.end),
-					   Int64GetDatum(CAGG_INVALIDATION_WRONG_GREATEST_VALUE) };
-	char nulls[] = { false, false, false, false, false, false, false };
 	MemoryContext oldcontext = CurrentMemoryContext;
 
 	if (SPI_connect() != SPI_OK_CONNECT)
@@ -1286,119 +1216,223 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 		elog(ERROR, "could not connect to SPI");
 	}
 
-	/* Lock down search_path */
 	int save_nestlevel = NewGUCNestLevel();
 	RestrictSearchPath();
 
-	res = SPI_execute_with_args(query_str,
-								7,
-								types,
-								values,
-								nulls,
-								false /* read_only */,
-								0 /* count */);
+	Oid inval_types[] = { INT4OID, INT4OID, INT8OID, INT8OID, INT8OID };
+	Datum inval_values[] = { Int32GetDatum(cagg->data.mat_hypertable_id),
+							 Int32GetDatum(ht->fd.id),
+							 Int64GetDatum(CAGG_INVALIDATION_WRONG_GREATEST_VALUE),
+							 Int64GetDatum(refresh_window.start),
+							 Int64GetDatum(refresh_window.end) };
+	char inval_nulls[] = { false, false, false, false, false };
 
+	res = SPI_execute_with_args(inval_query,
+								5,
+								inval_types,
+								inval_values,
+								inval_nulls,
+								true /* read_only */,
+								0);
 	if (res < 0)
 	{
-		elog(ERROR, "%s: could not produce batches for the policy cagg refresh", __func__);
+		elog(ERROR, "%s: could not fetch invalidation ranges for cagg refresh", __func__);
 	}
 
-	if (SPI_processed == 1)
+	Assert(SPI_processed <= INT_MAX);
+	int inval_count = (int) SPI_processed;
+	Assert(SPI_tuptable != NULL);
+	TupleDesc inval_tupdesc = SPI_tuptable->tupdesc;
+
+	/*
+	 * Open a streaming catalog scan for dimension slices overlapping the refresh
+	 * window.
+	 * Filter to slices overlapping [refresh_window.start, refresh_window.end):
+	 *   range_start < refresh_window.end   (BTLessStrategyNumber)
+	 *   range_end   > refresh_window.start (BTGreaterStrategyNumber; subtract 1 to
+	 *                                       offset the +1 adjustment in set_range)
+	 */
+	ScanIterator dim_it = ts_dimension_slice_scan_iterator_create(NULL, CurrentMemoryContext);
+	ts_dimension_slice_scan_iterator_set_range(&dim_it,
+											   time_dim->fd.id,
+											   BTLessStrategyNumber,
+											   refresh_window.end,
+											   BTGreaterStrategyNumber,
+											   (refresh_window.start > PG_INT64_MIN) ?
+												   refresh_window.start - 1 :
+												   PG_INT64_MIN);
+	ts_scan_iterator_start_or_restart_scan(&dim_it);
+
+	/*
+	 * Merge scan: walk oldest-first through the dimension slice cursor and the
+	 * SPI invalidations result. Note that the invalidations are ordered by lowest_modified_value
+	 * ascending, and dimension slices are ordered by range_start ascending).
+	 *
+	 * Rather than stepping through every bucket boundary, we skip ahead to the
+	 * bucket containing max(dim_low, inval_low) whenever cur is in a gap before
+	 * either source's next range.
+	 *
+	 * A batch is emitted only when it overlaps both an active dimension slice and
+	 * an active invalidation range.
+	 */
+	const ContinuousAggBucketFunction *bf = cagg->bucket_function;
+	int64 fixed_batch_size = bf->bucket_fixed_interval ? ts_continuous_agg_fixed_bucket_width(bf) *
+															 (int64) buckets_per_batch :
+														 0;
+	bool dim_has_more;
+	int64 dim_low = 0, dim_high = 0;
 	{
-		elog(DEBUG1,
-			 "only one batch produced for continuous aggregate \"%s.%s\", falling back to single "
-			 "batch processing",
-			 NameStr(cagg->data.user_view_schema),
-			 NameStr(cagg->data.user_view_name));
-
-		/* Restore search_path */
-		AtEOXact_GUC(false, save_nestlevel);
-
-		res = SPI_finish();
-		if (res != SPI_OK_FINISH)
+		TupleInfo *ti = ts_scan_iterator_next(&dim_it);
+		dim_has_more = (ti != NULL);
+		if (dim_has_more)
 		{
-			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(res));
+			bool isnull;
+			dim_low =
+				DatumGetInt64(slot_getattr(ti->slot, Anum_dimension_slice_range_start, &isnull));
+			dim_high =
+				DatumGetInt64(slot_getattr(ti->slot, Anum_dimension_slice_range_end, &isnull));
+		}
+	}
+
+	int inval_idx = 0;
+	int64 inval_low = 0, inval_high = 0;
+	if (inval_idx < inval_count)
+	{
+		bool isnull;
+		inval_low =
+			DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[inval_idx], inval_tupdesc, 1, &isnull));
+		inval_high =
+			DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[inval_idx], inval_tupdesc, 2, &isnull));
+	}
+
+	int64 cur = refresh_window.start;
+	while (cur < refresh_window.end)
+	{
+		/* Advance past dim slices that end at or before cur */
+		while (dim_has_more && dim_high <= cur)
+		{
+			TupleInfo *ti = ts_scan_iterator_next(&dim_it);
+			dim_has_more = (ti != NULL);
+			if (dim_has_more)
+			{
+				bool isnull;
+				dim_low = DatumGetInt64(
+					slot_getattr(ti->slot, Anum_dimension_slice_range_start, &isnull));
+				dim_high =
+					DatumGetInt64(slot_getattr(ti->slot, Anum_dimension_slice_range_end, &isnull));
+			}
 		}
 
-		return NIL;
-	}
+		/* Advance past invalidations that end at or before cur.
+		 * This is correct because we are reading invalidation entries already ordered by
+		 * lowest_modified_value.
+		 */
+		while (inval_idx < inval_count && inval_high <= cur)
+		{
+			inval_idx++;
+			if (inval_idx < inval_count)
+			{
+				bool isnull;
+				inval_low = DatumGetInt64(
+					SPI_getbinval(SPI_tuptable->vals[inval_idx], inval_tupdesc, 1, &isnull));
+				inval_high = DatumGetInt64(
+					SPI_getbinval(SPI_tuptable->vals[inval_idx], inval_tupdesc, 2, &isnull));
+			}
+		}
 
-	/* Build the batches list */
-	for (uint64 batch = 0; batch < SPI_processed; batch++)
-	{
-		bool range_start_isnull, range_end_isnull;
-		Datum range_start =
-			SPI_getbinval(SPI_tuptable->vals[batch], SPI_tuptable->tupdesc, 1, &range_start_isnull);
-		Datum range_end =
-			SPI_getbinval(SPI_tuptable->vals[batch], SPI_tuptable->tupdesc, 2, &range_end_isnull);
+		if (!dim_has_more || inval_idx >= inval_count)
+		{
+			break;
+		}
 
-		/* We need to allocate the list in the old memory context because here we're in the SPI
-		 * context */
-		MemoryContext saved_context = MemoryContextSwitchTo(oldcontext);
+		/*
+		 * If cur is before the start of either source, jump ahead to the bucket
+		 * containing max(dim_low, inval_low), skipping the empty gap entirely.
+		 * Guard new_cur > cur to avoid an infinite loop when the jump target falls
+		 * inside the current bucket (fall through to the emit check in that case).
+		 */
+		int64 jump_target = Max(dim_low, inval_low);
+		if (jump_target > cur)
+		{
+			int64 new_cur =
+				cagg_current_bucket_start(jump_target, original_refresh_window->type, bf);
+			if (new_cur > cur)
+			{
+				cur = new_cur;
+				continue;
+			}
+		}
+
+		/* Compute the end of this batch */
+		int64 next;
+		if (bf->bucket_fixed_interval)
+		{
+			next = cur + fixed_batch_size;
+		}
+		else
+		{
+			next = cur;
+			for (int32 i = 0; i < buckets_per_batch; i++)
+			{
+				next = ts_cagg_variable_next_bucket_start(next, bf);
+			}
+		}
+		if (next > refresh_window.end)
+		{
+			next = refresh_window.end;
+		}
+
+		/* Emit the batch */
+		MemoryContext spi_context = MemoryContextSwitchTo(oldcontext);
 		InternalTimeRange *range = palloc0(sizeof(InternalTimeRange));
-		range->start = DatumGetInt64(range_start);
-		range->start_isnull = range_start_isnull;
-		range->end = DatumGetInt64(range_end);
-		range->end_isnull = range_end_isnull;
+		range->start = cur;
+		range->end = next;
 		range->type = original_refresh_window->type;
-
-		/* For variable-length buckets, circumscribe the batch to bucket boundaries.
-		 * The batch size calculation uses a 30-day approximation for months, so we need
-		 * to expand batches to cover complete buckets.*/
-		if (cagg->bucket_function->bucket_fixed_interval == false)
-		{
-			ts_compute_circumscribed_bucketed_refresh_window_variable(&range->start,
-																	  &range->end,
-																	  cagg->bucket_function);
-		}
-		/*
-		 * To make sure that the first range (or last range in case of refreshing from oldest to
-		 * newest) is aligned with the end of the refresh window we need to set the end to the
-		 * maximum value of the time type if the original refresh window end is NULL.
-		 */
-		if (((batch == 0 && refresh_newest_first) ||
-			 (batch == (SPI_processed - 1) && !refresh_newest_first)) &&
-			original_refresh_window->end_isnull)
-		{
-			range->end = ts_time_get_noend_or_max(range->type);
-			range->end_isnull = true;
-		}
-
-		/*
-		 * To make sure that the last range (or first range in case of refreshing from oldest to
-		 * newest) is aligned with the start of the refresh window we need to set the start to the
-		 * maximum value of the time type if the original refresh window start is NULL.
-		 */
-		if (((batch == (SPI_processed - 1) && refresh_newest_first) ||
-			 (batch == 0 && !refresh_newest_first)) &&
-			original_refresh_window->start_isnull)
-		{
-			range->start = cagg_get_time_min(cagg);
-			range->start_isnull = true;
-		}
-
 		refresh_window_list = lappend(refresh_window_list, range);
-		MemoryContextSwitchTo(saved_context);
-
+		MemoryContextSwitchTo(spi_context);
 		debug_refresh_window(cagg, range, "batch produced");
+
+		cur = next;
 	}
 
+	ts_scan_iterator_close(&dim_it);
+
+	/* Done with SPI */
 	/* Restore search_path */
 	AtEOXact_GUC(false, save_nestlevel);
-
 	res = SPI_finish();
 	if (res != SPI_OK_FINISH)
 	{
 		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(res));
 	}
 
-	if (refresh_window_list == NIL)
+	/*
+	 * Apply null restoration to the first and last batch if needed
+	 */
+	if (list_length(refresh_window_list) >= 2)
+	{
+		if (original_refresh_window->start_isnull)
+		{
+			InternalTimeRange *oldest = linitial(refresh_window_list);
+			oldest->start = cagg_get_time_min(cagg);
+			oldest->start_isnull = true;
+		}
+		if (original_refresh_window->end_isnull)
+		{
+			InternalTimeRange *newest = llast(refresh_window_list);
+			newest->end = ts_time_get_noend_or_max(original_refresh_window->type);
+			newest->end_isnull = true;
+		}
+	}
+	else
 	{
 		elog(DEBUG1,
-			 "no valid batches produced for continuous aggregate \"%s.%s\", falling back to single "
-			 "batch processing",
+			 "only %d batch(es) produced for continuous aggregate \"%s.%s\", "
+			 "falling back to single batch processing",
+			 list_length(refresh_window_list),
 			 NameStr(cagg->data.user_view_schema),
 			 NameStr(cagg->data.user_view_name));
+		refresh_window_list = NIL;
 	}
 
 	return refresh_window_list;

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -21,8 +21,7 @@ extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg,
 											bool extend_last_bucket);
 extern List *continuous_agg_split_refresh_window(ContinuousAgg *cagg,
 												 InternalTimeRange *original_refresh_window,
-												 int32 buckets_per_batch,
-												 bool refresh_newest_first);
+												 int32 buckets_per_batch);
 InternalTimeRange
 compute_circumscribed_bucketed_refresh_window(const InternalTimeRange *const refresh_window,
 											  const ContinuousAggBucketFunction *bucket_function);

--- a/tsl/test/expected/cagg_bgw-15.out
+++ b/tsl/test/expected/cagg_bgw-15.out
@@ -326,16 +326,13 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                                            msg                                                            
---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 -- job ran once, successfully
 SELECT job_id, last_finish - next_start as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -371,24 +368,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
     FROM _timescaledb_internal.bgw_job_stat
@@ -451,24 +442,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
       0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]

--- a/tsl/test/expected/cagg_bgw-16.out
+++ b/tsl/test/expected/cagg_bgw-16.out
@@ -326,16 +326,13 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                                            msg                                                            
---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 -- job ran once, successfully
 SELECT job_id, last_finish - next_start as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -371,24 +368,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
     FROM _timescaledb_internal.bgw_job_stat
@@ -451,24 +442,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
       0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]

--- a/tsl/test/expected/cagg_bgw-17.out
+++ b/tsl/test/expected/cagg_bgw-17.out
@@ -326,16 +326,13 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                                            msg                                                            
---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 -- job ran once, successfully
 SELECT job_id, last_finish - next_start as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -371,24 +368,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
     FROM _timescaledb_internal.bgw_job_stat
@@ -451,24 +442,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
       0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]

--- a/tsl/test/expected/cagg_bgw-18.out
+++ b/tsl/test/expected/cagg_bgw-18.out
@@ -326,16 +326,13 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                                                            msg                                                            
---------+-----------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no | mock_time |              application_name              |                                                    msg                                                     
+--------+-----------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |         0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |         0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |         0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 -- job ran once, successfully
 SELECT job_id, last_finish - next_start as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -371,24 +368,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
 
 SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
     FROM _timescaledb_internal.bgw_job_stat
@@ -451,24 +442,18 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
  
 
 SELECT * FROM sorted_bgw_log;
- msg_no |  mock_time  |              application_name              |                                                            msg                                                            
---------+-------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------
+ msg_no |  mock_time  |              application_name              |                                                    msg                                                     
+--------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 10, 12 ] (batch 1 of 2)
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, 12 ]
       1 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 |           0 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -10, 10 ] (batch 2 of 2)
-      4 |           0 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 5 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 |           0 | Refresh Continuous Aggregate Policy [1001] | inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ -90, -10 ]
-      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
-      3 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
-      4 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
-      5 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 6, 8 ]
+      1 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_3"
+      2 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_3"
       0 | 86400000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 86400000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
       0 | 86400000000 | Refresh Continuous Aggregate Policy [1001] | continuous aggregate refresh (individual invalidation) on "test_continuous_agg_view" in window [ 0, 12 ]

--- a/tsl/test/expected/cagg_policy_incremental.out
+++ b/tsl/test/expected/cagg_policy_incremental.out
@@ -296,7 +296,7 @@ SELECT ts_bgw_params_reset_time(extract(epoch from interval '3 hour')::bigint * 
 --------------------------
  
 
--- Should process all four batches in the past
+-- Should process all three batches in the past
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
 ------------------------------------------------------------
@@ -307,18 +307,15 @@ SELECT * FROM sorted_bgw_log;
 --------+-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0 | 10800000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 10800000000 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Feb 29 00:00:00 2020 UTC, Fri Mar 06 00:00:00 2020 UTC ] (batch 1 of 4)
+      0 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Tue Feb 25 00:00:00 2020 UTC, Fri Mar 06 00:00:00 2020 UTC ] (batch 1 of 3)
       1 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
-      2 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 30 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-      3 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Wed Feb 19 00:00:00 2020 UTC, Sat Feb 29 00:00:00 2020 UTC ] (batch 2 of 4)
+      2 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
+      3 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sat Feb 15 00:00:00 2020 UTC, Tue Feb 25 00:00:00 2020 UTC ] (batch 2 of 3)
       4 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       5 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-      6 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Sun Feb 09 00:00:00 2020 UTC, Wed Feb 19 00:00:00 2020 UTC ] (batch 3 of 4)
+      6 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Wed Feb 05 00:00:00 2020 UTC, Sat Feb 15 00:00:00 2020 UTC ] (batch 3 of 3)
       7 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
       8 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 50 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
-      9 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | continuous aggregate refresh (individual invalidation) on "conditions_by_day" in window [ Wed Feb 05 00:00:00 2020 UTC, Sun Feb 09 00:00:00 2020 UTC ] (batch 4 of 4)
-     10 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_2"
-     11 | 10800000000 | Refresh Continuous Aggregate Policy [1000] | inserted 20 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_2"
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
  materialization_id | lowest_modified_value | greatest_modified_value 
@@ -808,51 +805,54 @@ ORDER BY low;
 --------------------+-----+------
 
 --verify that there is no duplicate/overlapping refreshes.
---Note that batch 1 and batch 12 contains 2 buckets instead of 1 bucket as set in the policy.
---This is due to the fact that we currently cut a batch of 30 days for monthly cagg,
---so first batch and batch containing February can have 2 buckets. After we have a cleaner solution to
---cut an exact batch size for variable-length buckets, this should be fixed.
+--Each batch should cover exactly 1 month (buckets_per_batch=1).
 SELECT * FROM sorted_bgw_log;
  msg_no | mock_time |              application_name              |                                                                                  msg                                                                                  
 --------+-----------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until (RANDOM), started at (RANDOM)
-      0 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Sun Dec 01 00:00:00 2024 UTC, Sat Feb 01 00:00:00 2025 UTC ] (batch 1 of 13)
+      0 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Wed Jan 01 00:00:00 2025 UTC, Sat Feb 01 00:00:00 2025 UTC ] (batch 1 of 14)
       1 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
-      2 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-      3 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Fri Nov 01 00:00:00 2024 UTC, Sun Dec 01 00:00:00 2024 UTC ] (batch 2 of 13)
+      2 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
+      3 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Sun Dec 01 00:00:00 2024 UTC, Wed Jan 01 00:00:00 2025 UTC ] (batch 2 of 14)
       4 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
       5 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-      6 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Tue Oct 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] (batch 3 of 13)
+      6 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Fri Nov 01 00:00:00 2024 UTC, Sun Dec 01 00:00:00 2024 UTC ] (batch 3 of 14)
       7 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
       8 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-      9 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Sun Sep 01 00:00:00 2024 UTC, Tue Oct 01 00:00:00 2024 UTC ] (batch 4 of 13)
+      9 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Tue Oct 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] (batch 4 of 14)
      10 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      11 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     12 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Thu Aug 01 00:00:00 2024 UTC, Sun Sep 01 00:00:00 2024 UTC ] (batch 5 of 13)
+     12 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Sun Sep 01 00:00:00 2024 UTC, Tue Oct 01 00:00:00 2024 UTC ] (batch 5 of 14)
      13 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      14 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     15 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Mon Jul 01 00:00:00 2024 UTC, Thu Aug 01 00:00:00 2024 UTC ] (batch 6 of 13)
+     15 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Thu Aug 01 00:00:00 2024 UTC, Sun Sep 01 00:00:00 2024 UTC ] (batch 6 of 14)
      16 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      17 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     18 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Sat Jun 01 00:00:00 2024 UTC, Mon Jul 01 00:00:00 2024 UTC ] (batch 7 of 13)
+     18 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Mon Jul 01 00:00:00 2024 UTC, Thu Aug 01 00:00:00 2024 UTC ] (batch 7 of 14)
      19 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      20 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     21 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] (batch 8 of 13)
+     21 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Sat Jun 01 00:00:00 2024 UTC, Mon Jul 01 00:00:00 2024 UTC ] (batch 8 of 14)
      22 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      23 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     24 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Mon Apr 01 00:00:00 2024 UTC, Wed May 01 00:00:00 2024 UTC ] (batch 9 of 13)
+     24 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] (batch 9 of 14)
      25 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      26 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     27 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Fri Mar 01 00:00:00 2024 UTC, Mon Apr 01 00:00:00 2024 UTC ] (batch 10 of 13)
+     27 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Mon Apr 01 00:00:00 2024 UTC, Wed May 01 00:00:00 2024 UTC ] (batch 10 of 14)
      28 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
      29 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     30 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Mon Jan 01 00:00:00 2024 UTC, Fri Mar 01 00:00:00 2024 UTC ] (batch 12 of 13)
+     30 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Fri Mar 01 00:00:00 2024 UTC, Mon Apr 01 00:00:00 2024 UTC ] (batch 11 of 14)
      31 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
-     32 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 2 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
-     33 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ -infinity, Mon Jan 01 00:00:00 2024 UTC ] (batch 13 of 13)
+     32 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
+     33 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Thu Feb 01 00:00:00 2024 UTC, Fri Mar 01 00:00:00 2024 UTC ] (batch 12 of 14)
      34 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
-     35 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
+     35 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
+     36 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ Mon Jan 01 00:00:00 2024 UTC, Thu Feb 01 00:00:00 2024 UTC ] (batch 13 of 14)
+     37 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
+     38 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
+     39 |         0 | Refresh Continuous Aggregate Policy [1005] | continuous aggregate refresh (individual invalidation) on "batch_test_cagg" in window [ -infinity, Mon Jan 01 00:00:00 2024 UTC ] (batch 14 of 14)
+     40 |         0 | Refresh Continuous Aggregate Policy [1005] | deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_6"
+     41 |         0 | Refresh Continuous Aggregate Policy [1005] | inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_6"
 
 --now run the refresh again, should not do anything
 TRUNCATE bgw_log;
@@ -965,6 +965,477 @@ FROM
 ----------
  f
 
+------------------------------------------------------------------------------------------
+-- Test variable-width bucket batching: demonstrates chunk gap skip and invalidation
+-- gap skip with non-null start/end offsets (no null-restoration).
+-- chunk_time_interval=25 days is intentionally not aligned with monthly buckets.
+--
+-- Chunk boundaries are fixed 25-day windows anchored to the Unix epoch
+-- (Jan 1 1970), so they fall at arbitrary calendar dates. The four data points land in:
+--   Mar 15 -> chunk [Feb 22, Mar 18): spans Feb and Mar bucket boundaries
+--   May 15 -> chunk [May  7, Jun  1): entirely within May
+--   Jun 10 -> chunk [Jun  1, Jun 26): entirely within June
+--   Oct 15 -> chunk [Oct  4, Oct 29): entirely within October
+--
+-- June is explicitly refreshed before the policy runs, consuming its invalidation.
+-- The sentinel [-inf, +inf] is cut into two residuals in mat_inval_log:
+--   left  [-inf,     May 31 23:59:59.999999]  (covers Mar and May)
+--   right [Jul 1,   +inf]                      (covers Oct and later)
+-- -> gap from Jun 1 to Jun 30 means June has no pending invalidation.
+--
+-- Expected batch behaviour (refresh_newest_first=false, buckets_per_batch=1,
+-- start_offset='10 years', end_offset='1 month'):
+--   Feb: batch [Feb 1, Mar 1) -- EMPTY: the Feb 22 chunk touches the Feb bucket but
+--        no data falls in February; illustrates a chunk intersecting a bucket boundary
+--   Mar: batch generated  (Mar chunk overlaps Mar bucket + left-residual inval)
+--   Apr: SKIPPED          (chunk gap: no chunks in April)
+--   May: batch generated  (May chunk + left-residual inval)
+--   Jun: SKIPPED          (invalidation gap: inval was consumed by explicit refresh)
+--   Jul-Sep: SKIPPED      (chunk gap)
+--   Oct: batch generated  (Oct chunk + right-residual inval)
+-- No null-restoration: start_offset and end_offset are both non-null.
+-- Final batches: [Feb 1, Mar 1),  [Mar 1, Apr 1),  [May 1, Jun 1),  [Oct 1, Nov 1).
+------------------------------------------------------------------------------------------
+-- Monthly bucket boundaries are at midnight UTC; set timezone to avoid PST-shift issues.
+SET timezone = 'UTC';
+CREATE TABLE sparse_data (
+    time TIMESTAMPTZ NOT NULL,
+    value INT
+);
+SELECT FROM create_hypertable('sparse_data', by_range('time', INTERVAL '25 days'));
+--
+
+INSERT INTO sparse_data VALUES
+    ('2024-03-15 00:00:00+00', 3),   -- lands in chunk [Feb 22, Mar 18)
+    ('2024-05-15 00:00:00+00', 5),   -- lands in chunk [May  7, Jun  1)
+    ('2024-06-10 00:00:00+00', 6),   -- lands in chunk [Jun  1, Jun 26)
+    ('2024-10-15 00:00:00+00', 10);  -- lands in chunk [Oct  4, Oct 29)
+CREATE MATERIALIZED VIEW sparse_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 month'::interval, time) AS bucket, count(*) AS cnt
+FROM sparse_data
+GROUP BY bucket
+WITH NO DATA;
+-- Consume June's invalidation so the June bucket has no pending invalidation.
+CALL refresh_continuous_aggregate('sparse_cagg',
+    '2024-06-01'::timestamptz, '2024-07-01'::timestamptz);
+-- Validate dimension slices: four chunks showing the epoch-aligned boundaries.
+SELECT
+    _timescaledb_functions.to_timestamp(ds.range_start) AS range_start,
+    _timescaledb_functions.to_timestamp(ds.range_end)   AS range_end
+FROM _timescaledb_catalog.dimension_slice ds
+JOIN _timescaledb_catalog.dimension d ON d.id = ds.dimension_id
+JOIN _timescaledb_catalog.hypertable h ON h.id = d.hypertable_id
+WHERE h.table_name = 'sparse_data'
+ORDER BY ds.range_start;
+         range_start          |          range_end           
+------------------------------+------------------------------
+ Thu Feb 22 00:00:00 2024 UTC | Mon Mar 18 00:00:00 2024 UTC
+ Tue May 07 00:00:00 2024 UTC | Sat Jun 01 00:00:00 2024 UTC
+ Sat Jun 01 00:00:00 2024 UTC | Wed Jun 26 00:00:00 2024 UTC
+ Fri Oct 04 00:00:00 2024 UTC | Tue Oct 29 00:00:00 2024 UTC
+
+-- Validate invalidation log: two residuals with a gap over June.
+SELECT
+    _timescaledb_functions.to_timestamp(lowest_modified_value)   AS lowest,
+    _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'sparse_cagg'
+)
+ORDER BY lowest_modified_value;
+            lowest            |              greatest               
+------------------------------+-------------------------------------
+ -infinity                    | Fri May 31 23:59:59.999999 2024 UTC
+ Mon Jul 01 00:00:00 2024 UTC | infinity
+
+SELECT add_continuous_aggregate_policy('sparse_cagg',
+    start_offset => INTERVAL '10 years',
+    end_offset => INTERVAL '1 month',
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1,
+    refresh_newest_first => false
+) AS sparse_job_id \gset
+-- Four batches expected: [Feb 1, Mar 1) empty, [Mar 1, Apr 1), [May 1, Jun 1), [Oct 1, Nov 1).
+-- Apr/Jul/Aug/Sep skipped (chunk gap), Jun skipped (invalidation gap).
+SET client_min_messages TO DEBUG1;
+CALL run_job(:sparse_job_id);
+LOG:  statement: CALL run_job(1007);
+DEBUG:  Executing policy_refresh_continuous_aggregate with parameters {"end_offset": "@ 1 mon", "start_offset": "@ 10 years", "buckets_per_batch": 1, "mat_hypertable_id": 8, "refresh_newest_first": false}
+DEBUG:  begin "sparse_cagg" in window [ Wed Mar 11 00:00:00 2015 UTC, Tue Feb 11 00:00:00 2025 UTC ] internal [ 1426032000000000, 1739232000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  before produce batches "sparse_cagg" in window [ Wed Apr 01 00:00:00 2015 UTC, Sat Feb 01 00:00:00 2025 UTC ] internal [ 1427846400000000, 1738368000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg" in window [ Thu Feb 01 00:00:00 2024 UTC, Fri Mar 01 00:00:00 2024 UTC ] internal [ 1706745600000000, 1709251200000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg" in window [ Fri Mar 01 00:00:00 2024 UTC, Mon Apr 01 00:00:00 2024 UTC ] internal [ 1709251200000000, 1711929600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] internal [ 1714521600000000, 1717200000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg" in window [ Tue Oct 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] internal [ 1727740800000000, 1730419200000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  refreshing continuous aggregate "sparse_cagg" from Thu Feb 01 00:00:00 2024 UTC to Fri Mar 01 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1719792000000000 1709251200000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg" in window [ Thu Feb 01 00:00:00 2024 UTC, Fri Mar 01 00:00:00 2024 UTC ] (batch 1 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_8"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_8"
+DEBUG:  refreshing continuous aggregate "sparse_cagg" from Fri Mar 01 00:00:00 2024 UTC to Mon Apr 01 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1719792000000000 1711929600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg" in window [ Fri Mar 01 00:00:00 2024 UTC, Mon Apr 01 00:00:00 2024 UTC ] (batch 2 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_8"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_8"
+DEBUG:  hypertable 8 existing watermark >= new watermark 1719792000000000 1719792000000000
+DEBUG:  refreshing continuous aggregate "sparse_cagg" from Wed May 01 00:00:00 2024 UTC to Sat Jun 01 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1719792000000000 1717200000000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] (batch 3 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_8"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_8"
+DEBUG:  hypertable 8 existing watermark >= new watermark 1719792000000000 1719792000000000
+DEBUG:  refreshing continuous aggregate "sparse_cagg" from Tue Oct 01 00:00:00 2024 UTC to Fri Nov 01 00:00:00 2024 UTC
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg" in window [ Tue Oct 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] (batch 4 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_8"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_8"
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+------------------------------------------------------------------------------------------
+-- Similar test using a fixed 10-day bucket CAgg on the same sparse_data table.
+-- time_bucket('10 days', ...) uses Jan 3 2000 as origin. Relevant 2024 boundaries:
+--   Feb 16, Feb 26, Mar 7, Mar 17, Mar 27, ..., May 6, May 16, May 26,
+--   Jun 5, Jun 15, Jun 25, Jul 5, ..., Oct 3, Oct 13, Oct 23, Nov 2, ...
+--
+-- Refresh [Jun 5, Jun 25) consumes two 10-day June buckets, leaving:
+--   left  [-inf,     Jun  4 23:59:59.999999]
+--   right [Jun 25,  +inf]
+--
+-- start_offset='10 years': window start is far in the past; jump logic advances
+-- directly to cagg_current_bucket_start(Feb 22) = Feb 16, the bucket containing
+-- the earliest chunk. No null-restoration (start_offset non-null).
+-- Gaps are skipped by jumping to cagg_current_bucket_start(jump_target), the same
+-- as for variable-width buckets. The chunk starts May 7 and Oct 4 fall mid-bucket:
+--   cagg_current_bucket_start(May 7) = May 6  (bucket [May  6, May 16))
+--   cagg_current_bucket_start(Oct 4) = Oct 3  (bucket [Oct  3, Oct 13))
+-- so those batches start one day before the corresponding chunk.
+--
+-- Expected batches (buckets_per_batch=1, refresh_newest_first=false):
+--   Feb: [Feb 16, Feb 26)  EMPTY (no Feb data; illustrates chunk spanning bucket boundary)
+--   Mar (3 buckets): [Feb 26, Mar 7), [Mar 7, Mar 17), [Mar 17, Mar 27)
+--   Apr: SKIPPED  (chunk gap: no chunks in April)
+--   May (3 buckets): [May 6, May 16), [May 16, May 26), [May 26, Jun 5)
+--                    May 6 = bucket start of May 7 (first chunk boundary)
+--   Jun 5-Jun 25: SKIPPED  (invalidation gap: consumed by explicit refresh)
+--   Jun 25: batch [Jun 25, Jul 5)  (last Jun chunk + right residual)
+--   Jul-Sep: SKIPPED  (chunk gap)
+--   Oct (3 buckets): [Oct 3, Oct 13), [Oct 13, Oct 23), [Oct 23, Nov 2)
+--                    Oct 3 = bucket start of Oct 4 (first chunk boundary)
+------------------------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW sparse_cagg_fixed
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('10 days'::interval, time) AS bucket, count(*) AS cnt
+FROM sparse_data
+GROUP BY bucket
+WITH NO DATA;
+-- Consume [Jun 5, Jun 25) to create an invalidation gap for those two June buckets.
+CALL refresh_continuous_aggregate('sparse_cagg_fixed',
+    '2024-06-05'::timestamptz, '2024-06-25'::timestamptz);
+-- Validate invalidation log: two residuals with a gap over [Jun 5, Jun 25).
+SELECT
+    _timescaledb_functions.to_timestamp(lowest_modified_value)   AS lowest,
+    _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'sparse_cagg_fixed'
+)
+ORDER BY lowest_modified_value;
+            lowest            |              greatest               
+------------------------------+-------------------------------------
+ -infinity                    | Tue Jun 04 23:59:59.999999 2024 UTC
+ Tue Jun 25 00:00:00 2024 UTC | infinity
+
+SELECT add_continuous_aggregate_policy('sparse_cagg_fixed',
+    start_offset => INTERVAL '10 years',
+    end_offset => INTERVAL '1 month',
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1,
+    refresh_newest_first => false
+) AS fixed_job_id \gset
+-- Eleven batches expected: 1 empty in Feb, 3 in Mar, 3 in May, 1 at Jun 25, 3 in Oct.
+SET client_min_messages TO DEBUG1;
+CALL run_job(:fixed_job_id);
+LOG:  statement: CALL run_job(1008);
+DEBUG:  Executing policy_refresh_continuous_aggregate with parameters {"end_offset": "@ 1 mon", "start_offset": "@ 10 years", "buckets_per_batch": 1, "mat_hypertable_id": 9, "refresh_newest_first": false}
+DEBUG:  begin "sparse_cagg_fixed" in window [ Wed Mar 11 00:00:00 2015 UTC, Tue Feb 11 00:00:00 2025 UTC ] internal [ 1426032000000000, 1739232000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  before produce batches "sparse_cagg_fixed" in window [ Sun Mar 15 00:00:00 2015 UTC, Mon Feb 10 00:00:00 2025 UTC ] internal [ 1426377600000000, 1739145600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Fri Feb 16 00:00:00 2024 UTC, Mon Feb 26 00:00:00 2024 UTC ] internal [ 1708041600000000, 1708905600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Mon Feb 26 00:00:00 2024 UTC, Thu Mar 07 00:00:00 2024 UTC ] internal [ 1708905600000000, 1709769600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Thu Mar 07 00:00:00 2024 UTC, Sun Mar 17 00:00:00 2024 UTC ] internal [ 1709769600000000, 1710633600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Sun Mar 17 00:00:00 2024 UTC, Wed Mar 27 00:00:00 2024 UTC ] internal [ 1710633600000000, 1711497600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Mon May 06 00:00:00 2024 UTC, Thu May 16 00:00:00 2024 UTC ] internal [ 1714953600000000, 1715817600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Thu May 16 00:00:00 2024 UTC, Sun May 26 00:00:00 2024 UTC ] internal [ 1715817600000000, 1716681600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Sun May 26 00:00:00 2024 UTC, Wed Jun 05 00:00:00 2024 UTC ] internal [ 1716681600000000, 1717545600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Tue Jun 25 00:00:00 2024 UTC, Fri Jul 05 00:00:00 2024 UTC ] internal [ 1719273600000000, 1720137600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Thu Oct 03 00:00:00 2024 UTC, Sun Oct 13 00:00:00 2024 UTC ] internal [ 1727913600000000, 1728777600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Sun Oct 13 00:00:00 2024 UTC, Wed Oct 23 00:00:00 2024 UTC ] internal [ 1728777600000000, 1729641600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_fixed" in window [ Wed Oct 23 00:00:00 2024 UTC, Sat Nov 02 00:00:00 2024 UTC ] internal [ 1729641600000000, 1730505600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Fri Feb 16 00:00:00 2024 UTC to Mon Feb 26 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1708905600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Fri Feb 16 00:00:00 2024 UTC, Mon Feb 26 00:00:00 2024 UTC ] (batch 1 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Mon Feb 26 00:00:00 2024 UTC to Thu Mar 07 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1709769600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Mon Feb 26 00:00:00 2024 UTC, Thu Mar 07 00:00:00 2024 UTC ] (batch 2 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Thu Mar 07 00:00:00 2024 UTC to Sun Mar 17 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1710633600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Thu Mar 07 00:00:00 2024 UTC, Sun Mar 17 00:00:00 2024 UTC ] (batch 3 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  hypertable 9 existing watermark >= new watermark 1718409600000000 1718409600000000
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Sun Mar 17 00:00:00 2024 UTC to Wed Mar 27 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1711497600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Sun Mar 17 00:00:00 2024 UTC, Wed Mar 27 00:00:00 2024 UTC ] (batch 4 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Mon May 06 00:00:00 2024 UTC to Thu May 16 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1715817600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Mon May 06 00:00:00 2024 UTC, Thu May 16 00:00:00 2024 UTC ] (batch 5 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  hypertable 9 existing watermark >= new watermark 1718409600000000 1718409600000000
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Thu May 16 00:00:00 2024 UTC to Sun May 26 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1716681600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Thu May 16 00:00:00 2024 UTC, Sun May 26 00:00:00 2024 UTC ] (batch 6 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Sun May 26 00:00:00 2024 UTC to Wed Jun 05 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1717545600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Sun May 26 00:00:00 2024 UTC, Wed Jun 05 00:00:00 2024 UTC ] (batch 7 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Tue Jun 25 00:00:00 2024 UTC to Fri Jul 05 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1720137600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Tue Jun 25 00:00:00 2024 UTC, Fri Jul 05 00:00:00 2024 UTC ] (batch 8 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Thu Oct 03 00:00:00 2024 UTC to Sun Oct 13 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1728777600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Thu Oct 03 00:00:00 2024 UTC, Sun Oct 13 00:00:00 2024 UTC ] (batch 9 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Sun Oct 13 00:00:00 2024 UTC to Wed Oct 23 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730419200000000 1729641600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Sun Oct 13 00:00:00 2024 UTC, Wed Oct 23 00:00:00 2024 UTC ] (batch 10 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  building index "_hyper_9_100_chunk__materialized_hypertable_9_bucket_idx" on table "_hyper_9_100_chunk" serially
+DEBUG:  index "_hyper_9_100_chunk__materialized_hypertable_9_bucket_idx" can safely use deduplication
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_fixed" from Wed Oct 23 00:00:00 2024 UTC to Sat Nov 02 00:00:00 2024 UTC
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_fixed" in window [ Wed Oct 23 00:00:00 2024 UTC, Sat Nov 02 00:00:00 2024 UTC ] (batch 11 of 11)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_9"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_9"
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+------------------------------------------------------------------------------------------
+-- Same sparse_data as above but with buckets_per_batch=3 to show how the algorithm
+-- groups consecutive buckets and absorbs inval gaps into batch windows.
+--
+-- Pre-refresh [Jun 1, Jul 1) creates the same residuals as for sparse_cagg:
+--   left  [-inf,     May 31 23:59:59.999999]
+--   right [Jul  1,  +inf]
+--
+-- With buckets_per_batch=3 the algorithm advances exactly 3 bucket widths per batch
+-- from the starting position; gaps within a batch window are not spliced out.
+--
+-- Batch analysis (oldest-first):
+--   1. jump to Feb 1 (cagg_current_bucket_start of first chunk Feb 22),
+--      emit 3 months: [Feb 1, May 1)
+--        Feb: empty (no data in Feb bucket -- chunk [Feb 22, Mar 18) has only Mar data)
+--        Mar: 1 row (Mar 15)
+--        Apr: chunk gap (absorbed into batch, nothing materialized)
+--   2. cur = May 1; cagg_current_bucket_start(May 7) = May 1 = cur, no jump;
+--      emit 3 months: [May 1, Aug 1)
+--      The batch window intersects two invalidation ranges, so two sub-refreshes run:
+--        [May 1, Jun 1): 1 row (May 15), from left residual [-inf, May 31]
+--        [Jun 1, Jul 1): SKIPPED -- no invalidation covers Jun (consumed by pre-refresh);
+--                                   the Jun row from pre-refresh is preserved unchanged
+--        [Jul 1, Aug 1): 0 rows, from right residual [Jul 1, +inf); no chunk data in Jul
+--   3. cur = Aug 1; jump: Max(Oct 4, Jul 1) -> cagg_current_bucket_start(Oct 4) = Oct 1;
+--      emit 3 months: [Oct 1, Jan 1 2025)
+--        Oct: 1 row (Oct 15); Nov-Dec: chunk gaps (absorbed into batch)
+--
+-- Three batches produced (vs four with buckets_per_batch=1).
+------------------------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW sparse_cagg_bp3
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 month'::interval, time) AS bucket, count(*) AS cnt
+FROM sparse_data
+GROUP BY bucket
+WITH NO DATA;
+-- Pre-refresh June to consume June's invalidation, creating the same inval gap.
+CALL refresh_continuous_aggregate('sparse_cagg_bp3',
+    '2024-06-01'::timestamptz, '2024-07-01'::timestamptz);
+SELECT add_continuous_aggregate_policy('sparse_cagg_bp3',
+    start_offset => INTERVAL '10 years',
+    end_offset => INTERVAL '1 month',
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 3,
+    refresh_newest_first => false
+) AS sparse_bp3_job_id \gset
+-- Three batches: [Feb 1, May 1), [May 1, Aug 1), [Oct 1, Jan 1 2025).
+-- Apr/Jul gaps and the Jun inval gap are absorbed inside batch windows.
+SET client_min_messages TO DEBUG1;
+CALL run_job(:sparse_bp3_job_id);
+LOG:  statement: CALL run_job(1009);
+DEBUG:  Executing policy_refresh_continuous_aggregate with parameters {"end_offset": "@ 1 mon", "start_offset": "@ 10 years", "buckets_per_batch": 3, "mat_hypertable_id": 10, "refresh_newest_first": false}
+DEBUG:  begin "sparse_cagg_bp3" in window [ Wed Mar 11 00:00:00 2015 UTC, Tue Feb 11 00:00:00 2025 UTC ] internal [ 1426032000000000, 1739232000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  before produce batches "sparse_cagg_bp3" in window [ Wed Apr 01 00:00:00 2015 UTC, Sat Feb 01 00:00:00 2025 UTC ] internal [ 1427846400000000, 1738368000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_bp3" in window [ Thu Feb 01 00:00:00 2024 UTC, Wed May 01 00:00:00 2024 UTC ] internal [ 1706745600000000, 1714521600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_bp3" in window [ Wed May 01 00:00:00 2024 UTC, Thu Aug 01 00:00:00 2024 UTC ] internal [ 1714521600000000, 1722470400000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "sparse_cagg_bp3" in window [ Tue Oct 01 00:00:00 2024 UTC, Wed Jan 01 00:00:00 2025 UTC ] internal [ 1727740800000000, 1735689600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  refreshing continuous aggregate "sparse_cagg_bp3" from Thu Feb 01 00:00:00 2024 UTC to Wed May 01 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730505600000000 1714521600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_bp3" in window [ Thu Feb 01 00:00:00 2024 UTC, Wed May 01 00:00:00 2024 UTC ] (batch 1 of 3)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_10"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_10"
+DEBUG:  hypertable 10 existing watermark >= new watermark 1719792000000000 1719792000000000
+DEBUG:  refreshing continuous aggregate "sparse_cagg_bp3" from Wed May 01 00:00:00 2024 UTC to Thu Aug 01 00:00:00 2024 UTC
+DEBUG:  hypertable 7 existing watermark >= new invalidation threshold 1730505600000000 1722470400000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_bp3" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] (batch 2 of 3)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_10"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_10"
+DEBUG:  hypertable 10 existing watermark >= new watermark 1719792000000000 1719792000000000
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_bp3" in window [ Mon Jul 01 00:00:00 2024 UTC, Thu Aug 01 00:00:00 2024 UTC ] (batch 2 of 3)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_10"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_10"
+DEBUG:  refreshing continuous aggregate "sparse_cagg_bp3" from Tue Oct 01 00:00:00 2024 UTC to Wed Jan 01 00:00:00 2025 UTC
+LOG:  continuous aggregate refresh (individual invalidation) on "sparse_cagg_bp3" in window [ Tue Oct 01 00:00:00 2024 UTC, Wed Jan 01 00:00:00 2025 UTC ] (batch 3 of 3)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_10"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_10"
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+------------------------------------------------------------------------------------------
+-- Test correct null-offset handling for BOTH start_offset=NULL and end_offset=NULL.
+--
+-- start_offset=NULL: window start capped to cagg_current_bucket_start(Feb 22) = Feb 1.
+--   Feb 1 is already a bucket boundary -> inscribing is a no-op.
+--   -> Feb bucket [Feb 1, Mar 1) gets its own dedicated batch.
+--
+-- end_offset=NULL: window end capped to cagg_next_bucket_start(Oct 29 - 1) = Nov 1.
+--   Nov 1 is already a bucket boundary -> inscribing is a no-op.
+--   -> Oct chunk [Oct 4, Oct 29) has range_start=Oct 4 < Nov 1, so it IS
+--      included in the dimension-slice scan; Oct gets a dedicated batch.
+--
+-- Inval log after refreshing June:
+--   left  [-inf,     May 31 23:59:59.999999]
+--   right [Jul 1,   +inf]
+--
+-- Merge scan over window [Feb 1, Nov 1):
+--   Feb: batch generated  (chunk [Feb 22, Mar 18) overlaps Feb bucket, left-residual inval)
+--   Mar: batch generated  (same chunk, left-residual inval covers Mar 15)
+--   Apr: SKIPPED          (chunk gap)
+--   May: batch generated  (chunk [May 7, Jun 1), left-residual inval)
+--   Jun: SKIPPED          (invalidation gap -- June already refreshed)
+--   Jul-Sep: SKIPPED      (chunk gap)
+--   Oct: batch generated  (chunk [Oct 4, Oct 29), right-residual inval [Jul 1, +inf))
+--
+-- Null-restoration (list_length=4 >= 2):
+--   first batch (Feb) start_isnull -> [-inf, Mar 1)   inserts 1 row: Feb 25
+--   last  batch (Oct) end_isnull   -> [Oct 1, +inf)   inserts 1 row: Oct 15
+-- Final batches: [-inf, Mar 1),  [Mar 1, Apr 1),  [May 1, Jun 1),  [Oct 1, +inf).
+------------------------------------------------------------------------------------------
+CREATE TABLE end_null_data (
+    time TIMESTAMPTZ NOT NULL,
+    value INT
+);
+SELECT FROM create_hypertable('end_null_data', by_range('time', INTERVAL '25 days'));
+--
+
+-- Same chunk layout as sparse_data, with an extra Feb 25 row (bucket Feb 1) to show
+-- that the Feb bucket gets its own dedicated first batch: null-restored to [-inf, Mar 1),
+-- inserting Feb 25 separately from the Mar 15 row in the following [Mar 1, Apr 1) batch.
+INSERT INTO end_null_data VALUES
+    ('2024-02-25 00:00:00+00', 2),   -- lands in chunk [Feb 22, Mar 18), bucket Feb 1
+    ('2024-03-15 00:00:00+00', 3),   -- lands in chunk [Feb 22, Mar 18), bucket Mar 1
+    ('2024-05-15 00:00:00+00', 5),   -- lands in chunk [May  7, Jun  1)
+    ('2024-06-10 00:00:00+00', 6),   -- lands in chunk [Jun  1, Jun 26)
+    ('2024-10-15 00:00:00+00', 10);  -- lands in chunk [Oct  4, Oct 29)
+CREATE MATERIALIZED VIEW end_null_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 month'::interval, time) AS bucket, count(*) AS cnt
+FROM end_null_data
+GROUP BY bucket
+WITH NO DATA;
+-- Consume June's invalidation to create an inval gap over June.
+CALL refresh_continuous_aggregate('end_null_cagg',
+    '2024-06-01'::timestamptz, '2024-07-01'::timestamptz);
+-- Validate invalidation log: two residuals with a gap over June.
+SELECT
+    _timescaledb_functions.to_timestamp(lowest_modified_value)   AS lowest,
+    _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'end_null_cagg'
+)
+ORDER BY lowest_modified_value;
+            lowest            |              greatest               
+------------------------------+-------------------------------------
+ -infinity                    | Fri May 31 23:59:59.999999 2024 UTC
+ Mon Jul 01 00:00:00 2024 UTC | infinity
+
+SELECT add_continuous_aggregate_policy('end_null_cagg',
+    start_offset => NULL,
+    end_offset => NULL,
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1,
+    refresh_newest_first => false
+) AS end_null_job_id \gset
+-- Four batches expected: [-inf, Mar 1), [Mar 1, Apr 1), [May 1, Jun 1), [Oct 1, +inf).
+-- Feb batch is the null-restored first batch (1 row: Feb 25).
+-- Oct batch is the null-restored last batch (1 row: Oct 15); Oct chunk now included
+-- because effective window end is Nov 1 (not Oct 1 as under the old inscribing bug).
+SET client_min_messages TO DEBUG1;
+CALL run_job(:end_null_job_id);
+LOG:  statement: CALL run_job(1010);
+DEBUG:  Executing policy_refresh_continuous_aggregate with parameters {"end_offset": null, "start_offset": null, "buckets_per_batch": 1, "mat_hypertable_id": 12, "refresh_newest_first": false}
+DEBUG:  begin "end_null_cagg" in window [ -infinity, infinity ] internal [ -9223372036854775808, 9223372036854775807 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  START IS NULL "end_null_cagg" in window [ -infinity, infinity ] internal [ -9223372036854775808, 9223372036854775807 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  END IS NULL "end_null_cagg" in window [ Thu Feb 01 00:00:00 2024 UTC, infinity ] internal [ 1706745600000000, 9223372036854775807 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  before produce batches "end_null_cagg" in window [ Thu Feb 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] internal [ 1706745600000000, 1730419200000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "end_null_cagg" in window [ Thu Feb 01 00:00:00 2024 UTC, Fri Mar 01 00:00:00 2024 UTC ] internal [ 1706745600000000, 1709251200000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "end_null_cagg" in window [ Fri Mar 01 00:00:00 2024 UTC, Mon Apr 01 00:00:00 2024 UTC ] internal [ 1709251200000000, 1711929600000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "end_null_cagg" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] internal [ 1714521600000000, 1717200000000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  batch produced "end_null_cagg" in window [ Tue Oct 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] internal [ 1727740800000000, 1730419200000000 ] minimum [ Wed Nov 24 00:00:00 4684 UTC BC ]
+DEBUG:  refreshing continuous aggregate "end_null_cagg" from -infinity to Fri Mar 01 00:00:00 2024 UTC
+DEBUG:  hypertable 11 existing watermark >= new invalidation threshold 1719792000000000 1709251200000000
+LOG:  continuous aggregate refresh (individual invalidation) on "end_null_cagg" in window [ -infinity, Fri Mar 01 00:00:00 2024 UTC ] (batch 1 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_12"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_12"
+DEBUG:  hypertable 12 existing watermark >= new watermark 1719792000000000 1719792000000000
+DEBUG:  refreshing continuous aggregate "end_null_cagg" from Fri Mar 01 00:00:00 2024 UTC to Mon Apr 01 00:00:00 2024 UTC
+DEBUG:  hypertable 11 existing watermark >= new invalidation threshold 1719792000000000 1711929600000000
+LOG:  continuous aggregate refresh (individual invalidation) on "end_null_cagg" in window [ Fri Mar 01 00:00:00 2024 UTC, Mon Apr 01 00:00:00 2024 UTC ] (batch 2 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_12"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_12"
+DEBUG:  hypertable 12 existing watermark >= new watermark 1719792000000000 1719792000000000
+DEBUG:  refreshing continuous aggregate "end_null_cagg" from Wed May 01 00:00:00 2024 UTC to Sat Jun 01 00:00:00 2024 UTC
+DEBUG:  hypertable 11 existing watermark >= new invalidation threshold 1719792000000000 1717200000000000
+LOG:  continuous aggregate refresh (individual invalidation) on "end_null_cagg" in window [ Wed May 01 00:00:00 2024 UTC, Sat Jun 01 00:00:00 2024 UTC ] (batch 3 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_12"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_12"
+DEBUG:  hypertable 12 existing watermark >= new watermark 1719792000000000 1719792000000000
+DEBUG:  refreshing continuous aggregate "end_null_cagg" from Tue Oct 01 00:00:00 2024 UTC to infinity
+LOG:  continuous aggregate refresh (individual invalidation) on "end_null_cagg" in window [ Tue Oct 01 00:00:00 2024 UTC, Fri Nov 01 00:00:00 2024 UTC ] (batch 4 of 4)
+LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_12"
+LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_12"
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+DROP TABLE end_null_data CASCADE;
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_106_chunk
+DROP TABLE sparse_data CASCADE;
+NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_98_chunk
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_101_chunk
+RESET timezone;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REASSIGN OWNED BY test_cagg_refresh_policy_user TO :ROLE_SUPERUSER;
 REVOKE ALL ON SCHEMA public FROM test_cagg_refresh_policy_user;

--- a/tsl/test/expected/cagg_uuid.out
+++ b/tsl/test/expected/cagg_uuid.out
@@ -240,7 +240,6 @@ VALUES
 SELECT add_continuous_aggregate_policy('daily_uuid_events', start_offset => NULL, end_offset => NULL, schedule_interval => '1 minute') AS job_id \gset
 CALL run_job(:job_id);
 WARNING:  disabling direct compress because of too small batch size
-WARNING:  disabling direct compress because of too small batch size
 CALL refresh_continuous_aggregate('weekly_uuid_events', NULL, NULL);
 CALL refresh_continuous_aggregate('daily_ts_events', NULL, NULL);
 CALL refresh_continuous_aggregate('weekly_ts_events', NULL, NULL);

--- a/tsl/test/sql/cagg_policy_incremental.sql
+++ b/tsl/test/sql/cagg_policy_incremental.sql
@@ -199,7 +199,7 @@ FROM
 -- advance time by 3h so that job runs one more time
 SELECT ts_bgw_params_reset_time(extract(epoch from interval '3 hour')::bigint * 1000000, true);
 
--- Should process all four batches in the past
+-- Should process all three batches in the past
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_ranges;
@@ -495,10 +495,7 @@ WHERE materialization_id IN
 ORDER BY low;
 
 --verify that there is no duplicate/overlapping refreshes.
---Note that batch 1 and batch 12 contains 2 buckets instead of 1 bucket as set in the policy.
---This is due to the fact that we currently cut a batch of 30 days for monthly cagg,
---so first batch and batch containing February can have 2 buckets. After we have a cleaner solution to
---cut an exact batch size for variable-length buckets, this should be fixed.
+--Each batch should cover exactly 1 month (buckets_per_batch=1).
 
 SELECT * FROM sorted_bgw_log;
 
@@ -577,6 +574,307 @@ FROM
     ((SELECT * FROM conditions_by_day_manual_refresh ORDER BY 1, 2)
     EXCEPT
     (SELECT * FROM conditions_by_day ORDER BY 1, 2)) AS diff;
+
+------------------------------------------------------------------------------------------
+-- Test variable-width bucket batching: demonstrates chunk gap skip and invalidation
+-- gap skip with non-null start/end offsets (no null-restoration).
+-- chunk_time_interval=25 days is intentionally not aligned with monthly buckets.
+--
+-- Chunk boundaries are fixed 25-day windows anchored to the Unix epoch
+-- (Jan 1 1970), so they fall at arbitrary calendar dates. The four data points land in:
+--   Mar 15 -> chunk [Feb 22, Mar 18): spans Feb and Mar bucket boundaries
+--   May 15 -> chunk [May  7, Jun  1): entirely within May
+--   Jun 10 -> chunk [Jun  1, Jun 26): entirely within June
+--   Oct 15 -> chunk [Oct  4, Oct 29): entirely within October
+--
+-- June is explicitly refreshed before the policy runs, consuming its invalidation.
+-- The sentinel [-inf, +inf] is cut into two residuals in mat_inval_log:
+--   left  [-inf,     May 31 23:59:59.999999]  (covers Mar and May)
+--   right [Jul 1,   +inf]                      (covers Oct and later)
+-- -> gap from Jun 1 to Jun 30 means June has no pending invalidation.
+--
+-- Expected batch behaviour (refresh_newest_first=false, buckets_per_batch=1,
+-- start_offset='10 years', end_offset='1 month'):
+--   Feb: batch [Feb 1, Mar 1) -- EMPTY: the Feb 22 chunk touches the Feb bucket but
+--        no data falls in February; illustrates a chunk intersecting a bucket boundary
+--   Mar: batch generated  (Mar chunk overlaps Mar bucket + left-residual inval)
+--   Apr: SKIPPED          (chunk gap: no chunks in April)
+--   May: batch generated  (May chunk + left-residual inval)
+--   Jun: SKIPPED          (invalidation gap: inval was consumed by explicit refresh)
+--   Jul-Sep: SKIPPED      (chunk gap)
+--   Oct: batch generated  (Oct chunk + right-residual inval)
+-- No null-restoration: start_offset and end_offset are both non-null.
+-- Final batches: [Feb 1, Mar 1),  [Mar 1, Apr 1),  [May 1, Jun 1),  [Oct 1, Nov 1).
+------------------------------------------------------------------------------------------
+-- Monthly bucket boundaries are at midnight UTC; set timezone to avoid PST-shift issues.
+SET timezone = 'UTC';
+CREATE TABLE sparse_data (
+    time TIMESTAMPTZ NOT NULL,
+    value INT
+);
+SELECT FROM create_hypertable('sparse_data', by_range('time', INTERVAL '25 days'));
+
+INSERT INTO sparse_data VALUES
+    ('2024-03-15 00:00:00+00', 3),   -- lands in chunk [Feb 22, Mar 18)
+    ('2024-05-15 00:00:00+00', 5),   -- lands in chunk [May  7, Jun  1)
+    ('2024-06-10 00:00:00+00', 6),   -- lands in chunk [Jun  1, Jun 26)
+    ('2024-10-15 00:00:00+00', 10);  -- lands in chunk [Oct  4, Oct 29)
+
+CREATE MATERIALIZED VIEW sparse_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 month'::interval, time) AS bucket, count(*) AS cnt
+FROM sparse_data
+GROUP BY bucket
+WITH NO DATA;
+
+-- Consume June's invalidation so the June bucket has no pending invalidation.
+CALL refresh_continuous_aggregate('sparse_cagg',
+    '2024-06-01'::timestamptz, '2024-07-01'::timestamptz);
+
+-- Validate dimension slices: four chunks showing the epoch-aligned boundaries.
+SELECT
+    _timescaledb_functions.to_timestamp(ds.range_start) AS range_start,
+    _timescaledb_functions.to_timestamp(ds.range_end)   AS range_end
+FROM _timescaledb_catalog.dimension_slice ds
+JOIN _timescaledb_catalog.dimension d ON d.id = ds.dimension_id
+JOIN _timescaledb_catalog.hypertable h ON h.id = d.hypertable_id
+WHERE h.table_name = 'sparse_data'
+ORDER BY ds.range_start;
+
+-- Validate invalidation log: two residuals with a gap over June.
+SELECT
+    _timescaledb_functions.to_timestamp(lowest_modified_value)   AS lowest,
+    _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'sparse_cagg'
+)
+ORDER BY lowest_modified_value;
+
+SELECT add_continuous_aggregate_policy('sparse_cagg',
+    start_offset => INTERVAL '10 years',
+    end_offset => INTERVAL '1 month',
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1,
+    refresh_newest_first => false
+) AS sparse_job_id \gset
+
+-- Four batches expected: [Feb 1, Mar 1) empty, [Mar 1, Apr 1), [May 1, Jun 1), [Oct 1, Nov 1).
+-- Apr/Jul/Aug/Sep skipped (chunk gap), Jun skipped (invalidation gap).
+SET client_min_messages TO DEBUG1;
+CALL run_job(:sparse_job_id);
+RESET client_min_messages;
+
+------------------------------------------------------------------------------------------
+-- Similar test using a fixed 10-day bucket CAgg on the same sparse_data table.
+-- time_bucket('10 days', ...) uses Jan 3 2000 as origin. Relevant 2024 boundaries:
+--   Feb 16, Feb 26, Mar 7, Mar 17, Mar 27, ..., May 6, May 16, May 26,
+--   Jun 5, Jun 15, Jun 25, Jul 5, ..., Oct 3, Oct 13, Oct 23, Nov 2, ...
+--
+-- Refresh [Jun 5, Jun 25) consumes two 10-day June buckets, leaving:
+--   left  [-inf,     Jun  4 23:59:59.999999]
+--   right [Jun 25,  +inf]
+--
+-- start_offset='10 years': window start is far in the past; jump logic advances
+-- directly to cagg_current_bucket_start(Feb 22) = Feb 16, the bucket containing
+-- the earliest chunk. No null-restoration (start_offset non-null).
+-- Gaps are skipped by jumping to cagg_current_bucket_start(jump_target), the same
+-- as for variable-width buckets. The chunk starts May 7 and Oct 4 fall mid-bucket:
+--   cagg_current_bucket_start(May 7) = May 6  (bucket [May  6, May 16))
+--   cagg_current_bucket_start(Oct 4) = Oct 3  (bucket [Oct  3, Oct 13))
+-- so those batches start one day before the corresponding chunk.
+--
+-- Expected batches (buckets_per_batch=1, refresh_newest_first=false):
+--   Feb: [Feb 16, Feb 26)  EMPTY (no Feb data; illustrates chunk spanning bucket boundary)
+--   Mar (3 buckets): [Feb 26, Mar 7), [Mar 7, Mar 17), [Mar 17, Mar 27)
+--   Apr: SKIPPED  (chunk gap: no chunks in April)
+--   May (3 buckets): [May 6, May 16), [May 16, May 26), [May 26, Jun 5)
+--                    May 6 = bucket start of May 7 (first chunk boundary)
+--   Jun 5-Jun 25: SKIPPED  (invalidation gap: consumed by explicit refresh)
+--   Jun 25: batch [Jun 25, Jul 5)  (last Jun chunk + right residual)
+--   Jul-Sep: SKIPPED  (chunk gap)
+--   Oct (3 buckets): [Oct 3, Oct 13), [Oct 13, Oct 23), [Oct 23, Nov 2)
+--                    Oct 3 = bucket start of Oct 4 (first chunk boundary)
+------------------------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW sparse_cagg_fixed
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('10 days'::interval, time) AS bucket, count(*) AS cnt
+FROM sparse_data
+GROUP BY bucket
+WITH NO DATA;
+
+-- Consume [Jun 5, Jun 25) to create an invalidation gap for those two June buckets.
+CALL refresh_continuous_aggregate('sparse_cagg_fixed',
+    '2024-06-05'::timestamptz, '2024-06-25'::timestamptz);
+
+-- Validate invalidation log: two residuals with a gap over [Jun 5, Jun 25).
+SELECT
+    _timescaledb_functions.to_timestamp(lowest_modified_value)   AS lowest,
+    _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'sparse_cagg_fixed'
+)
+ORDER BY lowest_modified_value;
+
+SELECT add_continuous_aggregate_policy('sparse_cagg_fixed',
+    start_offset => INTERVAL '10 years',
+    end_offset => INTERVAL '1 month',
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1,
+    refresh_newest_first => false
+) AS fixed_job_id \gset
+
+-- Eleven batches expected: 1 empty in Feb, 3 in Mar, 3 in May, 1 at Jun 25, 3 in Oct.
+SET client_min_messages TO DEBUG1;
+CALL run_job(:fixed_job_id);
+RESET client_min_messages;
+
+------------------------------------------------------------------------------------------
+-- Same sparse_data as above but with buckets_per_batch=3 to show how the algorithm
+-- groups consecutive buckets and absorbs inval gaps into batch windows.
+--
+-- Pre-refresh [Jun 1, Jul 1) creates the same residuals as for sparse_cagg:
+--   left  [-inf,     May 31 23:59:59.999999]
+--   right [Jul  1,  +inf]
+--
+-- With buckets_per_batch=3 the algorithm advances exactly 3 bucket widths per batch
+-- from the starting position; gaps within a batch window are not spliced out.
+--
+-- Batch analysis (oldest-first):
+--   1. jump to Feb 1 (cagg_current_bucket_start of first chunk Feb 22),
+--      emit 3 months: [Feb 1, May 1)
+--        Feb: empty (no data in Feb bucket -- chunk [Feb 22, Mar 18) has only Mar data)
+--        Mar: 1 row (Mar 15)
+--        Apr: chunk gap (absorbed into batch, nothing materialized)
+--   2. cur = May 1; cagg_current_bucket_start(May 7) = May 1 = cur, no jump;
+--      emit 3 months: [May 1, Aug 1)
+--      The batch window intersects two invalidation ranges, so two sub-refreshes run:
+--        [May 1, Jun 1): 1 row (May 15), from left residual [-inf, May 31]
+--        [Jun 1, Jul 1): SKIPPED -- no invalidation covers Jun (consumed by pre-refresh);
+--                                   the Jun row from pre-refresh is preserved unchanged
+--        [Jul 1, Aug 1): 0 rows, from right residual [Jul 1, +inf); no chunk data in Jul
+--   3. cur = Aug 1; jump: Max(Oct 4, Jul 1) -> cagg_current_bucket_start(Oct 4) = Oct 1;
+--      emit 3 months: [Oct 1, Jan 1 2025)
+--        Oct: 1 row (Oct 15); Nov-Dec: chunk gaps (absorbed into batch)
+--
+-- Three batches produced (vs four with buckets_per_batch=1).
+------------------------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW sparse_cagg_bp3
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 month'::interval, time) AS bucket, count(*) AS cnt
+FROM sparse_data
+GROUP BY bucket
+WITH NO DATA;
+
+-- Pre-refresh June to consume June's invalidation, creating the same inval gap.
+CALL refresh_continuous_aggregate('sparse_cagg_bp3',
+    '2024-06-01'::timestamptz, '2024-07-01'::timestamptz);
+
+SELECT add_continuous_aggregate_policy('sparse_cagg_bp3',
+    start_offset => INTERVAL '10 years',
+    end_offset => INTERVAL '1 month',
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 3,
+    refresh_newest_first => false
+) AS sparse_bp3_job_id \gset
+
+-- Three batches: [Feb 1, May 1), [May 1, Aug 1), [Oct 1, Jan 1 2025).
+-- Apr/Jul gaps and the Jun inval gap are absorbed inside batch windows.
+SET client_min_messages TO DEBUG1;
+CALL run_job(:sparse_bp3_job_id);
+RESET client_min_messages;
+
+------------------------------------------------------------------------------------------
+-- Test correct null-offset handling for BOTH start_offset=NULL and end_offset=NULL.
+--
+-- start_offset=NULL: window start capped to cagg_current_bucket_start(Feb 22) = Feb 1.
+--   Feb 1 is already a bucket boundary -> inscribing is a no-op.
+--   -> Feb bucket [Feb 1, Mar 1) gets its own dedicated batch.
+--
+-- end_offset=NULL: window end capped to cagg_next_bucket_start(Oct 29 - 1) = Nov 1.
+--   Nov 1 is already a bucket boundary -> inscribing is a no-op.
+--   -> Oct chunk [Oct 4, Oct 29) has range_start=Oct 4 < Nov 1, so it IS
+--      included in the dimension-slice scan; Oct gets a dedicated batch.
+--
+-- Inval log after refreshing June:
+--   left  [-inf,     May 31 23:59:59.999999]
+--   right [Jul 1,   +inf]
+--
+-- Merge scan over window [Feb 1, Nov 1):
+--   Feb: batch generated  (chunk [Feb 22, Mar 18) overlaps Feb bucket, left-residual inval)
+--   Mar: batch generated  (same chunk, left-residual inval covers Mar 15)
+--   Apr: SKIPPED          (chunk gap)
+--   May: batch generated  (chunk [May 7, Jun 1), left-residual inval)
+--   Jun: SKIPPED          (invalidation gap -- June already refreshed)
+--   Jul-Sep: SKIPPED      (chunk gap)
+--   Oct: batch generated  (chunk [Oct 4, Oct 29), right-residual inval [Jul 1, +inf))
+--
+-- Null-restoration (list_length=4 >= 2):
+--   first batch (Feb) start_isnull -> [-inf, Mar 1)   inserts 1 row: Feb 25
+--   last  batch (Oct) end_isnull   -> [Oct 1, +inf)   inserts 1 row: Oct 15
+-- Final batches: [-inf, Mar 1),  [Mar 1, Apr 1),  [May 1, Jun 1),  [Oct 1, +inf).
+------------------------------------------------------------------------------------------
+CREATE TABLE end_null_data (
+    time TIMESTAMPTZ NOT NULL,
+    value INT
+);
+SELECT FROM create_hypertable('end_null_data', by_range('time', INTERVAL '25 days'));
+
+-- Same chunk layout as sparse_data, with an extra Feb 25 row (bucket Feb 1) to show
+-- that the Feb bucket gets its own dedicated first batch: null-restored to [-inf, Mar 1),
+-- inserting Feb 25 separately from the Mar 15 row in the following [Mar 1, Apr 1) batch.
+INSERT INTO end_null_data VALUES
+    ('2024-02-25 00:00:00+00', 2),   -- lands in chunk [Feb 22, Mar 18), bucket Feb 1
+    ('2024-03-15 00:00:00+00', 3),   -- lands in chunk [Feb 22, Mar 18), bucket Mar 1
+    ('2024-05-15 00:00:00+00', 5),   -- lands in chunk [May  7, Jun  1)
+    ('2024-06-10 00:00:00+00', 6),   -- lands in chunk [Jun  1, Jun 26)
+    ('2024-10-15 00:00:00+00', 10);  -- lands in chunk [Oct  4, Oct 29)
+
+CREATE MATERIALIZED VIEW end_null_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('1 month'::interval, time) AS bucket, count(*) AS cnt
+FROM end_null_data
+GROUP BY bucket
+WITH NO DATA;
+
+-- Consume June's invalidation to create an inval gap over June.
+CALL refresh_continuous_aggregate('end_null_cagg',
+    '2024-06-01'::timestamptz, '2024-07-01'::timestamptz);
+
+-- Validate invalidation log: two residuals with a gap over June.
+SELECT
+    _timescaledb_functions.to_timestamp(lowest_modified_value)   AS lowest,
+    _timescaledb_functions.to_timestamp(greatest_modified_value) AS greatest
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE materialization_id = (
+    SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'end_null_cagg'
+)
+ORDER BY lowest_modified_value;
+
+SELECT add_continuous_aggregate_policy('end_null_cagg',
+    start_offset => NULL,
+    end_offset => NULL,
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1,
+    refresh_newest_first => false
+) AS end_null_job_id \gset
+
+-- Four batches expected: [-inf, Mar 1), [Mar 1, Apr 1), [May 1, Jun 1), [Oct 1, +inf).
+-- Feb batch is the null-restored first batch (1 row: Feb 25).
+-- Oct batch is the null-restored last batch (1 row: Oct 15); Oct chunk now included
+-- because effective window end is Nov 1 (not Oct 1 as under the old inscribing bug).
+SET client_min_messages TO DEBUG1;
+CALL run_job(:end_null_job_id);
+RESET client_min_messages;
+
+DROP TABLE end_null_data CASCADE;
+
+DROP TABLE sparse_data CASCADE;
+RESET timezone;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REASSIGN OWNED BY test_cagg_refresh_policy_user TO :ROLE_SUPERUSER;


### PR DESCRIPTION
Fix batch cutting for incremental refresh
    
Currently, incremental refresh uses 30days as the length
for the monthly bucket, which results in batches misaligned with
bucket boundary. Circumscription extends the batch to match
bucket boundary to ensure correctness, but leads to overlapping
between adjacent batches.

This patch fixes the batch cutting to use the exact number of days
in a calendar month.

The patch also makes the following modifications:
-  Generated batches will start right at the latest bucket that overlaps
   both a chunk and invalidations. Before, we generated batches first
   and picked those with overlapping, resulting in batches that started
   earlier than needed. For example, if invalidations is (-inf , +inf)
   and chunks are [10,30) , [50,70). With refresh windows [0,90),
   bucket = 10, and bucket_per_batch = 2, previously we would enumerate
   batches of [0,20), [20,40], [40,60), [60,80), [80,100), then select
   batches [0,20), [20,40), [40,60), [60,80) because these overlap with
   chunk slices and invalidations. With the new logic, we skip forward
   to the next max(dimension slice, invalidations), so we only generate
   batches [10,30) and [50,70). This explains some test diffs on existing
   tests, because we will have fewer batches in some cases.

- Bug fix: Previously, when the refresh window had null start/end, we
  capped it using the min/max dimension slice, then inscribed the
  window. So if the chunk boundary is not at the bucket boundary, we
  will generate batches based on a window range that is smaller than
  the original window. We restored null at the end so it's still correct
  with respect to the data range being refreshed, but the batches at
  the two ends could be a bucket bigger. Fix by capping to the start/end
  of the bucket that contains the boundary.
