### PR TITLE
Release 2.27.2

### DIFF
--- a/.unreleased/fix_9902
+++ b/.unreleased/fix_9902
@@ -1,1 +1,0 @@
-Fixes: #9902 Fix wrong results and crashes when grouping by columns that are not in the SELECT list with vectorized aggregation or columnar index scan

--- a/.unreleased/pr_9895
+++ b/.unreleased/pr_9895
@@ -1,1 +1,0 @@
-Fixes: #9895 Remove refresh policy check when adding columnstore policy

--- a/.unreleased/pr_9908
+++ b/.unreleased/pr_9908
@@ -1,1 +1,0 @@
-Fixes: #9908 Skip `ColumnarIndexScan` when the qual contains a SubPlan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,12 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.27.2 (2026-06-01)
+## 2.27.2 (2026-06-02)
 
-This release contains performance improvements and bug fixes since the 2.27.1 release. We recommend that you upgrade at the next available opportunity.
-
-**Highlighted features in TimescaleDB v2.27.2**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
+This release contains bug fixes since the 2.27.1 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
-* 
-
-**New Settings**
-
-**GUCs**
-
-**Thanks**
+* [#9895](https://github.com/timescale/timescaledb/pull/9895) Remove refresh policy check when adding columnstore policy
 
 ## 2.27.1 (2026-05-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This release contains bug fixes since the 2.27.1 release. We recommend that you 
 
 **Bugfixes**
 * [#9895](https://github.com/timescale/timescaledb/pull/9895) Remove refresh policy check when adding columnstore policy
+* [#9902](https://github.com/timescale/timescaledb/pull/9902) Fix wrong results and crashes when grouping by columns that are not in the SELECT list with vectorized aggregation or columnar index scan
+* [#9908](https://github.com/timescale/timescaledb/pull/9908) Skip `ColumnarIndexScan` when the qual contains a SubPlan
 
 ## 2.27.1 (2026-05-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.27.2 (2026-06-03)
+## 2.27.2 (2026-06-02)
 
 This release contains bug fixes since the 2.27.1 release. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This release contains bug fixes since the 2.27.1 release. We recommend that you 
 
 **Bugfixes**
 * [#9895](https://github.com/timescale/timescaledb/pull/9895) Remove refresh policy check when adding columnstore policy
-* [#9902](https://github.com/timescale/timescaledb/pull/9902) Fix wrong results and crashes when grouping by columns that are not in the SELECT list with vectorized aggregation or columnar index scan
+* [#9902](https://github.com/timescale/timescaledb/pull/9902) Fix wrong results and crashes when grouping by columns that are not in the `SELECT` list with vectorized aggregation or columnar index scan
 * [#9908](https://github.com/timescale/timescaledb/pull/9908) Skip `ColumnarIndexScan` when the qual contains a SubPlan
 
 ## 2.27.1 (2026-05-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.27.2 (2026-06-02)
+## 2.27.2 (2026-06-03)
 
 This release contains bug fixes since the 2.27.1 release. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.27.2 (2026-06-01)
+
+This release contains performance improvements and bug fixes since the 2.27.1 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.27.2**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* 
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+
 ## 2.27.1 (2026-05-19)
 
 This release contains performance improvements and bug fixes since the 2.27.0 release. We recommend that you upgrade at the next available opportunity.


### PR DESCRIPTION
## 2.27.2 (2026-06-02)

This release contains bug fixes since the 2.27.1 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#9895](https://github.com/timescale/timescaledb/pull/9895) Remove refresh policy check when adding columnstore policy
* [#9902](https://github.com/timescale/timescaledb/pull/9902) Fix wrong results and crashes when grouping by columns that are not in the `SELECT` list with vectorized aggregation or columnar index scan
* [#9908](https://github.com/timescale/timescaledb/pull/9908) Skip `ColumnarIndexScan` when the qual contains a SubPlan