### PR TITLE
Remove refresh policy check when adding columnstore policy

### DIFF
--- a/.unreleased/pr_9895
+++ b/.unreleased/pr_9895
@@ -1,0 +1,1 @@
+Fixes: #9895 Remove refresh policy check when adding columnstore policy

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -553,7 +553,6 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 	{
 		/*check if this is a cont aggregate view */
 		int32 mat_id;
-		bool found;
 
 		ContinuousAgg *cagg = ts_continuous_agg_find_by_relid(user_htoid);
 
@@ -578,17 +577,6 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 		mat_id = cagg->data.mat_hypertable_id;
 		ht = ts_hypertable_get_by_id(mat_id);
 
-		found = policy_refresh_cagg_exists(mat_id);
-		if (!found)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("continuous aggregate policy does not exist for \"%s\"",
-							get_rel_name(user_htoid)),
-					 errmsg("setup a refresh policy for \"%s\" before setting up a columnstore "
-							"policy",
-							get_rel_name(user_htoid))));
-		}
 		if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		{
 			ereport(ERROR,

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -1113,12 +1113,8 @@ SELECT remove_continuous_aggregate_policy('metrics_cagg');
 ------------------------------------
  
 
---can set compression policy only after setting up refresh policy --
+--can set columnstore policy only after enabling columnstore --
 SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
-ERROR:  setup a refresh policy for "metrics_cagg" before setting up a columnstore policy
---can set compression policy only after enabling compression --
-SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
-SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
 ERROR:  columnstore not enabled on continuous aggregate "metrics_cagg"
 ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
 NOTICE:  defaulting compress_orderby to dayb,device_id
@@ -1126,16 +1122,14 @@ NOTICE:  defaulting compress_orderby to dayb,device_id
 SELECT add_compression_policy('metrics_cagg', compress_created_before => '8 day'::interval) AS "COMP_JOB" ;
 ERROR:  cannot use "compress_created_before" with continuous aggregate "metrics_cagg" 
 \set ON_ERROR_STOP 1
-SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
- COMP_JOB 
-----------
-     1061
-
+--can set columnstore policy without setting up a refresh policy --
+CALL add_columnstore_policy('metrics_cagg', after => '8 day'::interval);
 SELECT remove_compression_policy('metrics_cagg');
  remove_compression_policy 
 ---------------------------
  t
 
+SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" \gset
 --verify that jobs were added for the policies ---
 SELECT materialization_hypertable_name AS "MAT_TABLE_NAME",

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -567,21 +567,18 @@ SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, '1 day'::interval, 
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, '1 day'::interval, '1h'::interval, if_not_exists=>true); -- same param values, so we get a NOTICE
 SELECT add_continuous_aggregate_policy('metrics_cagg', NULL, NULL, '1h'::interval, if_not_exists=>true); -- different values, so we get a WARNING
 SELECT remove_continuous_aggregate_policy('metrics_cagg');
---can set compression policy only after setting up refresh policy --
+--can set columnstore policy only after enabling columnstore --
 SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
-
---can set compression policy only after enabling compression --
-SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
-SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
 ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
 
 --cannot use compress_created_before with cagg
 SELECT add_compression_policy('metrics_cagg', compress_created_before => '8 day'::interval) AS "COMP_JOB" ;
 \set ON_ERROR_STOP 1
 
-
-SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ;
+--can set columnstore policy without setting up a refresh policy --
+CALL add_columnstore_policy('metrics_cagg', after => '8 day'::interval);
 SELECT remove_compression_policy('metrics_cagg');
+SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" \gset
 
 --verify that jobs were added for the policies ---
@@ -746,4 +743,3 @@ CREATE TABLE m(time timestamptz) WITH (tsdb.hypertable);
 CREATE MATERIALIZED VIEW cagg_error WITH (tsdb.continuous)
 AS SELECT time_bucket('1 day', time) FROM m GROUP BY 1;
 SELECT timescaledb_experimental.add_policies('cagg_error', drop_after => '20 days');
-


### PR DESCRIPTION
We no longer need to add a refresh policy before adding a columnstore policy (since compressed chunks support mutations), so we can get rid of the check we currently have. This also allows users to run custom refresh policies or handle refreshes manually, while still being able to use columnstore.

* Closes https://github.com/timescale/timescaledb/issues/9894