### PR TITLE
Remove telemetry_event table

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -320,15 +320,6 @@ CREATE TABLE _timescaledb_catalog.metadata (
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.metadata', $$ WHERE key <> 'uuid' $$);
 
--- Log with events that will be sent out with the telemetry. The log
--- will be flushed after it has been sent out. We do not save it to
--- backups since it should not contain important data.
-CREATE TABLE _timescaledb_catalog.telemetry_event (
-       created timestamptz NOT NULL DEFAULT current_timestamp,
-       tag name NOT NULL,
-       body jsonb NOT NULL
-);
-
 CREATE TABLE _timescaledb_catalog.continuous_agg (
   mat_hypertable_id integer NOT NULL,
   raw_hypertable_id integer NOT NULL,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -270,3 +270,8 @@ ALTER TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
 
 ANALYZE _timescaledb_catalog.continuous_agg;
 -- end rebuild _timescaledb_catalog.continuous_agg --
+
+-- drop telemetry_event
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.telemetry_event;
+DROP TABLE _timescaledb_catalog.telemetry_event;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -274,3 +274,11 @@ ALTER TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges
 ANALYZE _timescaledb_catalog.continuous_agg;
 -- end rebuild _timescaledb_catalog.continuous_agg --
 
+-- restore telemetry_event
+CREATE TABLE _timescaledb_catalog.telemetry_event (
+       created timestamptz NOT NULL DEFAULT current_timestamp,
+       tag name NOT NULL,
+       body jsonb NOT NULL
+);
+GRANT SELECT ON _timescaledb_catalog.telemetry_event TO PUBLIC;
+

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -74,7 +74,6 @@
 #define REQ_NUM_USER_DEFINED_ACTIONS "num_user_defined_actions"
 #define REQ_RELATED_EXTENSIONS "related_extensions"
 #define REQ_METADATA "db_metadata"
-#define REQ_TELEMETRY_EVENT "db_telemetry_events"
 #define REQ_LICENSE_EDITION_APACHE "apache_only"
 #define REQ_LICENSE_EDITION_COMMUNITY "community"
 #define REQ_TS_LAST_TUNE_TIME "last_tuned_time"
@@ -1082,13 +1081,6 @@ build_telemetry_report()
 	ts_telemetry_metadata_add_values(parse_state);
 	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
 
-	/* Add telemetry events */
-	key.type = jbvString;
-	key.val.string.val = REQ_TELEMETRY_EVENT;
-	key.val.string.len = strlen(REQ_TELEMETRY_EVENT);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	ts_telemetry_events_add(parse_state);
-
 	/* Add function call telemetry */
 	key.type = jbvString;
 	key.val.string.val = REQ_FUNCTIONS_USED;
@@ -1253,7 +1245,6 @@ ts_telemetry_main(const char *host, const char *path, const char *service)
 	}
 
 	ts_function_telemetry_reset_counts();
-	ts_telemetry_event_truncate();
 
 	/*
 	 * Do the version-check. Response is the body of a well-formed HTTP

--- a/src/telemetry/telemetry_metadata.c
+++ b/src/telemetry/telemetry_metadata.c
@@ -17,65 +17,6 @@
 #include "ts_catalog/metadata.h"
 #include "uuid.h"
 
-void
-ts_telemetry_event_truncate(void)
-{
-	RangeVar rv = {
-		.schemaname = CATALOG_SCHEMA_NAME,
-		.relname = TELEMETRY_EVENT_TABLE_NAME,
-	};
-	ExecuteTruncate(&(TruncateStmt){
-		.type = T_TruncateStmt,
-		.relations = list_make1(&rv),
-		.behavior = DROP_RESTRICT,
-	});
-}
-
-void
-ts_telemetry_events_add(JsonbParseState *state)
-{
-	ScanIterator iterator =
-		ts_scan_iterator_create(TELEMETRY_EVENT, AccessShareLock, CurrentMemoryContext);
-	pushJsonbValue(&state, WJB_BEGIN_ARRAY, NULL);
-	ts_scanner_foreach(&iterator)
-	{
-		TupleInfo *ti = iterator.tinfo;
-		TupleDesc tupdesc = ti->slot->tts_tupleDescriptor;
-		bool created_isnull, tag_isnull, value_isnull;
-		Datum created = slot_getattr(ti->slot, Anum_telemetry_event_created, &created_isnull);
-		Datum tag = slot_getattr(ti->slot, Anum_telemetry_event_tag, &tag_isnull);
-		Datum body = slot_getattr(ti->slot, Anum_telemetry_event_body, &value_isnull);
-
-		pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
-		if (!created_isnull)
-		{
-			ts_jsonb_add_str(state,
-							 NameStr(
-								 TupleDescAttr(tupdesc, Anum_telemetry_event_created - 1)->attname),
-							 DatumGetCString(DirectFunctionCall1(timestamptz_out, created)));
-		}
-
-		if (!tag_isnull)
-		{
-			ts_jsonb_add_str(state,
-							 NameStr(TupleDescAttr(tupdesc, Anum_telemetry_event_tag - 1)->attname),
-							 pstrdup(NameStr(*DatumGetName(tag))));
-		}
-
-		if (!value_isnull)
-		{
-			JsonbValue jsonb_value;
-			JsonbToJsonbValue(DatumGetJsonbPCopy(body), &jsonb_value);
-			ts_jsonb_add_value(state,
-							   NameStr(
-								   TupleDescAttr(tupdesc, Anum_telemetry_event_body - 1)->attname),
-							   &jsonb_value);
-		}
-		pushJsonbValue(&state, WJB_END_OBJECT, NULL);
-	}
-	pushJsonbValue(&state, WJB_END_ARRAY, NULL);
-}
-
 /*
  * add all entries from _timescaledb_catalog.metadata
  */

--- a/src/telemetry/telemetry_metadata.h
+++ b/src/telemetry/telemetry_metadata.h
@@ -11,5 +11,3 @@
 #include <export.h>
 
 extern void ts_telemetry_metadata_add_values(JsonbParseState *state);
-extern void ts_telemetry_events_add(JsonbParseState *state);
-extern void ts_telemetry_event_truncate(void);

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -109,10 +109,6 @@ static const TableInfoDef catalog_table_names[_MAX_CATALOG_TABLES + 1] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = CONTINUOUS_AGGS_WATERMARK_TABLE_NAME,
 	},
