### PR TITLE
Build dev .deb artifacts on each push

### DIFF
--- a/.github/workflows/build-deb-artifacts.yaml
+++ b/.github/workflows/build-deb-artifacts.yaml
@@ -1,0 +1,78 @@
+name: "Build .deb artifacts (dev)"
+
+"on":
+  push:
+    branches: [main]
+
+# Avoid stacking dispatches when commits land in quick succession.
+# Note: this cancels pending dispatches, not the builds themselves on the
+# release-build-scripts side. Each dispatch that does fire builds to its own
+# SHA-keyed S3 prefix, so there's no artifact conflict either way.
+concurrency:
+  group: dev-deb-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch .deb build
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+      WORKFLOW_REPO: timescale/release-build-scripts
+      WORKFLOW_FILE: timescaledb-apt.yml
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Compute build inputs
+        id: compute
+        run: |
+          set -euo pipefail
+          BASE=$(grep '^version = ' version.config | sed 's!^version = !!')
+          if [ -z "$BASE" ]; then
+            echo "::error::Could not extract version from version.config"
+            exit 1
+          fi
+          SHORT="${GITHUB_SHA:0:8}"
+          # ~ sorts before any character in Debian version comparison, so this
+          # always orders before any GA release of the same base version.
+          DEV_VERSION="${BASE}~dev.g${SHORT}"
+          # Replace / in branch names (e.g. users/brent/foo) for S3-friendly keys
+          BRANCH_KEY="${GITHUB_REF_NAME//\//_}"
+          echo "version=${DEV_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short-sha=${SHORT}" >> "$GITHUB_OUTPUT"
+          echo "branch-key=${BRANCH_KEY}" >> "$GITHUB_OUTPUT"
+          echo "Building version: ${DEV_VERSION} from sha ${GITHUB_SHA}"
+
+      - name: Dispatch build
+        env:
+          VERSION: ${{ steps.compute.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run "${WORKFLOW_FILE}" \
+            -R "${WORKFLOW_REPO}" \
+            -f version="${VERSION}" \
+            -f commit="${GITHUB_SHA}" \
+            -f skip-dev-guards=true \
+            -f matrix-mode=slim \
+            -f upload-mode=s3 \
+            -f s3-bucket=timescaledb-build-artifacts \
+            -f s3-prefix="builds/${GITHUB_SHA}" \
+            -f aws-role-arn="${{ secrets.TIMESCALEDB_CI_S3_WRITER }}"
+
+      - name: Summary
+        if: always()
+        env:
+          VERSION: ${{ steps.compute.outputs.version }}
+        run: |
+          {
+            echo "## Dispatched dev .deb build"
+            echo ""
+            echo "**Version:** \`${VERSION}\`"
+            echo "**Build workflow:** https://github.com/${WORKFLOW_REPO}/actions/workflows/${WORKFLOW_FILE}"
+            echo "**S3 prefix (after build completes):** \`s3://timescaledb-build-artifacts/builds/${GITHUB_SHA}/\`"
+            echo "**Public URL prefix:** https://timescaledb-build-artifacts.s3.amazonaws.com/builds/${GITHUB_SHA}/"
+            echo "**Manifest URL (after build completes):** https://timescaledb-build-artifacts.s3.amazonaws.com/manifests/${GITHUB_SHA}.json"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a workflow that builds .deb artifacts on every push to `main` and uploads them to a public S3 bucket. Enables downstream cloud testing to pull per-push .debs and exercise them against PostgreSQL.

## Mechanics

- Triggers on `push` to `main` only (initial rollout — feature-branch triggering can be added later).
- Computes a Debian-style dev version: `<version.config>~dev.g<short-sha>` (e.g. `2.28.0-dev~dev.gabc12345`). The `~` sorts before any character per Debian conventions, so dev versions always order before any GA release of the same base version.
- Dispatches `timescale/release-build-scripts/.github/workflows/timescaledb-apt.yml` via `gh workflow run` with `ORG_AUTOMATION_TOKEN` — same fire-and-forget pattern used by `release_build_packages.yml`.
- Slim matrix: ubuntu 22.04 + 24.04 × amd64 + arm64 × PG 15.18/16.14/17.10/18.4, TSL only = 16 jobs.
- Concurrency group dedupes rapid dispatches.

## S3 layout

Artifacts land at:
```
s3://timescaledb-build-artifacts/main/<sha>/<distro>-<ver>-<arch>-pg<ver>/<name>.deb
```

Bucket is public-read with a 90-day lifecycle (object expiration). Consumers can `curl + dpkg -i`:
```bash
curl -O https://timescaledb-build-artifacts.s3.amazonaws.com/main/<sha>/<prefix>/timescaledb-2-postgresql-17_<version>_amd64.deb
dpkg -i timescaledb-2-postgresql-17_<version>_amd64.deb
```
