### PR TITLE
Fix job scheduling fairness when not enough background workers are available.

### DIFF
--- a/.unreleased/pr_9929
+++ b/.unreleased/pr_9929
@@ -1,0 +1,1 @@
+Fixes: #9918 jobs can bumped in a queue forever and never run

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -331,15 +331,13 @@ calculate_jitter_percent()
 }
 
 /* For failures we have backoff based on consecutive failures
- * along with a ceiling at schedule_interval * MAX_INTERVALS_BACKOFF / 1 minute
- * for jobs failing at runtime / for jobs failing to launch.
+ * along with a ceiling at schedule_interval * MAX_INTERVALS_BACKOFF.
  * We also limit the backoff in case of consecutive failures as we don't
  * want to pass in input that leads to out of range timestamps and don't want to
  * put off the next start time for the job indefinitely
  */
 static TimestampTz
-calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failures, BgwJob *job,
-								bool launch_failure)
+calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failures, BgwJob *job)
 {
 	float8 jitter = calculate_jitter_percent();
 
@@ -358,9 +356,6 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 
 	MemoryContext oldctx = CurrentMemoryContext;
 	ResourceOwner oldowner = CurrentResourceOwner;
-	/* 2^(consecutive_failures) - 1, at most 2^20 */
-	int64 max_slots = (INT64CONST(1) << (int64) multiplier) - INT64CONST(1);
-	int64 rand_backoff = rand() % (max_slots * USECS_PER_SEC);
 
 	if (!IS_VALID_TIMESTAMP(finish_time))
 	{
@@ -373,30 +368,17 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 		Datum ival;
 		/* ival_max is the ceiling = MAX_INTERVALS_BACKOFF * schedule_interval */
 		Datum ival_max;
-		// max wait time to launch job is 1 minute
-		Interval interval_max = { .time = 60000000 };
-		Interval retry_ival = { .time = 2000000 };
-		retry_ival.time += rand_backoff;
 
 		BeginInternalSubTransaction("next start on failure");
 
-		if (launch_failure)
-		{
-			// random backoff seconds in [2, 2 + 2^f]
-			ival = IntervalPGetDatum(&retry_ival);
-			ival_max = IntervalPGetDatum(&interval_max);
-		}
-		else
-		{
-			/* ival = retry_period * (consecutive_failures)  */
-			ival = DirectFunctionCall2(interval_mul,
-									   IntervalPGetDatum(&job->fd.retry_period),
-									   Float8GetDatum(multiplier));
-			/* ival_max is the ceiling = MAX_INTERVALS_BACKOFF * schedule_interval */
-			ival_max = DirectFunctionCall2(interval_mul,
-										   IntervalPGetDatum(&job->fd.schedule_interval),
-										   Float8GetDatum(MAX_INTERVALS_BACKOFF));
-		}
+		/* ival = retry_period * (consecutive_failures)  */
+		ival = DirectFunctionCall2(interval_mul,
+								   IntervalPGetDatum(&job->fd.retry_period),
+								   Float8GetDatum(multiplier));
+		/* ival_max is the ceiling = MAX_INTERVALS_BACKOFF * schedule_interval */
+		ival_max = DirectFunctionCall2(interval_mul,
+									   IntervalPGetDatum(&job->fd.schedule_interval),
+									   Float8GetDatum(MAX_INTERVALS_BACKOFF));
 
 		if (DatumGetInt32(DirectFunctionCall2(interval_cmp, ival, ival_max)) > 0)
 		{
@@ -452,16 +434,6 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 	return res;
 }
 
-static TimestampTz
-calculate_next_start_on_failed_launch(int consecutive_failed_launches, BgwJob *job)
-{
-	TimestampTz now = ts_timer_get_current_timestamp();
-	TimestampTz failure_calc =
-		calculate_next_start_on_failure(now, consecutive_failed_launches, job, true);
-
-	return failure_calc;
-}
-
 /* For crashes, the logic is the similar as for failures except we also have
  *  a minimum wait after a crash that we wait, so that if an operator needs to disable the job,
  *  there will be enough time before another crash.
@@ -470,8 +442,7 @@ static TimestampTz
 calculate_next_start_on_crash(int consecutive_crashes, BgwJob *job)
 {
 	TimestampTz now = ts_timer_get_current_timestamp();
-	TimestampTz failure_calc =
-		calculate_next_start_on_failure(now, consecutive_crashes, job, false);
+	TimestampTz failure_calc = calculate_next_start_on_failure(now, consecutive_crashes, job);
 	TimestampTz min_time = TimestampTzPlusMilliseconds(now, MIN_WAIT_AFTER_CRASH_MS);
 
 	if (min_time > failure_calc)
@@ -546,8 +517,7 @@ bgw_job_stat_tuple_mark_end(TupleInfo *ti, void *const data)
 		{
 			fd->next_start = calculate_next_start_on_failure(fd->last_finish,
 															 fd->consecutive_failures,
-															 result_ctx->job,
-															 false);
+															 result_ctx->job);
 		}
 	}
 
@@ -828,13 +798,8 @@ ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job)
 }
 
 TimestampTz
-ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job, int32 consecutive_failed_launches)
+ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job)
 {
-	/* give the system some room to breathe, wait before trying to launch again */
-	if (consecutive_failed_launches > 0)
-	{
-		return calculate_next_start_on_failed_launch(consecutive_failed_launches, job);
-	}
 	if (jobstat == NULL)
 	{
 		/* Never previously run - run right away */

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -30,8 +30,7 @@ extern TSDLLEXPORT void ts_bgw_job_stat_upsert_next_start(int32 bgw_job_id, Time
 
 extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
 
-extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job,
-											  int32 consecutive_failed_launches);
+extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job);
 extern TSDLLEXPORT void ts_bgw_job_stat_mark_crash_reported(BgwJob *job, JobResult result);
 
 extern TSDLLEXPORT TimestampTz ts_get_next_scheduled_execution_slot(BgwJob *job,

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -319,7 +319,7 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 				return;
 			}
 
-			/* If we are unable to reserve a worker go back to the scheduled state */
+			/* If no worker is available, stay scheduled and keep the existing start time. */
 			sjob->reserved_worker = ts_bgw_worker_reserve();
 			if (!sjob->reserved_worker)
 			{
@@ -327,8 +327,6 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 					 "failed to launch job %d \"%s\": out of background workers",
 					 sjob->job.fd.id,
 					 NameStr(sjob->job.fd.application_name));
-				sjob->consecutive_failed_launches++;
-				scheduled_bgw_job_transition_state_to(sjob, JOB_STATE_SCHEDULED);
 				PopActiveSnapshot();
 				CommitTransactionCommand();
 				MemoryContextSwitchTo(scratch_mctx);

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -107,7 +107,6 @@ typedef struct ScheduledBgwJob
 	 * perform the mark_end
 	 */
 	bool may_need_mark_end;
-	int32 consecutive_failed_launches;
 } ScheduledBgwJob;
 
 static void on_failure_to_start_job(ScheduledBgwJob *sjob);
@@ -161,7 +160,6 @@ static void
 mark_job_as_started(ScheduledBgwJob *sjob)
 {
 	Assert(!sjob->may_need_mark_end);
-	sjob->consecutive_failed_launches = 0;
 	ts_bgw_job_stat_mark_start(&sjob->job);
 	sjob->may_need_mark_end = true;
 }
@@ -298,8 +296,7 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 			job_stat = ts_bgw_job_stat_find(sjob->job.fd.id);
 
 			Assert(!sjob->reserved_worker);
-			sjob->next_start =
-				ts_bgw_job_stat_next_start(job_stat, &sjob->job, sjob->consecutive_failed_launches);
+			sjob->next_start = ts_bgw_job_stat_next_start(job_stat, &sjob->job);
 			break;
 		case JOB_STATE_STARTED:
 			Assert(prev_state == JOB_STATE_SCHEDULED);

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -100,6 +100,7 @@ typedef struct ScheduledBgwJob
 	BackgroundWorkerHandle *handle;
 
 	bool reserved_worker;
+	bool worker_unavailable_logged;
 
 	/*
 	 * We say "may" here since under normal circumstances the job itself will
@@ -323,21 +324,25 @@ scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 			sjob->reserved_worker = ts_bgw_worker_reserve();
 			if (!sjob->reserved_worker)
 			{
-				elog(WARNING,
-					 "failed to launch job %d \"%s\": out of background workers",
-					 sjob->job.fd.id,
-					 NameStr(sjob->job.fd.application_name));
+				if (!sjob->worker_unavailable_logged)
+				{
+					elog(WARNING,
+						 "failed to launch job %d \"%s\": out of background workers",
+						 sjob->job.fd.id,
+						 NameStr(sjob->job.fd.application_name));
+					sjob->worker_unavailable_logged = true;
+				}
 				PopActiveSnapshot();
 				CommitTransactionCommand();
 				MemoryContextSwitchTo(scratch_mctx);
 				return;
 			}
-
 			/*
 			 * start the job before you can encounter any errors so that they
 			 * are always registered
 			 */
 			mark_job_as_started(sjob);
+			sjob->worker_unavailable_logged = false;
 			if (ts_bgw_job_has_timeout(&sjob->job))
 			{
 				sjob->timeout_at =

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -1574,6 +1574,102 @@ FROM _timescaledb_internal.bgw_job_stat WHERE job_id = :failover_job_id;
 ---------+----------------------+-----------------------+-----------------------
  t       | t                    | t                     | t
 
+--
+-- Test that jobs with the same fixed schedule start time are not starved when
+-- there is only one job worker available. All five jobs take 500ms and are due
+-- every second; after 5 seconds of scheduler time, each job should have run.
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_catalog.bgw_job;
+SELECT ts_bgw_params_reset_time();
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_ON_JOB);
+ ts_bgw_params_mock_wait_returns_immediately 
+---------------------------------------------
+ 
+
+CREATE OR REPLACE FUNCTION ts_bgw_worker_reserve() RETURNS BOOL
+AS '$libdir/timescaledb', 'ts_bgw_worker_reserve' LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_worker_release() RETURNS VOID
+AS '$libdir/timescaledb', 'ts_bgw_worker_release' LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_num_unreserved() RETURNS INT
+AS '$libdir/timescaledb', 'ts_bgw_num_unreserved' LANGUAGE C VOLATILE;
+CREATE TEMP TABLE starvation_reserved_workers(reserved_workers INTEGER);
+DO $$
+DECLARE
+  reserved_workers INTEGER := 0;
+BEGIN
+  WHILE ts_bgw_num_unreserved() > 1 LOOP
+    IF NOT ts_bgw_worker_reserve() THEN
+      RAISE EXCEPTION 'failed to reserve test background worker';
+    END IF;
+    reserved_workers := reserved_workers + 1;
+  END LOOP;
+
+  INSERT INTO starvation_reserved_workers VALUES (reserved_workers);
+END
+$$;
+CREATE OR REPLACE PROCEDURE starvation_sleep_job(job_id INT, config JSONB)
+LANGUAGE PLPGSQL AS $$
+BEGIN
+  PERFORM pg_sleep(0.5);
+END
+$$;
+INSERT INTO _timescaledb_catalog.bgw_job(
+  application_name, schedule_interval, max_runtime, max_retries, retry_period,
+  proc_name, proc_schema, owner, scheduled, fixed_schedule, initial_start)
+SELECT format('starvation_job_%s', job_no)::NAME,
+       INTERVAL '1 second',
+       INTERVAL '10 seconds',
+       5,
+       INTERVAL '1 second',
+       'starvation_sleep_job'::NAME,
+       'public'::NAME,
+       CURRENT_ROLE::regrole,
+       TRUE,
+       TRUE,
+       '2000-01-01 00:00:00+00'::timestamptz
+FROM generate_series(1, 5) job_no;
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(5000);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+
+SELECT count(*) FILTER (WHERE COALESCE(s.total_successes, 0) > 0) AS jobs_that_ran,
+       count(*) AS jobs_total
+FROM _timescaledb_catalog.bgw_job j
+LEFT JOIN _timescaledb_internal.bgw_job_stat s ON s.job_id = j.id
+WHERE j.application_name LIKE 'starvation_job_%';
+ jobs_that_ran | jobs_total 
+---------------+------------
+             5 |          5
+
+SELECT j.application_name,
+       COALESCE(s.total_successes, 0) > 0 AS ran
+FROM _timescaledb_catalog.bgw_job j
+LEFT JOIN _timescaledb_internal.bgw_job_stat s ON s.job_id = j.id
+WHERE j.application_name LIKE 'starvation_job_%'
+ORDER BY j.id;
+ application_name | ran 
+------------------+-----
+ starvation_job_1 | t
+ starvation_job_2 | t
+ starvation_job_3 | t
+ starvation_job_4 | t
+ starvation_job_5 | t
+
+DO $$
+BEGIN
+  FOR i IN 1..(SELECT reserved_workers FROM starvation_reserved_workers) LOOP
+    PERFORM ts_bgw_worker_release();
+  END LOOP;
+END
+$$;
 -- clean up jobs
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_functions.stop_background_workers();

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -733,6 +733,90 @@ SELECT total_successes > 0 AS job_ran,
        consecutive_crashes = 0 AS crash_counter_cleared
 FROM _timescaledb_internal.bgw_job_stat WHERE job_id = :failover_job_id;
 
+--
+-- Test that jobs with the same fixed schedule start time are not starved when
+-- there is only one job worker available. All five jobs take 500ms and are due
+-- every second; after 5 seconds of scheduler time, each job should have run.
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_catalog.bgw_job;
+SELECT ts_bgw_params_reset_time();
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_ON_JOB);
+
+CREATE OR REPLACE FUNCTION ts_bgw_worker_reserve() RETURNS BOOL
+AS '$libdir/timescaledb', 'ts_bgw_worker_reserve' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_worker_release() RETURNS VOID
+AS '$libdir/timescaledb', 'ts_bgw_worker_release' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_num_unreserved() RETURNS INT
+AS '$libdir/timescaledb', 'ts_bgw_num_unreserved' LANGUAGE C VOLATILE;
+
+CREATE TEMP TABLE starvation_reserved_workers(reserved_workers INTEGER);
+
+DO $$
+DECLARE
+  reserved_workers INTEGER := 0;
+BEGIN
+  WHILE ts_bgw_num_unreserved() > 1 LOOP
+    IF NOT ts_bgw_worker_reserve() THEN
+      RAISE EXCEPTION 'failed to reserve test background worker';
+    END IF;
+    reserved_workers := reserved_workers + 1;
+  END LOOP;
+
+  INSERT INTO starvation_reserved_workers VALUES (reserved_workers);
+END
+$$;
+
+CREATE OR REPLACE PROCEDURE starvation_sleep_job(job_id INT, config JSONB)
+LANGUAGE PLPGSQL AS $$
+BEGIN
+  PERFORM pg_sleep(0.5);
+END
+$$;
+
+INSERT INTO _timescaledb_catalog.bgw_job(
+  application_name, schedule_interval, max_runtime, max_retries, retry_period,
+  proc_name, proc_schema, owner, scheduled, fixed_schedule, initial_start)
+SELECT format('starvation_job_%s', job_no)::NAME,
+       INTERVAL '1 second',
+       INTERVAL '10 seconds',
+       5,
+       INTERVAL '1 second',
+       'starvation_sleep_job'::NAME,
+       'public'::NAME,
+       CURRENT_ROLE::regrole,
+       TRUE,
+       TRUE,
+       '2000-01-01 00:00:00+00'::timestamptz
+FROM generate_series(1, 5) job_no;
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(5000);
+
+SELECT count(*) FILTER (WHERE COALESCE(s.total_successes, 0) > 0) AS jobs_that_ran,
+       count(*) AS jobs_total
+FROM _timescaledb_catalog.bgw_job j
+LEFT JOIN _timescaledb_internal.bgw_job_stat s ON s.job_id = j.id
+WHERE j.application_name LIKE 'starvation_job_%';
+
+SELECT j.application_name,
+       COALESCE(s.total_successes, 0) > 0 AS ran
+FROM _timescaledb_catalog.bgw_job j
+LEFT JOIN _timescaledb_internal.bgw_job_stat s ON s.job_id = j.id
+WHERE j.application_name LIKE 'starvation_job_%'
+ORDER BY j.id;
+
+DO $$
+BEGIN
+  FOR i IN 1..(SELECT reserved_workers FROM starvation_reserved_workers) LOOP
+    PERFORM ts_bgw_worker_release();
+  END LOOP;
+END
+$$;
+
 -- clean up jobs
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_functions.stop_background_workers();