-	[TELEMETRY_EVENT] = {
-		.schema_name = CATALOG_SCHEMA_NAME,
-		.table_name = TELEMETRY_EVENT_TABLE_NAME,
-	},
 	[CHUNK_COLUMN_STATS] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = CHUNK_COLUMN_STATS_TABLE_NAME,

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -53,7 +53,6 @@ typedef enum CatalogTable
 	COMPRESSION_CHUNK_SIZE,
 	CONTINUOUS_AGGS_BUCKET_FUNCTION,
 	CONTINUOUS_AGGS_WATERMARK,
-	TELEMETRY_EVENT,
 	CHUNK_COLUMN_STATS,
 	/* Don't forget updating catalog.c when adding new tables! */
 	_MAX_CATALOG_TABLES,
@@ -737,22 +736,6 @@ enum
 	METADATA_PKEY_IDX = 0,
 	_MAX_METADATA_INDEX,
 };
-
-/*
- * telemetry_event table definition
- */
-
-#define TELEMETRY_EVENT_TABLE_NAME "telemetry_event"
-
-enum Anum_telemetry_event
-{
-	Anum_telemetry_event_created = 1,
-	Anum_telemetry_event_tag,
-	Anum_telemetry_event_body,
-	_Anum_telemetry_event_max,
-};
-
-#define Natts_telemetry_event_max (_Anum_telemetry_event_max - 1)
 
 /****** BGW_POLICY_CHUNK_STATS TABLE definitions */
 #define BGW_POLICY_CHUNK_STATS_TABLE_NAME "bgw_policy_chunk_stats"

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -201,7 +201,6 @@ SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_
  _timescaledb_catalog  | hypertable
  _timescaledb_catalog  | metadata
  _timescaledb_catalog  | tablespace
