### PR TITLE
Add rebuild_sparse_index function

### DIFF
--- a/.unreleased/pr_9938
+++ b/.unreleased/pr_9938
@@ -1,0 +1,1 @@
+Implements: #9938 Add rebuild_sparse_index function

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -59,6 +59,11 @@ CREATE OR REPLACE PROCEDURE _timescaledb_functions.rebuild_columnstore(
     chunk REGCLASS
 ) AS '@MODULE_PATHNAME@', 'ts_rebuild_columnstore' LANGUAGE C;
 
+CREATE OR REPLACE FUNCTION _timescaledb_functions.rebuild_sparse_index(
+    chunk REGCLASS,
+    force BOOLEAN = false
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_rebuild_sparse_index' LANGUAGE C VOLATILE;
+
 CREATE OR REPLACE PROCEDURE _timescaledb_functions.chunk_rewrite_cleanup()
 LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_chunk_rewrite_cleanup';
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -188,3 +188,4 @@ DROP FUNCTION IF EXISTS @extschema@.create_hypertable(relation REGCLASS, time_co
 -- Restore the chunk_target_size check constraint dropped in the forward path.
 ALTER TABLE _timescaledb_catalog.hypertable
     ADD CONSTRAINT hypertable_chunk_target_size_check CHECK (chunk_target_size >= 0);
+DROP FUNCTION IF EXISTS _timescaledb_functions.rebuild_sparse_index(REGCLASS, BOOLEAN);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -82,6 +82,7 @@ CROSSMODULE_WRAPPER(create_compressed_chunk);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
 CROSSMODULE_WRAPPER(rebuild_columnstore);
+CROSSMODULE_WRAPPER(rebuild_sparse_index);
 CROSSMODULE_WRAPPER(bloom1_contains);
 CROSSMODULE_WRAPPER(bloom1_contains_any);
 CROSSMODULE_WRAPPER(bloom1_contains_any_hashes);
@@ -353,6 +354,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.compress_chunk = error_no_default_fn_pg_community,
 	.decompress_chunk = error_no_default_fn_pg_community,
 	.rebuild_columnstore = error_no_default_fn_pg_community,
+	.rebuild_sparse_index = error_no_default_fn_pg_community,
 	.compressed_data_decompress_forward = error_no_default_fn_pg_community,
 	.compressed_data_decompress_reverse = error_no_default_fn_pg_community,
 	.compressed_data_column_size = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -124,6 +124,7 @@ typedef struct CrossModuleFunctions
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
 	PGFunction rebuild_columnstore;
+	PGFunction rebuild_sparse_index;
 	void (*decompress_batches_for_insert)(ChunkInsertState *state, TupleTableSlot *slot);
 	void (*init_decompress_state_for_insert)(ChunkInsertState *state, TupleTableSlot *slot);
 	bool (*decompress_target_segments)(ModifyHypertableState *ht_state);

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -28,8 +28,6 @@ static HeapTuple compression_settings_formdata_make_tuple(const FormData_compres
 														  TupleDesc desc);
 static Bitmapset *resolve_columns_to_attnos(List *column_names, Oid relid);
 static bool sparse_index_values_equal(List *left, List *right);
-static bool sparse_index_object_equal(SparseIndexSettingsObject *left,
-									  SparseIndexSettingsObject *right);
 
 /*
  * Compare two compression settings for equality
@@ -90,12 +88,56 @@ sparse_index_values_equal(List *left, List *right)
 	return true;
 }
 
+bool
+ts_sparse_index_object_get_type_and_columns(SparseIndexSettingsObject *obj, const char **type_out,
+											List **columns_out)
+{
+	const char *type = NULL;
+	List *columns = NIL;
+
+	foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+	{
+		if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyType]) == 0)
+		{
+			Assert(list_length(pair->values) == 1);
+			type = (const char *) lfirst(list_head(pair->values));
+		}
+		else if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol]) == 0)
+		{
+			columns = pair->values;
+		}
+	}
+
+	if (!type || !columns)
+	{
+		return false;
+	}
+
+	*type_out = type;
+	*columns_out = columns;
+	return true;
+}
+
+bool
+ts_sparse_index_is_orderby_source(SparseIndexSettingsObject *obj)
+{
+	foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
+	{
+		if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeySource]) == 0)
+		{
+			const char *source = (const char *) lfirst(list_head(pair->values));
+			return strcmp(source, ts_sparse_index_source_names[_SparseIndexSourceEnumOrderby]) == 0;
+		}
+	}
+	return false;
+}
+
 /*
  * Compare two sparse index objects for equality.
  * Two objects are equal if they have the same pairs with the same values.
  */
-static bool
-sparse_index_object_equal(SparseIndexSettingsObject *left, SparseIndexSettingsObject *right)
+bool
+ts_sparse_index_object_equal(SparseIndexSettingsObject *left, SparseIndexSettingsObject *right)
 {
 	if (list_length(left->pairs) != list_length(right->pairs))
 	{
@@ -165,7 +207,7 @@ ts_sparse_index_equal(const Jsonb *left, const Jsonb *right)
 		bool found = false;
 		foreach_ptr(SparseIndexSettingsObject, robj, right_settings->objects)
 		{
-			if (!already_found[ri] && sparse_index_object_equal(lobj, robj))
+			if (!already_found[ri] && ts_sparse_index_object_equal(lobj, robj))
 			{
 				already_found[ri] = true;
 				found = true;

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -154,6 +154,12 @@ TSDLLEXPORT bool ts_compression_settings_equal(const CompressionSettings *left,
 TSDLLEXPORT bool ts_compression_settings_equal_with_defaults(const CompressionSettings *ht,
 															 const CompressionSettings *chunk);
 TSDLLEXPORT bool ts_sparse_index_equal(const Jsonb *left, const Jsonb *right);
+TSDLLEXPORT bool ts_sparse_index_object_equal(SparseIndexSettingsObject *left,
+											  SparseIndexSettingsObject *right);
+TSDLLEXPORT bool ts_sparse_index_object_get_type_and_columns(SparseIndexSettingsObject *obj,
+															 const char **type_out,
+															 List **columns_out);
+TSDLLEXPORT bool ts_sparse_index_is_orderby_source(SparseIndexSettingsObject *obj);
 
 TSDLLEXPORT int ts_compression_settings_update(CompressionSettings *settings);
 TSDLLEXPORT void ts_compression_settings_rename_column_cascade(Oid parent_relid, const char *old,

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1071,6 +1071,74 @@ tsl_rebuild_columnstore(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+Datum
+tsl_rebuild_sparse_index(PG_FUNCTION_ARGS)
+{
+	Oid chunk_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	bool force = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
+
+	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
+
+	TS_PREVENT_FUNC_IF_READ_ONLY();
+
+	if (!OidIsValid(chunk_relid))
+	{
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid chunk OID")));
+	}
+
+	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
+
+	if (!ts_chunk_is_compressed(chunk) || ts_chunk_is_frozen(chunk))
+	{
+		ereport(NOTICE,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("chunk \"%s.%s\" is uncompressed or frozen, skipping",
+						NameStr(chunk->fd.schema_name),
+						NameStr(chunk->fd.table_name))));
+		PG_RETURN_VOID();
+	}
+
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
+
+	if (ht_settings->fd.index == NULL)
+	{
+		ereport(NOTICE,
+				(errmsg("no sparse index configured on hypertable \"%s\" for chunk \"%s.%s\", "
+						"skipping",
+						get_rel_name(chunk->hypertable_relid),
+						NameStr(chunk->fd.schema_name),
+						NameStr(chunk->fd.table_name))));
+		PG_RETURN_VOID();
+	}
+
+	/* Orderby changes require recompression since batch data is physically sorted by orderby */
+	if (!ts_array_equal(chunk_settings->fd.orderby, ht_settings->fd.orderby))
+	{
+		ereport(NOTICE,
+				(errmsg("orderby settings for chunk \"%s.%s\" differ from hypertable \"%s\"",
+						NameStr(chunk->fd.schema_name),
+						NameStr(chunk->fd.table_name),
+						get_rel_name(chunk->hypertable_relid)),
+				 errhint("Use compress_chunk(chunk, recompress => true) to recompress.")));
+		PG_RETURN_VOID();
+	}
+
+	if (!force && ts_sparse_index_equal(chunk_settings->fd.index, ht_settings->fd.index))
+	{
+		ereport(NOTICE,
+				(errmsg("sparse index settings for chunk \"%s.%s\" already match hypertable, "
+						"skipping (use force => true to override)",
+						NameStr(chunk->fd.schema_name),
+						NameStr(chunk->fd.table_name))));
+		PG_RETURN_VOID();
+	}
+
+	rebuild_sparse_index_impl(chunk, force);
+	PG_RETURN_VOID();
+}
+
 /*
  * This is hacky but it doesn't matter. We just want to check for the existence of such an index
  * on the compressed chunk.

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -16,6 +16,7 @@ extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_rebuild_columnstore(PG_FUNCTION_ARGS);
+extern Datum tsl_rebuild_sparse_index(PG_FUNCTION_ARGS);
 extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress);
 extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk);
 

--- a/tsl/src/compression/batch_metadata_builder.h
+++ b/tsl/src/compression/batch_metadata_builder.h
@@ -8,8 +8,6 @@
 #include <postgres.h>
 #include "funcapi.h" /* for PGFunction, FmgrInfo */
 
-typedef struct RowCompressor RowCompressor;
-
 enum BatchMetadataBuilderType
 {
 	METADATA_BUILDER_MINMAX,
@@ -20,8 +18,9 @@ enum BatchMetadataBuilderType
 typedef struct BatchMetadataBuilder
 {
 	void (*update_row)(void *builder, TupleTableSlot *slot);
-	void (*insert_to_compressed_row)(void *builder, RowCompressor *compressor);
-	void (*reset)(void *builder, RowCompressor *compressor);
+	void (*insert_to_compressed_row)(void *builder, Datum *compressed_values,
+									 bool *compressed_is_null);
+	void (*reset)(void *builder, Datum *compressed_values, bool *compressed_is_null);
 	enum BatchMetadataBuilderType builder_type;
 } BatchMetadataBuilder;
 
@@ -54,7 +53,8 @@ uint64 batch_metadata_builder_bloom1_calculate_hash(PGFunction hash_function, Fm
 void batch_metadata_builder_bloom1_update_bloom_filter_with_hash(void *varlena_ptr, uint64 hash);
 void batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(void *bloom_varlena,
 																		 int16 bloom_attr_offset,
-																		 RowCompressor *compressor);
+																		 Datum *compressed_values,
+																		 bool *compressed_is_null);
 
 /* Returns true if the hash is maybe present in a bloom filter, if the bloom filter data is
  * NULL, it returns true, because we cannot be sure if the hash is present or not. */

--- a/tsl/src/compression/batch_metadata_builder_bloom1.c
+++ b/tsl/src/compression/batch_metadata_builder_bloom1.c
@@ -217,7 +217,7 @@ bloom1_get_hash_function(Oid type, FmgrInfo **finfo)
 }
 
 static void
-bloom1_reset(void *builder_, RowCompressor *compressor)
+bloom1_reset(void *builder_, Datum *compressed_values, bool *compressed_is_null)
 {
 	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
 	Assert(builder->functions.builder_type == METADATA_BUILDER_BLOOM1);
@@ -226,8 +226,8 @@ bloom1_reset(void *builder_, RowCompressor *compressor)
 	memset(bloom, 0, builder->allocated_varlena_bytes);
 	SET_VARSIZE(bloom, builder->allocated_varlena_bytes);
 
-	compressor->compressed_is_null[builder->bloom_attr_offset] = true;
-	compressor->compressed_values[builder->bloom_attr_offset] = 0;
+	compressed_is_null[builder->bloom_attr_offset] = true;
+	compressed_values[builder->bloom_attr_offset] = 0;
 }
 
 static char *
@@ -245,7 +245,8 @@ bloom1_num_bits(const struct varlena *bloom)
 void
 batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(void *bloom_varlena,
 																	int16 bloom_attr_offset,
-																	RowCompressor *compressor)
+																	Datum *compressed_values,
+																	bool *compressed_is_null)
 {
 	struct varlena *bloom = (struct varlena *) bloom_varlena;
 	char *restrict words_buf = bloom1_words_buf(bloom);
@@ -267,8 +268,8 @@ batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(void *bloom_
 		 * but technically possible, and the following calculations will
 		 * segfault in this case.
 		 */
-		compressor->compressed_is_null[bloom_attr_offset] = true;
-		compressor->compressed_values[bloom_attr_offset] = PointerGetDatum(NULL);
+		compressed_is_null[bloom_attr_offset] = true;
+		compressed_values[bloom_attr_offset] = PointerGetDatum(NULL);
 		return;
 	}
 
@@ -330,17 +331,18 @@ batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(void *bloom_
 	Assert(bloom1_num_bits(bloom) % (sizeof(*words_buf) * 8) == 0);
 	Assert(bloom1_num_bits(bloom) % 64 == 0);
 
-	compressor->compressed_is_null[bloom_attr_offset] = false;
-	compressor->compressed_values[bloom_attr_offset] = PointerGetDatum(bloom);
+	compressed_is_null[bloom_attr_offset] = false;
+	compressed_values[bloom_attr_offset] = PointerGetDatum(bloom);
 }
 
 static void
-bloom1_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+bloom1_insert_to_compressed_row(void *builder_, Datum *compressed_values, bool *compressed_is_null)
 {
 	Bloom1MetadataBuilder *builder = (Bloom1MetadataBuilder *) builder_;
 	batch_metadata_builder_bloom1_insert_bloom_filter_to_compressed_row(builder->bloom_varlena,
 																		builder->bloom_attr_offset,
-																		compressor);
+																		compressed_values,
+																		compressed_is_null);
 }
 
 /*

--- a/tsl/src/compression/batch_metadata_builder_firstlast.c
+++ b/tsl/src/compression/batch_metadata_builder_firstlast.c
@@ -12,8 +12,9 @@
 #include "compression.h"
 
 static void firstlast_update_row(void *builder_, TupleTableSlot *slot);
-static void firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor);
-static void firstlast_reset(void *builder_, RowCompressor *compressor);
+static void firstlast_insert_to_compressed_row(void *builder_, Datum *compressed_values,
+											   bool *compressed_is_null);
+static void firstlast_reset(void *builder_, Datum *compressed_values, bool *compressed_is_null);
 
 BatchMetadataBuilder *
 batch_metadata_builder_firstlast_create(Oid type_oid, AttrNumber attnum, int first_attr_offset,
@@ -87,7 +88,7 @@ firstlast_update_row(void *builder_, TupleTableSlot *slot)
 }
 
 static void
-firstlast_reset(void *builder_, RowCompressor *compressor)
+firstlast_reset(void *builder_, Datum *compressed_values, bool *compressed_is_null)
 {
 	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
 
@@ -108,14 +109,15 @@ firstlast_reset(void *builder_, RowCompressor *compressor)
 	builder->first_is_null = true;
 	builder->last_is_null = true;
 
-	compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
-	compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
-	compressor->compressed_values[builder->first_metadata_attr_offset] = (Datum) 0;
-	compressor->compressed_values[builder->last_metadata_attr_offset] = (Datum) 0;
+	compressed_is_null[builder->first_metadata_attr_offset] = true;
+	compressed_is_null[builder->last_metadata_attr_offset] = true;
+	compressed_values[builder->first_metadata_attr_offset] = (Datum) 0;
+	compressed_values[builder->last_metadata_attr_offset] = (Datum) 0;
 }
 
 static void
-firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+firstlast_insert_to_compressed_row(void *builder_, Datum *compressed_values,
+								   bool *compressed_is_null)
 {
 	BatchMetadataBuilderFirstLast *builder = (BatchMetadataBuilderFirstLast *) builder_;
 	Assert(builder->first_metadata_attr_offset >= 0);
@@ -123,15 +125,15 @@ firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
 
 	if (builder->empty)
 	{
-		compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
-		compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+		compressed_is_null[builder->first_metadata_attr_offset] = true;
+		compressed_is_null[builder->last_metadata_attr_offset] = true;
 		return;
 	}
 
 	/* First value */
 	if (builder->first_is_null)
 	{
-		compressor->compressed_is_null[builder->first_metadata_attr_offset] = true;
+		compressed_is_null[builder->first_metadata_attr_offset] = true;
 	}
 	else
 	{
@@ -146,14 +148,14 @@ firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
 			first = unpacked;
 			builder->first = first;
 		}
-		compressor->compressed_is_null[builder->first_metadata_attr_offset] = false;
-		compressor->compressed_values[builder->first_metadata_attr_offset] = first;
+		compressed_is_null[builder->first_metadata_attr_offset] = false;
+		compressed_values[builder->first_metadata_attr_offset] = first;
 	}
 
 	/* Last value */
 	if (builder->last_is_null)
 	{
-		compressor->compressed_is_null[builder->last_metadata_attr_offset] = true;
+		compressed_is_null[builder->last_metadata_attr_offset] = true;
 	}
 	else
 	{
@@ -168,7 +170,7 @@ firstlast_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
 			last = unpacked;
 			builder->last = last;
 		}
-		compressor->compressed_is_null[builder->last_metadata_attr_offset] = false;
-		compressor->compressed_values[builder->last_metadata_attr_offset] = last;
+		compressed_is_null[builder->last_metadata_attr_offset] = false;
+		compressed_values[builder->last_metadata_attr_offset] = last;
 	}
 }

--- a/tsl/src/compression/batch_metadata_builder_firstlast.h
+++ b/tsl/src/compression/batch_metadata_builder_firstlast.h
@@ -29,5 +29,3 @@ typedef struct BatchMetadataBuilderFirstLast
 	int16 first_metadata_attr_offset;
 	int16 last_metadata_attr_offset;
 } BatchMetadataBuilderFirstLast;
-
-typedef struct RowCompressor RowCompressor;

--- a/tsl/src/compression/batch_metadata_builder_minmax.c
+++ b/tsl/src/compression/batch_metadata_builder_minmax.c
@@ -15,8 +15,9 @@
 #include "compression.h"
 
 static void minmax_update_row(void *builder_, TupleTableSlot *slot);
-static void minmax_insert_to_compressed_row(void *builder_, RowCompressor *compressor);
-static void minmax_reset(void *builder_, RowCompressor *compressor);
+static void minmax_insert_to_compressed_row(void *builder_, Datum *compressed_values,
+											bool *compressed_is_null);
+static void minmax_reset(void *builder_, Datum *compressed_values, bool *compressed_is_null);
 
 BatchMetadataBuilder *
 batch_metadata_builder_minmax_create(Oid type_oid, Oid collation, AttrNumber attnum,
@@ -104,7 +105,7 @@ minmax_update_row(void *builder_, TupleTableSlot *slot)
 }
 
 static void
-minmax_reset(void *builder_, RowCompressor *compressor)
+minmax_reset(void *builder_, Datum *compressed_values, bool *compressed_is_null)
 {
 	BatchMetadataBuilderMinMax *builder = (BatchMetadataBuilderMinMax *) builder_;
 	if (!builder->empty)
@@ -120,10 +121,10 @@ minmax_reset(void *builder_, RowCompressor *compressor)
 	builder->empty = true;
 	builder->has_null = false;
 
-	compressor->compressed_is_null[builder->max_metadata_attr_offset] = true;
-	compressor->compressed_is_null[builder->min_metadata_attr_offset] = true;
-	compressor->compressed_values[builder->min_metadata_attr_offset] = 0;
-	compressor->compressed_values[builder->max_metadata_attr_offset] = 0;
+	compressed_is_null[builder->max_metadata_attr_offset] = true;
+	compressed_is_null[builder->min_metadata_attr_offset] = true;
+	compressed_values[builder->min_metadata_attr_offset] = 0;
+	compressed_values[builder->max_metadata_attr_offset] = 0;
 }
 
 Datum
@@ -174,7 +175,7 @@ batch_metadata_builder_minmax_empty(void *builder_)
 }
 
 static void
-minmax_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
+minmax_insert_to_compressed_row(void *builder_, Datum *compressed_values, bool *compressed_is_null)
 {
 	BatchMetadataBuilderMinMax *builder = (BatchMetadataBuilderMinMax *) builder_;
 	Assert(builder->min_metadata_attr_offset >= 0);
@@ -182,17 +183,17 @@ minmax_insert_to_compressed_row(void *builder_, RowCompressor *compressor)
 
 	if (!batch_metadata_builder_minmax_empty(builder))
 	{
-		compressor->compressed_is_null[builder->min_metadata_attr_offset] = false;
-		compressor->compressed_is_null[builder->max_metadata_attr_offset] = false;
+		compressed_is_null[builder->min_metadata_attr_offset] = false;
+		compressed_is_null[builder->max_metadata_attr_offset] = false;
 
-		compressor->compressed_values[builder->min_metadata_attr_offset] =
+		compressed_values[builder->min_metadata_attr_offset] =
 			batch_metadata_builder_minmax_min(builder);
-		compressor->compressed_values[builder->max_metadata_attr_offset] =
+		compressed_values[builder->max_metadata_attr_offset] =
 			batch_metadata_builder_minmax_max(builder);
 	}
 	else
 	{
-		compressor->compressed_is_null[builder->min_metadata_attr_offset] = true;
-		compressor->compressed_is_null[builder->max_metadata_attr_offset] = true;
+		compressed_is_null[builder->min_metadata_attr_offset] = true;
+		compressed_is_null[builder->max_metadata_attr_offset] = true;
 	}
 }

--- a/tsl/src/compression/batch_metadata_builder_minmax.h
+++ b/tsl/src/compression/batch_metadata_builder_minmax.h
@@ -33,8 +33,6 @@ typedef struct BatchMetadataBuilderMinMax
 
 typedef struct BatchMetadataBuilderMinMax BatchMetadataBuilderMinMax;
 
-typedef struct RowCompressor RowCompressor;
-
 /*
  * This is exposed only for the old unit tests. Ideally they should be replaced
  * with functional tests inspecting the compressed chunk table, and this

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1652,7 +1652,9 @@ row_compressor_build_tuple(RowCompressor *row_compressor)
 	foreach (lc, row_compressor->metadata_builders)
 	{
 		BatchMetadataBuilder *builder = (BatchMetadataBuilder *) lfirst(lc);
-		builder->insert_to_compressed_row(builder, row_compressor);
+		builder->insert_to_compressed_row(builder,
+										  row_compressor->compressed_values,
+										  row_compressor->compressed_is_null);
 	}
 
 	row_compressor->compressed_values[row_compressor->count_metadata_column_offset] =
@@ -1709,7 +1711,9 @@ row_compressor_clear_batch(RowCompressor *row_compressor, bool changed_groups)
 	foreach (lc, row_compressor->metadata_builders)
 	{
 		BatchMetadataBuilder *builder = (BatchMetadataBuilder *) lfirst(lc);
-		builder->reset(builder, row_compressor);
+		builder->reset(builder,
+					   row_compressor->compressed_values,
+					   row_compressor->compressed_is_null);
 	}
 
 	row_compressor->rowcnt_pre_compression += row_compressor->rows_compressed_into_current_value;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -403,7 +403,7 @@ should_create_bloom_sparse_index(Oid atttypid, TypeCacheEntry *type, Oid src_rel
  * List of Form_pg_attribute elements. Min and max indices only use
  * the first element. Bloom filters may use multiple columns.
  */
-static ColumnDef *
+ColumnDef *
 create_sparse_index_column_def(List *attributes, const char *metadata_type)
 {
 	Assert(is_sparse_index_type(metadata_type));

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -32,6 +32,7 @@ char *column_segment_max_name(int16 column_index);
 char *compressed_column_metadata_name_v2(const char *metadata_type, const char **column_names,
 										 int num_columns);
 char *compressed_column_metadata_name_list_v2(const char *metadata_type, List *column_names_list);
+ColumnDef *create_sparse_index_column_def(List *attributes, const char *metadata_type);
 
 int compressed_column_metadata_attno(const CompressionSettings *settings, Oid chunk_reloid,
 									 AttrNumber chunk_attno, Oid compressed_reloid,

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -6,6 +6,7 @@
 
 #include <postgres.h>
 #include "debug_point.h"
+#include <access/tableam.h>
 #include <miscadmin.h>
 #include <parser/parse_coerce.h>
 #include <parser/parse_relation.h>
@@ -19,18 +20,22 @@
 #include <utils/typcache.h>
 
 #include "api.h"
+#include "batch_metadata_builder.h"
 #include "compression.h"
 #include "compression_dml.h"
 #include "create.h"
 #include "debug_assert.h"
+#include "foreach_ptr.h"
 #include "guc.h"
 #include "hypertable.h"
 #include "indexing.h"
 #include "recompress.h"
+#include "sparse_index_bloom1.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/chunk_column_stats.h"
 #include "ts_catalog/compression_chunk_size.h"
 #include "ts_catalog/compression_settings.h"
+#include "utils.h"
 #include "with_clause/alter_table_with_clause.h"
 
 /*
@@ -1358,4 +1363,499 @@ try_updating_chunk_status(Chunk *uncompressed_chunk, Relation uncompressed_chunk
 		/* changed chunk status, so invalidate any plans involving this chunk */
 		CacheInvalidateRelcacheByRelid(uncompressed_chunk->table_id);
 	}
+}
+
+/*
+ * Drop the physical metadata columns for a list of sparse index objects
+ * from the compressed chunk table in a single ALTER TABLE.
+ */
+static void
+drop_sparse_index_columns(Oid compressed_relid, List *index_objs)
+{
+	List *cmds = NIL;
+
+	foreach_ptr(SparseIndexSettingsObject, index_obj, index_objs)
+	{
+		const char *type;
+		List *columns;
+		if (!ts_sparse_index_object_get_type_and_columns(index_obj, &type, &columns))
+		{
+			continue;
+		}
+
+		if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumMinmax]) == 0)
+		{
+			const char *colname = (const char *) lfirst(list_head(columns));
+			static const char *minmax_prefixes[] = { "min", "max" };
+			for (size_t i = 0; i < sizeof(minmax_prefixes) / sizeof(minmax_prefixes[0]); i++)
+			{
+				char *meta_name =
+					compressed_column_metadata_name_v2(minmax_prefixes[i], &colname, 1);
+				Assert(get_attnum(compressed_relid, meta_name) != InvalidAttrNumber);
+				AlterTableCmd *cmd = makeNode(AlterTableCmd);
+				cmd->subtype = AT_DropColumn;
+				cmd->name = meta_name;
+				cmd->missing_ok = true;
+				cmds = lappend(cmds, cmd);
+			}
+		}
+		else if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumFirstLast]) == 0)
+		{
+			const char *colname = (const char *) lfirst(list_head(columns));
+			static const char *firstlast_prefixes[] = { "first", "last" };
+			for (size_t i = 0; i < sizeof(firstlast_prefixes) / sizeof(firstlast_prefixes[0]); i++)
+			{
+				char *meta_name =
+					compressed_column_metadata_name_v2(firstlast_prefixes[i], &colname, 1);
+				Assert(get_attnum(compressed_relid, meta_name) != InvalidAttrNumber);
+				AlterTableCmd *cmd = makeNode(AlterTableCmd);
+				cmd->subtype = AT_DropColumn;
+				cmd->name = meta_name;
+				cmd->missing_ok = true;
+				cmds = lappend(cmds, cmd);
+			}
+		}
+		else if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumBloom]) == 0)
+		{
+			char *meta_name =
+				compressed_column_metadata_name_list_v2(bloom1_column_prefix, columns);
+			Assert(get_attnum(compressed_relid, meta_name) != InvalidAttrNumber);
+			AlterTableCmd *cmd = makeNode(AlterTableCmd);
+			cmd->subtype = AT_DropColumn;
+			cmd->name = meta_name;
+			cmd->missing_ok = true;
+			cmds = lappend(cmds, cmd);
+		}
+	}
+
+	if (cmds != NIL)
+	{
+		ts_alter_table_with_event_trigger(compressed_relid, NULL, cmds, true);
+	}
+}
+
+/*
+ * Add physical metadata columns for a list of sparse index objects
+ * to the compressed chunk table in a single ALTER TABLE.
+ */
+static void
+add_sparse_index_columns(Chunk *chunk, Oid compressed_relid, List *index_objs)
+{
+	List *col_defs = NIL;
+	Relation uncompressed_rel = table_open(chunk->table_id, AccessShareLock);
+	TupleDesc tupdesc = RelationGetDescr(uncompressed_rel);
+
+	foreach_ptr(SparseIndexSettingsObject, index_obj, index_objs)
+	{
+		const char *type;
+		List *columns;
+		if (!ts_sparse_index_object_get_type_and_columns(index_obj, &type, &columns))
+		{
+			continue;
+		}
+
+		List *attrs = NIL;
+		foreach_ptr(const char, colname, columns)
+		{
+			AttrNumber attno = get_attnum(chunk->table_id, colname);
+			Ensure(AttributeNumberIsValid(attno),
+				   "column \"%s\" not found on chunk \"%s.%s\"",
+				   colname,
+				   NameStr(chunk->fd.schema_name),
+				   NameStr(chunk->fd.table_name));
+			attrs = lappend(attrs, TupleDescAttr(tupdesc, attno - 1));
+		}
+
+		if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumMinmax]) == 0)
+		{
+			col_defs = lappend(col_defs, create_sparse_index_column_def(attrs, "min"));
+			col_defs = lappend(col_defs, create_sparse_index_column_def(attrs, "max"));
+		}
+		else if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumFirstLast]) == 0)
+		{
+			col_defs = lappend(col_defs, create_sparse_index_column_def(attrs, "first"));
+			col_defs = lappend(col_defs, create_sparse_index_column_def(attrs, "last"));
+		}
+		else if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumBloom]) == 0)
+		{
+			col_defs =
+				lappend(col_defs, create_sparse_index_column_def(attrs, bloom1_column_prefix));
+		}
+	}
+
+	table_close(uncompressed_rel, AccessShareLock);
+
+	if (col_defs != NIL)
+	{
+		List *cmds = NIL;
+		foreach_ptr(ColumnDef, coldef, col_defs)
+		{
+			AlterTableCmd *cmd = makeNode(AlterTableCmd);
+			cmd->subtype = AT_AddColumn;
+			cmd->def = (Node *) coldef;
+			cmd->missing_ok = false;
+			cmds = lappend(cmds, cmd);
+		}
+		ts_alter_table_with_event_trigger(compressed_relid, NULL, cmds, true);
+	}
+}
+
+/*
+ * Create BatchMetadataBuilders for the sparse index objects in to_add.
+ * Must be called after add_sparse_index_columns so the compressed chunk
+ * already has the metadata columns.
+ */
+static List *
+create_sparse_index_builders(Relation uncompressed_rel, Oid compressed_relid, List *index_objs,
+							 bool *repl)
+{
+	List *builders = NIL;
+	TupleDesc tupdesc = RelationGetDescr(uncompressed_rel);
+	Oid chunk_relid = RelationGetRelid(uncompressed_rel);
+
+	foreach_ptr(SparseIndexSettingsObject, index_obj, index_objs)
+	{
+		const char *type;
+		List *columns;
+		if (!ts_sparse_index_object_get_type_and_columns(index_obj, &type, &columns))
+		{
+			continue;
+		}
+
+		if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumBloom]) == 0)
+		{
+			int num_columns = list_length(columns);
+			Oid type_oids[MAX_BLOOM_FILTER_COLUMNS];
+			AttrNumber attnums[MAX_BLOOM_FILTER_COLUMNS];
+			int col_idx = 0;
+
+			foreach_ptr(const char, colname, columns)
+			{
+				AttrNumber attno = get_attnum(chunk_relid, colname);
+				attnums[col_idx] = attno;
+				type_oids[col_idx] = TupleDescAttr(tupdesc, attno - 1)->atttypid;
+				col_idx++;
+			}
+
+			char *meta_name =
+				compressed_column_metadata_name_list_v2(bloom1_column_prefix, columns);
+			AttrNumber compressed_attno = get_attnum(compressed_relid, meta_name);
+			int bloom_offset = AttrNumberGetAttrOffset(compressed_attno);
+
+			repl[bloom_offset] = true;
+
+			builders = lappend(builders,
+							   batch_metadata_builder_bloom1_create(num_columns,
+																	type_oids,
+																	attnums,
+																	bloom_offset));
+		}
+		else if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumMinmax]) == 0)
+		{
+			const char *colname = (const char *) lfirst(list_head(columns));
+			AttrNumber attno = get_attnum(chunk_relid, colname);
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, attno - 1);
+
+			char *min_name = compressed_column_metadata_name_v2("min", &colname, 1);
+			char *max_name = compressed_column_metadata_name_v2("max", &colname, 1);
+			int min_offset = AttrNumberGetAttrOffset(get_attnum(compressed_relid, min_name));
+			int max_offset = AttrNumberGetAttrOffset(get_attnum(compressed_relid, max_name));
+
+			repl[min_offset] = true;
+			repl[max_offset] = true;
+
+			builders = lappend(builders,
+							   batch_metadata_builder_minmax_create(attr->atttypid,
+																	attr->attcollation,
+																	attno,
+																	min_offset,
+																	max_offset));
+		}
+		else if (strcmp(type, ts_sparse_index_type_names[_SparseIndexTypeEnumFirstLast]) == 0)
+		{
+			const char *colname = (const char *) lfirst(list_head(columns));
+			AttrNumber attno = get_attnum(chunk_relid, colname);
+
+			char *first_name = compressed_column_metadata_name_v2("first", &colname, 1);
+			char *last_name = compressed_column_metadata_name_v2("last", &colname, 1);
+			int first_offset = AttrNumberGetAttrOffset(get_attnum(compressed_relid, first_name));
+			int last_offset = AttrNumberGetAttrOffset(get_attnum(compressed_relid, last_name));
+
+			repl[first_offset] = true;
+			repl[last_offset] = true;
+
+			builders =
+				lappend(builders,
+						batch_metadata_builder_firstlast_create(TupleDescAttr(tupdesc, attno - 1)
+																	->atttypid,
+																attno,
+																first_offset,
+																last_offset));
+		}
+	}
+
+	return builders;
+}
+
+static List *
+modify_compressed_table(Chunk *chunk, bool force)
+{
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
+
+	SparseIndexSettings *ht_index = ts_convert_to_sparse_index_settings(ht_settings->fd.index);
+	SparseIndexSettings *chunk_index =
+		ts_convert_to_sparse_index_settings(chunk_settings->fd.index);
+
+	/* Step 1: collect sparse index objects to drop, then drop all at once */
+	List *to_drop = NIL;
+	foreach_ptr(SparseIndexSettingsObject, chunk_obj, chunk_index->objects)
+	{
+		/* ignore orderby sparse indexes */
+		if (ts_sparse_index_is_orderby_source(chunk_obj))
+		{
+			continue;
+		}
+
+		if (force)
+		{
+			to_drop = lappend(to_drop, chunk_obj);
+			continue;
+		}
+
+		bool found = false;
+		foreach_ptr(SparseIndexSettingsObject, ht_obj, ht_index->objects)
+		{
+			if (ts_sparse_index_object_equal(chunk_obj, ht_obj))
+			{
+				found = true;
+				break;
+			}
+		}
+		if (!found)
+		{
+			to_drop = lappend(to_drop, chunk_obj);
+		}
+	}
+
+	if (to_drop != NIL)
+	{
+		drop_sparse_index_columns(chunk_settings->fd.compress_relid, to_drop);
+	}
+
+	/* Step 2: collect sparse index objects to add, then add all at once */
+	List *to_add = NIL;
+	foreach_ptr(SparseIndexSettingsObject, ht_obj, ht_index->objects)
+	{
+		/* ignore orderby sparse indexes */
+		if (ts_sparse_index_is_orderby_source(ht_obj))
+		{
+			continue;
+		}
+
+		if (force)
+		{
+			to_add = lappend(to_add, ht_obj);
+			continue;
+		}
+
+		bool found = false;
+		foreach_ptr(SparseIndexSettingsObject, chunk_obj, chunk_index->objects)
+		{
+			if (ts_sparse_index_object_equal(ht_obj, chunk_obj))
+			{
+				found = true;
+				break;
+			}
+		}
+		if (!found)
+		{
+			to_add = lappend(to_add, ht_obj);
+		}
+	}
+
+	if (to_add != NIL)
+	{
+		add_sparse_index_columns(chunk, chunk_settings->fd.compress_relid, to_add);
+	}
+
+	/* Update the chunk's compression settings to match the hypertable */
+	chunk_settings->fd.index = ht_settings->fd.index;
+	ts_compression_settings_update(chunk_settings);
+
+	return to_add;
+}
+
+/*
+ * Scan every compressed batch, decompress it, feed the rows through the
+ * builders, and update the compressed tuple with the computed sparse index
+ * values.
+ */
+static void
+populate_sparse_index_columns(Relation compressed_rel, RowDecompressor *decompressor,
+							  List *builders, bool *repl)
+{
+	TupleDesc compressed_desc = RelationGetDescr(compressed_rel);
+	TableScanDesc scan = table_beginscan(compressed_rel, GetActiveSnapshot(), 0, NULL);
+	TupleTableSlot *scan_slot = table_slot_create(compressed_rel, NULL);
+	TupleTableSlot *update_slot = MakeSingleTupleTableSlot(compressed_desc, &TTSOpsHeapTuple);
+
+	while (table_scan_getnextslot(scan, ForwardScanDirection, scan_slot))
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		bool should_free;
+		HeapTuple compressed_tuple = ExecFetchSlotHeapTuple(scan_slot, false, &should_free);
+
+		heap_deform_tuple(compressed_tuple,
+						  compressed_desc,
+						  decompressor->compressed_datums,
+						  decompressor->compressed_is_nulls);
+
+		int n_batch_rows = decompress_batch(decompressor);
+
+		/* Feed each decompressed row through the builders */
+		for (int i = 0; i < n_batch_rows; i++)
+		{
+			foreach_ptr(BatchMetadataBuilder, builder, builders)
+			{
+				builder->update_row(builder, decompressor->decompressed_slots[i]);
+			}
+		}
+
+		/* Write computed sparse index values into the datum arrays */
+		foreach_ptr(BatchMetadataBuilder, builder, builders)
+		{
+			builder->insert_to_compressed_row(builder,
+											  decompressor->compressed_datums,
+											  decompressor->compressed_is_nulls);
+		}
+
+		/* Update the compressed tuple in-place */
+		ItemPointerData tid = scan_slot->tts_tid;
+		HeapTuple new_tuple = heap_modify_tuple(compressed_tuple,
+												compressed_desc,
+												decompressor->compressed_datums,
+												decompressor->compressed_is_nulls,
+												repl);
+		ExecStoreHeapTuple(new_tuple, update_slot, false);
+
+		/*
+		 * Sparse index metadata columns are not covered by any index.
+		 * If indexes on metadata columns are added in the future,
+		 * this will need to handle index updates via update_indexes.
+		 */
+#if PG16_LT
+		bool update_indexes;
+#else
+		TU_UpdateIndexes update_indexes;
+#endif
+		simple_table_tuple_update(compressed_rel,
+								  &tid,
+								  update_slot,
+								  GetActiveSnapshot(),
+								  &update_indexes);
+		ExecClearTuple(update_slot);
+
+		/* Reset */
+		foreach_ptr(BatchMetadataBuilder, builder, builders)
+		{
+			builder->reset(builder,
+						   decompressor->compressed_datums,
+						   decompressor->compressed_is_nulls);
+		}
+
+		row_decompressor_reset(decompressor);
+
+		if (should_free)
+		{
+			heap_freetuple(compressed_tuple);
+		}
+	}
+
+	ExecDropSingleTupleTableSlot(update_slot);
+	ExecDropSingleTupleTableSlot(scan_slot);
+	table_endscan(scan);
+}
+
+void
+rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
+{
+	Hypertable *ht = ts_hypertable_get_by_id(uncompressed_chunk->fd.hypertable_id);
+	Hypertable *compress_ht = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
+
+	LockRelationOid(ht->main_table_relid, AccessShareLock);
+	LockRelationOid(compress_ht->main_table_relid, AccessShareLock);
+	LockRelationOid(uncompressed_chunk->table_id, ShareUpdateExclusiveLock);
+
+	/* Re-read chunk state after locks — another process may have changed it */
+	uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk->table_id, true);
+	if (!ts_chunk_is_compressed(uncompressed_chunk) || ts_chunk_is_frozen(uncompressed_chunk))
+	{
+		ereport(NOTICE,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("chunk \"%s.%s\" is no longer compressed or is frozen, skipping",
+						NameStr(uncompressed_chunk->fd.schema_name),
+						NameStr(uncompressed_chunk->fd.table_name))));
+		return;
+	}
+
+	CompressionSettings *chunk_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *ht_settings =
+		ts_compression_settings_get(uncompressed_chunk->hypertable_relid);
+
+	/* Orderby changes require recompression, not sparse index rebuild */
+	if (!ts_array_equal(chunk_settings->fd.orderby, ht_settings->fd.orderby))
+	{
+		ereport(NOTICE,
+				(errmsg("orderby settings for chunk \"%s.%s\" differ from hypertable \"%s\"",
+						NameStr(uncompressed_chunk->fd.schema_name),
+						NameStr(uncompressed_chunk->fd.table_name),
+						get_rel_name(uncompressed_chunk->hypertable_relid)),
+				 errhint("Use compress_chunk(chunk, recompress => true) to recompress.")));
+		return;
+	}
+
+	if (!force && ts_sparse_index_equal(chunk_settings->fd.index, ht_settings->fd.index))
+	{
+		ereport(NOTICE,
+				(errmsg("sparse index settings for chunk \"%s.%s\" already match hypertable "
+						"after acquiring locks, skipping",
+						NameStr(uncompressed_chunk->fd.schema_name),
+						NameStr(uncompressed_chunk->fd.table_name))));
+		return;
+	}
+
+	/* Step 1: drop old columns, add new ones, update compression settings */
+	List *added_indexes = modify_compressed_table(uncompressed_chunk, force);
+
+	if (added_indexes == NIL)
+	{
+		return;
+	}
+
+	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
+
+	/* Step 2: initialize builders and decompressor */
+	Relation compressed_rel = table_open(compressed_chunk->table_id, RowExclusiveLock);
+	Relation uncompressed_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
+	TupleDesc compressed_desc = RelationGetDescr(compressed_rel);
+
+	bool *repl = palloc0(sizeof(bool) * compressed_desc->natts);
+	List *builders = create_sparse_index_builders(uncompressed_rel,
+												  compressed_chunk->table_id,
+												  added_indexes,
+												  repl);
+
+	RowDecompressor decompressor = build_decompressor(compressed_desc,
+													  RelationGetDescr(uncompressed_rel),
+													  compressed_chunk->table_id,
+													  uncompressed_chunk->table_id);
+
+	/* Step 3: scan, decompress, populate, update */
+	populate_sparse_index_columns(compressed_rel, &decompressor, builders, repl);
+
+	row_decompressor_close(&decompressor);
+	table_close(uncompressed_rel, AccessShareLock);
+	table_close(compressed_rel, RowExclusiveLock);
 }

