### PR TITLE
Drop chunk-side foreign keys via event trigger

### DIFF
--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -110,35 +110,7 @@ run_sql_file test/sql/updates/post.${TEST_VERSION}.sql updated > "${OUTPUT_DIR}/
 run_sql_file test/sql/updates/post.${TEST_VERSION}.sql restored > "${OUTPUT_DIR}/post.restored.log"
 
 sed -i -E -e 's!"*_ts_meta_v2_bl[0-9A-Za-z]+_([_0-9A-Za-z]+)"*!regress-test-bloom_\1!g' \
-    -e 's!(_timescaledb_internal\._hyper_[0-9]+_[0-9]+_chunk" CONSTRAINT ")[0-9]+_[0-9]+_!\1!g' \
     "${OUTPUT_DIR}"/post.*.log
-
-# Sort \d "Referenced by:" blocks: psql's conname-only sort leaves heap-scan
-# order as a tiebreaker, which differs between fresh and upgraded installs.
-for log in "${OUTPUT_DIR}"/post.*.log; do
-  python3 - "${log}" <<'PYEOF'
-import re, sys
-path = sys.argv[1]
-with open(path) as f:
-    lines = f.readlines()
-con_re = re.compile(r'CONSTRAINT "([^"]+)"')
-def sort_key(line):
-    m = con_re.search(line)
-    return (m.group(1) if m else "", line)
-out, buf = [], []
-for line in lines:
-    if line.startswith('    TABLE "'):
-        buf.append(line)
-    else:
-        if buf:
-            out.extend(sorted(buf, key=sort_key))
-            buf = []
-        out.append(line)
-out.extend(sorted(buf, key=sort_key))
-with open(path, "w") as f:
-    f.writelines(out)
-PYEOF
-done
 
 if [ "${TEST_REPAIR}" = "true" ]; then
   echo "Creating repair database"

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -9,7 +9,7 @@ WHERE cc.chunk_id = c.id
   AND cc.constraint_name = cc.hypertable_constraint_name;
 
 -- Rename legacy <chunk_id>_<seq>_<parent> chunk-side FKs to the parent name
--- so the pg_depend backfill below can match them.
+-- so the event-trigger hooks can locate them by name on DROP/RENAME.
 DO $$
 DECLARE
     r RECORD;
@@ -35,34 +35,8 @@ BEGIN
 END
 $$;
 