### PR DESCRIPTION
During each scheduling cycle, eligible jobs try to reserve background workers.
When there are not enough workers available, some jobs are necessarily left
behind and must run later.

The scheduler prioritises jobs by next_start. Previously, jobs left without a
worker had their in-memory next_start moved into the future using launch-failure
backoff. This loses an important signal: a job that had already been skipped is
on equal footing with a job making its first attempt. When multiple jobs compete
for the same workers, a deterministic but implicit job_id tie-breaker was used.
This led to a situation where some jobs might never run at all when not enough
workers are available.

This change fixes unfairness by leaving next_start unchanged when a worker
cannot be allocated. This allows the scheduler to prioritise jobs that were
skipped in previous scheduling cycles, because their next_start remains in the
past.

This might appear to weaken fixed-schedule behavior, since such jobs are
expected to run at fixed slots. The existing behavior already allowed that:
fixed-schedule jobs could already run at non-slot-aligned times, as long as the
new value did not go beyond the next fixed slot. In other words, the
fixed-schedule contract is about how the next start is calculated, not a
guarantee that execution always happens exactly at that timestamp. Jobs are
attempted at fixed intervals, but failing that, they can still actually run at
arbitrary non-slot-aligned times, and this fix does not change that.

Not updating next_start on worker allocation failure also has the positive side
effect of making the scheduler's in-memory next_start for every job match the
persisted and therefore user-visible next_start in the catalog.

The new bgw_db_scheduler test creates five jobs scheduled to run at the same
time, but leaves only one worker available. Before the fix, one job ran
repeatedly and the others never ran. After the fix, each job runs once,
confirming scheduler fairness.

---
Fixes #9918 
Disable-check: commit-count