--- a/tsl/src/compression/recompress.h
+++ b/tsl/src/compression/recompress.h
@@ -32,6 +32,7 @@ extern Datum tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS);
 
 Oid recompress_chunk_segmentwise_impl(Chunk *chunk, bool fullrecompress);
 bool recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk);
+void rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force);
 
 /* Result of matching an uncompressed tuple against a compressed batch */
 enum Batch_match_result

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -169,6 +169,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.compress_chunk = tsl_compress_chunk,
 	.decompress_chunk = tsl_decompress_chunk,
 	.rebuild_columnstore = tsl_rebuild_columnstore,
+	.rebuild_sparse_index = tsl_rebuild_sparse_index,
 	.decompress_batches_for_insert = decompress_batches_for_insert,
 	.init_decompress_state_for_insert = init_decompress_state_for_insert,
 	.decompress_target_segments = decompress_target_segments,

--- a/tsl/test/expected/rebuild_sparse_index.out
+++ b/tsl/test/expected/rebuild_sparse_index.out
@@ -1,0 +1,603 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test rebuild_sparse_index function
+CREATE OR REPLACE FUNCTION show_compressed_columns(chunk_regclass regclass)
+RETURNS TABLE(attname name, typname name) AS $$
+    SELECT a.attname, t.typname
+    FROM pg_attribute a
+    JOIN pg_type t ON a.atttypid = t.oid
+    WHERE a.attrelid = (
+        SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass
+        FROM _timescaledb_catalog.chunk uc
+        JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+        WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass
+    )
+    AND a.attname LIKE '_ts_meta_%'
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+    ORDER BY a.attname;
+$$ LANGUAGE sql;
+CREATE OR REPLACE FUNCTION show_chunk_index(chunk_regclass regclass)
+RETURNS jsonb AS $$
+    SELECT cs.index
+    FROM _timescaledb_catalog.compression_settings cs
+    WHERE cs.relid = chunk_regclass;
+$$ LANGUAGE sql;
+CREATE TABLE rsi_test(
+    time timestamptz NOT NULL,
+    device int,
+    sensor int,
+    temp float8,
+    val int
+);
+SELECT create_hypertable('rsi_test', 'time', chunk_time_interval => INTERVAL '1 day');
+   create_hypertable   
+-----------------------
+ (1,public,rsi_test,t)
+
+INSERT INTO rsi_test
+SELECT t, (i % 5) + 1, (i % 3) + 1, random() * 100, (i * 7) % 13
+FROM generate_series('2024-01-01 01:00'::timestamptz, '2024-01-01 23:59', '1 minute') t,
+     generate_series(1, 3) i;
+SELECT format('%I.%I', schema_name, table_name) AS chunk1
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                        WHERE table_name = 'rsi_test')
+ORDER BY id LIMIT 1 \gset
+-- Test 1: initial compression with bloom + minmax
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("device"), minmax("temp")'
+);
+SELECT compress_chunk(:'chunk1');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SELECT show_chunk_index(:'chunk1'::regclass);
+                                                                                                                show_chunk_index                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"type": "bloom", "column": "device", "source": "config"}, {"type": "minmax", "column": "temp", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}, {"type": "firstlast", "column": "time", "source": "orderby"}]
+
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+          attname          |   typname   
+---------------------------+-------------
+ _ts_meta_count            | int4
+ _ts_meta_max_1            | timestamptz
+ _ts_meta_min_1            | timestamptz
+ regress-test-bloom_device | bloom1
+ _ts_meta_v2_first_time    | timestamptz
+ _ts_meta_v2_last_time     | timestamptz
+ _ts_meta_v2_max_temp      | float8
+ _ts_meta_v2_min_temp      | float8
+
+-- Test 2: settings match, should skip
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+NOTICE:  sparse index settings for chunk "_timescaledb_internal._hyper_1_1_chunk" already match hypertable, skipping (use force => true to override)
+ rebuild_sparse_index 
+----------------------
+ 
+
+-- Test 3: swap bloom("device") for bloom("device","sensor"), keep minmax("temp")
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("device","sensor"), minmax("temp")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT show_chunk_index(:'chunk1'::regclass);
+                                                                                                                show_chunk_index                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"type": "bloom", "column": "device", "source": "config"}, {"type": "minmax", "column": "temp", "source": "config"}, {"type": "minmax", "column": "time", "source": "orderby"}, {"type": "firstlast", "column": "time", "source": "orderby"}]
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+                attname                |   typname   
+---------------------------------------+-------------
+ _ts_meta_count                        | int4
+ _ts_meta_max_1                        | timestamptz
+ _ts_meta_min_1                        | timestamptz
+ regress-test-bloom_2b4d_device_sensor | bloom1
+ _ts_meta_v2_first_time                | timestamptz
+ _ts_meta_v2_last_time                 | timestamptz
+ _ts_meta_v2_max_temp                  | float8
+ _ts_meta_v2_min_temp                  | float8
+
+-- Test 4: remove all sparse indexes
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+        attname         |   typname   
+------------------------+-------------
+ _ts_meta_count         | int4
+ _ts_meta_max_1         | timestamptz
+ _ts_meta_min_1         | timestamptz
+ _ts_meta_v2_first_time | timestamptz
+ _ts_meta_v2_last_time  | timestamptz
+
+-- Test 5: add back bloom + minmax + composite bloom
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("device"), minmax("temp"), bloom("device","val")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+              attname               |   typname   
+------------------------------------+-------------
+ _ts_meta_count                     | int4
+ _ts_meta_max_1                     | timestamptz
+ _ts_meta_min_1                     | timestamptz
+ regress-test-bloom_device          | bloom1
+ regress-test-bloom_e076_device_val | bloom1
+ _ts_meta_v2_first_time             | timestamptz
+ _ts_meta_v2_last_time              | timestamptz
+ _ts_meta_v2_max_temp               | float8
+ _ts_meta_v2_min_temp               | float8
+
+-- Test 6: force rebuild when settings already match
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass, force => true);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+              attname               |   typname   
+------------------------------------+-------------
+ _ts_meta_count                     | int4
+ _ts_meta_max_1                     | timestamptz
+ _ts_meta_min_1                     | timestamptz
+ regress-test-bloom_device          | bloom1
+ regress-test-bloom_e076_device_val | bloom1
+ _ts_meta_v2_first_time             | timestamptz
+ _ts_meta_v2_last_time              | timestamptz
+ _ts_meta_v2_max_temp               | float8
+ _ts_meta_v2_min_temp               | float8
+
+-- Test 7: uncompressed chunk, should skip
+SELECT decompress_chunk(:'chunk1');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+NOTICE:  chunk "_timescaledb_internal._hyper_1_1_chunk" is uncompressed or frozen, skipping
+ rebuild_sparse_index 
+----------------------
+ 
+
+DROP TABLE rsi_test CASCADE;
+-- Data integrity tests: verify rebuilt sparse index values match the
+-- original compression output (file diff) and that bloom filters
+-- correctly identify present and absent values.
+\set TEST_BASE_NAME rebuild_sparse_index
+CREATE TABLE rsi_integrity(
+    time timestamptz NOT NULL,
+    device text NOT NULL,
+    temp float8,
+    humidity int,
+    label text,
+    reading uuid
+);
+SELECT create_hypertable('rsi_integrity', 'time', chunk_time_interval => INTERVAL '1 day');
+     create_hypertable      
+----------------------------
+ (3,public,rsi_integrity,t)
+
+-- NULLs at row 5000/5001 to stress firstlast NULL handling at batch boundaries
+SELECT setseed(0.42);
+ setseed 
+---------
+ 
+
+INSERT INTO rsi_integrity
+SELECT
+    '2024-01-01'::timestamptz + ((row_num - 1) * interval '10 seconds'),
+    'd' || ((row_num % 5) + 1),
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE random() * 100 END,
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE (random() * 200)::int END,
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE 'label_' || (row_num % 7) END,
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE gen_random_uuid() END
+FROM generate_series(1, 15000) row_num;
+SELECT format('%I.%I', schema_name, table_name) AS ichunk1
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'rsi_integrity')
+ORDER BY id LIMIT 1 \gset
+SELECT format('%I.%I', schema_name, table_name) AS ichunk2
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'rsi_integrity')
+ORDER BY id LIMIT 1 OFFSET 1 \gset
+SELECT format('%s/results/%s_original.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "ORIGINAL",
+       format('%s/results/%s_rebuilt.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "REBUILT"
+\gset
+-- Dump _ts_meta_v2_* columns sorted by name (avoids column reorder after drop+add)
+CREATE OR REPLACE FUNCTION dump_sparse_metadata(chunk_regclass regclass)
+RETURNS SETOF text AS $$
+DECLARE
+    compressed_relid oid;
+    col_list text;
+BEGIN
+    SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass INTO compressed_relid
+    FROM _timescaledb_catalog.chunk uc
+    JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+    WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass;
+
+    SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY a.attname) INTO col_list
+    FROM pg_attribute a
+    WHERE a.attrelid = compressed_relid
+      AND a.attname LIKE '_ts_meta_v2_%'
+      AND a.attnum > 0
+      AND NOT a.attisdropped;
+
+    RETURN QUERY EXECUTE format(
+        'SELECT row(%s)::text FROM %s ORDER BY _ts_meta_min_1',
+        col_list, compressed_relid::regclass);
+END;
+$$ LANGUAGE plpgsql;
+-- Test 8: minmax integrity (compress, save, drop+rebuild, save, diff)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'minmax("temp"), minmax("humidity"), minmax("label"), minmax("reading")'
+);
+SELECT compress_chunk(:'ichunk1');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+SELECT compress_chunk(:'ichunk2');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+\o :ORIGINAL
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'minmax("temp"), minmax("humidity"), minmax("label"), minmax("reading")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+\o :REBUILT
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+SELECT format('\! diff -u --label "minmax original" --label "minmax rebuilt" %s %s',
+              :'ORIGINAL', :'REBUILT') AS "DIFF_CMD" \gset
+:DIFF_CMD
+SELECT decompress_chunk(:'ichunk1');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+SELECT decompress_chunk(:'ichunk2');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+-- Test 9: firstlast integrity (compress, save, drop+rebuild, save, diff)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'firstlast("temp"), firstlast("humidity"), firstlast("label"), firstlast("reading")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(:'ichunk1');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+SELECT compress_chunk(:'ichunk2');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+-- re-fetch compressed chunk names after recompress
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+\o :ORIGINAL
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'firstlast("temp"), firstlast("humidity"), firstlast("label"), firstlast("reading")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+\o :REBUILT
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+SELECT format('\! diff -u --label "firstlast original" --label "firstlast rebuilt" %s %s',
+              :'ORIGINAL', :'REBUILT') AS "DIFF_CMD" \gset
+:DIFF_CMD
+SELECT decompress_chunk(:'ichunk1');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+SELECT decompress_chunk(:'ichunk2');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_5_chunk
+
+-- Test 10: single-column bloom integrity (drop, rebuild, check contains)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity"), bloom("label")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(:'ichunk1');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'ichunk1'::regclass);
+        attname         |   typname   
+------------------------+-------------
+ _ts_meta_count         | int4
+ _ts_meta_max_1         | timestamptz
+ _ts_meta_min_1         | timestamptz
+ _ts_meta_v2_first_time | timestamptz
+ _ts_meta_v2_last_time  | timestamptz
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity"), bloom("label")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+-- look up bloom column names (prefix varies between test/production builds)
+SELECT a.attname AS bloom_humidity
+FROM pg_attribute a
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE a.attrelid = (:'ic_schema1' || '.' || :'ic_table1')::regclass
+  AND t.typname = 'bloom1' AND a.attname LIKE '%humidity'
+  AND NOT a.attisdropped LIMIT 1 \gset
+SELECT a.attname AS bloom_label
+FROM pg_attribute a
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE a.attrelid = (:'ic_schema1' || '.' || :'ic_table1')::regclass
+  AND t.typname = 'bloom1' AND a.attname LIKE '%label'
+  AND NOT a.attisdropped LIMIT 1 \gset
+-- present values (expect true)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_humidity", 42) AS val_42,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 100) AS val_100,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 7) AS val_7
+FROM :ic_schema1.:ic_table1 WHERE device = 'd1' LIMIT 1;
+ val_42 | val_100 | val_7 
+--------+---------+-------
+ t      | t       | t
+
+-- absent values (expect false)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_humidity", -999) AS val_neg999,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 999) AS val_999,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 12345) AS val_12345
+FROM :ic_schema1.:ic_table1 WHERE device = 'd1' LIMIT 1;
+ val_neg999 | val_999 | val_12345 
+------------+---------+-----------
+ f          | f       | f
+
+-- present labels (expect true)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_label", 'label_0'::text) AS label_0,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'label_3'::text) AS label_3,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'label_6'::text) AS label_6
+FROM :ic_schema1.:ic_table1 WHERE device = 'd2' LIMIT 1;
+ label_0 | label_3 | label_6 
+---------+---------+---------
+ t       | t       | t
+
+-- absent labels (expect false)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_label", 'nonexistent'::text) AS nope1,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'zzz_never'::text) AS nope2,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'NOPE'::text) AS nope3
+FROM :ic_schema1.:ic_table1 WHERE device = 'd2' LIMIT 1;
+ nope1 | nope2 | nope3 
+-------+-------+-------
+ f     | f     | f
+
+SELECT decompress_chunk(:'ichunk1');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+-- Test 11: composite bloom integrity (drop, rebuild, verify via explain)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity","label")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(:'ichunk1');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_3_4_chunk
+
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'ichunk1'::regclass);
+        attname         |   typname   
+------------------------+-------------
+ _ts_meta_count         | int4
+ _ts_meta_max_1         | timestamptz
+ _ts_meta_min_1         | timestamptz
+ _ts_meta_v2_first_time | timestamptz
+ _ts_meta_v2_last_time  | timestamptz
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity","label")'
+);
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+ rebuild_sparse_index 
+----------------------
+ 
+
+SELECT * FROM show_compressed_columns(:'ichunk1'::regclass);
+                attname                 |   typname   
+----------------------------------------+-------------
+ _ts_meta_count                         | int4
+ _ts_meta_max_1                         | timestamptz
+ _ts_meta_min_1                         | timestamptz
+ regress-test-bloom_577c_humidity_label | bloom1
+ _ts_meta_v2_first_time                 | timestamptz
+ _ts_meta_v2_last_time                  | timestamptz
+
+-- composite bloom should appear in the plan filter
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM rsi_integrity WHERE device = 'd1' AND humidity = 42 AND label = 'label_0';
+--- QUERY PLAN ---
+ Append (actual rows=0.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_3_4_chunk (actual rows=0.00 loops=1)
+         Vectorized Filter: ((humidity = 42) AND (label = 'label_0'::text))
+         ->  Index Scan using compress_hyper_4_12_chunk_device__ts_meta_v2_first_time__ts_idx on compress_hyper_4_12_chunk (actual rows=0.00 loops=1)
+               Index Cond: (device = 'd1'::text)
+               Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_577c_humidity_label, TEST-HASHES::bigint[])
+   ->  Seq Scan on _hyper_3_5_chunk (actual rows=0.00 loops=1)
+         Filter: ((device = 'd1'::text) AND (humidity = 42) AND (label = 'label_0'::text))
+         Rows Removed by Filter: 8640
+   ->  Seq Scan on _hyper_3_6_chunk (actual rows=0.00 loops=1)
+         Filter: ((device = 'd1'::text) AND (humidity = 42) AND (label = 'label_0'::text))
+         Rows Removed by Filter: 600
+
+DROP TABLE rsi_integrity CASCADE;
+DROP FUNCTION show_compressed_columns(regclass);
+DROP FUNCTION show_chunk_index(regclass);
+DROP FUNCTION dump_sparse_metadata(regclass);

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -110,6 +110,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.process_ddl_event()
  _timescaledb_functions.range_value_to_pretty(bigint,regtype)
  _timescaledb_functions.rebuild_columnstore(regclass)