--- Backfill DEPENDENCY_AUTO edge so DROP/RENAME cascade to chunks, then
--- drop the obsolete chunk_constraint rows.
-INSERT INTO pg_catalog.pg_depend
-    (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
-SELECT 'pg_constraint'::regclass, child.oid, 0,
-       'pg_constraint'::regclass, parent.oid, 0, 'a'
-FROM _timescaledb_catalog.chunk_constraint cc
-JOIN _timescaledb_catalog.chunk c ON c.id = cc.chunk_id
-JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
-JOIN pg_constraint parent
-    ON parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
-    AND parent.conname = cc.hypertable_constraint_name
-    AND parent.contype = 'f'
-JOIN pg_constraint child
-    ON child.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
-    AND child.conname = cc.hypertable_constraint_name
-    AND child.contype = 'f'
-WHERE cc.dimension_slice_id IS NULL
-  AND cc.hypertable_constraint_name IS NOT NULL
-  AND NOT EXISTS (
-      SELECT 1 FROM pg_depend d
-      WHERE d.classid = 'pg_constraint'::regclass
-        AND d.objid = child.oid
-        AND d.refclassid = 'pg_constraint'::regclass
-        AND d.refobjid = parent.oid
-        AND d.deptype = 'a'
-  );
-
+-- Drop the obsolete chunk_constraint rows for outbound FKs; the event-trigger
+-- hooks locate chunk-side FKs by name and no longer need this catalog.
 DELETE FROM _timescaledb_catalog.chunk_constraint cc
 USING _timescaledb_catalog.chunk c,
       _timescaledb_catalog.hypertable ht,

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -10,40 +10,19 @@ JOIN pg_constraint con
 WHERE c.osm_chunk
 ON CONFLICT DO NOTHING;
 
--- Restore chunk_constraint rows for outbound FKs, derived from the
--- DEPENDENCY_AUTO edge that replaced them.
+-- Restore chunk_constraint rows for outbound FKs by matching chunk-side
+-- FKs to their hypertable-side counterpart by name.
 INSERT INTO _timescaledb_catalog.chunk_constraint
     (chunk_id, dimension_slice_id, constraint_name, hypertable_constraint_name)
 SELECT c.id, NULL, child.conname, parent.conname
 FROM _timescaledb_catalog.chunk c
 JOIN _timescaledb_catalog.hypertable ht ON ht.id = c.hypertable_id
+JOIN pg_constraint parent
+    ON parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
+    AND parent.contype = 'f'
 JOIN pg_constraint child
     ON child.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
     AND child.contype = 'f'
-JOIN pg_depend d
-    ON d.classid = 'pg_constraint'::regclass
-    AND d.objid = child.oid
-    AND d.refclassid = 'pg_constraint'::regclass
-    AND d.deptype = 'a'
-JOIN pg_constraint parent
-    ON parent.oid = d.refobjid
-    AND parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass
-    AND parent.contype = 'f'
+    AND child.conname = parent.conname
 ON CONFLICT DO NOTHING;
-
-DELETE FROM pg_catalog.pg_depend d
-USING pg_constraint child,
-      pg_constraint parent,
-      _timescaledb_catalog.chunk c,
-      _timescaledb_catalog.hypertable ht
-WHERE d.classid = 'pg_constraint'::regclass
-  AND d.objid = child.oid
-  AND d.refclassid = 'pg_constraint'::regclass
-  AND d.refobjid = parent.oid
-  AND d.deptype = 'a'
-  AND child.contype = 'f'
-  AND parent.contype = 'f'
-  AND ht.id = c.hypertable_id
-  AND child.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
-  AND parent.conrelid = pg_catalog.format('%I.%I', ht.schema_name, ht.table_name)::regclass;
 

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -752,8 +752,9 @@ ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkCo
 static bool
 chunk_constraint_need_on_chunk(Form_pg_constraint conform)
 {
-	/* CHECK and NOT NULL propagate via PG inheritance; FKs are linked via
-	 * pg_depend (see ts_chunk_inherit_outbound_fk_by_oid). */
+	/* CHECK and NOT NULL propagate via PG inheritance; FKs are cloned onto
+	 * the chunk by ts_chunk_inherit_outbound_fk_by_oid and propagated by
+	 * the event-trigger hooks. */
 	if (conform->contype == CONSTRAINT_CHECK ||
 		conform->contype == CONSTRAINT_FOREIGN
 #if PG18_GE

--- a/src/foreign_key.c
+++ b/src/foreign_key.c
@@ -20,7 +20,6 @@
 #include "access/table.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
-#include "catalog/pg_depend.h"
 #include "catalog/pg_trigger.h"
 #include "commands/trigger.h"
 #include "parser/parser.h"
@@ -618,15 +617,14 @@ ts_chunk_drop_referencing_fk_by_chunk_id(Oid chunk_id)
 
 /*
  * Clone an outbound FK from the hypertable onto a chunk under the parent's
- * name and link it with DEPENDENCY_AUTO so DROP CONSTRAINT cascades.
+ * name. The chunk-side constraint shares the parent's name so DROP and
+ * RENAME on the hypertable can locate it by name in the event-trigger hooks.
  */
 void
 ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 {
 	char *parent_name;
 	Oid child_oid;
-	ObjectAddress child_addr;
-	ObjectAddress parent_addr;
 
 	if (chunk->relkind == RELKIND_FOREIGN_TABLE || IS_OSM_CHUNK(chunk))
 	{
@@ -643,8 +641,7 @@ ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 	if (OidIsValid(child_oid))
 	{
 		/* Only adopt an existing constraint if it's a FK to the same target;
-		 * otherwise the AUTO edge would later cascade-drop an unrelated
-		 * constraint. */
+		 * the DROP/RENAME hooks act on any FK with the matching name. */
 		HeapTuple parent_tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(parent_fk_oid));
 		HeapTuple child_tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(child_oid));
 		Oid parent_confrelid;
@@ -671,8 +668,9 @@ ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 
 		ReleaseSysCache(child_tup);
 		ReleaseSysCache(parent_tup);
+		return;
 	}
-	else
+
 	{
 		CatalogSecurityContext sec_ctx;
 
@@ -686,75 +684,7 @@ ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 		ts_process_utility_set_expect_chunk_modification(false);
 		ts_catalog_restore_user(&sec_ctx);
 		CommandCounterIncrement();
-		child_oid = get_relation_constraint_oid(chunk->table_id, parent_name, false);
 	}
-
-	/* Drop any prior edge so re-attach doesn't accumulate duplicates. */
-	deleteDependencyRecordsForClass(ConstraintRelationId,
-									child_oid,
-									ConstraintRelationId,
-									DEPENDENCY_AUTO);
-	ObjectAddressSet(child_addr, ConstraintRelationId, child_oid);
-	ObjectAddressSet(parent_addr, ConstraintRelationId, parent_fk_oid);
-	recordDependencyOn(&child_addr, &parent_addr, DEPENDENCY_AUTO);
-}
-
-/*
- * Find the chunk-side FK linked to parent_fk_oid via DEPENDENCY_AUTO.
- * Needed because chunks created before 2.28 use the legacy
- * <ht_id>_<chunk_id>_<parent> name, so we can't look up by name.
- */
-Oid
-ts_chunk_find_outbound_fk_by_parent(Oid chunk_relid, Oid parent_fk_oid)
-{
-	Relation chunk_rel = table_open(chunk_relid, AccessShareLock);
-	Relation depRel = table_open(DependRelationId, AccessShareLock);
-	Oid result = InvalidOid;
-	ListCell *lc;
-
-	foreach (lc, RelationGetFKeyList(chunk_rel))
-	{
-		Oid child_oid = ((ForeignKeyCacheInfo *) lfirst(lc))->conoid;
-		ScanKeyData key[2];
-		SysScanDesc scan;
-		HeapTuple tup;
-
-		ScanKeyInit(&key[0],
-					Anum_pg_depend_classid,
-					BTEqualStrategyNumber,
-					F_OIDEQ,
-					ObjectIdGetDatum(ConstraintRelationId));
-		ScanKeyInit(&key[1],
-					Anum_pg_depend_objid,
-					BTEqualStrategyNumber,
-					F_OIDEQ,
-					ObjectIdGetDatum(child_oid));
-
-		scan = systable_beginscan(depRel, DependDependerIndexId, true, NULL, 2, key);
-
-		while (HeapTupleIsValid(tup = systable_getnext(scan)))
-		{
-			Form_pg_depend dep = (Form_pg_depend) GETSTRUCT(tup);
-
-			if (dep->refclassid == ConstraintRelationId && dep->refobjid == parent_fk_oid &&
-				dep->deptype == DEPENDENCY_AUTO)
-			{
-				result = child_oid;
-				break;
-			}
-		}
-
-		systable_endscan(scan);
-
-		if (OidIsValid(result))
-		{
-			break;
-		}
-	}
-
-	table_close(depRel, AccessShareLock);
-	table_close(chunk_rel, AccessShareLock);
-	return result;
 }
 
 /*

--- a/src/foreign_key.h
+++ b/src/foreign_key.h
@@ -17,4 +17,3 @@ extern TSDLLEXPORT void ts_chunk_copy_referencing_fk(const Hypertable *ht, const
 extern TSDLLEXPORT void ts_chunk_drop_referencing_fk_by_chunk_id(Oid chunk_id);
 extern TSDLLEXPORT void ts_chunk_inherit_outbound_fk(const Hypertable *ht, const Chunk *chunk);
 extern TSDLLEXPORT void ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid);
-extern TSDLLEXPORT Oid ts_chunk_find_outbound_fk_by_parent(Oid chunk_relid, Oid parent_fk_oid);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2690,18 +2690,29 @@ rename_hypertable_constraint(Hypertable *ht, Oid chunk_relid, void *arg)
 {
 	RenameStmt *stmt = (RenameStmt *) arg;
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
-	Oid chunk_con_oid;
-	Oid parent_con_oid;
+	Oid chunk_con_oid = InvalidOid;
+	Oid candidate;
 
 	ts_chunk_constraint_rename_hypertable_constraint(chunk->fd.id, stmt->subname, stmt->newname);
 
-	/* Inherited FKs aren't in chunk_constraint; locate the chunk-side
-	 * constraint via the pg_depend edge to handle legacy names. */
-	chunk_con_oid = InvalidOid;
-	parent_con_oid = get_relation_constraint_oid(ht->main_table_relid, stmt->subname, true);
-	if (OidIsValid(parent_con_oid))
+	/* Inherited FKs aren't tracked in chunk_constraint. The chunk-side FK
+	 * carries the parent's name, so look it up by name and only retarget
+	 * unmanaged foreign keys. */
+	candidate = get_relation_constraint_oid(chunk_relid, stmt->subname, true);
+	if (OidIsValid(candidate))
 	{
-		chunk_con_oid = ts_chunk_find_outbound_fk_by_parent(chunk_relid, parent_con_oid);
+		HeapTuple tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(candidate));
+
+		if (HeapTupleIsValid(tup))
+		{
+			Form_pg_constraint con = (Form_pg_constraint) GETSTRUCT(tup);
+
+			if (con->contype == CONSTRAINT_FOREIGN && !OidIsValid(con->conparentid))
+			{
+				chunk_con_oid = candidate;
+			}
+			ReleaseSysCache(tup);
+		}
 	}
 	if (OidIsValid(chunk_con_oid))
 	{
@@ -6179,10 +6190,35 @@ process_drop_constraint_on_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 {
 	const char *hypertable_constraint_name = arg;
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	Oid chunk_con_oid;
 
 	/* drop both metadata and table; sql_drop won't be called recursively */
 	ts_chunk_constraint_delete_by_hypertable_constraint_name(chunk->fd.id,
 															 hypertable_constraint_name);
+
+	chunk_con_oid =
+		get_relation_constraint_oid(chunk_relid, hypertable_constraint_name, true /* missing_ok */);
+	if (OidIsValid(chunk_con_oid))
+	{
+		HeapTuple tup = SearchSysCache1(CONSTROID, ObjectIdGetDatum(chunk_con_oid));
+
+		if (HeapTupleIsValid(tup))
+		{
+			Form_pg_constraint con = (Form_pg_constraint) GETSTRUCT(tup);
+			bool drop_it = (con->contype == CONSTRAINT_FOREIGN && !OidIsValid(con->conparentid));
+
+			ReleaseSysCache(tup);
+
+			if (drop_it)
+			{
+				ObjectAddress conobj = {
+					.classId = ConstraintRelationId,
+					.objectId = chunk_con_oid,
+				};
+				performDeletion(&conobj, DROP_RESTRICT, 0);
+			}
+		}
+	}
 }
 
 static void

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -425,7 +425,7 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 
 --test CASCADE drop behavior
 DROP TABLE devices CASCADE;
-NOTICE:  drop cascades to constraint hyper_fk_device_id_fkey on table hyper_fk
+NOTICE:  drop cascades to 2 other objects
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_4_8_chunk');
        Constraint        | Type |  Columns   |                   Index                    |                                           Expr                                           | Deferrable | Deferred | Validated 
 -------------------------+------+------------+--------------------------------------------+------------------------------------------------------------------------------------------+------------+----------+-----------

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -814,7 +814,7 @@ ERROR:  insert or update on table "_hyper_19_17_chunk" violates foreign key cons
 \set ON_ERROR_STOP 1
 -- cleanup
 DROP TABLE regular cascade;
-NOTICE:  drop cascades to constraint timescale_id_fkey on table timescale
+NOTICE:  drop cascades to 4 other objects
 DROP TABLE timescale cascade;
 -- test PARTITION BY RANGE
 CREATE TABLE regular(
@@ -869,7 +869,7 @@ ERROR:  insert or update on table "_hyper_20_20_chunk" violates foreign key cons
 \set ON_ERROR_STOP 1
 -- cleanup
 DROP TABLE regular cascade;
-NOTICE:  drop cascades to constraint timescale_id_fkey on table timescale
+NOTICE:  drop cascades to 4 other objects
 DROP TABLE timescale cascade;
 -- test PARTITION BY LIST
 CREATE TABLE regular(
@@ -916,7 +916,7 @@ ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key cons
 \set ON_ERROR_STOP 1
 -- cleanup
 DROP TABLE regular cascade;
-NOTICE:  drop cascades to constraint timescale_id_fkey on table timescale
+NOTICE:  drop cascades to 2 other objects
 DROP TABLE timescale cascade;
 -- github issue 4872
 -- If subplan of ChunkAppend is TidRangeScan, then SELECT on

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -120,7 +120,6 @@ SELECT n.nspname || '.' || c.relname AS relation,
          WHEN 'c' THEN 'composite type'
          WHEN 'f' THEN 'foreign table'
        END AS kind,
-       a.attnum,
        a.attname,
        pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
        a.attnotnull AS notnull,
@@ -152,9 +151,10 @@ SELECT
 		conrelid::regclass AS conrelid,
 		confrelid::regclass AS confrelid,
     contype,
-    pg_get_constraintdef(oid) AS def
+    pg_get_constraintdef(con.oid) AS def
 FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_class c ON c.oid = conrelid AND c.relnamespace = 'public'::regnamespace
+WHERE con.contype <> 'n'
 ORDER BY conrelid::regclass::text, contype, conname, confrelid::regclass::text;
 
 -- child tables


### PR DESCRIPTION
The previous approach linked each chunk-side foreign key to its
hypertable parent with a DEPENDENCY_AUTO edge in pg_depend so DROP
and RENAME on the hypertable would cascade. pg_dump does not dump
pg_depend rows, so the edge was gone after a restore and the chunk
constraints survived.

Disable-check: force-changelog-file
Disable-check: approval-count