### PR TITLE
Disable DML optimizations with enable_optimizations GUC

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -794,6 +794,14 @@ copy_table_to_chunk_error_callback(void *arg)
 static TSCopyInsertMethod
 choose_copy_method(Hypertable *ht, CopyChunkState *ccstate, ResultRelInfo *resultRelInfo)
 {
+	if (!ts_guc_enable_optimizations)
+	{
+		ereport(DEBUG1,
+				(errmsg("Using normal unbuffered copy operation (TS_CIM_SINGLE) "
+						"because the optimizations are disabled.")));
+		return TS_CIM_SINGLE;
+	}
+
 	/*
 	 * Multi-insert buffers (TS_CIM_MULTI_CONDITIONAL) can only be used if no triggers are
 	 * defined on the target table. Otherwise, the tuples may be inserted in an out-of-order

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -23,6 +23,11 @@
 static bool
 should_use_direct_compress(ModifyHypertableState *state)
 {
+	if (!ts_guc_enable_optimizations)
+	{
+		return false;
+	}
+
 	if (!ts_guc_enable_direct_compress_insert)
 	{
 		return false;

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -242,6 +242,16 @@ SELECT count(*) FROM hyper_copy;
 -------
    154
 
+-- Disabled by the debug GUC
+SET timescaledb.enable_optimizations TO OFF;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (TS_CIM_SINGLE) because the optimizations are disabled.
+RESET timescaledb.enable_optimizations;
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   179
+
 RESET client_min_messages;
 RESET timescaledb.max_open_chunks_per_insert;
 ----------------------------------------------------------------

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -214,6 +214,14 @@ COPY hyper_copy FROM STDIN DELIMITER ',' NULL AS 'null';
 
 SELECT count(*) FROM hyper_copy;
 
+-- Disabled by the debug GUC
+SET timescaledb.enable_optimizations TO OFF;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+RESET timescaledb.enable_optimizations;
+
+SELECT count(*) FROM hyper_copy;
+
+
 RESET client_min_messages;
 RESET timescaledb.max_open_chunks_per_insert;
 

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -1769,7 +1769,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				/*
 				 * Segmentby columns are checked as part of batch scan so no need to redo the check.
 				 */
-				if (ts_guc_enable_dml_decompression_tuple_filtering)
+				if (ts_guc_enable_optimizations && ts_guc_enable_dml_decompression_tuple_filtering)
 				{
 					ScanKeyEntryInitialize(&(*mem_scankeys)[(*num_mem_scankeys)++],
 										   arg_value->constisnull ? SK_ISNULL : 0,

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -350,7 +350,7 @@ init_decompress_state_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 		Bitmapset *index_columns = NULL;
 		Relation index_rel = NULL;
 
-		if (ts_guc_enable_dml_decompression_tuple_filtering)
+		if (ts_guc_enable_optimizations && ts_guc_enable_dml_decompression_tuple_filtering)
 		{
 			cdst->mem_scankeys.scankeys =
 				build_mem_scankeys_from_slot(cis->hypertable_relid,
@@ -2025,7 +2025,8 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 	 * equality predicates, compute hashes, and collect matches.
 	 * Results are sorted by selectivity (most columns first).
 	 */
-	if (eq_preds != NIL && settings->fd.index != NULL && ts_guc_enable_dml_bloom_filter)
+	if (eq_preds != NIL && settings->fd.index != NULL && ts_guc_enable_dml_bloom_filter &&
+		ts_guc_enable_optimizations)
 	{
 		SparseIndexSettings *parsed = ts_convert_to_sparse_index_settings(settings->fd.index);
 		TsBmsList per_column_attnos =
@@ -2358,7 +2359,7 @@ can_delete_without_decompression(ModifyHypertableState *ht_state, CompressionSet
 {
 	ListCell *lc;
 
-	if (!ts_guc_enable_compressed_direct_batch_delete)
+	if (!ts_guc_enable_compressed_direct_batch_delete || !ts_guc_enable_optimizations)
 	{
 		return false;
 	}

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -39,6 +39,16 @@ EXPLAIN (BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) INSERT INTO metrics SE
    ->  Insert on metrics
          ->  Function Scan on generate_series i
 
+-- EXPLAIN with debug GUC disabled
+SET timescaledb.enable_optimizations TO OFF;
+EXPLAIN (BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) INSERT INTO metrics SELECT '2025-01-01'::timestamptz, 'd1', i::float FROM generate_series(0,500) i;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   Direct Compress: false
+   ->  Insert on metrics
+         ->  Function Scan on generate_series i
+
+RESET timescaledb.enable_optimizations;
 -- simple test with compressed insert enabled
 BEGIN;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -323,6 +323,22 @@ BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND devi
                      Rows Removed by Filter: 6000
 
 RESET timescaledb.enable_dml_decompression_tuple_filtering;
+-- Same for the debug GUC
+SET timescaledb.enable_optimizations TO off;
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
+   Batches scanned: 6
+   Batches decompressed: 6
+   Tuples decompressed: 6000
+   ->  Update on lazy_decompress (actual rows=0.00 loops=1)
+         Update on _hyper_X_X_chunk lazy_decompress_1
+         ->  Result (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk lazy_decompress_1 (actual rows=0.00 loops=1)
+                     Filter: ((value = '0'::double precision) AND (device = 'd1'::text))
+                     Rows Removed by Filter: 6000
+
+RESET timescaledb.enable_optimizations;
 -- no decompression cause no match in batch
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
 --- QUERY PLAN ---

--- a/tsl/test/shared/sql/compression_dml.sql
+++ b/tsl/test/shared/sql/compression_dml.sql
@@ -173,6 +173,11 @@ SET timescaledb.enable_dml_decompression_tuple_filtering TO off;
 BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
 RESET timescaledb.enable_dml_decompression_tuple_filtering;
 
+-- Same for the debug GUC
+SET timescaledb.enable_optimizations TO off;
+BEGIN; :ANALYZE UPDATE lazy_decompress SET value = 3.14 WHERE value = 0 AND device='d1'; ROLLBACK;
+RESET timescaledb.enable_optimizations;
+
 -- no decompression cause no match in batch
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0; ROLLBACK;
 BEGIN; :ANALYZE DELETE FROM lazy_decompress WHERE value = 0 AND device='d1'; ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -21,6 +21,11 @@ EXPLAIN (BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) INSERT INTO metrics SE
 -- EXPLAIN with large enough batch
 EXPLAIN (BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) INSERT INTO metrics SELECT '2025-01-01'::timestamptz, 'd1', i::float FROM generate_series(0,500) i;
 
+-- EXPLAIN with debug GUC disabled
+SET timescaledb.enable_optimizations TO OFF;
+EXPLAIN (BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) INSERT INTO metrics SELECT '2025-01-01'::timestamptz, 'd1', i::float FROM generate_series(0,500) i;
+RESET timescaledb.enable_optimizations;
+
 -- simple test with compressed insert enabled
 BEGIN;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;


### PR DESCRIPTION
Same logic as before, we want to execute the queries but using the most basic unoptimized mechanism, so that we can then compare the results to verify our optimizations. Extend this GUC to cover some DML optimizations too.

Disable-check: force-changelog-file