+ _timescaledb_functions.rebuild_sparse_index(regclass,boolean)
  _timescaledb_functions.recompress_chunk_segmentwise(regclass,boolean)
  _timescaledb_functions.relation_approximate_size(regclass)
  _timescaledb_functions.relation_size(regclass)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -75,6 +75,7 @@ set(TEST_FILES
     plan_skip_scan_pg_partition.sql
     policy_generalization.sql
     rebuild_columnstore_tests.sql
+    rebuild_sparse_index.sql
     recompression_integrity_tests.sql
     recompression_integrity_unordered.sql
     recompression_nullable_orderby.sql

--- a/tsl/test/sql/rebuild_sparse_index.sql
+++ b/tsl/test/sql/rebuild_sparse_index.sql
@@ -1,0 +1,396 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test rebuild_sparse_index function
+
+CREATE OR REPLACE FUNCTION show_compressed_columns(chunk_regclass regclass)
+RETURNS TABLE(attname name, typname name) AS $$
+    SELECT a.attname, t.typname
+    FROM pg_attribute a
+    JOIN pg_type t ON a.atttypid = t.oid
+    WHERE a.attrelid = (
+        SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass
+        FROM _timescaledb_catalog.chunk uc
+        JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+        WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass
+    )
+    AND a.attname LIKE '_ts_meta_%'
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+    ORDER BY a.attname;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION show_chunk_index(chunk_regclass regclass)
+RETURNS jsonb AS $$
+    SELECT cs.index
+    FROM _timescaledb_catalog.compression_settings cs
+    WHERE cs.relid = chunk_regclass;
+$$ LANGUAGE sql;
+
+CREATE TABLE rsi_test(
+    time timestamptz NOT NULL,
+    device int,
+    sensor int,
+    temp float8,
+    val int
+);
+SELECT create_hypertable('rsi_test', 'time', chunk_time_interval => INTERVAL '1 day');
+
+INSERT INTO rsi_test
+SELECT t, (i % 5) + 1, (i % 3) + 1, random() * 100, (i * 7) % 13
+FROM generate_series('2024-01-01 01:00'::timestamptz, '2024-01-01 23:59', '1 minute') t,
+     generate_series(1, 3) i;
+
+SELECT format('%I.%I', schema_name, table_name) AS chunk1
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable
+                        WHERE table_name = 'rsi_test')
+ORDER BY id LIMIT 1 \gset
+
+-- Test 1: initial compression with bloom + minmax
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("device"), minmax("temp")'
+);
+SELECT compress_chunk(:'chunk1');
+
+SELECT show_chunk_index(:'chunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+
+-- Test 2: settings match, should skip
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+
+-- Test 3: swap bloom("device") for bloom("device","sensor"), keep minmax("temp")
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("device","sensor"), minmax("temp")'
+);
+
+SELECT show_chunk_index(:'chunk1'::regclass);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+
+-- Test 4: remove all sparse indexes
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+
+-- Test 5: add back bloom + minmax + composite bloom
+ALTER TABLE rsi_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("device"), minmax("temp"), bloom("device","val")'
+);
+
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+
+-- Test 6: force rebuild when settings already match
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass, force => true);
+SELECT * FROM show_compressed_columns(:'chunk1'::regclass);
+
+-- Test 7: uncompressed chunk, should skip
+SELECT decompress_chunk(:'chunk1');
+SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);
+
+DROP TABLE rsi_test CASCADE;
+
+-- Data integrity tests: verify rebuilt sparse index values match the
+-- original compression output (file diff) and that bloom filters
+-- correctly identify present and absent values.
+
+\set TEST_BASE_NAME rebuild_sparse_index
+
+CREATE TABLE rsi_integrity(
+    time timestamptz NOT NULL,
+    device text NOT NULL,
+    temp float8,
+    humidity int,
+    label text,
+    reading uuid
+);
+SELECT create_hypertable('rsi_integrity', 'time', chunk_time_interval => INTERVAL '1 day');
+
+
+-- NULLs at row 5000/5001 to stress firstlast NULL handling at batch boundaries
+SELECT setseed(0.42);
+INSERT INTO rsi_integrity
+SELECT
+    '2024-01-01'::timestamptz + ((row_num - 1) * interval '10 seconds'),
+    'd' || ((row_num % 5) + 1),
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE random() * 100 END,
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE (random() * 200)::int END,
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE 'label_' || (row_num % 7) END,
+    CASE WHEN row_num % 5000 IN (0, 1) THEN NULL ELSE gen_random_uuid() END
+FROM generate_series(1, 15000) row_num;
+
+SELECT format('%I.%I', schema_name, table_name) AS ichunk1
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'rsi_integrity')
+ORDER BY id LIMIT 1 \gset
+
+SELECT format('%I.%I', schema_name, table_name) AS ichunk2
+FROM _timescaledb_catalog.chunk
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'rsi_integrity')
+ORDER BY id LIMIT 1 OFFSET 1 \gset
+
+SELECT format('%s/results/%s_original.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "ORIGINAL",
+       format('%s/results/%s_rebuilt.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "REBUILT"
+\gset
+
+-- Dump _ts_meta_v2_* columns sorted by name (avoids column reorder after drop+add)
+CREATE OR REPLACE FUNCTION dump_sparse_metadata(chunk_regclass regclass)
+RETURNS SETOF text AS $$
+DECLARE
+    compressed_relid oid;
+    col_list text;
+BEGIN
+    SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass INTO compressed_relid
+    FROM _timescaledb_catalog.chunk uc
+    JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+    WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass;
+
+    SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY a.attname) INTO col_list
+    FROM pg_attribute a
+    WHERE a.attrelid = compressed_relid
+      AND a.attname LIKE '_ts_meta_v2_%'
+      AND a.attnum > 0
+      AND NOT a.attisdropped;
+
+    RETURN QUERY EXECUTE format(
+        'SELECT row(%s)::text FROM %s ORDER BY _ts_meta_min_1',
+        col_list, compressed_relid::regclass);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Test 8: minmax integrity (compress, save, drop+rebuild, save, diff)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'minmax("temp"), minmax("humidity"), minmax("label"), minmax("reading")'
+);
+SELECT compress_chunk(:'ichunk1');
+SELECT compress_chunk(:'ichunk2');
+
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+
+SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+
+\o :ORIGINAL
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'minmax("temp"), minmax("humidity"), minmax("label"), minmax("reading")'
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+
+\o :REBUILT
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+
+SELECT format('\! diff -u --label "minmax original" --label "minmax rebuilt" %s %s',
+              :'ORIGINAL', :'REBUILT') AS "DIFF_CMD" \gset
+:DIFF_CMD
+
+SELECT decompress_chunk(:'ichunk1');
+SELECT decompress_chunk(:'ichunk2');
+
+-- Test 9: firstlast integrity (compress, save, drop+rebuild, save, diff)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'firstlast("temp"), firstlast("humidity"), firstlast("label"), firstlast("reading")'
+);
+SELECT compress_chunk(:'ichunk1');
+SELECT compress_chunk(:'ichunk2');
+
+-- re-fetch compressed chunk names after recompress
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+
+SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+
+\o :ORIGINAL
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'firstlast("temp"), firstlast("humidity"), firstlast("label"), firstlast("reading")'
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk2'::regclass);
+
+\o :REBUILT
+SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
+SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
+\o
+
+SELECT format('\! diff -u --label "firstlast original" --label "firstlast rebuilt" %s %s',
+              :'ORIGINAL', :'REBUILT') AS "DIFF_CMD" \gset
+:DIFF_CMD
+
+SELECT decompress_chunk(:'ichunk1');
+SELECT decompress_chunk(:'ichunk2');
+
+-- Test 10: single-column bloom integrity (drop, rebuild, check contains)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity"), bloom("label")'
+);
+SELECT compress_chunk(:'ichunk1');
+
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'ichunk1'::regclass);
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity"), bloom("label")'
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+
+-- look up bloom column names (prefix varies between test/production builds)
+SELECT a.attname AS bloom_humidity
+FROM pg_attribute a
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE a.attrelid = (:'ic_schema1' || '.' || :'ic_table1')::regclass
+  AND t.typname = 'bloom1' AND a.attname LIKE '%humidity'
+  AND NOT a.attisdropped LIMIT 1 \gset
+
+SELECT a.attname AS bloom_label
+FROM pg_attribute a
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE a.attrelid = (:'ic_schema1' || '.' || :'ic_table1')::regclass
+  AND t.typname = 'bloom1' AND a.attname LIKE '%label'
+  AND NOT a.attisdropped LIMIT 1 \gset
+
+-- present values (expect true)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_humidity", 42) AS val_42,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 100) AS val_100,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 7) AS val_7
+FROM :ic_schema1.:ic_table1 WHERE device = 'd1' LIMIT 1;
+
+-- absent values (expect false)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_humidity", -999) AS val_neg999,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 999) AS val_999,
+       _timescaledb_functions.bloom1_contains(:"bloom_humidity", 12345) AS val_12345
+FROM :ic_schema1.:ic_table1 WHERE device = 'd1' LIMIT 1;
+
+-- present labels (expect true)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_label", 'label_0'::text) AS label_0,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'label_3'::text) AS label_3,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'label_6'::text) AS label_6
+FROM :ic_schema1.:ic_table1 WHERE device = 'd2' LIMIT 1;
+
+-- absent labels (expect false)
+SELECT _timescaledb_functions.bloom1_contains(:"bloom_label", 'nonexistent'::text) AS nope1,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'zzz_never'::text) AS nope2,
+       _timescaledb_functions.bloom1_contains(:"bloom_label", 'NOPE'::text) AS nope3
+FROM :ic_schema1.:ic_table1 WHERE device = 'd2' LIMIT 1;
+
+SELECT decompress_chunk(:'ichunk1');
+
+-- Test 11: composite bloom integrity (drop, rebuild, verify via explain)
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity","label")'
+);
+SELECT compress_chunk(:'ichunk1');
+
+SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
+FROM _timescaledb_catalog.chunk uc
+JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = ''
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'ichunk1'::regclass);
+
+ALTER TABLE rsi_integrity SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'device',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_index = 'bloom("humidity","label")'
+);
+SELECT _timescaledb_functions.rebuild_sparse_index(:'ichunk1'::regclass);
+SELECT * FROM show_compressed_columns(:'ichunk1'::regclass);
+
+-- composite bloom should appear in the plan filter
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT * FROM rsi_integrity WHERE device = 'd1' AND humidity = 42 AND label = 'label_0';
+
+DROP TABLE rsi_integrity CASCADE;
+DROP FUNCTION show_compressed_columns(regclass);
+DROP FUNCTION show_chunk_index(regclass);
+DROP FUNCTION dump_sparse_metadata(regclass);


### PR DESCRIPTION
Rebuild sparse index metadata columns on compressed chunks in-place without full recompression.

Adds _timescaledb_functions.rebuild_sparse_index(chunk, force) which diffs chunk vs hypertable sparse index settings, drops/adds metadata columns, then populates them by decompressing each batch through the existing RowDecompressor and BatchMetadataBuilder pipeline.