- _timescaledb_catalog  | telemetry_event
  _timescaledb_internal | bgw_job_stat
  _timescaledb_internal | bgw_job_stat_history
  _timescaledb_internal | bgw_policy_chunk_stats

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -401,7 +401,6 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  _timescaledb_catalog.chunk_rewrite
  _timescaledb_catalog.compression_algorithm
  _timescaledb_catalog.tablespace_id_seq
- _timescaledb_catalog.telemetry_event
  _timescaledb_config.bgw_job
  _timescaledb_internal.bgw_job_stat
  _timescaledb_internal.bgw_job_stat_history

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -333,7 +333,6 @@ WHERE key != 'os_name_pretty';
  last_tuned_version
  postgresql_version
  related_extensions
- db_telemetry_events
  timescaledb_version
  errors_by_sqlerrcode
  num_reorder_policies
@@ -527,15 +526,3 @@ SELECT key from _timescaledb_catalog.metadata;
 -- test that the telemetry gathering code doesn't break nonexistent statements
 EXECUTE noexistent_statement;
 ERROR:  prepared statement "noexistent_statement" does not exist
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- Insert some data into the telemetry event table
-INSERT INTO _timescaledb_catalog.telemetry_event(tag, body) VALUES
-    ('ummagumma', '{"title": "Careful with that Axe Eugene!"}'),
-    ('kaboom', '{"title": "Where is that kaboom?"}');
--- Check that it is present in the telemetry report
-SELECT * FROM jsonb_to_recordset(get_telemetry_report()->'db_telemetry_events') AS x(tag name, body text);
-    tag    |                    body                    
------------+--------------------------------------------
- ummagumma | {"title": "Careful with that Axe Eugene!"}
- kaboom    | {"title": "Where is that kaboom?"}
-

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -266,11 +266,3 @@ SELECT key from _timescaledb_catalog.metadata;
 -- test that the telemetry gathering code doesn't break nonexistent statements
 EXECUTE noexistent_statement;
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- Insert some data into the telemetry event table
-INSERT INTO _timescaledb_catalog.telemetry_event(tag, body) VALUES
-    ('ummagumma', '{"title": "Careful with that Axe Eugene!"}'),
-    ('kaboom', '{"title": "Where is that kaboom?"}');
-
--- Check that it is present in the telemetry report
-SELECT * FROM jsonb_to_recordset(get_telemetry_report()->'db_telemetry_events') AS x(tag name, body text);

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -110,11 +110,6 @@ set(TEST_TEMPLATES
     transparent_decompression.sql.in
     transparent_decompression_ordered_index.sql.in)
 
-# WAL numbers will differ on 32-bit platform so we only run on 64-bit
-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
-  list(APPEND TEST_FILES explain_wal.sql)
-endif()
-
 if(USE_TELEMETRY)
   list(APPEND TEST_FILES bgw_telemetry.sql)
 endif()
@@ -227,6 +222,12 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "16"))
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))
+  # WAL numbers will differ on 32-bit platform so we only run on 64-bit only run
+  # on PG17+ since the test can be flaky at times
+  if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+    list(APPEND TEST_FILES explain_wal.sql)
+  endif()
+
   list(APPEND TEST_FILES privilege_maintain.sql
        merge_append_partially_compressed.sql)
 endif()


### PR DESCRIPTION
Remove _timescaledb_catalog.telemetry_event and associated code.
This is part of legacy telemetry and not used by our code.

Disable-check: commit-count
Disable-check: force-changelog-file