### PR TITLE
Modified and reimplemented FastLanes library in C

### DIFF
--- a/coverage/CMakeLists.txt
+++ b/coverage/CMakeLists.txt
@@ -72,7 +72,7 @@ else()
       --rc
       lcov_branch_coverage=1
       --rc
-      "lcov_excl_br_line=Assert\\(|Ensure\\(|ereport\\("
+      "lcov_excl_br_line=TestAssert(Int64Eq|True)\\(|Assert\\(|Ensure\\(|ereport\\("
       --no-external
       --base-directory
       ${CMAKE_SOURCE_DIR}

--- a/tsl/src/compression/algorithms/CMakeLists.txt
+++ b/tsl/src/compression/algorithms/CMakeLists.txt
@@ -8,3 +8,5 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/null.c
     ${CMAKE_CURRENT_SOURCE_DIR}/uuid_compress.c)
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})
+
+add_subdirectory(fastlanes)

--- a/tsl/src/compression/algorithms/fastlanes/CMakeLists.txt
+++ b/tsl/src/compression/algorithms/fastlanes/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor_8.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor_16.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor_32.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor_64.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor_128.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_ffor_256.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack_8.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack_16.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack_32.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack_64.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack_128.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_pack_256.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/fastlanes_sizing.c)
+target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/compression/algorithms/fastlanes/README.md
+++ b/tsl/src/compression/algorithms/fastlanes/README.md
@@ -1,0 +1,296 @@
+# FastLanes reimplementation in C
+
+## What is this library
+
+This is mostly a header only, C library that implements FastLanes inspired bit-packing using C
+macros and a very thin C wrapper over these. The library only uses portable C and the main
+objective is to allow compilers generate efficient SIMD code from this. This is not a compression
+library. It is a building block for higher level compression algorithms.
+
+## Credits and introduction
+
+[The FastLanes Compression Layout:
+Decoding >100 Billion Integers per Second with Scalar Code](https://doi.org/10.14778/3598581.3598587)
+
+That paper is the main inspiration basis of the implementation. There are other C++ and Rust
+implementations out there, like [cwida/fastlanes](https://github.com/cwida/fastlanes) and
+[spiraldb/fastlanes](https://github.com/spiraldb/fastlanes).
+
+FastLanes is used as a building block for higher level compression algorithms, but not as a standalone
+compression algorithm. The main use of FastLanes is to pack integers. The callers need to do extra work
+to make this useful. For example, the callers need to determine the bit-width of the integers, or the
+base value for the FFOR packing. See the below sections for more info.
+
+The idea in FastLanes is to store the integers in a transposed format and the conversion between the
+original and the transposed format is done with clever bit arithmetic operations. In the original paper,
+the authors defined a virtual 1024 bit register and used logical bit operations for transposing the
+register. In our implementation we define a series of smaller width registers and use operations defined
+on these registers. Our operations are not exactly the same as those in the paper but heavily inspired
+by them.
+
+FastLanes lays N values out across S parallel lanes. Each lane stores N/S values, dense-packed at W bits
+per slot. The "trick" is that the lanes are interleaved in memory so potentially a single SIMD instruction
+can pack or unpack S values from S adjacent lanes at once — values stay contiguous within a lane (so
+unpacking is just bit-extracts), but adjacent values in the input land in different lanes (so SIMD
+parallelism is free).
+
+So why do we want to do this at all? The reason is that we want to tightly pack same bitwidth integers together.
+In case of odd bitwidths, for example 5 bits, and we want to pack them into a 64 bit integer, we have two options:
+
+ 1) either we pack 12 integers and waste 4 bits, or
+ 2) we split the 13th integer and handle the overflow
+
+None of the options are ideal. The beauty of the FastLanes approach is that we can pack odd width integers when we
+have 'enough' of them. In the compression context we tend to have many integers so the numbers are not an issue.
+
+The second advantage of the FastLanes approach is that it takes advantage of the 'enough' numbers to pack, and
+developed a set of instructions that allows to transpose the data with SIMD instructions. This is a huge
+performance boost as compared to the sequential encoding and decoding of the integers.
+
+Finally, FastLanes instructions are defined in portable C (in our case, and C++ in the original paper), so
+there are no platform specific features needed. This allows us to use the same code in a wide variety of
+platforms and we can rely on the compiler to generate efficient SIMD code.
+
+## Overview
+
+This implementation needs to be compiled as part of the TimescaleDB extension in C. For this reason integrating
+the existing Rust or C++ implementations would cause a disproportionate amount of headache for us.
+
+Another difference is that in TimescaleDB we need to support input sizes different than 1024. The current version
+of TimescaleDB (2.27) targets 1000 as batch size. A further complication is that the database needs to support
+NULL values, in which case the underlying compression will only store the non-NULL values, so we can easily end
+up with way less than 1000 non-NULL values. Finally, there are situations specific to TimescaleDB where we
+naturally have smaller batch sizes.
+
+The problem with targeting a fixed size of 1024 elements (as in the original paper) when we often have much
+smaller batches is that it leads to a lot of wasted space which will erode the packing advantages of FastLanes.
+The natural pack boundary of FL1024 is 128 bytes, so the smallest amount we can truncate from the output is
+128 bytes. This causes too much waste for smaller batches.
+
+### Supporting vectorized execution
+
+The FastLanes approach was chosen because of its speed advantages. These advantages are coming from the
+vectorized instructions that allow to pack and unpack multiple values in parallel. This library tries to
+hide the details of the internal mechanics of the FastLanes packing and unpacking, but still it requires
+some level of cooperation from the caller. The three areas where it is required are:
+
+- the input and output buffers need to be aligned as instructed by the library, because the SIMD instructions have alignment requirements
+- the input buffer needs to have space for a certain number of elements, potentially more than the actual number of elements being packed
+- the packed buffer needs to be allocated with a certain size, potentially more than the actual size of the packed data, and the caller needs to use the returned truncated size to determine the result size
+
+Imagine that we have 249 integers to pack. It is faster to pad it to 256 elements and use AVX2 instructions
+than use SSE2 to pack 128 and handle the remaining 121 separately. The requirements the library has are
+designed along these lines, so we maximize speed at the expense of some extra buffer capacity.
+
+The library provides functions to inform the user about these requirements, and there is a section below, that
+goes into more details. From the high level perspective, the alignment and sizing requirements all derives from
+these three parameters:
+
+- the number of elements to pack (N)
+- the width of the input elements (T)
+- the actual bit-width of the packed elements (W)
+
+Where W is <= T, and N is <= 256. These determine the actual packing method the library uses and the requirements
+for the buffers.
+
+'N', 'W' and 'T' are the central concepts in the FastLanes library and they are often referred to by only these
+initials. The number of parallel lanes (S) is also a central concept but it is derived from T and the tier bits,
+so it is not as commonly used as N, W and T. 'S' is an internal variable that is not exposed to the caller.
+
+The library uses `fl_elem_width_t` enum to represent the element width (T) in bits, and it has values for 8, 16,
+32 and 64 bits.
+
+## Tiered FastLanes (FL)
+
+The solution for the FL1024 waste is that we introduce the concept of "Tiered FastLanes". The idea is to implement
+FastLanes with a set of 'virtual register sizes' and use the smallest one that fits. This saves space but reduces
+SIMD performance. We have 8, 16, 32, 64, 128 and 256 bits FastLanes. This reduces the number of wasted bytes
+significantly for smaller batches. The tradeoff is slightly reduced SIMD performance.
+
+Another way to look at this, is that if we pack a small number of integers into a format that is targeted at
+1024 integers, then we will execute a transpose operation that is designed for 1024 integers, so much of the
+work is wasted. Even if the bigger register width allows better SIMD efficiency, the wasted work offsets the
+performance gain, and using a smaller FL tier becomes a better performance deal.
+
+The tiered FL packing is used in many places in the compression algorithm, not only to store the compressed bit
+values but also for smaller integer arrays, for example the new dictionary compression has a smaller array of the
+dictionary entries, or in the PFOR compression the exceptions are stored as small integer arrays. In these cases
+we easily end up storing only a handful of elements and this is why the very small tiers are useful. The small
+tiers don't offer much SIMD performance but they save significant amount of space.
+
+The library provides wrappers over the FL tiers in the `fastlanes/fastlanes.h` file and the internal
+tiers are not exposed.
+
+## The C implementation
+
+Compared to the C++ implementation, where the kernel is auto-generated code and C++ templates or the Rust
+implementation which uses Rust macros, the C implementation heavily relies on C macros. The implementation
+still uses portable C and avoids any platform specific features. The macros are structured such that the C
+compiler can vectorize the code as much as possible.
+
+## Truncation
+
+The truncation term appears in several places in this doc and also in the code itself. This refers to the action when
+the number of elements we pass to an FL tier is less than it can maximally pack. This results in unused space in
+the output buffer. We can truncate the output buffer by removing this unused space. The amount of truncation
+depends on the tier (the virtual register size). For example, if we store 179 (N=179) five bits (W=5) elements in
+FL256, we will be able to truncate the output buffer from 160 bytes (allocated) to 128 bytes (truncated), so
+in case of FL256, multiples of 32 bytes.
+
+Here is the truncation formula for reference:
+
+```
+S = tier_bits / T
+rows = ceil(N / S)
+truncated_size = ceil(rows * W / T) * tier_bytes
+```
+
+## Allocation, alignment and input sizing
+
+The SIMD operations mandate certain alignment and padding of the data. This includes both the input and the
+output buffers. For example, in case of the input buffer for the packing operation we may over-read the
+input data beyond the useful elements and it needs to be properly sized. For the output data, the encoder
+may overwrite adjacent memory if not properly sized. Similarly, during unpacking we must carefully size the
+output buffer and ensure that the input buffer is aligned and padded by zeros.
+
+The exact amount of alignment and padding depends on the FL tier. For example FL256 operates on 32 byte aligned
+data and it requires the tail padding to be 32 bytes as well. The other tiers have different (smaller)
+requirements. The natural truncation point of the output also depends on the tier.
+
+The [fastlanes/fastlanes.h](./fastlanes.h) header provides functions to size, pack, and unpack data.
+The right internal tier is automatically selected based on the input parameters.
+
+The 'fastlanes/fastlanes.h' header has functions to determine the required alignment and allocation
+size based on the (N, W, T) triple. These functions are:
+
+``` C
+/*
+ * Tells how many bytes to allocate for the pack/unpack buffer based on the (N, W, T) triple.
+ * This function determines the right FL tier based on the input parameters and returns the required
+ * allocation size based on the parameters.
+ */
+size_t fl_required_bytes(uint32_t n, uint8_t w, fl_elem_width_t t);
+
+/*
+ * The function determines the result size in the output buffer. With this we can determine the
+ * part of the output buffer that is actually used. Remember, this is needed because the FL tiers
+ * operate on a fixed number of elements which is larger or equal to the actual number of elements
+ * we pack (for SIMD efficiency).
+ */
+size_t fl_result_bytes(uint32_t n, uint8_t w, fl_elem_width_t t);
+
+/*
+ * The fl_alignment function returns the required alignment for the buffers based on the
+ * (N, T) pair. The same alignment is required for both the input and output buffers.
+ *
+ * Note: The same alignment is optimal for both buffers. For the pack/unpack buffer it's a hard
+ *  correctness requirement (UB if violated). For the input buffer it's a performance recommendation:
+ *  the kernel works correctly with natural alignment but pays a penalty on hot decode loops.
+ */
+size_t fl_alignment(uint32_t n, fl_elem_width_t t);
+
+/*
+ * The number of input elements of the `values` to be packed. The library expects
+ * this many elements and it is the caller's responsibility to provide it. As the
+ * library uses SIMD instructions, it needs to operate on fixed sized element chunks.
+ */
+uint32_t fl_input_count(uint32_t n, fl_elem_width_t t);
+
+/*
+ * The number of bytes to read from the input buffer. This is a convenience alternative
+ * to multiplying the `fl_input_count` by the element width and calculate the byte size.
+ */
+size_t fl_input_bytes(uint32_t n, fl_elem_width_t t);
+```
+
+| Buffer         | Min size                        | Alignment                                   |
+|----------------|---------------------------------|---------------------------------------------|
+| values (input) | `fl_input_count` elements       | `fl_alignment` recommended, minimum natural |
+| packed         | `fl_required_bytes` bytes       | `fl_alignment` mandatory                    |
+| unpack output  | `fl_input_count` elements       | `fl_alignment` recommended, minimum natural |
+
+## Unpack tail padding
+
+The input of the unpack functions must be padded with zeros up to `fl_required_bytes`. This
+is because the SIMD instructions will read beyond the actual packed data, up to the allocated size.
+
+## Interface contract
+
+This is a concise recap of the previous sections.
+
+- the buffer for the input values MUST have at least `fl_input_count` elements (not bytes) and it SHOULD be aligned to `fl_alignment` bytes, and it MUST be aligned naturally
+- the packed buffer (pack output / unpack input) MUST be aligned to `fl_alignment` bytes
+- the output of the unpack function holding the unpacked values SHOULD be aligned to `fl_alignment` bytes, and MUST be aligned naturally
+- the size of the pack/unpack buffer must be `fl_required_bytes` bytes
+- the unpack input buffer must be padded with zeros up to `fl_required_bytes` bytes
+- `fl_pack` and `fl_pack_ffor` return the packed size in bytes, which is the same as `fl_result_bytes`
+- the input size `n` MUST NOT exceed 256
+
+## Simple packing vs FFOR packing
+
+The simple packing function `fl_pack` packs the integers as they are. The caller is expected
+to determine the bit-width of the integers and pass it as an argument. Similarly, the unpacking
+function `fl_unpack` unpacks the integers as they are and the caller is expected to know the
+bit-width of the integers to unpack.
+
+The FFOR (Frame of Reference) packing function `fl_pack_ffor` packs the integers based on a
+`base` value. The base value is subtracted from the integers before packing, so the packed integers
+are the difference between the original integers and the base value. This allows to pack integers
+with smaller bit-width. The `w` parameter in the FFOR packing is the bit-width of the integers
+_after_ subtracting the base value. This is the caller's responsibility to determine.
+
+`base` must fit the same input bit-width as the values, otherwise it will be truncated and
+the behavior is undefined.
+
+The FFOR functions don't add much functionality on top of the simple packing functions, as
+the caller could do the same subtraction and then call the simple packing functions. The FFOR
+functions does these subtractions in the same loop as the packing, so it is more efficient
+than doing the subtraction in a separate loop and then calling the simple packing functions.
+The same applies to the unpacking functions.
+
+The pack function masks the input based on the `w` parameter, so it is essential to pass the
+correct value, otherwise the input will be truncated.
+
+The FFOR pack function does not store the `base` in the results and the unpack function
+expects the caller to pass the `base` value as a parameter. As a consequence, it is the
+caller's responsibility to store the `base` value, similar to `w` and `n`.
+
+## Batch sizing
+
+The maximum number of elements the FL tiers can handle is 256 elements (FL256 tier). It is the
+caller's responsibility to manage the inputs and potentially split it such that it fits. This
+is a deliberate decision, because in practice, using the same bitwidth for more than 256 elements
+is rarely economical because of the outliers.
+
+When passing less than 256 elements, the library chooses the best tier based on performance
+and packing efficiency.
+
+## Signed integers and input validation
+
+The library treats all inputs as unsigned integers. It is the caller's responsibility to
+make sure that the inputs are non-negative, or in case of FFOR packing, the base value
+is chosen such that the subtracted values are non-negative. The library does not validate
+the inputs, so if the caller passes negative values, the behavior is undefined.
+
+Similarly, the library doesn't validate the 'W' parameter to be <= T, or N <= 256, so
+it is the caller's responsibility to ensure that these conditions are met.
+
+## The W=0 special case
+
+There is one case that can happen during a real compressor, when the bit-width of the
+integers is 0. This happens when all the integers are the same. Both unpack functions fill
+only the first N positions (not up to `fl_input_count`). The FFOR variant fills with the base
+value; the simple variant fills with zeros.
+
+The pack functions in both cases will return 0, and they handle this special case as no-op,
+and with that, the functions ignore the buffers and passing NULLs as buffers is safe. The
+unpack functions need a valid result buffer. Also the below holds:
+
+``` C
+fl_required_bytes(n, 0, t) == fl_result_bytes(n, 0, t) == 0
+```
+
+## Test and usage examples
+
+Example usage is provided in the `test_fastlanes.c` file. The purpose of this file is to
+demonstrate the usage of the library.

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes.h
@@ -1,0 +1,98 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes.h -- public interface for the FastLanes pack/unpack
+ * layer.
+ *
+ *   This is the ONLY header callers should include. All functions are
+ *   declared here; their definitions live in fastlanes_sizing.c
+ *   (tier selection + sizing API), fastlanes_pack.c (plain pack and
+ *   unpack), and fastlanes_ffor.c (FFOR pack and unpack).
+ *
+ * Conventions:
+ *
+ *   - 'N' is the number of values to pack (0..256).
+ *   - 'T' is the element bit width (8, 16, 32, or 64), expressed
+ *     via fl_elem_width_t.
+ *   - 'W' is the actual bit width of the packed elements (0..T).
+ *
+ *   See README.md for the full caller contract: alignment and
+ *   sizing rules.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include "fastlanes_types.h" /* fl_elem_width_t, fl_tier_width_t */
+
+/*
+ * Tier selection.
+ *
+ *   | N range  | T = 8 | T = 16 | T = 32 | T = 64 |
+ *   |   0..8   | FL8   | FL16   | FL32   | FL128  |
+ *   |   9..16  | FL16  | FL16   | FL32   | FL128  |
+ *   |  17..32  | FL32  | FL32   | FL32   | FL128  |
+ *   |  33..64  | FL64  | FL64   | FL64   | FL128  |
+ *   |  65..128 | FL128 | FL128  | FL128  | FL128  |
+ *   | 129..256 | FL256 | FL256  | FL256  | FL256  |
+ */
+extern fl_tier_width_t fl_tier_select(uint32 n, fl_elem_width_t t);
+
+/* Required size for the tier (selected by fl_tier_select(N, T)).
+ * Determines the sizes of pack output and unpack input buffers exactly.
+ */
+extern size_t fl_required_bytes(uint32 n, uint8 w, fl_elem_width_t t);
+
+/* Bytes the encoded output carries for N elements (<= fl_required_bytes).
+ * Matches the return of fl_pack / fl_pack_ffor; useful for sizing the
+ * truncated prefix without running the encoder. */
+extern size_t fl_result_bytes(uint32 n, uint8 w, fl_elem_width_t t);
+
+/* Required alignment for the _packed_ input and output buffers.
+ * Recommended alignment for the input and output _values_.
+ */
+extern size_t fl_alignment(uint32 n, fl_elem_width_t t);
+
+/* Number of input ELEMENTS the kernel reads -- callers must provide
+ * at least this many readable elements at `values` (positions past N
+ * are read but only the [0..N) outputs are meaningful). */
+extern uint32 fl_input_count(uint32 n, fl_elem_width_t t);
+
+/* Byte size of the input buffer (= fl_input_count() * t / 8). */
+extern size_t fl_input_bytes(uint32 n, fl_elem_width_t t);
+
+/*
+ * Plain pack / unpack.
+ *
+ *   fl_pack returns the truncated byte count (<= fl_required_bytes) --
+ *   the size of the `packed` data in bytes. The kernel reads
+ *   fl_input_count() elements from `values` and writes fl_required_bytes
+ *   to `packed`.
+ *
+ *   fl_unpack reverses the operation. The caller MUST pre-zero
+ *   packed[truncated_bytes..alloc_bytes) before calling unpack.
+ *
+ *   W = 0 (constant block) is a special case: fl_pack returns 0 and
+ *   writes nothing; fl_unpack fills outputs [0..N) with 0.
+ */
+extern size_t fl_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/*
+ * FFOR (Frame Of Reference) variants.
+ *
+ *   `base` is subtracted from each value before packing and added back
+ *   after unpacking. Equivalent to packing `values - base` with the
+ *   plain functions, but combined into the same loop.
+ *
+ *   W = 0: fl_pack_ffor returns 0 and writes nothing; fl_unpack_ffor
+ *   fills outputs [0..N) with `base`.
+ */
+extern size_t fl_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+						   uint64 base);
+extern void fl_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+						   uint64 base);

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_common.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_common.h
@@ -1,0 +1,100 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_common.h -- shared macros for the FL tier headers.
+ *
+ * Two pieces every tier needs:
+ *
+ *   1. Bit-position helpers (FL_SHIFT, FL_WORD, FL_NWORD, FL_SPLITS,
+ *      FL_REM, FL_CUR, FL_CUR_SAFE) -- pure (row, W, T) arithmetic.
+ *
+ *   2. Cascading row-enumeration macros (FL_P2..FL_P64, FL_U2..FL_U64,
+ *      FL_FP2..FL_FP64, FL_FU2..FL_FU64) and their typed "ALL"
+ *      wrappers. Each tier binds FL_P1 / FL_U1 / FL_FP1 / FL_FU1 to
+ *      its own row body before invoking the per-W generator; C
+ *      macros are late-bound so the same cascade expands tier-
+ *      specific code under each binding.
+ */
+
+#pragma once
+
+#include "fastlanes_types.h"
+
+/*
+ * Bit-position helpers -- compile-time when (row, W, T) are constants.
+ *
+ *   SHIFT  bit offset of this row's first bit within its word
+ *   WORD   word index containing this row's first bit
+ *   NWORD  word index containing the next row's first bit
+ *   SPLITS this row crosses a word boundary
+ *   REM    bits spilling into the next word
+ *   CUR    bits remaining in the current word
+ */
+
+#define FL_SHIFT(row, W, T) (((row) * (W)) % (T))
+#define FL_WORD(row, W, T) (((row) * (W)) / (T))
+#define FL_NWORD(row, W, T) ((((row) + 1) * (W)) / (T))
+#define FL_SPLITS(row, W, T) (FL_NWORD(row, W, T) > FL_WORD(row, W, T))
+#define FL_REM(row, W, T) ((((row) + 1) * (W)) % (T))
+#define FL_CUR(row, W, T) ((W) -FL_REM(row, W, T))
+
+/* MSVC C4293: keep the intermediate non-negative so the warning checker
+ * (which runs before constant folding through the mask) sees a small
+ * positive value. Equivalent to ((W - FL_REM) mod T). */
+#define FL_CUR_SAFE(row, W, T) (((W) + (T) -FL_REM(row, W, T)) & ((unsigned) (T) -1u))
+
+/* Doubling macro expansion cascades. */
+#define FL_P2(T, S, W, b) FL_P1(T, S, W, (b)) FL_P1(T, S, W, (b) + 1)
+#define FL_P4(T, S, W, b) FL_P2(T, S, W, (b)) FL_P2(T, S, W, (b) + 2)
+#define FL_P8(T, S, W, b) FL_P4(T, S, W, (b)) FL_P4(T, S, W, (b) + 4)
+#define FL_P16(T, S, W, b) FL_P8(T, S, W, (b)) FL_P8(T, S, W, (b) + 8)
+#define FL_P32(T, S, W, b) FL_P16(T, S, W, (b)) FL_P16(T, S, W, (b) + 16)
+#define FL_P64(T, S, W, b) FL_P32(T, S, W, (b)) FL_P32(T, S, W, (b) + 32)
+
+#define FL_PACK_ALL_8(S, W) FL_P8(8, S, W, 0)
+#define FL_PACK_ALL_16(S, W) FL_P16(16, S, W, 0)
+#define FL_PACK_ALL_32(S, W) FL_P32(32, S, W, 0)
+#define FL_PACK_ALL_64(S, W) FL_P64(64, S, W, 0)
+
+/* Doubling macro expansion cascades. */
+#define FL_U2(TYPE, T, S, W, b) FL_U1(TYPE, T, S, W, (b)) FL_U1(TYPE, T, S, W, (b) + 1)
+#define FL_U4(TYPE, T, S, W, b) FL_U2(TYPE, T, S, W, (b)) FL_U2(TYPE, T, S, W, (b) + 2)
+#define FL_U8(TYPE, T, S, W, b) FL_U4(TYPE, T, S, W, (b)) FL_U4(TYPE, T, S, W, (b) + 4)
+#define FL_U16(TYPE, T, S, W, b) FL_U8(TYPE, T, S, W, (b)) FL_U8(TYPE, T, S, W, (b) + 8)
+#define FL_U32(TYPE, T, S, W, b) FL_U16(TYPE, T, S, W, (b)) FL_U16(TYPE, T, S, W, (b) + 16)
+#define FL_U64(TYPE, T, S, W, b) FL_U32(TYPE, T, S, W, (b)) FL_U32(TYPE, T, S, W, (b) + 32)
+
+#define FL_UNPACK_ALL_8(TYPE, S, W) FL_U8(TYPE, 8, S, W, 0)
+#define FL_UNPACK_ALL_16(TYPE, S, W) FL_U16(TYPE, 16, S, W, 0)
+#define FL_UNPACK_ALL_32(TYPE, S, W) FL_U32(TYPE, 32, S, W, 0)
+#define FL_UNPACK_ALL_64(TYPE, S, W) FL_U64(TYPE, 64, S, W, 0)
+
+/* Doubling macro expansion cascades. */
+#define FL_FP2(T, S, W, b) FL_FP1(T, S, W, (b)) FL_FP1(T, S, W, (b) + 1)
+#define FL_FP4(T, S, W, b) FL_FP2(T, S, W, (b)) FL_FP2(T, S, W, (b) + 2)
+#define FL_FP8(T, S, W, b) FL_FP4(T, S, W, (b)) FL_FP4(T, S, W, (b) + 4)
+#define FL_FP16(T, S, W, b) FL_FP8(T, S, W, (b)) FL_FP8(T, S, W, (b) + 8)
+#define FL_FP32(T, S, W, b) FL_FP16(T, S, W, (b)) FL_FP16(T, S, W, (b) + 16)
+#define FL_FP64(T, S, W, b) FL_FP32(T, S, W, (b)) FL_FP32(T, S, W, (b) + 32)
+
+#define FL_FFOR_PACK_ALL_8(S, W) FL_FP8(8, S, W, 0)
+#define FL_FFOR_PACK_ALL_16(S, W) FL_FP16(16, S, W, 0)
+#define FL_FFOR_PACK_ALL_32(S, W) FL_FP32(32, S, W, 0)
+#define FL_FFOR_PACK_ALL_64(S, W) FL_FP64(64, S, W, 0)
+
+/* Doubling macro expansion cascades. */
+#define FL_FU2(TYPE, T, S, W, b) FL_FU1(TYPE, T, S, W, (b)) FL_FU1(TYPE, T, S, W, (b) + 1)
+#define FL_FU4(TYPE, T, S, W, b) FL_FU2(TYPE, T, S, W, (b)) FL_FU2(TYPE, T, S, W, (b) + 2)
+#define FL_FU8(TYPE, T, S, W, b) FL_FU4(TYPE, T, S, W, (b)) FL_FU4(TYPE, T, S, W, (b) + 4)
+#define FL_FU16(TYPE, T, S, W, b) FL_FU8(TYPE, T, S, W, (b)) FL_FU8(TYPE, T, S, W, (b) + 8)
+#define FL_FU32(TYPE, T, S, W, b) FL_FU16(TYPE, T, S, W, (b)) FL_FU16(TYPE, T, S, W, (b) + 16)
+#define FL_FU64(TYPE, T, S, W, b) FL_FU32(TYPE, T, S, W, (b)) FL_FU32(TYPE, T, S, W, (b) + 32)
+
+#define FL_FFOR_UNPACK_ALL_8(TYPE, S, W) FL_FU8(TYPE, 8, S, W, 0)
+#define FL_FFOR_UNPACK_ALL_16(TYPE, S, W) FL_FU16(TYPE, 16, S, W, 0)
+#define FL_FFOR_UNPACK_ALL_32(TYPE, S, W) FL_FU32(TYPE, 32, S, W, 0)
+#define FL_FFOR_UNPACK_ALL_64(TYPE, S, W) FL_FU64(TYPE, 64, S, W, 0)

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor.c
@@ -1,0 +1,102 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_ffor.c -- public FFOR (Frame Of Reference)
+ * pack/unpack entry points.
+ *
+ * Defines fl_pack_ffor and fl_unpack_ffor as switches
+ * on fl_tier_select that forward to the matching per-tier static.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl8_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							uint64 base);
+extern size_t fl16_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern size_t fl32_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern size_t fl64_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern size_t fl128_pack_ffor(const void *values, void *packed, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+extern size_t fl256_pack_ffor(const void *values, void *packed, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+extern void fl8_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							uint64 base);
+extern void fl16_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern void fl32_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern void fl64_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern void fl128_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+extern void fl256_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+
+/* Public FFOR pack/unpack
+ *
+ * Each per-tier fl{T}_pack_ffor already computes the truncated byte
+ * count internally, so the dispatcher just forwards the result.
+ */
+
+size_t
+fl_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t, uint64 base)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_pack_ffor(values, packed, n, w, t, base);
+		case FL_TIER_W16:
+			return fl16_pack_ffor(values, packed, n, w, t, base);
+		case FL_TIER_W32:
+			return fl32_pack_ffor(values, packed, n, w, t, base);
+		case FL_TIER_W64:
+			return fl64_pack_ffor(values, packed, n, w, t, base);
+		case FL_TIER_W128:
+			return fl128_pack_ffor(values, packed, n, w, t, base);
+		case FL_TIER_W256:
+			return fl256_pack_ffor(values, packed, n, w, t, base);
+	}
+	Assert(false);
+	return 0;
+}
+
+void
+fl_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t, uint64 base)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			fl8_unpack_ffor(packed, values, n, w, t, base);
+			break;
+		case FL_TIER_W16:
+			fl16_unpack_ffor(packed, values, n, w, t, base);
+			break;
+		case FL_TIER_W32:
+			fl32_unpack_ffor(packed, values, n, w, t, base);
+			break;
+		case FL_TIER_W64:
+			fl64_unpack_ffor(packed, values, n, w, t, base);
+			break;
+		case FL_TIER_W128:
+			fl128_unpack_ffor(packed, values, n, w, t, base);
+			break;
+		case FL_TIER_W256:
+			fl256_unpack_ffor(packed, values, n, w, t, base);
+			break;
+	}
+}

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_128.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_128.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_ffor.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl128_pack_ffor(const void *values, void *packed, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+extern void fl128_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 128
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_ffor_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_16.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_16.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_ffor.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl16_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern void fl16_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 16
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_ffor_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_256.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_256.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_ffor.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl256_pack_ffor(const void *values, void *packed, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+extern void fl256_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w,
+							  fl_elem_width_t t, uint64 base);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 256
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_ffor_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_32.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_32.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_ffor.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl32_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern void fl32_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 32
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_ffor_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_64.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_64.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_ffor.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl64_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+extern void fl64_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							 uint64 base);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 64
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_ffor_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_8.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_ffor_8.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all FFOR
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_ffor.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl8_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+							uint64 base);
+extern void fl8_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+							uint64 base);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 8
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_ffor_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack.c
@@ -1,0 +1,94 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_pack.c -- public plain pack/unpack entry points.
+ *
+ * Uses fastlanes_tier_sizing.h + fastlanes_tier_pack_impl.h as
+ * templates driven by the FL_TIER.
+ *
+ * Defines fl_pack and fl_unpack as switches
+ * on fl_tier_select that forward to the matching per-tier static.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+
+extern size_t fl8_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern size_t fl16_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern size_t fl32_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern size_t fl64_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern size_t fl128_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern size_t fl256_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl8_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl16_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl32_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl64_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl128_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl256_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* Public plain pack/unpack
+ *
+ * Each per-tier fl{T}_pack already computes the truncated byte count
+ * internally (its return is fl{T}_words_needed(n, w, t) * WORD_BYTES),
+ * so the dispatcher just forwards the result.
+ */
+
+size_t
+fl_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_pack(values, packed, n, w, t);
+		case FL_TIER_W16:
+			return fl16_pack(values, packed, n, w, t);
+		case FL_TIER_W32:
+			return fl32_pack(values, packed, n, w, t);
+		case FL_TIER_W64:
+			return fl64_pack(values, packed, n, w, t);
+		case FL_TIER_W128:
+			return fl128_pack(values, packed, n, w, t);
+		case FL_TIER_W256:
+			return fl256_pack(values, packed, n, w, t);
+	}
+	Assert(false);
+	return 0;
+}
+
+void
+fl_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			fl8_unpack(packed, values, n, w, t);
+			break;
+		case FL_TIER_W16:
+			fl16_unpack(packed, values, n, w, t);
+			break;
+		case FL_TIER_W32:
+			fl32_unpack(packed, values, n, w, t);
+			break;
+		case FL_TIER_W64:
+			fl64_unpack(packed, values, n, w, t);
+			break;
+		case FL_TIER_W128:
+			fl128_unpack(packed, values, n, w, t);
+			break;
+		case FL_TIER_W256:
+			fl256_unpack(packed, values, n, w, t);
+			break;
+	}
+}

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_128.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_128.c
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_pack.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl128_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl128_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 128
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_pack_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_16.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_16.c
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_pack.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl16_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl16_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 16
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_pack_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_256.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_256.c
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_pack.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl256_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl256_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 256
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_pack_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_32.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_32.c
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_pack.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl32_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl32_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 32
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_pack_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_64.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_64.c
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_pack.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl64_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl64_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 64
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_pack_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_8.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_pack_8.c
@@ -1,0 +1,29 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+#include "fastlanes_common.h"
+
+/*
+ * These extern declarations are needed because MSVC runs out of the heap space if all `pack`
+ * macro expansion happens in the same C file. The functions are being called from
+ * `fastlanes_pack.c`, which dispatches between the tiers. These functions are intentionally
+ * not placed in a header file, to discourage direct use.
+ */
+extern size_t fl8_pack(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t);
+extern void fl8_unpack(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t);
+
+/* clang format would reorder the headers which is not desired here */
+/* clang-format off */
+
+#define FL_TIER 8
+#include "fastlanes_tier_sizing.h"
+#include "fastlanes_tier_pack_impl.h"
+#undef FL_TIER
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_sizing.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_sizing.c
@@ -1,0 +1,212 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_sizing.c -- tier selection + public sizing API.
+ *
+ * Owns the library's "root" surface that both pack and FFOR call into:
+ *
+ *   fl_tier_select        chooses the internal tier for an (N, T)
+ *                         pair, deterministic and W-independent.
+ *   fl_required_bytes     buffer size to allocate (worst-case N).
+ *   fl_result_bytes       truncated byte count for a specific N.
+ *   fl_alignment          required buffer alignment.
+ *   fl_input_count        number of input elements the kernel reads.
+ *   fl_input_bytes        byte size of the input buffer.
+ *
+ * Per-tier sizing helpers (fl{T}_required_bytes, ...) are
+ * instantiated as file-local static functions by looping
+ * fastlanes_tier_sizing.h over the six tiers. Each public entry
+ * point switches on fl_tier_select(N, T) and forwards to the
+ * matching static.
+ *
+ * The pack and FFOR object files link against fl_tier_select only
+ * -- one extern call per public fl_pack / fl_unpack /
+ * fl_pack_ffor / fl_unpack_ffor invocation, outside any inner
+ * loop.
+ */
+
+#include <postgres.h>
+
+#include "fastlanes.h"
+
+#define FL_TIER 8
+#include "fastlanes_tier_sizing.h"
+#undef FL_TIER
+
+#define FL_TIER 16
+#include "fastlanes_tier_sizing.h"
+#undef FL_TIER
+
+#define FL_TIER 32
+#include "fastlanes_tier_sizing.h"
+#undef FL_TIER
+
+#define FL_TIER 64
+#include "fastlanes_tier_sizing.h"
+#undef FL_TIER
+
+#define FL_TIER 128
+#include "fastlanes_tier_sizing.h"
+#undef FL_TIER
+
+#define FL_TIER 256
+#include "fastlanes_tier_sizing.h"
+#undef FL_TIER
+
+/* Tier selection
+ *
+ *   |   0..8   T=8  -> FL8         T=16 -> FL16   T=32 -> FL32   T=64 -> FL128
+ *   |   9..16  T=8  -> FL16        T=16 -> FL16   T=32 -> FL32   T=64 -> FL128
+ *   |  17..32                      -> FL32                       T=64 -> FL128
+ *   |  33..64                      -> FL64                       T=64 -> FL128
+ *   |  65..128                     -> FL128                      T=64 -> FL128
+ *   | 129..256                     -> FL256                      T=64 -> FL256
+ *
+ * T=64 routes straight to FL128/256 (better SIMD utilisation than
+ * FL64 for 64-bit values).
+ */
+fl_tier_width_t
+fl_tier_select(uint32 n, fl_elem_width_t t)
+{
+	if (t == FL_ELEM_W64)
+	{
+		return (n <= 128) ? FL_TIER_W128 : FL_TIER_W256;
+	}
+	if (n <= 8 && t == FL_ELEM_W8)
+	{
+		return FL_TIER_W8;
+	}
+	if (n <= 16 && (t == FL_ELEM_W8 || t == FL_ELEM_W16))
+	{
+		return FL_TIER_W16;
+	}
+	if (n <= 32)
+	{
+		return FL_TIER_W32;
+	}
+	if (n <= 64)
+	{
+		return FL_TIER_W64;
+	}
+	if (n <= 128)
+	{
+		return FL_TIER_W128;
+	}
+	return FL_TIER_W256;
+}
+
+/* Public sizing entry points */
+
+size_t
+fl_required_bytes(uint32 n, uint8 w, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_required_bytes(w, t);
+		case FL_TIER_W16:
+			return fl16_required_bytes(w, t);
+		case FL_TIER_W32:
+			return fl32_required_bytes(w, t);
+		case FL_TIER_W64:
+			return fl64_required_bytes(w, t);
+		case FL_TIER_W128:
+			return fl128_required_bytes(w, t);
+		case FL_TIER_W256:
+			return fl256_required_bytes(w, t);
+	}
+	Assert(false);
+	return 0;
+}
+
+size_t
+fl_result_bytes(uint32 n, uint8 w, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_result_bytes(n, w, t);
+		case FL_TIER_W16:
+			return fl16_result_bytes(n, w, t);
+		case FL_TIER_W32:
+			return fl32_result_bytes(n, w, t);
+		case FL_TIER_W64:
+			return fl64_result_bytes(n, w, t);
+		case FL_TIER_W128:
+			return fl128_result_bytes(n, w, t);
+		case FL_TIER_W256:
+			return fl256_result_bytes(n, w, t);
+	}
+	Assert(false);
+	return 0;
+}
+
+size_t
+fl_alignment(uint32 n, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_alignment();
+		case FL_TIER_W16:
+			return fl16_alignment();
+		case FL_TIER_W32:
+			return fl32_alignment();
+		case FL_TIER_W64:
+			return fl64_alignment();
+		case FL_TIER_W128:
+			return fl128_alignment();
+		case FL_TIER_W256:
+			return fl256_alignment();
+	}
+	Assert(false);
+	return 0;
+}
+
+uint32
+fl_input_count(uint32 n, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_input_count();
+		case FL_TIER_W16:
+			return fl16_input_count();
+		case FL_TIER_W32:
+			return fl32_input_count();
+		case FL_TIER_W64:
+			return fl64_input_count();
+		case FL_TIER_W128:
+			return fl128_input_count();
+		case FL_TIER_W256:
+			return fl256_input_count();
+	}
+	Assert(false);
+	return 0;
+}
+
+size_t
+fl_input_bytes(uint32 n, fl_elem_width_t t)
+{
+	switch (fl_tier_select(n, t))
+	{
+		case FL_TIER_W8:
+			return fl8_input_bytes(t);
+		case FL_TIER_W16:
+			return fl16_input_bytes(t);
+		case FL_TIER_W32:
+			return fl32_input_bytes(t);
+		case FL_TIER_W64:
+			return fl64_input_bytes(t);
+		case FL_TIER_W128:
+			return fl128_input_bytes(t);
+		case FL_TIER_W256:
+			return fl256_input_bytes(t);
+	}
+	Assert(false);
+	return 0;
+}

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_template_macros.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_template_macros.h
@@ -1,0 +1,124 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_template_macros.h -- shared macros for fastlanes_tier_pack_impl.h
+ * and fastlanes_tier_ffor_impl.h.
+ *
+ * On top of fastlanes_common.h this defines:
+ *
+ *   1. The tier-agnostic row-body macros (FL_PACK_ROW, FL_PACK_FLUSH,
+ *      FL_UNPACK_ROW, FL_UNPACK_LOAD and their FFOR counterparts).
+ *
+ *   2. W-iteration macros (FL_W_LIST_8/16/32/64) that let the
+ *      templates enumerate W=1..T via a single token.
+ */
+#pragma once
+
+#include "fastlanes_common.h"
+
+/*
+ * All macros reference local names (in, out, mask, tmp, src, lane,
+ * packed, base) belonging to the per-W function they're expanded
+ * into.
+ */
+
+#define FL_PACK_ROW(T, S, W, row)                                                                  \
+	src = in[(row) * (S) + lane] & mask;                                                           \
+	tmp |= src << FL_SHIFT(row, W, T);                                                             \
+	if (FL_SPLITS(row, W, T))                                                                      \
+	{                                                                                              \
+		out[FL_WORD(row, W, T) * (S) + lane] = tmp;                                                \
+		tmp = (FL_REM(row, W, T) != 0) ? (src >> FL_CUR_SAFE(row, W, T)) : 0;                      \
+	}
+
+#define FL_PACK_FLUSH(T, S, W, T_ROWS)                                                             \
+	if (!FL_SPLITS((T_ROWS) -1, W, T))                                                             \
+	{                                                                                              \
+		out[FL_WORD((T_ROWS) -1, W, T) * (S) + lane] = tmp;                                        \
+	}
+
+#define FL_UNPACK_LOAD(T, S, W, row)                                                               \
+	if (FL_WORD(row, W, T) > FL_WORD((row) -1, W, T) && FL_REM((row) -1, W, T) == 0)               \
+	{                                                                                              \
+		src = packed[FL_WORD(row, W, T) * (S) + lane];                                             \
+	}
+
+#define FL_UNPACK_ROW(TYPE, T, S, W, row)                                                          \
+	if (FL_SPLITS(row, W, T))                                                                      \
+	{                                                                                              \
+		tmp = (src >> FL_SHIFT(row, W, T)) &                                                       \
+			  ((FL_CUR(row, W, T) == (T)) ? (TYPE) (~(TYPE) 0) :                                   \
+											(((TYPE) 1 << FL_CUR_SAFE(row, W, T)) - 1));           \
+		if (FL_REM(row, W, T) != 0)                                                                \
+		{                                                                                          \
+			src = packed[FL_NWORD(row, W, T) * (S) + lane];                                        \
+			tmp |= (src & (((TYPE) 1 << FL_REM(row, W, T)) - 1)) << FL_CUR_SAFE(row, W, T);        \
+		}                                                                                          \
+	}                                                                                              \
+	else                                                                                           \
+	{                                                                                              \
+		tmp = (src >> FL_SHIFT(row, W, T)) & mask;                                                 \
+	}                                                                                              \
+	out[(row) * (S) + lane] = tmp;
+
+#define FL_FFOR_PACK_ROW(T, S, W, row)                                                             \
+	src = (in[(row) * (S) + lane] - base) & mask;                                                  \
+	tmp |= src << FL_SHIFT(row, W, T);                                                             \
+	if (FL_SPLITS(row, W, T))                                                                      \
+	{                                                                                              \
+		out[FL_WORD(row, W, T) * (S) + lane] = tmp;                                                \
+		tmp = (FL_REM(row, W, T) != 0) ? (src >> FL_CUR_SAFE(row, W, T)) : 0;                      \
+	}
+
+#define FL_FFOR_UNPACK_ROW(TYPE, T, S, W, row)                                                     \
+	if (FL_SPLITS(row, W, T))                                                                      \
+	{                                                                                              \
+		tmp = (src >> FL_SHIFT(row, W, T)) &                                                       \
+			  ((FL_CUR(row, W, T) == (T)) ? (TYPE) (~(TYPE) 0) :                                   \
+											(((TYPE) 1 << FL_CUR_SAFE(row, W, T)) - 1));           \
+		if (FL_REM(row, W, T) != 0)                                                                \
+		{                                                                                          \
+			src = packed[FL_NWORD(row, W, T) * (S) + lane];                                        \
+			tmp |= (src & (((TYPE) 1 << FL_REM(row, W, T)) - 1)) << FL_CUR_SAFE(row, W, T);        \
+		}                                                                                          \
+	}                                                                                              \
+	else                                                                                           \
+	{                                                                                              \
+		tmp = (src >> FL_SHIFT(row, W, T)) & mask;                                                 \
+	}                                                                                              \
+	out[(row) * (S) + lane] = tmp + base;
+
+/* (2) W-iteration X-macros */
+/* clang-format off */
+
+#define FL_W_LIST_8(X)                                                                             \
+	X(1) X(2) X(3) X(4) X(5) X(6) X(7) X(8)
+
+/* Flat (no recursion) so MSVC's preprocessor doesn't stack four nested
+ * FL_W_LIST_N expansion frames while iterating the kernel definers. */
+
+#define FL_W_LIST_16(X)                                                                            \
+	X(1)  X(2)  X(3)  X(4)  X(5)  X(6)  X(7)  X(8)                                                 \
+	X(9)  X(10) X(11) X(12) X(13) X(14) X(15) X(16)
+
+#define FL_W_LIST_32(X)                                                                            \
+	X(1)  X(2)  X(3)  X(4)  X(5)  X(6)  X(7)  X(8)                                                 \
+	X(9)  X(10) X(11) X(12) X(13) X(14) X(15) X(16)                                                \
+	X(17) X(18) X(19) X(20) X(21) X(22) X(23) X(24)                                                \
+	X(25) X(26) X(27) X(28) X(29) X(30) X(31) X(32)
+
+#define FL_W_LIST_64(X)                                                                            \
+	X(1)  X(2)  X(3)  X(4)  X(5)  X(6)  X(7)  X(8)                                                 \
+	X(9)  X(10) X(11) X(12) X(13) X(14) X(15) X(16)                                                \
+	X(17) X(18) X(19) X(20) X(21) X(22) X(23) X(24)                                                \
+	X(25) X(26) X(27) X(28) X(29) X(30) X(31) X(32)                                                \
+	X(33) X(34) X(35) X(36) X(37) X(38) X(39) X(40)                                                \
+	X(41) X(42) X(43) X(44) X(45) X(46) X(47) X(48)                                                \
+	X(49) X(50) X(51) X(52) X(53) X(54) X(55) X(56)                                                \
+	X(57) X(58) X(59) X(60) X(61) X(62) X(63) X(64)
+
+/* clang-format on */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_tier_ffor_impl.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_tier_ffor_impl.h
@@ -1,0 +1,456 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_tier_ffor_impl.h -- FFOR pack/unpack template.
+ *
+ * Usage:
+ *     #define FL_TIER 256                 // 8/16/32/64/128/256
+ *     #include "fastlanes_tier_sizing.h"  // REQUIRED first --
+ *                                         // FFOR pack returns size
+ *                                         // via fl{T}_words_needed
+ *     #include "fastlanes_tier_ffor_impl.h"
+ *     #undef FL_TIER
+ *
+ * Emits:
+ *   - FFOR per-W kernels: fl{T}_ffor_{pack,unpack}_u{8..64}_w{1..T}
+ *   - FFOR per-T dispatchers: fl{T}_ffor_{pack,unpack}_t{8..64}
+ *   - public entry points: fl{T}_pack_ffor, fl{T}_unpack_ffor
+ */
+
+#if !defined(FL_TIER)
+#error "fastlanes_tier_ffor_impl.h requires FL_TIER (one of 8, 16, 32, 64, 128, 256)"
+#endif
+
+#if FL_TIER != 8 && FL_TIER != 16 && FL_TIER != 32 && FL_TIER != 64 && FL_TIER != 128 &&           \
+	FL_TIER != 256
+#error "FL_TIER must be 8, 16, 32, 64, 128, or 256"
+#endif
+
+#include "fastlanes_template_macros.h"
+
+/* Symbol-name plumbing */
+#define FL_PASTE3_(a, b, c) a##b##c
+#define FL_PASTE3(a, b, c) FL_PASTE3_(a, b, c)
+#define FL_FN(suffix) FL_PASTE3(fl, FL_TIER, suffix)
+#define FL_FNW(suffix, W) FL_PASTE3(FL_FN(suffix), _w, W)
+#define FL_VEC_SIZE FL_TIER
+#define FL_WORD_BYTES (FL_TIER / 8)
+/* Per-tier S = FL_TIER / T constants. Baked to single literals so MSVC's
+ * preprocessor doesn't blow up. */
+#if FL_TIER == 256
+#define FL_S8 32
+#define FL_S16 16
+#define FL_S32 8
+#define FL_S64 4
+#elif FL_TIER == 128
+#define FL_S8 16
+#define FL_S16 8
+#define FL_S32 4
+#define FL_S64 2
+#elif FL_TIER == 64
+#define FL_S8 8
+#define FL_S16 4
+#define FL_S32 2
+#define FL_S64 1
+#elif FL_TIER == 32
+#define FL_S8 4
+#define FL_S16 2
+#define FL_S32 1
+#elif FL_TIER == 16
+#define FL_S8 2
+#define FL_S16 1
+#elif FL_TIER == 8
+#define FL_S8 1
+#endif
+
+/* Bind FL_FP1 / FL_FU1 to the promoted FFOR row bodies */
+
+#undef FL_FP1
+#define FL_FP1(T, S, W, r) FL_FFOR_PACK_ROW(T, S, W, r)
+
+#undef FL_FU1
+#define FL_FU1(TYPE, T, S, W, r)                                                                   \
+	if ((r) > 0)                                                                                   \
+	{                                                                                              \
+		FL_UNPACK_LOAD(T, S, W, r)                                                                 \
+	}                                                                                              \
+	FL_FFOR_UNPACK_ROW(TYPE, T, S, W, r)
+
+/* Per-W FFOR kernel generators */
+
+#if FL_TIER >= 64
+#define FL_DEF_FFOR_PACK_U64(W)                                                                    \
+	static void FL_FNW(_ffor_pack_u64,                                                             \
+					   W)(const uint64 *restrict in, uint64 *restrict out, uint64 base)            \
+	{                                                                                              \
+		const uint64 mask = ((W) == 64) ? UINT64_MAX : ((uint64) 1 << ((W) & 63)) - 1;             \
+		for (int lane = 0; lane < FL_S64; lane++)                                                  \
+		{                                                                                          \
+			uint64 tmp = 0, src;                                                                   \
+			FL_FFOR_PACK_ALL_64(FL_S64, W)                                                         \
+			FL_PACK_FLUSH(64, FL_S64, W, 64)                                                       \
+		}                                                                                          \
+	}
+#define FL_DEF_FFOR_UNPACK_U64(W)                                                                  \
+	static void FL_FNW(_ffor_unpack_u64,                                                           \
+					   W)(const uint64 *restrict packed, uint64 *restrict out, uint64 base)        \
+	{                                                                                              \
+		const uint64 mask = ((W) == 64) ? UINT64_MAX : ((uint64) 1 << ((W) & 63)) - 1;             \
+		for (int lane = 0; lane < FL_S64; lane++)                                                  \
+		{                                                                                          \
+			uint64 src = packed[lane], tmp;                                                        \
+			FL_FFOR_UNPACK_ALL_64(uint64, FL_S64, W)                                               \
+		}                                                                                          \
+	}
+FL_W_LIST_64(FL_DEF_FFOR_PACK_U64)
+FL_W_LIST_64(FL_DEF_FFOR_UNPACK_U64)
+#endif /* FL_TIER >= 64 */
+
+#if FL_TIER >= 32
+#define FL_DEF_FFOR_PACK_U32(W)                                                                    \
+	static void FL_FNW(_ffor_pack_u32,                                                             \
+					   W)(const uint32 *restrict in, uint32 *restrict out, uint32 base)            \
+	{                                                                                              \
+		const uint32 mask = ((W) == 32) ? UINT32_MAX : ((uint32) 1 << ((W) & 31)) - 1;             \
+		for (int lane = 0; lane < FL_S32; lane++)                                                  \
+		{                                                                                          \
+			uint32 tmp = 0, src;                                                                   \
+			FL_FFOR_PACK_ALL_32(FL_S32, W)                                                         \
+			FL_PACK_FLUSH(32, FL_S32, W, 32)                                                       \
+		}                                                                                          \
+	}
+#define FL_DEF_FFOR_UNPACK_U32(W)                                                                  \
+	static void FL_FNW(_ffor_unpack_u32,                                                           \
+					   W)(const uint32 *restrict packed, uint32 *restrict out, uint32 base)        \
+	{                                                                                              \
+		const uint32 mask = ((W) == 32) ? UINT32_MAX : ((uint32) 1 << ((W) & 31)) - 1;             \
+		for (int lane = 0; lane < FL_S32; lane++)                                                  \
+		{                                                                                          \
+			uint32 src = packed[lane], tmp;                                                        \
+			FL_FFOR_UNPACK_ALL_32(uint32, FL_S32, W)                                               \
+		}                                                                                          \
+	}
+FL_W_LIST_32(FL_DEF_FFOR_PACK_U32)
+FL_W_LIST_32(FL_DEF_FFOR_UNPACK_U32)
+#endif /* FL_TIER >= 32 */
+
+#if FL_TIER >= 16
+#define FL_DEF_FFOR_PACK_U16(W)                                                                    \
+	static void FL_FNW(_ffor_pack_u16,                                                             \
+					   W)(const uint16 *restrict in, uint16 *restrict out, uint16 base)            \
+	{                                                                                              \
+		const uint16 mask =                                                                        \
+			((W) == 16) ? (uint16) UINT16_MAX : (uint16) (((uint16) 1 << ((W) & 15)) - 1);         \
+		for (int lane = 0; lane < FL_S16; lane++)                                                  \
+		{                                                                                          \
+			uint16 tmp = 0, src;                                                                   \
+			FL_FFOR_PACK_ALL_16(FL_S16, W)                                                         \
+			FL_PACK_FLUSH(16, FL_S16, W, 16)                                                       \
+		}                                                                                          \
+	}
+#define FL_DEF_FFOR_UNPACK_U16(W)                                                                  \
+	static void FL_FNW(_ffor_unpack_u16,                                                           \
+					   W)(const uint16 *restrict packed, uint16 *restrict out, uint16 base)        \
+	{                                                                                              \
+		const uint16 mask =                                                                        \
+			((W) == 16) ? (uint16) UINT16_MAX : (uint16) (((uint16) 1 << ((W) & 15)) - 1);         \
+		for (int lane = 0; lane < FL_S16; lane++)                                                  \
+		{                                                                                          \
+			uint16 src = packed[lane], tmp;                                                        \
+			FL_FFOR_UNPACK_ALL_16(uint16, FL_S16, W)                                               \
+		}                                                                                          \
+	}
+FL_W_LIST_16(FL_DEF_FFOR_PACK_U16)
+FL_W_LIST_16(FL_DEF_FFOR_UNPACK_U16)
+#endif /* FL_TIER >= 16 */
+
+/* T=8 always present. */
+#define FL_DEF_FFOR_PACK_U8(W)                                                                     \
+	static void FL_FNW(_ffor_pack_u8,                                                              \
+					   W)(const uint8 *restrict in, uint8 *restrict out, uint8 base)               \
+	{                                                                                              \
+		const uint8 mask =                                                                         \
+			((W) == 8) ? (uint8) UINT8_MAX : (uint8) (((uint8) 1 << ((W) & 7)) - 1);               \
+		for (int lane = 0; lane < FL_S8; lane++)                                                   \
+		{                                                                                          \
+			uint8 tmp = 0, src;                                                                    \
+			FL_FFOR_PACK_ALL_8(FL_S8, W)                                                           \
+			FL_PACK_FLUSH(8, FL_S8, W, 8)                                                          \
+		}                                                                                          \
+	}
+#define FL_DEF_FFOR_UNPACK_U8(W)                                                                   \
+	static void FL_FNW(_ffor_unpack_u8,                                                            \
+					   W)(const uint8 *restrict packed, uint8 *restrict out, uint8 base)           \
+	{                                                                                              \
+		const uint8 mask =                                                                         \
+			((W) == 8) ? (uint8) UINT8_MAX : (uint8) (((uint8) 1 << ((W) & 7)) - 1);               \
+		for (int lane = 0; lane < FL_S8; lane++)                                                   \
+		{                                                                                          \
+			uint8 src = packed[lane], tmp;                                                         \
+			FL_FFOR_UNPACK_ALL_8(uint8, FL_S8, W)                                                  \
+		}                                                                                          \
+	}
+FL_W_LIST_8(FL_DEF_FFOR_PACK_U8)
+FL_W_LIST_8(FL_DEF_FFOR_UNPACK_U8)
+
+/* Per-T FFOR dispatchers */
+
+#if FL_TIER >= 64
+static inline void
+FL_FN(_ffor_pack_t64)(const uint64 *in, void *out, uint8 w, uint64 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_pack_u64, W)(in, (uint64 *) out, base);                                       \
+		break;
+		FL_W_LIST_64(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_ffor_unpack_t64)(const void *packed, uint64 *out, uint8 w, uint64 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_unpack_u64, W)((const uint64 *) packed, out, base);                           \
+		break;
+		FL_W_LIST_64(FL_CASE)
+#undef FL_CASE
+	}
+}
+#endif /* FL_TIER >= 64 */
+
+#if FL_TIER >= 32
+static inline void
+FL_FN(_ffor_pack_t32)(const uint32 *in, void *out, uint8 w, uint32 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_pack_u32, W)(in, (uint32 *) out, base);                                       \
+		break;
+		FL_W_LIST_32(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_ffor_unpack_t32)(const void *packed, uint32 *out, uint8 w, uint32 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_unpack_u32, W)((const uint32 *) packed, out, base);                           \
+		break;
+		FL_W_LIST_32(FL_CASE)
+#undef FL_CASE
+	}
+}
+#endif /* FL_TIER >= 32 */
+
+#if FL_TIER >= 16
+static inline void
+FL_FN(_ffor_pack_t16)(const uint16 *in, void *out, uint8 w, uint16 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_pack_u16, W)(in, (uint16 *) out, base);                                       \
+		break;
+		FL_W_LIST_16(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_ffor_unpack_t16)(const void *packed, uint16 *out, uint8 w, uint16 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_unpack_u16, W)((const uint16 *) packed, out, base);                           \
+		break;
+		FL_W_LIST_16(FL_CASE)
+#undef FL_CASE
+	}
+}
+#endif /* FL_TIER >= 16 */
+
+static inline void
+FL_FN(_ffor_pack_t8)(const uint8 *in, void *out, uint8 w, uint8 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_pack_u8, W)(in, (uint8 *) out, base);                                         \
+		break;
+		FL_W_LIST_8(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_ffor_unpack_t8)(const void *packed, uint8 *out, uint8 w, uint8 base)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_ffor_unpack_u8, W)((const uint8 *) packed, out, base);                             \
+		break;
+		FL_W_LIST_8(FL_CASE)
+#undef FL_CASE
+	}
+}
+
+/* Public entry points */
+
+extern size_t
+FL_FN(_pack_ffor)(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t,
+				  uint64 base)
+{
+	if (w == 0)
+	{
+		return 0;
+	}
+
+	switch (t)
+	{
+#if FL_TIER >= 64
+		case FL_ELEM_W64:
+			FL_FN(_ffor_pack_t64)((const uint64 *) values, packed, w, base);
+			break;
+#endif
+#if FL_TIER >= 32
+		case FL_ELEM_W32:
+			FL_FN(_ffor_pack_t32)((const uint32 *) values, packed, w, (uint32) base);
+			break;
+#endif
+#if FL_TIER >= 16
+		case FL_ELEM_W16:
+			FL_FN(_ffor_pack_t16)((const uint16 *) values, packed, w, (uint16) base);
+			break;
+#endif
+		case FL_ELEM_W8:
+			FL_FN(_ffor_pack_t8)((const uint8 *) values, packed, w, (uint8) base);
+			break;
+		default:
+			Assert(false);
+			break;
+	}
+	return (size_t) FL_FN(_words_needed)(n, w, t) * FL_WORD_BYTES;
+}
+
+extern void
+FL_FN(_unpack_ffor)(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
+					uint64 base)
+{
+	if (w == 0)
+	{
+		/* we need all elem widths, no matter what the tier is */
+		switch (t)
+		{
+			case FL_ELEM_W64:
+			{
+				uint64 *out = (uint64 *) values;
+				uint64 b = base;
+				for (uint32 i = 0; i < n; i++)
+				{
+					out[i] = b;
+				}
+				break;
+			}
+			case FL_ELEM_W32:
+			{
+				uint32 *out = (uint32 *) values;
+				uint32 b = (uint32) base;
+				for (uint32 i = 0; i < n; i++)
+				{
+					out[i] = b;
+				}
+				break;
+			}
+			case FL_ELEM_W16:
+			{
+				uint16 *out = (uint16 *) values;
+				uint16 b = (uint16) base;
+				for (uint32 i = 0; i < n; i++)
+				{
+					out[i] = b;
+				}
+				break;
+			}
+			case FL_ELEM_W8:
+			{
+				uint8 *out = (uint8 *) values;
+				uint8 b = (uint8) base;
+				for (uint32 i = 0; i < n; i++)
+				{
+					out[i] = b;
+				}
+				break;
+			}
+			default:
+				Assert(false);
+				break;
+		}
+		return;
+	}
+
+	switch (t)
+	{
+#if FL_TIER >= 64
+		case FL_ELEM_W64:
+			FL_FN(_ffor_unpack_t64)(packed, (uint64 *) values, w, base);
+			break;
+#endif
+#if FL_TIER >= 32
+		case FL_ELEM_W32:
+			FL_FN(_ffor_unpack_t32)(packed, (uint32 *) values, w, (uint32) base);
+			break;
+#endif
+#if FL_TIER >= 16
+		case FL_ELEM_W16:
+			FL_FN(_ffor_unpack_t16)(packed, (uint16 *) values, w, (uint16) base);
+			break;
+#endif
+		case FL_ELEM_W8:
+			FL_FN(_ffor_unpack_t8)(packed, (uint8 *) values, w, (uint8) base);
+			break;
+		default:
+			Assert(false);
+			break;
+	}
+}
+
+/* Teardown */
+
+#undef FL_DEF_FFOR_PACK_U64
+#undef FL_DEF_FFOR_UNPACK_U64
+#undef FL_DEF_FFOR_PACK_U32
+#undef FL_DEF_FFOR_UNPACK_U32
+#undef FL_DEF_FFOR_PACK_U16
+#undef FL_DEF_FFOR_UNPACK_U16
+#undef FL_DEF_FFOR_PACK_U8
+#undef FL_DEF_FFOR_UNPACK_U8
+#undef FL_FN
+#undef FL_FNW
+#undef FL_PASTE3
+#undef FL_PASTE3_
+#undef FL_VEC_SIZE
+#undef FL_WORD_BYTES
+#undef FL_S8
+#undef FL_S16
+#undef FL_S32
+#undef FL_S64
+/* Leaves FL_TIER defined; the caller undefs it after the final tier include. */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_tier_pack_impl.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_tier_pack_impl.h
@@ -1,0 +1,401 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_tier_pack_impl.h -- plain pack/unpack template.
+ *
+ * Usage:
+ *     #define FL_TIER 256                 // 8/16/32/64/128/256
+ *     #include "fastlanes_tier_sizing.h"  // REQUIRED first --
+ *                                         // pack returns size via
+ *                                         // fl{T}_words_needed
+ *     #include "fastlanes_tier_pack_impl.h"
+ *     #undef FL_TIER                      // caller owns FL_TIER's lifetime
+ *
+ * Emits:
+ *   - plain per-W kernels: fl{T}_{pack,unpack}_u{8..64}_w{1..T}
+ *   - plain per-T dispatchers: fl{T}_{pack,unpack}_t{8..64}
+ *   - public entry points: fl{T}_pack, fl{T}_unpack
+ */
+
+#if !defined(FL_TIER)
+#error "fastlanes_tier_pack_impl.h requires FL_TIER (one of 8, 16, 32, 64, 128, 256)"
+#endif
+
+#if FL_TIER != 8 && FL_TIER != 16 && FL_TIER != 32 && FL_TIER != 64 && FL_TIER != 128 &&           \
+	FL_TIER != 256
+#error "FL_TIER must be 8, 16, 32, 64, 128, or 256"
+#endif
+
+#include "fastlanes_template_macros.h"
+
+/* Symbol-name plumbing */
+#define FL_PASTE3_(a, b, c) a##b##c
+#define FL_PASTE3(a, b, c) FL_PASTE3_(a, b, c)
+#define FL_FN(suffix) FL_PASTE3(fl, FL_TIER, suffix)
+#define FL_FNW(suffix, W) FL_PASTE3(FL_FN(suffix), _w, W)
+#define FL_VEC_SIZE FL_TIER
+#define FL_WORD_BYTES (FL_TIER / 8)
+/* Per-tier S = FL_TIER / T constants. Baked to single literals so MSVC's
+ * preprocessor doesn't blow up. */
+#if FL_TIER == 256
+#define FL_S8 32
+#define FL_S16 16
+#define FL_S32 8
+#define FL_S64 4
+#elif FL_TIER == 128
+#define FL_S8 16
+#define FL_S16 8
+#define FL_S32 4
+#define FL_S64 2
+#elif FL_TIER == 64
+#define FL_S8 8
+#define FL_S16 4
+#define FL_S32 2
+#define FL_S64 1
+#elif FL_TIER == 32
+#define FL_S8 4
+#define FL_S16 2
+#define FL_S32 1
+#elif FL_TIER == 16
+#define FL_S8 2
+#define FL_S16 1
+#elif FL_TIER == 8
+#define FL_S8 1
+#endif
+
+/* Bind FL_P1 / FL_U1 to the promoted row bodies in fastlanes_template_macros.h */
+
+#undef FL_P1
+#define FL_P1(T, S, W, r) FL_PACK_ROW(T, S, W, r)
+
+#undef FL_U1
+#define FL_U1(TYPE, T, S, W, r)                                                                    \
+	if ((r) > 0)                                                                                   \
+	{                                                                                              \
+		FL_UNPACK_LOAD(T, S, W, r)                                                                 \
+	}                                                                                              \
+	FL_UNPACK_ROW(TYPE, T, S, W, r)
+
+/* Per-W kernel generators */
+
+#if FL_TIER >= 64
+#define FL_DEF_PACK_U64(W)                                                                         \
+	static void FL_FNW(_pack_u64, W)(const uint64 *restrict in, uint64 *restrict out)              \
+	{                                                                                              \
+		const uint64 mask = ((W) == 64) ? UINT64_MAX : ((uint64) 1 << ((W) & 63)) - 1;             \
+		for (int lane = 0; lane < FL_S64; lane++)                                                  \
+		{                                                                                          \
+			uint64 tmp = 0, src;                                                                   \
+			FL_PACK_ALL_64(FL_S64, W)                                                              \
+			FL_PACK_FLUSH(64, FL_S64, W, 64)                                                       \
+		}                                                                                          \
+	}
+#define FL_DEF_UNPACK_U64(W)                                                                       \
+	static void FL_FNW(_unpack_u64, W)(const uint64 *restrict packed, uint64 *restrict out)        \
+	{                                                                                              \
+		const uint64 mask = ((W) == 64) ? UINT64_MAX : ((uint64) 1 << ((W) & 63)) - 1;             \
+		for (int lane = 0; lane < FL_S64; lane++)                                                  \
+		{                                                                                          \
+			uint64 src = packed[lane], tmp;                                                        \
+			FL_UNPACK_ALL_64(uint64, FL_S64, W)                                                    \
+		}                                                                                          \
+	}
+FL_W_LIST_64(FL_DEF_PACK_U64)
+FL_W_LIST_64(FL_DEF_UNPACK_U64)
+#endif /* FL_TIER >= 64 */
+
+#if FL_TIER >= 32
+#define FL_DEF_PACK_U32(W)                                                                         \
+	static void FL_FNW(_pack_u32, W)(const uint32 *restrict in, uint32 *restrict out)              \
+	{                                                                                              \
+		const uint32 mask = ((W) == 32) ? UINT32_MAX : ((uint32) 1 << ((W) & 31)) - 1;             \
+		for (int lane = 0; lane < FL_S32; lane++)                                                  \
+		{                                                                                          \
+			uint32 tmp = 0, src;                                                                   \
+			FL_PACK_ALL_32(FL_S32, W)                                                              \
+			FL_PACK_FLUSH(32, FL_S32, W, 32)                                                       \
+		}                                                                                          \
+	}
+#define FL_DEF_UNPACK_U32(W)                                                                       \
+	static void FL_FNW(_unpack_u32, W)(const uint32 *restrict packed, uint32 *restrict out)        \
+	{                                                                                              \
+		const uint32 mask = ((W) == 32) ? UINT32_MAX : ((uint32) 1 << ((W) & 31)) - 1;             \
+		for (int lane = 0; lane < FL_S32; lane++)                                                  \
+		{                                                                                          \
+			uint32 src = packed[lane], tmp;                                                        \
+			FL_UNPACK_ALL_32(uint32, FL_S32, W)                                                    \
+		}                                                                                          \
+	}
+FL_W_LIST_32(FL_DEF_PACK_U32)
+FL_W_LIST_32(FL_DEF_UNPACK_U32)
+#endif /* FL_TIER >= 32 */
+
+#if FL_TIER >= 16
+#define FL_DEF_PACK_U16(W)                                                                         \
+	static void FL_FNW(_pack_u16, W)(const uint16 *restrict in, uint16 *restrict out)              \
+	{                                                                                              \
+		const uint16 mask =                                                                        \
+			((W) == 16) ? (uint16) UINT16_MAX : (uint16) (((uint16) 1 << ((W) & 15)) - 1);         \
+		for (int lane = 0; lane < FL_S16; lane++)                                                  \
+		{                                                                                          \
+			uint16 tmp = 0, src;                                                                   \
+			FL_PACK_ALL_16(FL_S16, W)                                                              \
+			FL_PACK_FLUSH(16, FL_S16, W, 16)                                                       \
+		}                                                                                          \
+	}
+#define FL_DEF_UNPACK_U16(W)                                                                       \
+	static void FL_FNW(_unpack_u16, W)(const uint16 *restrict packed, uint16 *restrict out)        \
+	{                                                                                              \
+		const uint16 mask =                                                                        \
+			((W) == 16) ? (uint16) UINT16_MAX : (uint16) (((uint16) 1 << ((W) & 15)) - 1);         \
+		for (int lane = 0; lane < FL_S16; lane++)                                                  \
+		{                                                                                          \
+			uint16 src = packed[lane], tmp;                                                        \
+			FL_UNPACK_ALL_16(uint16, FL_S16, W)                                                    \
+		}                                                                                          \
+	}
+FL_W_LIST_16(FL_DEF_PACK_U16)
+FL_W_LIST_16(FL_DEF_UNPACK_U16)
+#endif /* FL_TIER >= 16 */
+
+/* T=8 always supported -- smallest tier (FL8) is exactly T=8. */
+#define FL_DEF_PACK_U8(W)                                                                          \
+	static void FL_FNW(_pack_u8, W)(const uint8 *restrict in, uint8 *restrict out)                 \
+	{                                                                                              \
+		const uint8 mask =                                                                         \
+			((W) == 8) ? (uint8) UINT8_MAX : (uint8) (((uint8) 1 << ((W) & 7)) - 1);               \
+		for (int lane = 0; lane < FL_S8; lane++)                                                   \
+		{                                                                                          \
+			uint8 tmp = 0, src;                                                                    \
+			FL_PACK_ALL_8(FL_S8, W)                                                                \
+			FL_PACK_FLUSH(8, FL_S8, W, 8)                                                          \
+		}                                                                                          \
+	}
+#define FL_DEF_UNPACK_U8(W)                                                                        \
+	static void FL_FNW(_unpack_u8, W)(const uint8 *restrict packed, uint8 *restrict out)           \
+	{                                                                                              \
+		const uint8 mask =                                                                         \
+			((W) == 8) ? (uint8) UINT8_MAX : (uint8) (((uint8) 1 << ((W) & 7)) - 1);               \
+		for (int lane = 0; lane < FL_S8; lane++)                                                   \
+		{                                                                                          \
+			uint8 src = packed[lane], tmp;                                                         \
+			FL_UNPACK_ALL_8(uint8, FL_S8, W)                                                       \
+		}                                                                                          \
+	}
+FL_W_LIST_8(FL_DEF_PACK_U8)
+FL_W_LIST_8(FL_DEF_UNPACK_U8)
+
+/* Per-T dispatchers */
+
+#if FL_TIER >= 64
+static inline void
+FL_FN(_pack_t64)(const uint64 *in, void *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_pack_u64, W)(in, (uint64 *) out);                                                  \
+		break;
+		FL_W_LIST_64(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_unpack_t64)(const void *packed, uint64 *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_unpack_u64, W)((const uint64 *) packed, out);                                      \
+		break;
+		FL_W_LIST_64(FL_CASE)
+#undef FL_CASE
+	}
+}
+#endif /* FL_TIER >= 64 */
+
+#if FL_TIER >= 32
+static inline void
+FL_FN(_pack_t32)(const uint32 *in, void *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_pack_u32, W)(in, (uint32 *) out);                                                  \
+		break;
+		FL_W_LIST_32(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_unpack_t32)(const void *packed, uint32 *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_unpack_u32, W)((const uint32 *) packed, out);                                      \
+		break;
+		FL_W_LIST_32(FL_CASE)
+#undef FL_CASE
+	}
+}
+#endif /* FL_TIER >= 32 */
+
+#if FL_TIER >= 16
+static inline void
+FL_FN(_pack_t16)(const uint16 *in, void *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_pack_u16, W)(in, (uint16 *) out);                                                  \
+		break;
+		FL_W_LIST_16(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_unpack_t16)(const void *packed, uint16 *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_unpack_u16, W)((const uint16 *) packed, out);                                      \
+		break;
+		FL_W_LIST_16(FL_CASE)
+#undef FL_CASE
+	}
+}
+#endif /* FL_TIER >= 16 */
+
+static inline void
+FL_FN(_pack_t8)(const uint8 *in, void *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_pack_u8, W)(in, (uint8 *) out);                                                    \
+		break;
+		FL_W_LIST_8(FL_CASE)
+#undef FL_CASE
+	}
+}
+static inline void
+FL_FN(_unpack_t8)(const void *packed, uint8 *out, uint8 w)
+{
+	switch (w)
+	{
+#define FL_CASE(W)                                                                                 \
+	case W:                                                                                        \
+		FL_FNW(_unpack_u8, W)((const uint8 *) packed, out);                                        \
+		break;
+		FL_W_LIST_8(FL_CASE)
+#undef FL_CASE
+	}
+}
+
+/* Public entry points */
+
+extern size_t
+FL_FN(_pack)(const void *values, void *packed, uint32 n, uint8 w, fl_elem_width_t t)
+{
+	if (w == 0)
+	{
+		return 0;
+	}
+
+	switch (t)
+	{
+#if FL_TIER >= 64
+		case FL_ELEM_W64:
+			FL_FN(_pack_t64)((const uint64 *) values, packed, w);
+			break;
+#endif
+#if FL_TIER >= 32
+		case FL_ELEM_W32:
+			FL_FN(_pack_t32)((const uint32 *) values, packed, w);
+			break;
+#endif
+#if FL_TIER >= 16
+		case FL_ELEM_W16:
+			FL_FN(_pack_t16)((const uint16 *) values, packed, w);
+			break;
+#endif
+		case FL_ELEM_W8:
+			FL_FN(_pack_t8)((const uint8 *) values, packed, w);
+			break;
+		default:
+			Assert(false);
+			break;
+	}
+	return (size_t) FL_FN(_words_needed)(n, w, t) * FL_WORD_BYTES;
+}
+
+extern void
+FL_FN(_unpack)(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t)
+{
+	if (w == 0)
+	{
+		size_t sz = n * (int) t / 8;
+		memset(values, 0, sz);
+		return;
+	}
+
+	switch (t)
+	{
+#if FL_TIER >= 64
+		case FL_ELEM_W64:
+			FL_FN(_unpack_t64)(packed, (uint64 *) values, w);
+			break;
+#endif
+#if FL_TIER >= 32
+		case FL_ELEM_W32:
+			FL_FN(_unpack_t32)(packed, (uint32 *) values, w);
+			break;
+#endif
+#if FL_TIER >= 16
+		case FL_ELEM_W16:
+			FL_FN(_unpack_t16)(packed, (uint16 *) values, w);
+			break;
+#endif
+		case FL_ELEM_W8:
+			FL_FN(_unpack_t8)(packed, (uint8 *) values, w);
+			break;
+		default:
+			Assert(false);
+			break;
+	}
+}
+
+/* Teardown */
+
+#undef FL_DEF_PACK_U64
+#undef FL_DEF_UNPACK_U64
+#undef FL_DEF_PACK_U32
+#undef FL_DEF_UNPACK_U32
+#undef FL_DEF_PACK_U16
+#undef FL_DEF_UNPACK_U16
+#undef FL_DEF_PACK_U8
+#undef FL_DEF_UNPACK_U8
+#undef FL_FN
+#undef FL_FNW
+#undef FL_PASTE3
+#undef FL_PASTE3_
+#undef FL_VEC_SIZE
+#undef FL_WORD_BYTES
+#undef FL_S8
+#undef FL_S16
+#undef FL_S32
+#undef FL_S64
+/* Leaves FL_TIER defined; the caller undefs it after the final tier include. */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_tier_sizing.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_tier_sizing.h
@@ -1,0 +1,91 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_tier_sizing.h -- per-tier sizing/alignment helpers.
+ *
+ * Usage:
+ *     #define FL_TIER 256                 // 8/16/32/64/128/256
+ *     #include "fastlanes_tier_sizing.h"
+ *     #undef FL_TIER
+ *
+ * Emits seven static inline helpers per included tier:
+ *
+ *   fl{T}_words_needed, fl{T}_words_full,     // bit-arithmetic primitives
+ *   fl{T}_alignment, fl{T}_required_bytes,    // public sizing dispatch backers
+ *   fl{T}_result_bytes,
+ *   fl{T}_input_count, fl{T}_input_bytes
+ */
+
+#if !defined(FL_TIER)
+#error "fastlanes_tier_sizing.h requires FL_TIER (one of 8, 16, 32, 64, 128, 256)"
+#endif
+
+#if FL_TIER != 8 && FL_TIER != 16 && FL_TIER != 32 && FL_TIER != 64 && FL_TIER != 128 &&           \
+	FL_TIER != 256
+#error "FL_TIER must be 8, 16, 32, 64, 128, or 256"
+#endif
+
+#include "fastlanes_types.h"
+
+/* Symbol-name plumbing */
+#define FL_PASTE3_(a, b, c) a##b##c
+#define FL_PASTE3(a, b, c) FL_PASTE3_(a, b, c)
+#define FL_FN(suffix) FL_PASTE3(fl, FL_TIER, suffix)
+#define FL_VEC_SIZE FL_TIER
+#define FL_WORD_BYTES (FL_TIER / 8)
+
+static inline uint32
+FL_FN(_words_needed)(uint32 n, uint8 w, fl_elem_width_t t)
+{
+	uint32 s = FL_VEC_SIZE / t;
+	uint32 r = (n + s - 1) / s;
+	return (r * w + t - 1) / t;
+}
+
+static inline uint32
+FL_FN(_words_full)(uint8 w, fl_elem_width_t t)
+{
+	return FL_FN(_words_needed)(FL_VEC_SIZE, w, t);
+}
+
+static inline size_t
+FL_FN(_alignment)(void)
+{
+	return FL_WORD_BYTES;
+}
+
+static inline size_t
+FL_FN(_required_bytes)(uint8 w, fl_elem_width_t t)
+{
+	return (size_t) FL_FN(_words_full)(w, t) * FL_WORD_BYTES;
+}
+
+static inline size_t
+FL_FN(_result_bytes)(uint32 n, uint8 w, fl_elem_width_t t)
+{
+	return (size_t) FL_FN(_words_needed)(n, w, t) * FL_WORD_BYTES;
+}
+
+static inline uint32
+FL_FN(_input_count)(void)
+{
+	return FL_VEC_SIZE;
+}
+
+static inline size_t
+FL_FN(_input_bytes)(fl_elem_width_t t)
+{
+	return (size_t) FL_VEC_SIZE * t / 8;
+}
+
+/* Teardown */
+#undef FL_FN
+#undef FL_PASTE3
+#undef FL_PASTE3_
+#undef FL_VEC_SIZE
+#undef FL_WORD_BYTES
+/* Leaves FL_TIER defined; the caller undefs it after the final tier include. */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_types.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_types.h
@@ -1,0 +1,33 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * fastlanes/fastlanes_types.h -- shared enum types for the FastLanes pack/unpack layer.
+ *
+ *   fl_elem_width_t  -- input element width T (8, 16, 32, 64 bits)
+ *   fl_tier_width_t  -- selected tier (FL8..FL256)
+ */
+#pragma once
+
+/* Element width T in bits. */
+typedef enum
+{
+	FL_ELEM_W8 = 8,
+	FL_ELEM_W16 = 16,
+	FL_ELEM_W32 = 32,
+	FL_ELEM_W64 = 64,
+} fl_elem_width_t;
+
+/* Selected FL tier. */
+typedef enum
+{
+	FL_TIER_W8 = 8,
+	FL_TIER_W16 = 16,
+	FL_TIER_W32 = 32,
+	FL_TIER_W64 = 64,
+	FL_TIER_W128 = 128,
+	FL_TIER_W256 = 256,
+} fl_tier_width_t;

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -5,6 +5,8 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE OR REPLACE FUNCTION ts_test_compression() RETURNS VOID
 AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_test_fastlanes() RETURNS VOID
+AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
 \ir include/compression_utils.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -20,6 +22,11 @@ create or replace function mix(x timestamptz) returns float4 as $$ select mix(ex
 SELECT ts_test_compression();
  ts_test_compression 
 ---------------------
+ 
+
+SELECT ts_test_fastlanes();
+ ts_test_fastlanes 
+-------------------
  
 
 ------------------------

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -6,6 +6,8 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE OR REPLACE FUNCTION ts_test_compression() RETURNS VOID
 AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_test_fastlanes() RETURNS VOID
+AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
 \ir include/compression_utils.sql
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
@@ -18,6 +20,7 @@ create or replace function mix(x timestamptz) returns float4 as $$ select mix(ex
 ------------------
 
 SELECT ts_test_compression();
+SELECT ts_test_fastlanes();
 
 ------------------------
 -- BIGINT Compression --

--- a/tsl/test/src/CMakeLists.txt
+++ b/tsl/test/src/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(SOURCES
-    test_chunk_stats.c test_merge_chunk.c compression_unit_test.c
-    compression_sql_test.c decompress_text_test_impl.c test_continuous_agg.c)
+    test_chunk_stats.c
+    test_merge_chunk.c
+    compression_unit_test.c
+    test_fastlanes.c
+    compression_sql_test.c
+    decompress_text_test_impl.c
+    test_continuous_agg.c)
 
 include(${PROJECT_SOURCE_DIR}/tsl/src/build-defs.cmake)
 

--- a/tsl/test/src/test_fastlanes.c
+++ b/tsl/test/src/test_fastlanes.c
@@ -1,0 +1,828 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include "compression/algorithms/fastlanes/fastlanes.h"
+
+#include "port.h"
+#include "test_utils.h"
+#include <c.h>
+#include <port/pg_bitutils.h>
+#include <time.h>
+#include <utils/palloc.h>
+
+TS_FUNCTION_INFO_V1(ts_test_fastlanes);
+
+/*
+ * palloc_aligned was added in PG 16. As PG 15 support
+ * is about to be removed, this test is skipped on PG15.
+ */
+#if PG_VERSION_NUM < 160000
+
+Datum
+ts_test_fastlanes(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_VOID();
+}
+
+#else
+#define pfree_aligned(p) pfree(p)
+
+/*
+ * The below tests have a few goals to achieve, to act as a full
+ * correctness suite is _not_ one of them. The main goals are:
+ *
+ *  - have a decent coverage of the fl/ library such that the code
+ *    coverage tools in the CI will pass. this is because the fl/
+ *    library will be rolled out before the actual compression code is
+ *
+ *  - serve as a tutorial for how to use the fl/ library, and to
+ *    demonstrate the caller contract and the expected behavior of the
+ *    library. there is further information about this in the fl/README.md
+ *
+ *  - to highlight certain properties of the library with examples
+ */
+
+/*
+ * This test demonstrates the packing and unpacking of 7 elements with
+ * 3 bits per element. This will use the FL8 tier and it shows that we
+ * can pack these numbers in 3 bytes.
+ */
+static void
+test_fl8_pack_7x3b()
+{
+	const uint32 n = 7; /* seven elements */
+	uint8 values_in[8] = {
+		1, 2, 3, 4, 5, 6, 7, 8,
+	};
+	size_t input_size = fl_input_bytes(n, FL_ELEM_W8);
+	TestAssertInt64Eq(input_size, 8LL);
+	TestAssertInt64Eq((int64) sizeof(values_in), input_size);
+
+	size_t required_size = fl_required_bytes(n, 3, FL_ELEM_W8);
+	TestAssertInt64Eq(required_size, 3LL);
+	size_t result_size = fl_result_bytes(n, 3, FL_ELEM_W8);
+	TestAssertInt64Eq(result_size, 3LL);
+
+	uint8 values_out[8] = { 255, 255, 255, 255, 255, 255, 255, 255 };
+	size_t packed_bytes = fl_pack(values_in, values_out, n, 3, FL_ELEM_W8);
+	TestAssertInt64Eq(packed_bytes, result_size);
+
+	/* the tail padding must not change */
+	for (int i = result_size; i < 8; ++i)
+	{
+		TestAssertInt64Eq(values_out[i], 255LL);
+	}
+
+	/*
+	 * copy the compressed payload only, so we make sure we don't fool
+	 * ourselves by allowing the decompressor to see parts that it shouldn't
+	 * see.
+	 */
+	uint8 compressed_payload[8] = { 0 };
+	memcpy(compressed_payload, values_out, packed_bytes);
+
+	/* try the decoding too, with the right decoded output size */
+	uint8 decoded[8] = { 255, 255, 255, 255, 255, 255, 255, 255 };
+	fl_unpack(compressed_payload, decoded, n, 3, FL_ELEM_W8);
+	for (uint32 i = 0; i < n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], values_in[i]);
+	}
+}
+
+/*
+ * This test demonstrates the FFOR packing, which subtracts a base value
+ * from the input values before packing. This allows us to pack 7 elements
+ * that originally took 8 bits each into 3 bytes by using a base value of 210.
+ */
+static void
+test_fl8_pack_7x3b_ffor()
+{
+	const uint32 n = 7; /* seven elements */
+	uint8 values_in[8] = {
+		211, 212, 213, 214, 215, 216, 217, 255,
+	};
+	uint8 values_out[8] = { 255, 255, 255, 255, 255, 255, 255, 255 };
+	uint8 base = 210;
+	size_t packed_bytes = fl_pack_ffor(values_in, values_out, n, 3, FL_ELEM_W8, base);
+	size_t result_size = fl_result_bytes(n, 3, FL_ELEM_W8);
+	TestAssertInt64Eq(packed_bytes, result_size);
+	TestAssertInt64Eq(packed_bytes, 3ULL);
+
+	/* the tail padding must not change */
+	for (int i = result_size; i < 8; ++i)
+	{
+		TestAssertInt64Eq(values_out[i], 255LL);
+	}
+
+	/*
+	 * copy the compressed payload only, so we make sure we don't fool
+	 * ourselves by allowing the decompressor to see parts that it shouldn't
+	 * see.
+	 */
+	uint8 compressed_payload[8] = { 0 };
+	memcpy(compressed_payload, values_out, packed_bytes);
+
+	/* try the decoding too, with the right decoded output size */
+	uint8 decoded[8] = { 255, 255, 255, 255, 255, 255, 255, 255 };
+	fl_unpack_ffor(compressed_payload, decoded, n, 3, FL_ELEM_W8, base);
+	for (uint32 i = 0; i < n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], values_in[i]);
+	}
+}
+
+/*
+ * This test exercises the FL16 tier (N > 8 elements forces FL16) and
+ * demonstrates two things:
+ *
+ *  (1) Alignment contract via the proper allocator pattern: ask the
+ *      library for the required alignment and size, then use
+ *      palloc_aligned() to obtain a buffer that satisfies both. For
+ *      FL16 the alignment is 2 bytes (= the tier's WORD_BYTES).
+ *
+ *  (2) An eye-catching packing ratio: 16 boolean-like values stored
+ *      naively as uint16 take 32 bytes; packed at W=1 they fit in
+ *      2 bytes -- a 16x reduction.
+ */
+static void
+test_fl16_pack_16x1b()
+{
+	const uint32 n = 16;
+	const uint8 W = 1;
+	const fl_elem_width_t T = FL_ELEM_W16;
+
+	/* Step 1: ask the library what we need. */
+	size_t alignment = fl_alignment(n, T);
+	size_t input_size = fl_input_bytes(n, T);
+	size_t required_size = fl_required_bytes(n, W, T);
+	size_t result_size = fl_result_bytes(n, W, T);
+
+	/* These verifications are to demonstrating the contract */
+	TestAssertInt64Eq(alignment, 2LL);
+	TestAssertInt64Eq(input_size, 32LL);
+	TestAssertInt64Eq(required_size, 2LL);
+	TestAssertInt64Eq(result_size, 2LL);
+
+	/* The headline: 32 bytes in -> 2 bytes out : 16x */
+	TestAssertInt64Eq((int64) (input_size / result_size), 16LL);
+
+	/*
+	 * Step 2: allocate buffers satisfying both alignment and size.
+	 * palloc_aligned(size, alignment, 0) requires size to be a multiple
+	 * of alignment -- both fl_input_bytes and fl_required_bytes are
+	 * multiples of fl_alignment by construction.
+	 */
+	uint16 *values_in = palloc_aligned(input_size, alignment, 0);
+	uint8 *packed = palloc_aligned(required_size, alignment, 0);
+	uint16 *decoded = palloc_aligned(input_size, alignment, 0);
+	TestAssertTrue(values_in != NULL);
+	TestAssertTrue(packed != NULL);
+	TestAssertTrue(decoded != NULL);
+
+	/* Step 3: verify the addresses actually meet the contract. */
+	TestAssertInt64Eq((int64) ((uintptr_t) values_in % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) packed % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) decoded % alignment), 0LL);
+
+	/* Step 4: fill the input. */
+	const uint16 pattern[16] = {
+		1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1,
+	};
+	memcpy(values_in, pattern, input_size);
+
+	/* Step 5: pack and verify the returned byte count. */
+	size_t packed_bytes = fl_pack(values_in, packed, n, W, T);
+	TestAssertInt64Eq(packed_bytes, result_size);
+
+	/* Step 6: unpack and verify roundtrip. */
+	fl_unpack(packed, decoded, n, W, T);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], pattern[i]);
+	}
+
+	pfree_aligned(values_in);
+	pfree_aligned(packed);
+	pfree_aligned(decoded);
+}
+
+/*
+ * This test exercises the FL32 tier (N=23 routes to FL32) and
+ * demonstrates three things:
+ *
+ *  (1) Truncation in action: at N=23 (partial N within FL32's 32-
+ *      element vector) the meaningful packed result is 16 bytes while
+ *      the kernel writes the full 20-byte alloc. The caller stores
+ *      only result_size bytes; before decode the caller must
+ *      pre-zero the [truncated_bytes..alloc_bytes) tail of a fresh
+ *      scratch buffer.
+ *
+ *  (2) An inconvenient bit width: W=5 doesn't align to any byte
+ *      boundary, but the bit-packing handles it. 23 uint32 values
+ *      (92 bytes of meaningful data) compress to 16 bytes -- 5.75x.
+ *
+ *  (3) The full allocator-based alignment contract for FL32, which
+ *      requires 4-byte alignment.
+ */
+static void
+test_fl32_pack_23x5b()
+{
+	const uint32 n = 23;
+	const uint8 W = 5;
+	const fl_elem_width_t T = FL_ELEM_W32;
+
+	/* Step 1: ask the library what we need. */
+	size_t alignment = fl_alignment(n, T);
+	size_t input_size = fl_input_bytes(n, T);
+	size_t required_size = fl_required_bytes(n, W, T);
+	size_t result_size = fl_result_bytes(n, W, T);
+
+	TestAssertInt64Eq(alignment, 4LL);
+	TestAssertInt64Eq(input_size, 128LL);	/* 32 elements x 4 bytes */
+	TestAssertInt64Eq(required_size, 20LL); /* 5 words x 4 bytes     */
+	TestAssertInt64Eq(result_size, 16LL);	/* 4 words x 4 bytes -- saves 4 vs alloc */
+
+	/* Headline: 23 uint32 (92 bytes meaningful) -> 16 bytes packed = 5.75x. */
+	TestAssertInt64Eq((int64) (n * sizeof(uint32)), 92LL);
+
+	/* Step 2: allocate buffers satisfying alignment and size. */
+	uint32 *values_in = palloc_aligned(input_size, alignment, 0);
+	uint8 *packed = palloc_aligned(required_size, alignment, 0);
+	uint32 *decoded = palloc_aligned(input_size, alignment, 0);
+	TestAssertTrue(values_in != NULL);
+	TestAssertTrue(packed != NULL);
+	TestAssertTrue(decoded != NULL);
+
+	/* Step 3: verify the addresses meet the contract. */
+	TestAssertInt64Eq((int64) ((uintptr_t) values_in % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) packed % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) decoded % alignment), 0LL);
+
+	/*
+	 * Step 4: fill 23 values that fit in 5 bits (0..31). Positions
+	 * 23..31 are left with whatever values aligned_alloc returned;
+	 * the kernel reads them per the contract but the decoder, given
+	 * the correct N, ignores their encoded bits.
+	 */
+	for (int i = 0; i < (int) n; ++i)
+	{
+		values_in[i] = (uint32) (i % 32); /* 0, 1, 2, ..., 22 */
+	}
+
+	/* Step 5: pack. fl_pack returns result_size, not required_size. */
+	size_t packed_bytes = fl_pack(values_in, packed, n, W, T);
+	TestAssertInt64Eq(packed_bytes, result_size);
+
+	/*
+	 * Step 6: simulate "store the meaningful prefix; reconstruct a
+	 * decode-ready buffer". A fresh scratch buffer receives the
+	 * truncated bytes followed by an explicit zero-pad of
+	 * [result_size..required_size). The kernel reads required_size
+	 * bytes on decode; the zero-pad satisfies the contract for the
+	 * region the caller never stored.
+	 */
+	uint8 *decode_in = palloc_aligned(required_size, alignment, 0);
+	TestAssertTrue(decode_in != NULL);
+	memcpy(decode_in, packed, result_size);
+	memset(decode_in + result_size, 0, required_size - result_size);
+
+	/* Step 7: unpack and verify roundtrip for the first N elements. */
+	fl_unpack(decode_in, decoded, n, W, T);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], values_in[i]);
+	}
+
+	pfree_aligned(values_in);
+	pfree_aligned(packed);
+	pfree_aligned(decoded);
+	pfree_aligned(decode_in);
+}
+
+/*
+ * This test demonstrates the W=0 constant-block special case on the
+ * FL64 tier. When all values are equal, the encoded form is empty
+ * (0 packed bytes). The decoder reconstructs them from (N, base)
+ * alone -- the maximum-compression endpoint of FastLanes.
+ *
+ *  - Plain pack returns 0 bytes; unpack fills the first N positions
+ *    with 0.
+ *  - FFOR pack returns 0 bytes; unpack fills the first N positions
+ *    with `base`.
+ *
+ * Because no packed bytes are produced, the `packed` argument can
+ * be NULL on both pack and unpack -- the kernel never dereferences
+ * it on the W=0 fast path.
+ */
+static void
+test_fl64_constant_block()
+{
+	const uint32 n = 50; /* routes to FL64 (33..64) */
+	const uint8 W = 0;	 /* the constant-block special case */
+	const fl_elem_width_t T = FL_ELEM_W32;
+	const uint32 base_value = 0xCAFEBABE;
+
+	/* Step 1: ask the library what we need. For W=0, required_size is 0. */
+	size_t alignment = fl_alignment(n, T);
+	size_t input_size = fl_input_bytes(n, T);
+	size_t required_size = fl_required_bytes(n, W, T);
+
+	TestAssertInt64Eq(alignment, 8LL);
+	TestAssertInt64Eq(input_size, 256LL);  /* 64 elements x 4 bytes */
+	TestAssertInt64Eq(required_size, 0LL); /* the headline: zero packed bytes */
+
+	/* No packed buffer needed; we still allocate values_in and decoded
+	 * because a real caller would have data prepared. */
+	uint32 *values_in = palloc_aligned(input_size, alignment, 0);
+	uint32 *decoded = palloc_aligned(input_size, alignment, 0);
+	TestAssertTrue(values_in != NULL);
+	TestAssertTrue(decoded != NULL);
+
+	for (int i = 0; i < (int) n; ++i)
+	{
+		values_in[i] = base_value;
+	}
+
+	/* Plain pack returns 0; packed buffer can be NULL. */
+	size_t packed_bytes = fl_pack(values_in, NULL, n, W, T);
+	TestAssertInt64Eq(packed_bytes, 0LL);
+
+	/* Plain unpack fills the first N positions with 0. */
+	for (int i = 0; i < (int) n; ++i)
+	{
+		decoded[i] = 0xDEADBEEF; /* pre-fill to verify overwrite */
+	}
+	fl_unpack(NULL, decoded, n, W, T);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], 0LL);
+	}
+
+	/* FFOR pack: same -- returns 0. */
+	size_t ffor_bytes = fl_pack_ffor(values_in, NULL, n, W, T, (uint64) base_value);
+	TestAssertInt64Eq(ffor_bytes, 0LL);
+
+	/* FFOR unpack fills the first N positions with `base`. */
+	for (int i = 0; i < (int) n; ++i)
+	{
+		decoded[i] = 0xDEADBEEF;
+	}
+	fl_unpack_ffor(NULL, decoded, n, W, T, (uint64) base_value);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], base_value);
+	}
+
+	pfree_aligned(values_in);
+	pfree_aligned(decoded);
+}
+
+/*
+ * This test demonstrates FL64 with the interleaved multi-lane layout
+ * (T=8 gives S = 64/8 = 8 lanes) and FFOR base offset. 64 byte-sized
+ * values that all fall in [100, 107] compress to 24 bytes -- 2.67x.
+ * The base captures the shared 100 prefix; the 3-bit residuals 0..7
+ * pack tightly across the 8 parallel lanes.
+ *
+ * On the layout side: with T=8 in FL64, adjacent input elements land
+ * in different lanes (round-robin: element i is in lane i % 8). The
+ * kernel processes all 8 lanes per FL64 word, with the FFOR fusion
+ * subtracting the base on pack and re-adding on unpack -- a single
+ * pass across the lanes. This is the FastLanes property that makes
+ * SIMD auto-vectorization free at higher tiers.
+ */
+static void
+test_fl64_ffor_8lanes()
+{
+	const uint32 n = 64; /* full FL64 vector */
+	const uint8 W = 3;
+	const fl_elem_width_t T = FL_ELEM_W8;
+	const uint8 base = 100;
+
+	size_t alignment = fl_alignment(n, T);
+	size_t input_size = fl_input_bytes(n, T);
+	size_t required_size = fl_required_bytes(n, W, T);
+	size_t result_size = fl_result_bytes(n, W, T);
+
+	TestAssertInt64Eq(alignment, 8LL);
+	TestAssertInt64Eq(input_size, 64LL);	/* 64 elements x 1 byte */
+	TestAssertInt64Eq(required_size, 24LL); /* 3 words x 8 bytes    */
+	TestAssertInt64Eq(result_size, 24LL);	/* N == VEC_SIZE: no truncation savings */
+
+	/* Headline: 64 bytes in -> 24 bytes packed = 2.67x compression. */
+
+	uint8 *values_in = palloc_aligned(input_size, alignment, 0);
+	uint8 *packed = palloc_aligned(required_size, alignment, 0);
+	uint8 *decoded = palloc_aligned(input_size, alignment, 0);
+	TestAssertTrue(values_in != NULL);
+	TestAssertTrue(packed != NULL);
+	TestAssertTrue(decoded != NULL);
+
+	TestAssertInt64Eq((int64) ((uintptr_t) values_in % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) packed % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) decoded % alignment), 0LL);
+
+	/* 64 values cycling 100, 101, ..., 107, 100, 101, ... */
+	for (int i = 0; i < (int) n; ++i)
+	{
+		values_in[i] = (uint8) (base + (i % 8));
+	}
+
+	size_t packed_bytes = fl_pack_ffor(values_in, packed, n, W, T, base);
+	TestAssertInt64Eq(packed_bytes, result_size);
+
+	fl_unpack_ffor(packed, decoded, n, W, T, base);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], values_in[i]);
+	}
+
+	pfree_aligned(values_in);
+	pfree_aligned(packed);
+	pfree_aligned(decoded);
+}
+
+/*
+ * This test exercises FL128 with the widest element width and an
+ * inconvenient bit budget:
+ *
+ *  - T=64 (uint64 elements -- the library's widest)
+ *  - W=43 (not a power of 2, not byte-aligned, not native; W=43
+ *          forces T=64 since W can't exceed T)
+ *  - N=100 (partial within FL128's 128-element vector)
+ *
+ * In FL128 T=64 gives S = 128/64 = 2 lanes -- a real but minimal
+ * multi-lane layout. 16-byte alignment is required.
+ *
+ * 100 uint64 values (800 bytes of meaningful input) compress to
+ * 544 bytes (1.47x). The full alloc is 688 bytes; partial-N
+ * truncation saves 144 bytes -- visible at FL128's 16-byte word
+ * granularity.
+ */
+static void
+test_fl128_pack_100x43b()
+{
+	const uint32 n = 100;
+	const uint8 W = 43;
+	const fl_elem_width_t T = FL_ELEM_W64;
+
+	/* Step 1: ask the library. */
+	size_t alignment = fl_alignment(n, T);
+	size_t input_size = fl_input_bytes(n, T);
+	size_t required_size = fl_required_bytes(n, W, T);
+	size_t result_size = fl_result_bytes(n, W, T);
+
+	TestAssertInt64Eq(alignment, 16LL);
+	TestAssertInt64Eq(input_size, 1024LL);	 /* 128 elements x 8 bytes */
+	TestAssertInt64Eq(required_size, 688LL); /* 43 words x 16 bytes */
+	TestAssertInt64Eq(result_size, 544LL);	 /* 34 words x 16 bytes -- saves 144 vs alloc */
+
+	/* Headline: 100 uint64 (800 bytes meaningful) -> 544 bytes packed = 1.47x. */
+	TestAssertInt64Eq((int64) (n * sizeof(uint64)), 800LL);
+
+	/* Step 2: allocate buffers satisfying alignment and size. */
+	uint64 *values_in = palloc_aligned(input_size, alignment, 0);
+	uint8 *packed = palloc_aligned(required_size, alignment, 0);
+	uint64 *decoded = palloc_aligned(input_size, alignment, 0);
+	TestAssertTrue(values_in != NULL);
+	TestAssertTrue(packed != NULL);
+	TestAssertTrue(decoded != NULL);
+
+	/* Step 3: verify the addresses meet the contract. */
+	TestAssertInt64Eq((int64) ((uintptr_t) values_in % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) packed % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) decoded % alignment), 0LL);
+
+	/*
+	 * Step 4: fill 100 varied 64-bit values that fit in 43 bits.
+	 * The multiplier 0x1000000000 = 2^36 puts the highest set bit
+	 * around position 42 for the largest index, exercising most of
+	 * the W=43 budget without overflowing.
+	 */
+	for (int i = 0; i < (int) n; ++i)
+	{
+		values_in[i] = (uint64) i * 0x1000000000ULL;
+	}
+
+	/* Step 5: pack. fl_pack returns result_size; the kernel
+	 * still writes required_size bytes total (the 144-byte tail past
+	 * result_size is scratch). */
+	size_t packed_bytes = fl_pack(values_in, packed, n, W, T);
+	TestAssertInt64Eq(packed_bytes, result_size);
+
+	/*
+	 * Step 6: zero the alloc-vs-truncated tail in place before
+	 * decoding. Simpler variant of the FL32 test's "store the
+	 * prefix elsewhere" pattern -- here we reuse `packed`.
+	 */
+	memset(packed + result_size, 0, required_size - result_size);
+
+	/* Step 7: unpack and verify roundtrip. */
+	fl_unpack(packed, decoded, n, W, T);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], values_in[i]);
+	}
+
+	pfree_aligned(values_in);
+	pfree_aligned(packed);
+	pfree_aligned(decoded);
+}
+
+/*
+ * This test exercises FL256, the largest tier, with FFOR and
+ * truncation:
+ *
+ *  - N=144 (partial within FL256's 256-element vector; N>128 forces
+ *           routing into FL256 rather than FL128)
+ *  - T=32 (uint32 elements)
+ *  - W=13 (inconvenient: not a power of 2, not byte-aligned)
+ *  - base=100000 (a large uint32 base that captures the shared
+ *                 prefix; residuals fit in 13 bits)
+ *
+ * FL256 with T=32 gives S = 256/32 = 8 parallel lanes -- same lane
+ * count as the FL64 multi-lane test, but in a 256-bit virtual word
+ * (32-byte WORD_BYTES). 32-byte alignment is required.
+ *
+ * 144 uint32 values clustered in [100000, 100000+8191] (576 bytes
+ * of meaningful input) compress to 256 bytes via FFOR's base
+ * subtraction + 13-bit packing -- 2.25x. The full alloc is 416
+ * bytes; partial-N truncation saves 160 bytes.
+ */
+static void
+test_fl256_ffor_144x13b()
+{
+	const uint32 n = 144;
+	const uint8 W = 13;
+	const fl_elem_width_t T = FL_ELEM_W32;
+	const uint32 base = 100000;
+
+	/* Step 1: ask the library. */
+	size_t alignment = fl_alignment(n, T);
+	size_t input_size = fl_input_bytes(n, T);
+	size_t required_size = fl_required_bytes(n, W, T);
+	size_t result_size = fl_result_bytes(n, W, T);
+
+	TestAssertInt64Eq(alignment, 32LL);
+	TestAssertInt64Eq(input_size, 1024LL);	 /* 256 elements x 4 bytes */
+	TestAssertInt64Eq(required_size, 416LL); /* 13 words x 32 bytes */
+	TestAssertInt64Eq(result_size, 256LL);	 /* 8 words x 32 bytes -- saves 160 vs alloc */
+
+	/* Headline: 144 uint32 (576 bytes meaningful) -> 256 bytes packed = 2.25x. */
+	TestAssertInt64Eq((int64) (n * sizeof(uint32)), 576LL);
+
+	/* Step 2: allocate. */
+	uint32 *values_in = palloc_aligned(input_size, alignment, 0);
+	uint8 *packed = palloc_aligned(required_size, alignment, 0);
+	uint32 *decoded = palloc_aligned(input_size, alignment, 0);
+	TestAssertTrue(values_in != NULL);
+	TestAssertTrue(packed != NULL);
+	TestAssertTrue(decoded != NULL);
+
+	/* Step 3: verify alignment. */
+	TestAssertInt64Eq((int64) ((uintptr_t) values_in % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) packed % alignment), 0LL);
+	TestAssertInt64Eq((int64) ((uintptr_t) decoded % alignment), 0LL);
+
+	/*
+	 * Step 4: fill 144 values in [base, base + 8191]. Residuals
+	 * must fit in W=13 bits (< 2^13 = 8192). The multiplier 53 is
+	 * prime and coprime with 8192, so (i * 53) % 8192 cycles
+	 * through distinct residuals over the full 13-bit range.
+	 */
+	for (int i = 0; i < (int) n; ++i)
+	{
+		values_in[i] = base + (uint32) ((i * 53) % 8192);
+	}
+
+	/* Step 5: FFOR pack. fl_pack_ffor returns result_size; the
+	 * kernel writes required_size bytes (the 160-byte tail past
+	 * result_size is scratch). */
+	size_t packed_bytes = fl_pack_ffor(values_in, packed, n, W, T, base);
+	TestAssertInt64Eq(packed_bytes, result_size);
+
+	/* Step 6: zero the alloc-vs-truncated tail in place before
+	 * decoding. */
+	memset(packed + result_size, 0, required_size - result_size);
+
+	/* Step 7: FFOR unpack and verify roundtrip. */
+	fl_unpack_ffor(packed, decoded, n, W, T, base);
+	for (int i = 0; i < (int) n; ++i)
+	{
+		TestAssertInt64Eq(decoded[i], values_in[i]);
+	}
+
+	pfree_aligned(values_in);
+	pfree_aligned(packed);
+	pfree_aligned(decoded);
+}
+
+#define CALC_MINMAX(min, max, values, n)                                                           \
+	do                                                                                             \
+	{                                                                                              \
+		min = *values;                                                                             \
+		max = *values;                                                                             \
+		for (size_t i = 0; i < n; ++i)                                                             \
+		{                                                                                          \
+			if (min > values[i])                                                                   \
+			{                                                                                      \
+				min = values[i];                                                                   \
+			}                                                                                      \
+			if (max < values[i])                                                                   \
+			{                                                                                      \
+				max = values[i];                                                                   \
+			}                                                                                      \
+		}                                                                                          \
+	} while (0)
+
+static uint8
+calc_width(uint64 val)
+{
+	if (val == 0)
+	{
+		return 1;
+	}
+	return 1 + pg_leftmost_one_pos64(val);
+}
+
+#define TEST_PASTE3_(a, b, c) a##b##c
+#define TEST_PASTE3(a, b, c) TEST_PASTE3_(a, b, c)
+#define TEST_FN(TT) TEST_PASTE3(test_, TT, _pack)
+
+#define TEST_FN_IMPL(IN_T, TT)                                                                     \
+	static void TEST_FN(IN_T)(const IN_T *values, size_t n)                                        \
+	{                                                                                              \
+		size_t test_input_size = n * sizeof(*values);                                              \
+		IN_T min, max;                                                                             \
+		CALC_MINMAX(min, max, values, n);                                                          \
+		uint8 W = calc_width(max);                                                                 \
+                                                                                                   \
+		const fl_elem_width_t T = TT;                                                              \
+		size_t alignment = fl_alignment(n, T);                                                     \
+		size_t input_size = fl_input_bytes(n, T);                                                  \
+		size_t required_size = fl_required_bytes(n, W, T);                                         \
+		/* add input_count() too to make codecov happy */                                          \
+		size_t input_count = fl_input_count(n, T);                                                 \
+		TestAssertInt64Eq(input_count * sizeof(IN_T), input_size);                                 \
+                                                                                                   \
+		uint8 *values_in = palloc_aligned(input_size, alignment, 0);                               \
+		memcpy(values_in, values, test_input_size);                                                \
+		uint8 *packed = palloc_aligned(required_size, alignment, 0);                               \
+		size_t packed_size = fl_pack(values_in, packed, n, W, T);                                  \
+                                                                                                   \
+		/* copy the result into a different buffer up to packed_size */                            \
+		uint8 *to_unpack = palloc_aligned(required_size, alignment, 0);                            \
+		memset(to_unpack, 0, required_size);                                                       \
+		memcpy(to_unpack, packed, packed_size);                                                    \
+                                                                                                   \
+		/* allocate a separate result buffer */                                                    \
+		IN_T *unpacked = palloc_aligned(input_size, alignment, 0);                                 \
+		fl_unpack(to_unpack, unpacked, n, W, T);                                                   \
+                                                                                                   \
+		int eq = memcmp(unpacked, values, test_input_size);                                        \
+		if (eq != 0)                                                                               \
+		{                                                                                          \
+			/* print the values for debugging and then fail the test */                            \
+			elog(WARNING,                                                                          \
+				 "Unpack failed for the following [%zu] values (W=%u, min=" UINT64_FORMAT          \
+				 ", max=" UINT64_FORMAT ")",                                                       \
+				 n,                                                                                \
+				 (unsigned) W,                                                                     \
+				 (uint64) min,                                                                     \
+				 (uint64) max);                                                                    \
+			for (size_t i = 0; i < n; ++i)                                                         \
+			{                                                                                      \
+				elog(WARNING,                                                                      \
+					 "%zu : in=" UINT64_FORMAT " %s out=" UINT64_FORMAT,                           \
+					 i,                                                                            \
+					 (uint64) values[i],                                                           \
+					 (values[i] == unpacked[i] ? "==" : "!="),                                     \
+					 (uint64) unpacked[i]);                                                        \
+			}                                                                                      \
+			TestAssertTrue(eq == 0);                                                               \
+		}                                                                                          \
+                                                                                                   \
+		memset(packed, 0, required_size);                                                          \
+		memset(unpacked, 0, required_size);                                                        \
+		memset(to_unpack, 0, required_size);                                                       \
+		memset(unpacked, 0, input_size);                                                           \
+                                                                                                   \
+		/* try the same with FFOR */                                                               \
+		uint64 base = min;                                                                         \
+		uint8 bW = calc_width(max - min);                                                          \
+		packed_size = fl_pack_ffor(values_in, packed, n, bW, T, base);                             \
+		memcpy(to_unpack, packed, packed_size);                                                    \
+		fl_unpack_ffor(to_unpack, unpacked, n, bW, T, base);                                       \
+                                                                                                   \
+		eq = memcmp(unpacked, values, test_input_size);                                            \
+		if (eq != 0)                                                                               \
+		{                                                                                          \
+			/* print the values for debugging and then fail the test */                            \
+			elog(WARNING,                                                                          \
+				 "FFOR Unpack failed for the following [%zu] values (bW=%u, min=" UINT64_FORMAT    \
+				 ", max=" UINT64_FORMAT ", base=" UINT64_FORMAT ")",                               \
+				 n,                                                                                \
+				 (unsigned) bW,                                                                    \
+				 (uint64) min,                                                                     \
+				 (uint64) max,                                                                     \
+				 base);                                                                            \
+			for (size_t i = 0; i < n; ++i)                                                         \
+			{                                                                                      \
+				elog(WARNING,                                                                      \
+					 "%zu : in=" UINT64_FORMAT " %s out=" UINT64_FORMAT,                           \
+					 i,                                                                            \
+					 (uint64) values[i],                                                           \
+					 (values[i] == unpacked[i] ? "==" : "!="),                                     \
+					 (uint64) unpacked[i]);                                                        \
+			}                                                                                      \
+			TestAssertTrue(eq == 0);                                                               \
+		}                                                                                          \
+	}
+
+TEST_FN_IMPL(uint8, FL_ELEM_W8)
+TEST_FN_IMPL(uint16, FL_ELEM_W16)
+TEST_FN_IMPL(uint32, FL_ELEM_W32)
+TEST_FN_IMPL(uint64, FL_ELEM_W64)
+
+/*
+ * Randomized tests for better code coverage.
+ */
+static void
+test_randomized()
+{
+	uint64 values[256];
+	if (!pg_strong_random(values, sizeof(values)))
+	{
+		elog(ERROR, "pg_strong_random failed");
+	}
+	/* take the first 200 random values and generate a test length */
+	for (int i = 0; i < 200; ++i)
+	{
+		size_t len = 1 + (values[i] % 255);
+		test_uint8_pack((const uint8 *) values, len);
+		test_uint16_pack((const uint16 *) values, len);
+		test_uint32_pack((const uint32 *) values, len);
+		test_uint64_pack((const uint64 *) values, len);
+	}
+}
+
+#define CHECK_VALUES(V, SZ, E)                                                                     \
+	do                                                                                             \
+	{                                                                                              \
+		for (int i = 0; i < SZ; ++i)                                                               \
+		{                                                                                          \
+			TestAssertInt64Eq(V[i], E);                                                            \
+		}                                                                                          \
+	} while (0)
+
+/* this test doesn't make a lot of sense, I only add this to make codecove happy */
+static void
+test_w0_coverage()
+{
+	uint8 v8[2] = { 0 };
+	uint16 v16[2] = { 0 };
+	uint32 v32[2] = { 0 };
+	uint64 v64[2] = { 0 };
+
+	/* start with FFOR to see the values are filled with base as expected */
+	fl_unpack_ffor(NULL, v8, 2, 0, FL_ELEM_W8, 9);
+	CHECK_VALUES(v8, 2, 9);
+	fl_unpack_ffor(NULL, v16, 2, 0, FL_ELEM_W16, 9999);
+	CHECK_VALUES(v16, 2, 9999);
+	fl_unpack_ffor(NULL, v32, 2, 0, FL_ELEM_W32, 99998888UL);
+	CHECK_VALUES(v32, 2, 99998888UL);
+	fl_unpack_ffor(NULL, v64, 2, 0, FL_ELEM_W64, 9999888877776666ULL);
+	CHECK_VALUES(v64, 2, 9999888877776666ULL);
+
+	/* reused the same buffer so I can test that the values are zeroed */
+	fl_unpack(NULL, v8, 2, 0, FL_ELEM_W8);
+	CHECK_VALUES(v8, 2, 0);
+	fl_unpack(NULL, v16, 2, 0, FL_ELEM_W16);
+	CHECK_VALUES(v16, 2, 0);
+	fl_unpack(NULL, v32, 2, 0, FL_ELEM_W32);
+	CHECK_VALUES(v32, 2, 0);
+	fl_unpack(NULL, v64, 2, 0, FL_ELEM_W64);
+	CHECK_VALUES(v64, 2, 0);
+}
+
+Datum
+ts_test_fastlanes(PG_FUNCTION_ARGS)
+{
+	test_fl8_pack_7x3b();
+	test_fl8_pack_7x3b_ffor();
+	test_fl16_pack_16x1b();
+	test_fl32_pack_23x5b();
+	test_fl64_constant_block();
+	test_fl64_ffor_8lanes();
+	test_fl128_pack_100x43b();
+	test_fl256_ffor_144x13b();
+	test_randomized();
+	test_w0_coverage();
+	PG_RETURN_VOID();
+}
+
+#endif


### PR DESCRIPTION
There is a background and intro document in tsl/src/compression/algorithms/fastlanes/README.md

The short version is: this change brings a C implementation of the FastLanes library to Timescale DB. The original idea is from 'The FastLanes Compression Layout: Decoding >100 Billion Integers per Second with Scalar Code' by Azim Afroozeh and Peter Boncz (https://doi.org/10.14778/3598581.3598587)

Our version departs from the original ideas in a few ways:

- instead of having a single 1024 bit virtual register, I introduce multiple smaller register widths, that I call 'tiered FL', the widths are 8, 16, 32, 64, 128 and 256

- we do not have 1024 bit virtual registers

- our implementation relies on C macros, instead of C++ templates and code generation

The README.md file provides more details about the library.

The changelog file is disabled, as this change doesn't provide any useful functionality to the user on its own.
This change provides the basis for later compression algorithms to be introduced.

Disable-check: force-changelog-file

Co-authored-by: Sven Klemm <31455525+svenklemm@users.noreply.github.com>
Signed-off-by: David Beck <david.beck.priv@gmail.com>