### PR TITLE
Fix wrong grouping in VectorAgg and ColumnarIndexScan

### DIFF
--- a/.unreleased/fix_9902
+++ b/.unreleased/fix_9902
@@ -1,0 +1,1 @@
+Fixes: #9902 Fix wrong results and crashes when grouping by columns that are not in the SELECT list with vectorized aggregation or columnar index scan

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
@@ -469,6 +469,8 @@ validate_entries_walker(Node *node, void *context)
 typedef struct RewriteContext
 {
 	Agg *agg;
+	/* Original grpColIdx, matched against so rewritten entries don't collide. */
+	AttrNumber *old_grpColIdx;
 	List *custom_scan_tlist;
 	AttrNumber next_resno;
 } RewriteContext;
@@ -496,7 +498,7 @@ rewrite_agg_tlist_mutator(Node *node, void *context)
 		/* Update grpColIdx for GROUP BY Vars */
 		for (int k = 0; k < ctx->agg->numCols; k++)
 		{
-			if (ctx->agg->grpColIdx[k] == var->varattno)
+			if (ctx->old_grpColIdx[k] == var->varattno)
 			{
 				ctx->agg->grpColIdx[k] = resno;
 			}
@@ -663,8 +665,16 @@ columnar_index_scan_plan_create(Agg *agg, CustomScan *cscan, List *rtable)
 	 * Rewrite pass: walk the Agg's targetlist with a mutator that rewrites
 	 * Var and Aggref nodes to reference ColumnarIndexScan output columns.
 	 */
+	AttrNumber *old_grpColIdx = NULL;
+	if (agg->numCols > 0)
+	{
+		old_grpColIdx = palloc(sizeof(AttrNumber) * agg->numCols);
+		memcpy(old_grpColIdx, agg->grpColIdx, sizeof(AttrNumber) * agg->numCols);
+	}
+
 	RewriteContext rewrite_ctx = {
 		.agg = agg,
+		.old_grpColIdx = old_grpColIdx,
 		.custom_scan_tlist = custom_scan_tlist,
 		.next_resno = 1,
 	};

--- a/tsl/src/nodes/vector_agg/plan.c
+++ b/tsl/src/nodes/vector_agg/plan.c
@@ -557,6 +557,8 @@ mark_partial_aggref_mutator(Node *node, void *context)
 typedef struct MakeFinalizeAggContext
 {
 	Agg *agg;
+	/* Original grpColIdx, matched against so rewritten entries don't collide. */
+	AttrNumber *old_grpColIdx;
 	List *vector_agg_targetlist;
 } MakeFinalizeAggContext;
 
@@ -581,7 +583,7 @@ make_finalize_agg_mutator(Node *node, void *context)
 			var->varattno = tle->resno;
 			for (int k = 0; k < ctx->agg->numCols; k++)
 			{
-				if (ctx->agg->grpColIdx[k] == old_attno)
+				if (ctx->old_grpColIdx[k] == old_attno)
 				{
 					ctx->agg->grpColIdx[k] = tle->resno;
 				}
@@ -813,8 +815,16 @@ insert_vector_agg(Plan *plan, void *context)
 		agg->aggsplit = AGGSPLIT_FINAL_DESERIAL;
 		agg->plan.lefttree = vector_agg_plan;
 
+		AttrNumber *old_grpColIdx = NULL;
+		if (agg->numCols > 0)
+		{
+			old_grpColIdx = palloc(sizeof(AttrNumber) * agg->numCols);
+			memcpy(old_grpColIdx, agg->grpColIdx, sizeof(AttrNumber) * agg->numCols);
+		}
+
 		MakeFinalizeAggContext finalize_ctx = {
 			.agg = agg,
+			.old_grpColIdx = old_grpColIdx,
 			.vector_agg_targetlist = vector_agg->scan.plan.targetlist,
 		};
 		agg->plan.targetlist = (List *) expression_tree_mutator((Node *) agg->plan.targetlist,

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -3316,3 +3316,19 @@ NOTICE:  using column "ts" as partitioning column
      1
      1
 
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -3311,3 +3311,19 @@ NOTICE:  using column "ts" as partitioning column
      1
      1
 
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -3473,3 +3473,19 @@ NOTICE:  using column "ts" as partitioning column
      1
      1
 
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -3479,3 +3479,19 @@ NOTICE:  using column "ts" as partitioning column
      1
      1
 
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+
+ count 
+-------
+     6
+

--- a/tsl/test/expected/vector_agg_grouping.out
+++ b/tsl/test/expected/vector_agg_grouping.out
@@ -2005,3 +2005,40 @@ select sum(t), a, b from groupnull group by b, a order by 1;
 
 reset timescaledb.debug_require_vector_agg;
 reset timescaledb.enable_vectorized_aggregation;
+-- Grouping columns not in the output targetlist must map to the right output
+-- positions, even when one column's input position equals another's output.
+create table groupnotinto(t int, a int, b int);
+select create_hypertable('groupnotinto', 't', chunk_time_interval => 1000000);
+     create_hypertable      
+----------------------------
+ (11,public,groupnotinto,t)
+
+insert into groupnotinto select g, g % 100, g % 5 from generate_series(1, 1000) g;
+alter table groupnotinto set (timescaledb.compress, timescaledb.compress_segmentby = 'b');
+select count(compress_chunk(x)) from show_chunks('groupnotinto') x;
+ count 
+-------
+     1
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+-- Expecting 100 distinct (a, b) groups.
+select count(*) from (select count(*) from groupnotinto group by a, b) g;
+ count 
+-------
+   100
+
+select count(*) from (select count(*) from groupnotinto group by b, a) g;
+ count 
+-------
+   100
+
+-- A grouping column also used in the output is handled the same way.
+select count(*) from (select b, count(*) from groupnotinto group by a, b) g;
+ count 
+-------
+   100
+
+reset timescaledb.debug_require_vector_agg;
+reset timescaledb.enable_vectorized_aggregation;

--- a/tsl/test/sql/columnar_index_scan.sql.in
+++ b/tsl/test/sql/columnar_index_scan.sql.in
@@ -146,3 +146,11 @@ SET timescaledb.enable_columnarindexscan = on;
 EXPLAIN (costs off) SELECT count(*) FROM :CAST_CHUNK GROUP BY (device_id)::text;
 SELECT count(*) FROM :CAST_CHUNK GROUP BY (device_id)::text ORDER BY 1;
 
+-- Multiple GROUP BY columns not in SELECT must map to the right output columns.
+SET timescaledb.enable_columnarindexscan = off;
+SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY device, sensor) g;
+SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY sensor, device) g;
+SET timescaledb.enable_columnarindexscan = on;
+SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY device, sensor) g;
+SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY sensor, device) g;
+

