### PR TITLE
Make ordering in update test deterministic

### DIFF
--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -109,9 +109,60 @@ WHERE n.nspname OPERATOR(pg_catalog.~) '^(_timescaledb_internal|_timescaledb_fun
 ORDER BY 1, 2, 4;
 
 \dy
-\a
-\d public.*
-\a
+
+-- Relations in the public schema and their columns
+SELECT n.nspname || '.' || c.relname AS relation,
+       CASE c.relkind
+         WHEN 'r' THEN 'table'
+         WHEN 'p' THEN 'partitioned table'
+         WHEN 'v' THEN 'view'
+         WHEN 'm' THEN 'materialized view'
+         WHEN 'c' THEN 'composite type'
+         WHEN 'f' THEN 'foreign table'
+       END AS kind,
+       a.attnum,
+       a.attname,
+       pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
+       a.attnotnull AS notnull,
+       pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS "default"
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+WHERE n.nspname = 'public'
+  AND c.relkind IN ('r', 'p', 'v', 'm', 'c', 'f')
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+ORDER BY relation, a.attnum;
+
+-- indexes on public tables
+SELECT c.relname AS table_name,
+       i.relname AS index_name,
+       pg_catalog.pg_get_indexdef(idx.indexrelid) AS definition
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_index idx ON idx.indrelid = c.oid
+JOIN pg_catalog.pg_class i ON i.oid = idx.indexrelid
+WHERE n.nspname = 'public'
+ORDER BY 1, 2;
+
+-- constraints on public tables
+SELECT
+    conname AS constraint_name,
+		conrelid::regclass AS conrelid,
+		confrelid::regclass AS confrelid,
+    contype,
+    pg_get_constraintdef(oid) AS def
+FROM pg_catalog.pg_constraint con
+JOIN pg_catalog.pg_class c ON c.oid = conrelid AND c.relnamespace = 'public'::regnamespace
+ORDER BY conrelid::regclass::text, contype, conname, confrelid::regclass::text;
+
+-- child tables
+SELECT parent.relname AS table_name,
+    i.inhrelid::regclass AS child_table
+FROM pg_catalog.pg_inherits i
+JOIN pg_catalog.pg_class parent ON parent.oid = i.inhparent AND parent.relnamespace = 'public'::regnamespace
+ORDER BY parent.relname, i.inhrelid::regclass::text;
 
 -- Keep the output backward compatible
 \if :PG_UPGRADE_TEST


### PR DESCRIPTION
psql \d does not order constraints with same name deterministically
so replace \d with equivalent catalog queries

Disable-check: approval-count
Disable-check: force-changelog-file