### PR TITLE
Make estimate_gapfill_groups return double as caught by LLM fuzzer

### DIFF
--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -577,8 +577,8 @@ gapfill_build_pathtarget(PathTarget *pt_upper, PathTarget *pt_path, PathTarget *
 	}
 }
 
-static int
-estimate_gapfill_groups(PlannerInfo *root, int path_rows)
+static double
+estimate_gapfill_groups(PlannerInfo *root, double path_rows)
 {
 #if PG16_GE
 	List *group_exprs = get_sortgrouplist_exprs(root->processed_groupClause, root->processed_tlist);
@@ -601,7 +601,7 @@ estimate_gapfill_groups(PlannerInfo *root, int path_rows)
 			group_exprs_without_gapfill = lappend(group_exprs_without_gapfill, group_expr);
 		}
 	}
-	int num_groups = 1;
+	double num_groups = 1.0;
 	if (group_exprs_without_gapfill != NULL)
 	{
 		num_groups = estimate_num_groups(root, group_exprs_without_gapfill, path_rows, NULL, NULL);
@@ -633,7 +633,7 @@ gapfill_path_create(PlannerInfo *root, Path *subpath, FuncExpr *func)
 
 	/* If we can estimate gapfills, we should estimate number of non-gapfill groups
 	 * as gapfills will be repeated for each group. */
-	int num_groups = 1;
+	double num_groups = 1.0;
 	if (gapfill_rows > 0)
 	{
 		num_groups = estimate_gapfill_groups(root, subpath->rows);

--- a/tsl/test/shared/expected/gapfill_bug.out
+++ b/tsl/test/shared/expected/gapfill_bug.out
@@ -489,3 +489,24 @@ SELECT * FROM STATS LEFT JOIN VOLUME USING (bucket);
 DROP TABLE gf8844_table1;
 DROP TABLE gf8844_table2;
 RESET timezone;
+-- Test that there is no overflow when number of gapfill groups exceeds INT_MAX
+CREATE TABLE gf_t1(t int, d int);
+INSERT INTO gf_t1 SELECT i % 10, i FROM generate_series(1, 50000) i;
+ANALYZE gf_t1;
+-- Cross join: 50000 * 50000 = 2.5e9 estimated rows, exceeding INT_MAX (2,147,483,647).
+-- GROUP BY with high-cardinality columns makes the aggregate estimate ~2.5e9 groups.
+EXPLAIN (costs off) SELECT time_bucket_gapfill(1, t1.t, 0, 10), t1.d, t2.d
+FROM gf_t1 t1, gf_t1 t2
+GROUP BY 1, 2, 3;
+--- QUERY PLAN ---
+ Custom Scan (GapFill)
+   ->  Sort
+         Sort Key: t1.d, t2.d, (time_bucket_gapfill(1, t1.t, 0, 10))
+         ->  HashAggregate
+               Group Key: time_bucket_gapfill(1, t1.t, 0, 10), t1.d, t2.d
+               ->  Nested Loop
+                     ->  Seq Scan on gf_t1 t1
+                     ->  Materialize
+                           ->  Seq Scan on gf_t1 t2
+
+drop table gf_t1 cascade;

--- a/tsl/test/shared/sql/gapfill_bug.sql
+++ b/tsl/test/shared/sql/gapfill_bug.sql
@@ -279,3 +279,16 @@ DROP TABLE gf8844_table1;
 DROP TABLE gf8844_table2;
 
 RESET timezone;
+
+-- Test that there is no overflow when number of gapfill groups exceeds INT_MAX
+CREATE TABLE gf_t1(t int, d int);
+INSERT INTO gf_t1 SELECT i % 10, i FROM generate_series(1, 50000) i;
+ANALYZE gf_t1;
+
+-- Cross join: 50000 * 50000 = 2.5e9 estimated rows, exceeding INT_MAX (2,147,483,647).
+-- GROUP BY with high-cardinality columns makes the aggregate estimate ~2.5e9 groups.
+EXPLAIN (costs off) SELECT time_bucket_gapfill(1, t1.t, 0, 10), t1.d, t2.d
+FROM gf_t1 t1, gf_t1 t2
+GROUP BY 1, 2, 3;
+
+drop table gf_t1 cascade;


### PR DESCRIPTION
Caught by LLM fuzzer: new routine estimating number of gapfill  groups returned int instead of double, it is now fixed. Not marked as Bug as it's a fix on the new code, we don't want to backport.

Disable-check: force-changelog-file