--- a/tsl/test/sql/vector_agg_grouping.sql
+++ b/tsl/test/sql/vector_agg_grouping.sql
@@ -214,3 +214,25 @@ select sum(t), a, b from groupnull group by b, a order by 1;
 reset timescaledb.debug_require_vector_agg;
 reset timescaledb.enable_vectorized_aggregation;
 
+
+-- Grouping columns not in the output targetlist must map to the right output
+-- positions, even when one column's input position equals another's output.
+create table groupnotinto(t int, a int, b int);
+select create_hypertable('groupnotinto', 't', chunk_time_interval => 1000000);
+insert into groupnotinto select g, g % 100, g % 5 from generate_series(1, 1000) g;
+alter table groupnotinto set (timescaledb.compress, timescaledb.compress_segmentby = 'b');
+select count(compress_chunk(x)) from show_chunks('groupnotinto') x;
+
+set timescaledb.debug_require_vector_agg = 'require';
+-- Uncomment to generate reference.
+--set timescaledb.enable_vectorized_aggregation to off; set timescaledb.debug_require_vector_agg = 'allow';
+
+-- Expecting 100 distinct (a, b) groups.
+select count(*) from (select count(*) from groupnotinto group by a, b) g;
+select count(*) from (select count(*) from groupnotinto group by b, a) g;
+-- A grouping column also used in the output is handled the same way.
+select count(*) from (select b, count(*) from groupnotinto group by a, b) g;
+
+reset timescaledb.debug_require_vector_agg;
+reset timescaledb.enable_vectorized_aggregation;
+


### PR DESCRIPTION
VectorAgg and ColumnarIndexScan rewrite the plan and have to renumber
the grouping columns to point at their new positions. The renumbering
changed the list while still reading from it. A new position can reuse
a number that an old position used, so an entry that was already given
its new number could be mistaken for an old one and changed a second
time. Two grouping columns then pointed at the same column: GROUP BY a, b
became GROUP BY b, b. This returned wrong results and could crash
ColumnarIndexScan.

Fixes #9902
