### PR TITLE
Skip ColumnarIndexScan when the qual contains a SubPlan

### DIFF
--- a/.unreleased/pr_9908
+++ b/.unreleased/pr_9908
@@ -1,0 +1,1 @@
+Fixes: #9908 Skip `ColumnarIndexScan` when the qual contains a SubPlan

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
@@ -162,76 +162,6 @@ is_supported_aggregate(Aggref *aggref, Var **arg_var_out, const char **meta_type
 }
 
 /*
- * Check if all quals reference only segmentby columns.
- *
- * This function is only relevant for partial chunks.  For fully compressed
- * chunks, segmentby quals are pushed to the compressed scan and removed from
- * plan->qual, so plan->qual is NIL and this function is never called.
- * For partial chunks, segmentby quals remain on plan->qual because they must
- * also be checked against the uncompressed portion, but they have already been
- * pushed to the compressed scan as well.  ColumnarIndexScan only reads
- * compressed metadata, so these quals are already handled.
- *
- * Uses the decompression_map and is_segmentby_column lists from the
- * ColumnarScan's custom_private to build a set of custom_scan_tlist
- * positions that are segmentby columns, then checks each qual's Vars
- * against that set.
- *
- * Returns false for quals containing no Vars (e.g. constified tableoid),
- * since those constant expressions are not handled by the compressed scan
- * and must still be evaluated.  In practice these only appear on partial
- * chunks from constraint exclusion checks (e.g. tableoid comparisons for
- * hypertable expansion) and should be uncommon.
- */
-static bool
-quals_only_reference_segmentby(List *quals, CustomScan *cscan)
-{
-	List *decompression_map = list_nth(cscan->custom_private, DCP_DecompressionMap);
-	List *is_segmentby = list_nth(cscan->custom_private, DCP_IsSegmentbyColumn);
-
-	Bitmapset *segmentby_positions = NULL;
-	ListCell *lc_map, *lc_seg;
-	forboth (lc_map, decompression_map, lc_seg, is_segmentby)
-	{
-		int tlist_pos = lfirst_int(lc_map);
-		if (lfirst_int(lc_seg) && tlist_pos > 0)
-		{
-			segmentby_positions = bms_add_member(segmentby_positions, tlist_pos);
-		}
-	}
-
-	bool result = true;
-	ListCell *lc;
-	foreach (lc, quals)
-	{
-		List *vars = pull_var_clause(lfirst(lc), 0);
-		if (vars == NIL)
-		{
-			result = false;
-			break;
-		}
-
-		ListCell *lc2;
-		foreach (lc2, vars)
-		{
-			Var *var = lfirst_node(Var, lc2);
-			if (!bms_is_member(var->varattno, segmentby_positions))
-			{
-				result = false;
-				break;
-			}
-		}
-		if (!result)
-		{
-			break;
-		}
-	}
-
-	bms_free(segmentby_positions);
-	return result;
-}
-
-/*
  * Check if the ColumnarScan's vectorized quals are empty (no filters applied).
  */
 static bool
@@ -759,11 +689,11 @@ insert_columnar_index_scan(Plan *plan, void *context)
 	CustomScan *cscan = castNode(CustomScan, childplan);
 
 	/*
-	 * No Postgres quals on the ColumnarScan, or quals only on segmentby
-	 * columns. Segmentby filters are pushed to the compressed scan so
-	 * ColumnarIndexScan can skip them.
+	 * Any qual still on plan.qual at this point was not pushed down to the
+	 * compressed scan without a recheck — qual_pushdown either rejected it
+	 * or kept it for rechecking, so we have to leave it to the ColumnarScan.
 	 */
-	if (childplan->qual != NIL && !quals_only_reference_segmentby(childplan->qual, cscan))
+	if (childplan->qual != NIL)
 	{
 		return plan;
 	}

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -69,7 +69,8 @@ static void create_compressed_scan_paths(PlannerInfo *root, RelOptInfo *compress
 										 const SortInfo *sort_info);
 
 static ColumnarScanPath *columnar_scan_path_create(PlannerInfo *root, const CompressionInfo *info,
-												   Path *compressed_path);
+												   Path *compressed_path,
+												   bool all_quals_pushed_down);
 
 static void columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info,
 										  const Chunk *chunk, RelOptInfo *chunk_rel,
@@ -1119,12 +1120,10 @@ make_chunk_sorted_path(PlannerInfo *root, RelOptInfo *chunk_rel, Path *path, Pat
 	return sorted_path;
 }
 
-static List *build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk,
-											 RelOptInfo *chunk_rel, Path *compressed_path,
-											 bool add_uncompressed_part,
-											 List *uncompressed_table_pathlist,
-											 const SortInfo *sort_info,
-											 const CompressionInfo *compression_info);
+static List *build_on_single_compressed_path(
+	PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel, Path *compressed_path,
+	bool add_uncompressed_part, List *uncompressed_table_pathlist, const SortInfo *sort_info,
+	const CompressionInfo *compression_info, bool all_quals_pushed_down);
 
 void
 ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const Hypertable *ht,
@@ -1196,13 +1195,14 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 	compressed_rel->consider_parallel = chunk_rel->consider_parallel;
 
 	/* translate chunk_rel->baserestrictinfo */
+	bool all_quals_pushed_down = false;
 	if (ts_guc_enable_columnar_scan_filter_pushdown)
 	{
-		columnar_scan_filter_pushdown(root,
-									  compression_info->settings,
-									  chunk_rel,
-									  compressed_rel,
-									  add_uncompressed_part);
+		all_quals_pushed_down = columnar_scan_filter_pushdown(root,
+															  compression_info->settings,
+															  chunk_rel,
+															  compressed_rel,
+															  add_uncompressed_part);
 	}
 	/*
 	 * Estimate the size of the compressed chunk table.
@@ -1265,7 +1265,8 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 																   add_uncompressed_part,
 																   uncompressed_table_pathlist,
 																   &sort_info,
-																   compression_info);
+																   compression_info,
+																   all_quals_pushed_down);
 
 		/*
 		 * We want to consider startup costs so that IndexScan is preferred to
@@ -1312,7 +1313,8 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 																   add_uncompressed_part,
 																   uncompressed_paths_with_parallel,
 																   &sort_info,
-																   compression_info);
+																   compression_info,
+																   all_quals_pushed_down);
 		/*
 		 * Add the paths to the chunk relation.
 		 */
@@ -1348,7 +1350,7 @@ static List *
 build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 								Path *compressed_path, bool add_uncompressed_part,
 								List *uncompressed_table_pathlist, const SortInfo *sort_info,
-								const CompressionInfo *compression_info)
+								const CompressionInfo *compression_info, bool all_quals_pushed_down)
 {
 	/*
 	 * We skip any BitmapScan parameterized paths here as supporting
@@ -1394,8 +1396,8 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 		}
 	}
 
-	Path *chunk_path_no_sort =
-		(Path *) columnar_scan_path_create(root, compression_info, compressed_path);
+	Path *chunk_path_no_sort = (Path *)
+		columnar_scan_path_create(root, compression_info, compressed_path, all_quals_pushed_down);
 	List *decompressed_paths = list_make1(chunk_path_no_sort);
 
 	/*
@@ -2429,7 +2431,7 @@ columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Ch
 
 static ColumnarScanPath *
 columnar_scan_path_create(PlannerInfo *root, const CompressionInfo *compression_info,
-						  Path *compressed_path)
+						  Path *compressed_path, bool all_quals_pushed_down)
 {
 	ColumnarScanPath *path;
 
@@ -2491,6 +2493,7 @@ columnar_scan_path_create(PlannerInfo *root, const CompressionInfo *compression_
 	path->custom_path.custom_paths = list_make1(compressed_path);
 	path->reverse = false;
 	path->chunk_status = compression_info->chunk_status;
+	path->all_quals_pushed_down = all_quals_pushed_down;
 	path->required_compressed_pathkeys = NIL;
 	cost_columnar_scan(compression_info, path, compressed_path);
 

--- a/tsl/src/nodes/columnar_scan/columnar_scan.h
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.h
@@ -62,6 +62,14 @@ typedef struct ColumnarScanPath
 	bool batch_sorted_merge;
 	bool enable_bulk_decompression;
 	int32 chunk_status;
+
+	/*
+	 * True if every filter on the compressed chunk is checked at the compressed
+	 * scan level exactly, that is, does not have to be rechecked on decompressed data.
+	 * This allows us to answer some queries from metadata only, without decompression,
+	 * for example with ColumnarIndexScan.
+	 */
+	bool all_quals_pushed_down;
 } ColumnarScanPath;
 
 void ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *rel, const Hypertable *ht,

--- a/tsl/src/nodes/columnar_scan/planner.c
+++ b/tsl/src/nodes/columnar_scan/planner.c
@@ -1094,6 +1094,15 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 	decompress_plan->methods = &columnar_scan_plan_methods;
 	decompress_plan->scan.scanrelid = dcpath->info->chunk_rel->relid;
 
+	/*
+	 * `clauses` is chunk_rel->baserestrictinfo plus any parameterized join
+	 * clauses PG attached for this path.  When every baserestrictinfo entry
+	 * was pushed to the compressed scan without recheck we can skip them on
+	 * plan.qual: the compressed scan enforces them on its own, and dropping
+	 * them lets ColumnarIndexScan apply for partial chunks too.  Param
+	 * clauses are not in baserestrictinfo, so they always stay on plan.qual.
+	 */
+	List *base_clauses = dcpath->info->chunk_rel->baserestrictinfo;
 	if (IsA(compressed_path, IndexPath))
 	{
 		/*
@@ -1106,6 +1115,16 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 		foreach (lc, clauses)
 		{
 			RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+			/*
+			 * Since we need the original quals for partial chunks we can't remove
+			 * them while pushing down to the compressed scan and only remove them
+			 * here.
+			 */
+			if (dcpath->all_quals_pushed_down && list_member_ptr(base_clauses, rinfo))
+			{
+				continue;
+			}
 
 			ListCell *indexclause_cell = NULL;
 			if (rinfo->parent_ec != NULL)
@@ -1140,6 +1159,12 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 		foreach (lc, clauses)
 		{
 			RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+			if (dcpath->all_quals_pushed_down && list_member_ptr(base_clauses, rinfo))
+			{
+				continue;
+			}
+
 			decompress_plan->scan.plan.qual =
 				lappend(decompress_plan->scan.plan.qual, rinfo->clause);
 		}

--- a/tsl/src/nodes/columnar_scan/qual_pushdown.c
+++ b/tsl/src/nodes/columnar_scan/qual_pushdown.c
@@ -81,12 +81,13 @@ static Node *make_bloom1_hash_array(PlannerInfo *root, List *exprs, Oid input_co
 static FuncExpr *make_bloom1_check(Var *bloom_var, Node *hash_array);
 static List *deconstruct_array_const(Const *array_const);
 
-void
+bool
 columnar_scan_filter_pushdown(PlannerInfo *root, CompressionSettings *settings,
 							  RelOptInfo *chunk_rel, RelOptInfo *compressed_rel, bool chunk_partial)
 {
 	ListCell *lc;
 	List *decompress_clauses = NIL;
+	bool all_pushed_down = true;
 	QualPushdownContext base_context = {
 		.root = root,
 		.chunk_rel = chunk_rel,
@@ -153,8 +154,14 @@ columnar_scan_filter_pushdown(PlannerInfo *root, CompressionSettings *settings,
 		{
 			decompress_clauses = lappend(decompress_clauses, ri);
 		}
+
+		if (!clause_context.can_pushdown || clause_context.needs_recheck)
+		{
+			all_pushed_down = false;
+		}
 	}
 	chunk_rel->baserestrictinfo = decompress_clauses;
+	return all_pushed_down;
 }
 
 static OpExpr *

--- a/tsl/src/nodes/columnar_scan/qual_pushdown.h
+++ b/tsl/src/nodes/columnar_scan/qual_pushdown.h
@@ -7,6 +7,11 @@
 
 #include <postgres.h>
 
-void columnar_scan_filter_pushdown(PlannerInfo *root, CompressionSettings *settings,
+/*
+ * Push qualifying clauses from decompressed chunk scan down to compressed chunk
+ * scan. Returns true if every clause was pushed down without needing a recheck after
+ * decompression, i.e. the compressed scan can enforce all WHERE clauses on its own.
+ */
+bool columnar_scan_filter_pushdown(PlannerInfo *root, CompressionSettings *settings,
 								   RelOptInfo *chunk_rel, RelOptInfo *compressed_rel,
 								   bool chunk_partial);

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -158,7 +158,6 @@ SELECT * from _timescaledb_catalog.chunk_column_stats WHERE chunk_id = :'CHUNK_I
 --- QUERY PLAN ---
  Append
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         Filter: (sensor_id > 9)
          ->  Index Scan using compress_hyper_2_3_chunk_sensor_id__ts_meta_min_1__ts_meta__idx on compress_hyper_2_3_chunk
                Index Cond: (sensor_id > 9)
    ->  Index Scan using _hyper_1_1_chunk_sense_idx on _hyper_1_1_chunk

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -710,6 +710,29 @@ SET enable_partitionwise_aggregate = off;
                Index Cond: (device = 'd1'::text)
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (NOT (hashed SubPlan 1))
+               ->  Seq Scan on compress_hyper_2_2_chunk
+               SubPlan 1
+                 ->  Function Scan on generate_series g
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (device = ('d'::text || (g.g)::text))
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
@@ -1899,6 +1922,33 @@ SET enable_partitionwise_aggregate = off;
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: ((value > '10'::double precision) AND (device = 'd1'::text))
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Hash Semi Join
+         Hash Cond: (metrics.device = ('d'::text || (g.g)::text))
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Hash
+               ->  Function Scan on generate_series g
 
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
@@ -3213,6 +3263,38 @@ SET enable_partitionwise_aggregate = off;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
                            Index Cond: (device = 'd1'::text)
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
 
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -710,6 +710,29 @@ SET enable_partitionwise_aggregate = off;
                Index Cond: (device = 'd1'::text)
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (NOT (hashed SubPlan 1))
+               ->  Seq Scan on compress_hyper_2_2_chunk
+               SubPlan 1
+                 ->  Function Scan on generate_series g
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (device = ('d'::text || (g.g)::text))
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
@@ -1896,6 +1919,33 @@ SET enable_partitionwise_aggregate = off;
          ->  Partial GroupAggregate
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: ((value > '10'::double precision) AND (device = 'd1'::text))
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Hash Semi Join
+         Hash Cond: (metrics.device = ('d'::text || (g.g)::text))
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Hash
+               ->  Function Scan on generate_series g
 
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
@@ -3208,6 +3258,38 @@ SET enable_partitionwise_aggregate = off;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
                            Index Cond: (device = 'd1'::text)
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
 
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -710,6 +710,29 @@ SET enable_partitionwise_aggregate = off;
                Index Cond: (device = 'd1'::text)
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+               ->  Seq Scan on compress_hyper_2_2_chunk
+               SubPlan 1
+                 ->  Function Scan on generate_series g
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (device = ('d'::text || (g.g)::text))
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
@@ -2088,6 +2111,33 @@ SET enable_partitionwise_aggregate = off;
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: ((value > '10'::double precision) AND (device = 'd1'::text))
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Hash Semi Join
+         Hash Cond: (metrics.device = ('d'::text || (g.g)::text))
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Hash
+               ->  Function Scan on generate_series g
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
@@ -3408,6 +3458,38 @@ SET enable_partitionwise_aggregate = off;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
                            Index Cond: (device = 'd1'::text)
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
 
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -712,6 +712,29 @@ SET enable_partitionwise_aggregate = off;
                Index Cond: (device = 'd1'::text)
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+               ->  Seq Scan on compress_hyper_2_2_chunk
+               SubPlan 1
+                 ->  Function Scan on generate_series g
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                     Index Cond: (device = ('d'::text || (g.g)::text))
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
@@ -2092,6 +2115,33 @@ SET enable_partitionwise_aggregate = off;
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: ((value > '10'::double precision) AND (device = 'd1'::text))
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Hash Semi Join
+         Hash Cond: (metrics.device = ('d'::text || (g.g)::text))
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Seq Scan on _hyper_1_1_chunk
+         ->  Hash
+               ->  Function Scan on generate_series g
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
@@ -3414,6 +3464,38 @@ SET enable_partitionwise_aggregate = off;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
                            Index Cond: (device = 'd1'::text)
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_min_1__ts_m_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
 
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1673,7 +1673,6 @@ SELECT * FROM f_sensor_data WHERE sensor_id > 1000;
    ->  Parallel Append
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_37_73_chunk
                Output: _hyper_37_73_chunk."time", _hyper_37_73_chunk.sensor_id, _hyper_37_73_chunk.cpu, _hyper_37_73_chunk.temperature
-               Filter: (_hyper_37_73_chunk.sensor_id > 1000)
                Chunk Status: PARTIAL
                ->  Parallel Index Scan using compress_hyper_38_74_chunk_sensor_id__ts_meta_min_1__ts_met_idx on _timescaledb_internal.compress_hyper_38_74_chunk
                      Output: compress_hyper_38_74_chunk._ts_meta_count, compress_hyper_38_74_chunk.sensor_id, compress_hyper_38_74_chunk._ts_meta_min_1, compress_hyper_38_74_chunk._ts_meta_max_1, compress_hyper_38_74_chunk."time", compress_hyper_38_74_chunk.cpu, compress_hyper_38_74_chunk.temperature

--- a/tsl/test/expected/merge_append_partially_compressed.out
+++ b/tsl/test/expected/merge_append_partially_compressed.out
@@ -247,7 +247,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
                      Sort Key: _hyper_1_3_chunk."time" DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=27.00 loops=1)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=3.00 loops=1)
                                  Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Index Scan using _hyper_1_3_chunk_ht_metrics_compressed_time_idx on _hyper_1_3_chunk (actual rows=1.00 loops=1)
@@ -257,7 +256,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time" DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
                                  Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Index Scan using _hyper_1_2_chunk_ht_metrics_compressed_time_idx on _hyper_1_2_chunk (never executed)
@@ -267,7 +265,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
                ->  Sort (never executed)
                      Sort Key: _hyper_1_1_chunk."time" DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
                                  Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Index Scan using _hyper_1_1_chunk_ht_metrics_compressed_time_idx on _hyper_1_1_chunk (never executed)
@@ -284,7 +281,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
                      Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device DESC
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=84.00 loops=1)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Seq Scan on compress_hyper_2_4_chunk (actual rows=3.00 loops=1)
                                  Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1.00 loops=1)
@@ -297,7 +293,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
                ->  Sort (never executed)
                      Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
                                  Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
@@ -309,7 +304,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
                ->  Sort (never executed)
                      Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device DESC
                      ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (never executed)
-                           Filter: (device = ANY ('{1,2,3}'::integer[]))
                            ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
                                  Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (never executed)
@@ -326,7 +320,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
          ->  Merge Append (actual rows=1.00 loops=1)
                Sort Key: ht_metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1.00 loops=1)
-                     Filter: (device = 3)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                            Sort Method: quicksort 
@@ -339,7 +332,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
          ->  Merge Append (never executed)
                Sort Key: ht_metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (never executed)
-                     Filter: (device = 3)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
@@ -349,7 +341,6 @@ SELECT show_chunks('ht_metrics_compressed') AS "CHUNK" LIMIT 1 \gset
          ->  Merge Append (never executed)
                Sort Key: ht_metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (never executed)
-                     Filter: (device = 3)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_2_4_chunk (never executed)
@@ -368,7 +359,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
    ->  Merge Append (actual rows=1.00 loops=1)
          Sort Key: ht_metrics_compressed."time" DESC
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1.00 loops=1)
-               Filter: (device = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -379,7 +369,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                Filter: (device = 3)
                Rows Removed by Filter: 2
          ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=1.00 loops=1)
-               Filter: (device = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -390,7 +379,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time DESC LIMIT 1;
                Filter: (device = 3)
                Rows Removed by Filter: 2
          ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1.00 loops=1)
-               Filter: (device = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -414,7 +402,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
          ->  Merge Append (actual rows=1.00 loops=1)
                Sort Key: ht_metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1.00 loops=1)
-                     Filter: (device = 3)
                      ->  Sort (actual rows=1.00 loops=1)
                            Sort Key: compress_hyper_2_4_chunk._ts_meta_min_1, compress_hyper_2_4_chunk._ts_meta_max_1
                            Sort Method: quicksort 
@@ -426,7 +413,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
          ->  Merge Append (never executed)
                Sort Key: ht_metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (never executed)
-                     Filter: (device = 3)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_5_chunk._ts_meta_min_1, compress_hyper_2_5_chunk._ts_meta_max_1
                            ->  Seq Scan on compress_hyper_2_5_chunk (never executed)
@@ -436,7 +422,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY device, time DESC 
          ->  Merge Append (never executed)
                Sort Key: ht_metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (never executed)
-                     Filter: (device = 3)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_2_6_chunk._ts_meta_min_1, compress_hyper_2_6_chunk._ts_meta_max_1
                            ->  Seq Scan on compress_hyper_2_6_chunk (never executed)
@@ -489,7 +474,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
    ->  Merge Append (actual rows=1.00 loops=1)
          Sort Key: ht_metrics_compressed.device, ht_metrics_compressed."time" DESC
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1.00 loops=1)
-               Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_2_4_chunk.device, compress_hyper_2_4_chunk._ts_meta_min_1 DESC, compress_hyper_2_4_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -501,7 +485,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Seq Scan on _hyper_1_1_chunk (actual rows=57.00 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Custom Scan (ColumnarScan) on _hyper_1_2_chunk (actual rows=1.00 loops=1)
-               Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_2_5_chunk.device, compress_hyper_2_5_chunk._ts_meta_min_1 DESC, compress_hyper_2_5_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -513,7 +496,6 @@ SELECT * FROM ht_metrics_compressed WHERE device = 3 ORDER BY time, device DESC 
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=57.00 loops=1)
                      Filter: (device = ANY ('{1,2,3}'::integer[]))
          ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=1.00 loops=1)
-               Filter: (device = ANY ('{1,2,3}'::integer[]))
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_2_6_chunk.device, compress_hyper_2_6_chunk._ts_meta_min_1 DESC, compress_hyper_2_6_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -397,7 +397,6 @@ select * from mergeme where device = 1;
 --- QUERY PLAN ---
  Append
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
-         Filter: (device = 1)
          ->  Index Scan using compress_hyper_2_6_chunk_device__ts_meta_min_1__ts_meta_max_idx on compress_hyper_2_6_chunk
                Index Cond: (device = 1)
    ->  Index Scan using _hyper_1_1_chunk_mergeme_device_time_idx on _hyper_1_1_chunk

--- a/tsl/test/shared/expected/bulk_decompression_limit.out
+++ b/tsl/test/shared/expected/bulk_decompression_limit.out
@@ -21,7 +21,6 @@ LIMIT 5;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -68,7 +67,6 @@ OFFSET 5;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -115,7 +113,6 @@ LIMIT 0;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (never executed)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -158,7 +155,6 @@ OFFSET 0;
          Sort Key: metrics_compressed."time"
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -205,7 +201,6 @@ LIMIT 10000;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -252,7 +247,6 @@ OFFSET 10000;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -299,7 +293,6 @@ LIMIT 70 OFFSET 70;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -346,7 +339,6 @@ LIMIT 1 OFFSET 1;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -392,7 +384,6 @@ LIMIT 1 OFFSET 1;
                Sort Method: top-N heapsort 
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Bulk Decompression: true
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -446,7 +437,6 @@ LIMIT 1::numeric;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -493,7 +483,6 @@ LIMIT 1.1;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true
@@ -540,7 +529,6 @@ LIMIT 1.1::float;
                Sort Key: metrics_compressed."time"
                ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                      Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0
-                     Filter: (_hyper_X_X_chunk.device_id = 1)
                      Chunk Status: PARTIAL
                      Reverse: true
                      Bulk Decompression: true

--- a/tsl/test/shared/expected/constraint_exclusion_prepared-15.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-15.out
@@ -1466,7 +1466,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1505,7 +1504,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1544,7 +1542,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1583,7 +1580,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1622,7 +1618,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/constraint_exclusion_prepared-16.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-16.out
@@ -1466,7 +1466,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1505,7 +1504,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1544,7 +1542,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1583,7 +1580,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1622,7 +1618,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/constraint_exclusion_prepared-17.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-17.out
@@ -1466,7 +1466,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1505,7 +1504,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1544,7 +1542,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1583,7 +1580,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1622,7 +1618,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/constraint_exclusion_prepared-18.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-18.out
@@ -1466,7 +1466,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1505,7 +1504,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1544,7 +1542,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1583,7 +1580,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)
@@ -1622,7 +1618,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=0.00 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -1694,7 +1694,6 @@ LIMIT 1;
          ->  Merge Append (never executed)
                Sort Key: metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Filter: (device_id = 1)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -1931,7 +1930,6 @@ ORDER BY o1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Filter: (device_id = 2)
                      ->  Sort (actual rows=4.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -1952,7 +1950,6 @@ ORDER BY o1.time;
                ->  Merge Append (actual rows=3598.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Sort (actual rows=2.00 loops=1)
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  Sort Method: quicksort 
@@ -2043,7 +2040,6 @@ ORDER BY time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
@@ -2109,7 +2105,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2126,7 +2121,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2157,7 +2151,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2174,7 +2167,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2223,7 +2215,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2240,7 +2231,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2271,7 +2261,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2288,7 +2277,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2319,7 +2307,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2336,7 +2323,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2368,7 +2354,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2385,7 +2370,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2416,7 +2400,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2433,7 +2416,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2515,7 +2497,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=1.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
@@ -2529,7 +2510,6 @@ LIMIT 100;
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
@@ -2561,7 +2541,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2578,7 +2557,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2612,7 +2590,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 3)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
@@ -2631,7 +2608,6 @@ LIMIT 100;
                            ->  Merge Append (actual rows=100.00 loops=1)
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 2)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2648,7 +2624,6 @@ LIMIT 100;
                                  ->  Merge Append (actual rows=100.00 loops=1)
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                             Filter: (device_id = 1)
                                              ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-16.out
+++ b/tsl/test/shared/expected/ordered_append_join-16.out
@@ -1694,7 +1694,6 @@ LIMIT 1;
          ->  Merge Append (never executed)
                Sort Key: metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Filter: (device_id = 1)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -1931,7 +1930,6 @@ ORDER BY o1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Filter: (device_id = 2)
                      ->  Sort (actual rows=4.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -1952,7 +1950,6 @@ ORDER BY o1.time;
                ->  Merge Append (actual rows=3598.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Sort (actual rows=2.00 loops=1)
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  Sort Method: quicksort 
@@ -2043,7 +2040,6 @@ ORDER BY time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
@@ -2109,7 +2105,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2126,7 +2121,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2157,7 +2151,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2174,7 +2167,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2223,7 +2215,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2240,7 +2231,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2271,7 +2261,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2288,7 +2277,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2319,7 +2307,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2336,7 +2323,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2368,7 +2354,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2385,7 +2370,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2416,7 +2400,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2433,7 +2416,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2515,7 +2497,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=1.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
@@ -2529,7 +2510,6 @@ LIMIT 100;
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
@@ -2561,7 +2541,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2578,7 +2557,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2612,7 +2590,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 3)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
@@ -2631,7 +2608,6 @@ LIMIT 100;
                            ->  Merge Append (actual rows=100.00 loops=1)
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 2)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2648,7 +2624,6 @@ LIMIT 100;
                                  ->  Merge Append (actual rows=100.00 loops=1)
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                             Filter: (device_id = 1)
                                              ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-17.out
+++ b/tsl/test/shared/expected/ordered_append_join-17.out
@@ -1682,7 +1682,6 @@ LIMIT 1;
          ->  Merge Append (never executed)
                Sort Key: metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Filter: (device_id = 1)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -1926,7 +1925,6 @@ ORDER BY o1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Filter: (device_id = 2)
                      ->  Sort (actual rows=4.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -1947,7 +1945,6 @@ ORDER BY o1.time;
                ->  Merge Append (actual rows=3598.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Sort (actual rows=2.00 loops=1)
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  Sort Method: quicksort 
@@ -2038,7 +2035,6 @@ ORDER BY time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
@@ -2100,7 +2096,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2117,7 +2112,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2148,7 +2142,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2165,7 +2158,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2214,7 +2206,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2231,7 +2222,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2262,7 +2252,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2279,7 +2268,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2310,7 +2298,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2327,7 +2314,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2359,7 +2345,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2376,7 +2361,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2407,7 +2391,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2424,7 +2407,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2506,7 +2488,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=1.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
@@ -2520,7 +2501,6 @@ LIMIT 100;
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
@@ -2552,7 +2532,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2569,7 +2548,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2603,7 +2581,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 3)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
@@ -2622,7 +2599,6 @@ LIMIT 100;
                            ->  Merge Append (actual rows=100.00 loops=1)
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 2)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2639,7 +2615,6 @@ LIMIT 100;
                                  ->  Merge Append (actual rows=100.00 loops=1)
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                             Filter: (device_id = 1)
                                              ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)

--- a/tsl/test/shared/expected/ordered_append_join-18.out
+++ b/tsl/test/shared/expected/ordered_append_join-18.out
@@ -1682,7 +1682,6 @@ LIMIT 1;
          ->  Merge Append (never executed)
                Sort Key: metrics_compressed."time" DESC
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Filter: (device_id = 1)
                      ->  Sort (never executed)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                            ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -1926,7 +1925,6 @@ ORDER BY o1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=3598.00 loops=1)
-                     Filter: (device_id = 2)
                      ->  Sort (actual rows=4.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -1947,7 +1945,6 @@ ORDER BY o1.time;
                ->  Merge Append (actual rows=3598.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Sort (actual rows=2.00 loops=1)
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  Sort Method: quicksort 
@@ -2038,7 +2035,6 @@ ORDER BY time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: o1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                            Sort Method: quicksort 
@@ -2100,7 +2096,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2117,7 +2112,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2148,7 +2142,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2165,7 +2158,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2214,7 +2206,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2231,7 +2222,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2262,7 +2252,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2279,7 +2268,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2310,7 +2298,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2327,7 +2314,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2359,7 +2345,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2376,7 +2361,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2407,7 +2391,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2424,7 +2407,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2506,7 +2488,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=1.00 loops=1)
                      Sort Key: o1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
@@ -2520,7 +2501,6 @@ LIMIT 100;
          ->  Materialize (actual rows=100.00 loops=1)
                ->  Append (actual rows=100.00 loops=1)
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 1)
                            ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 1)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (never executed)
@@ -2552,7 +2532,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o2."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 2)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 2)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2569,7 +2548,6 @@ LIMIT 100;
                      ->  Merge Append (actual rows=100.00 loops=1)
                            Sort Key: o1."time"
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                 Filter: (device_id = 1)
                                  ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                        Index Cond: (device_id = 1)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)
@@ -2603,7 +2581,6 @@ LIMIT 100;
                ->  Merge Append (actual rows=100.00 loops=1)
                      Sort Key: o3."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o3_1 (actual rows=100.00 loops=1)
-                           Filter: (device_id = 3)
                            ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=1.00 loops=1)
                                  Index Cond: (device_id = 3)
                      ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o3_1 (actual rows=0.00 loops=1)
@@ -2622,7 +2599,6 @@ LIMIT 100;
                            ->  Merge Append (actual rows=100.00 loops=1)
                                  Sort Key: o2."time"
                                  ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o2_1 (actual rows=100.00 loops=1)
-                                       Filter: (device_id = 2)
                                        ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=1.00 loops=1)
                                              Index Cond: (device_id = 2)
                                  ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk o2_1 (actual rows=0.00 loops=1)
@@ -2639,7 +2615,6 @@ LIMIT 100;
                                  ->  Merge Append (actual rows=100.00 loops=1)
                                        Sort Key: o1."time"
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk o1_1 (actual rows=1.00 loops=1)
-                                             Filter: (device_id = 1)
                                              ->  Index Scan Backward using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1.00 loops=1)
                                                    Index Cond: (device_id = 1)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk o1_1 (actual rows=100.00 loops=1)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -20,7 +20,6 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -92,7 +91,6 @@ ORDER BY time, device_id;
    ->  Result (actual rows=7196.00 loops=1)
          ->  Append (actual rows=7196.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -112,7 +110,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Filter: (device_id < 0)
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
@@ -135,7 +132,6 @@ ORDER BY time, device_id;
    Sort Method: quicksort 
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -150,7 +146,6 @@ ORDER BY time, device_id;
    Sort Method: quicksort 
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -162,7 +157,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-         Filter: (device_id = 1)
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 16
@@ -201,7 +195,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -219,7 +212,6 @@ ORDER BY time, device_id;
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          ->  Append
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id IS NOT NULL)
                      ->  Seq Scan on compress_hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
                ->  Seq Scan on _hyper_X_X_chunk
@@ -233,7 +225,6 @@ ORDER BY time, device_id;
          Sort Method: quicksort 
          ->  Append (actual rows=0.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-                     Filter: (device_id IS NULL)
                      ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                            Index Cond: (device_id IS NULL)
                ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
@@ -248,7 +239,6 @@ ORDER BY time, device_id;
          Sort Method: top-N heapsort 
          ->  Append (actual rows=7196.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -262,7 +252,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -304,7 +293,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -321,7 +309,6 @@ ORDER BY time, device_id;
    ->  Merge Append
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-               Filter: (device_id = length("substring"(version(), 1, 3)))
                ->  Sort
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
                      ->  Seq Scan on compress_hyper_X_X_chunk
@@ -659,7 +646,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
    ->  Merge Append (actual rows=3598.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-               Filter: (device_id = 2)
                ->  Sort (actual rows=4.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -672,7 +658,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: _hyper_X_X_chunk_1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -696,7 +681,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -717,7 +701,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -738,7 +721,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               Filter: (test_table.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -755,7 +737,6 @@ SET enable_seqscan TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -771,7 +752,6 @@ SET enable_seqscan TO FALSE;
    Output: count(*)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -788,7 +768,6 @@ SET enable_hashjoin TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -831,7 +810,6 @@ RESET enable_hashjoin;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -895,7 +873,6 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time" DESC
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -961,7 +938,6 @@ FROM :TEST_TABLE m1
                            ->  Hash
                                  ->  Append
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                             Filter: (device_id = 3)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                                                    Filter: (device_id = 3)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
@@ -986,7 +962,6 @@ FROM :TEST_TABLE m1
          ->  Merge Append
                Sort Key: m2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     Filter: (device_id = 2)
                      ->  Sort
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
@@ -997,7 +972,6 @@ FROM :TEST_TABLE m1
                ->  Merge Append
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           Filter: (device_id = 1)
                            ->  Sort
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  ->  Seq Scan on compress_hyper_X_X_chunk
@@ -1097,7 +1071,6 @@ LIMIT 100;
                ->  Hash
                      ->  Append
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 Filter: (device_id = 2)
                                  ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
                                        Filter: (device_id = 2)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
@@ -1190,7 +1163,6 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16

--- a/tsl/test/shared/expected/transparent_decompress_chunk-16.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-16.out
@@ -20,7 +20,6 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -92,7 +91,6 @@ ORDER BY time, device_id;
    ->  Result (actual rows=7196.00 loops=1)
          ->  Append (actual rows=7196.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -112,7 +110,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Filter: (device_id < 0)
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
@@ -135,7 +132,6 @@ ORDER BY time, device_id;
    Sort Method: quicksort 
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -150,7 +146,6 @@ ORDER BY time, device_id;
    Sort Method: quicksort 
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -162,7 +157,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-         Filter: (device_id = 1)
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 16
@@ -201,7 +195,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -219,7 +212,6 @@ ORDER BY time, device_id;
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          ->  Append
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id IS NOT NULL)
                      ->  Seq Scan on compress_hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
                ->  Seq Scan on _hyper_X_X_chunk
@@ -233,7 +225,6 @@ ORDER BY time, device_id;
          Sort Method: quicksort 
          ->  Append (actual rows=0.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-                     Filter: (device_id IS NULL)
                      ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                            Index Cond: (device_id IS NULL)
                ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
@@ -248,7 +239,6 @@ ORDER BY time, device_id;
          Sort Method: top-N heapsort 
          ->  Append (actual rows=7196.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -262,7 +252,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -304,7 +293,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -321,7 +309,6 @@ ORDER BY time, device_id;
    ->  Merge Append
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-               Filter: (device_id = length("substring"(version(), 1, 3)))
                ->  Sort
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
                      ->  Seq Scan on compress_hyper_X_X_chunk
@@ -659,7 +646,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
    ->  Merge Append (actual rows=3598.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-               Filter: (device_id = 2)
                ->  Sort (actual rows=4.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -672,7 +658,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: _hyper_X_X_chunk_1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -696,7 +681,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -717,7 +701,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -738,7 +721,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               Filter: (test_table.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -755,7 +737,6 @@ SET enable_seqscan TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -771,7 +752,6 @@ SET enable_seqscan TO FALSE;
    Output: count(*)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -788,7 +768,6 @@ SET enable_hashjoin TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -831,7 +810,6 @@ RESET enable_hashjoin;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -895,7 +873,6 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time" DESC
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -961,7 +938,6 @@ FROM :TEST_TABLE m1
                            ->  Hash
                                  ->  Append
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                             Filter: (device_id = 3)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                                                    Filter: (device_id = 3)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
@@ -986,7 +962,6 @@ FROM :TEST_TABLE m1
          ->  Merge Append
                Sort Key: m2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     Filter: (device_id = 2)
                      ->  Sort
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
@@ -997,7 +972,6 @@ FROM :TEST_TABLE m1
                ->  Merge Append
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           Filter: (device_id = 1)
                            ->  Sort
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  ->  Seq Scan on compress_hyper_X_X_chunk
@@ -1097,7 +1071,6 @@ LIMIT 100;
                ->  Hash
                      ->  Append
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 Filter: (device_id = 2)
                                  ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
                                        Filter: (device_id = 2)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
@@ -1190,7 +1163,6 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16

--- a/tsl/test/shared/expected/transparent_decompress_chunk-17.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-17.out
@@ -20,7 +20,6 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -92,7 +91,6 @@ ORDER BY time, device_id;
    ->  Result (actual rows=7196.00 loops=1)
          ->  Append (actual rows=7196.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -112,7 +110,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Filter: (device_id < 0)
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
@@ -136,7 +133,6 @@ ORDER BY time, device_id;
          Sort Key: _hyper_X_X_chunk.v1
          Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -155,7 +151,6 @@ ORDER BY time, device_id;
          Sort Key: _hyper_X_X_chunk.v1
          Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -170,7 +165,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-         Filter: (device_id = 1)
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 16
@@ -209,7 +203,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -228,7 +221,6 @@ ORDER BY time, device_id;
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id IS NOT NULL)
                      ->  Seq Scan on compress_hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
          ->  Sort
@@ -245,7 +237,6 @@ ORDER BY time, device_id;
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-                     Filter: (device_id IS NULL)
                      ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                            Index Cond: (device_id IS NULL)
          ->  Sort (actual rows=0.00 loops=1)
@@ -264,7 +255,6 @@ ORDER BY time, device_id;
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Method: top-N heapsort 
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -281,7 +271,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -329,7 +318,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -346,7 +334,6 @@ ORDER BY time, device_id;
    ->  Merge Append
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-               Filter: (device_id = length("substring"(version(), 1, 3)))
                ->  Sort
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
                      ->  Seq Scan on compress_hyper_X_X_chunk
@@ -725,7 +712,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
    ->  Merge Append (actual rows=3598.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-               Filter: (device_id = 2)
                ->  Sort (actual rows=4.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -738,7 +724,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: _hyper_X_X_chunk_1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -762,7 +747,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -783,7 +767,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -804,7 +787,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               Filter: (test_table.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -821,7 +803,6 @@ SET enable_seqscan TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -837,7 +818,6 @@ SET enable_seqscan TO FALSE;
    Output: count(*)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -854,7 +834,6 @@ SET enable_hashjoin TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -897,7 +876,6 @@ RESET enable_hashjoin;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -961,7 +939,6 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time" DESC
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -1027,7 +1004,6 @@ FROM :TEST_TABLE m1
                            ->  Hash
                                  ->  Append
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                             Filter: (device_id = 3)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                                                    Filter: (device_id = 3)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
@@ -1052,7 +1028,6 @@ FROM :TEST_TABLE m1
          ->  Merge Append
                Sort Key: m2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     Filter: (device_id = 2)
                      ->  Sort
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
@@ -1063,7 +1038,6 @@ FROM :TEST_TABLE m1
                ->  Merge Append
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           Filter: (device_id = 1)
                            ->  Sort
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  ->  Seq Scan on compress_hyper_X_X_chunk
@@ -1163,7 +1137,6 @@ LIMIT 100;
                ->  Hash
                      ->  Append
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 Filter: (device_id = 2)
                                  ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
                                        Filter: (device_id = 2)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
@@ -1256,7 +1229,6 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16

--- a/tsl/test/shared/expected/transparent_decompress_chunk-18.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-18.out
@@ -20,7 +20,6 @@ SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=1.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -92,7 +91,6 @@ ORDER BY time, device_id;
    ->  Result (actual rows=7196.00 loops=1)
          ->  Append (actual rows=7196.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk t (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -112,7 +110,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=0.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Filter: (device_id < 0)
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
@@ -136,7 +133,6 @@ ORDER BY time, device_id;
          Sort Key: _hyper_X_X_chunk.v1
          Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -155,7 +151,6 @@ ORDER BY time, device_id;
          Sort Key: _hyper_X_X_chunk.v1
          Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16
@@ -170,7 +165,6 @@ ORDER BY time, device_id;
 --- QUERY PLAN ---
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-         Filter: (device_id = 1)
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                Filter: (device_id = 1)
                Rows Removed by Filter: 16
@@ -209,7 +203,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -228,7 +221,6 @@ ORDER BY time, device_id;
          ->  Sort
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-                     Filter: (device_id IS NOT NULL)
                      ->  Seq Scan on compress_hyper_X_X_chunk
                            Filter: (device_id IS NOT NULL)
          ->  Sort
@@ -245,7 +237,6 @@ ORDER BY time, device_id;
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Method: quicksort 
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-                     Filter: (device_id IS NULL)
                      ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on compress_hyper_X_X_chunk (actual rows=0.00 loops=1)
                            Index Cond: (device_id IS NULL)
          ->  Sort (actual rows=0.00 loops=1)
@@ -264,7 +255,6 @@ ORDER BY time, device_id;
                Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
                Sort Method: top-N heapsort 
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5598.00 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 12
@@ -281,7 +271,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -329,7 +318,6 @@ ORDER BY time, device_id;
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 3)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -346,7 +334,6 @@ ORDER BY time, device_id;
    ->  Merge Append
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk
-               Filter: (device_id = length("substring"(version(), 1, 3)))
                ->  Sort
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1
                      ->  Seq Scan on compress_hyper_X_X_chunk
@@ -725,7 +712,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
    ->  Merge Append (actual rows=3598.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time"
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=3598.00 loops=1)
-               Filter: (device_id = 2)
                ->  Sort (actual rows=4.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                      Sort Method: quicksort 
@@ -738,7 +724,6 @@ SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
          ->  Merge Append (actual rows=3598.00 loops=1)
                Sort Key: _hyper_X_X_chunk_1."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=2000.00 loops=1)
-                     Filter: (device_id = 1)
                      ->  Sort (actual rows=2.00 loops=1)
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            Sort Method: quicksort 
@@ -762,7 +747,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -783,7 +767,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
                Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -804,7 +787,6 @@ SET enable_seqscan TO FALSE;
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=2000.00 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               Filter: (test_table.device_id = 1)
                Chunk Status: PARTIAL
                Reverse: true
                Bulk Decompression: true
@@ -821,7 +803,6 @@ SET enable_seqscan TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -837,7 +818,6 @@ SET enable_seqscan TO FALSE;
    Output: count(*)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (_hyper_X_X_chunk.device_id = 1)
                Chunk Status: PARTIAL
                Bulk Decompression: false
                ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -854,7 +834,6 @@ SET enable_hashjoin TO FALSE;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -871,7 +850,6 @@ SET enable_hashjoin TO FALSE;
  Append (actual rows=7196.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5598.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -888,7 +866,6 @@ RESET enable_hashjoin;
  Append (actual rows=3598.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=2000.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = 1)
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
@@ -905,7 +882,6 @@ RESET enable_hashjoin;
  Append (actual rows=7196.00 loops=1)
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5598.00 loops=1)
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
          Chunk Status: PARTIAL
          Bulk Decompression: false
          ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=6.00 loops=1)
@@ -923,7 +899,6 @@ SET seq_page_cost = 100;
  Append
    ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_X_X_chunk
          Output: _hyper_X_X_chunk.device_id
-         Filter: (_hyper_X_X_chunk.device_id = ANY ('{1,2}'::integer[]))
          Chunk Status: PARTIAL
          ->  Index Scan using compress_hyper_X_X_chunk_device_id__ts_meta_min_1__ts_meta_idx on _timescaledb_internal.compress_hyper_X_X_chunk
                Output: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_count
@@ -941,7 +916,6 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
    ->  Merge Append (actual rows=10.00 loops=1)
          Sort Key: _hyper_X_X_chunk."time" DESC
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=10.00 loops=1)
-               Filter: (device_id = 1)
                ->  Sort (actual rows=1.00 loops=1)
                      Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1 DESC, compress_hyper_X_X_chunk._ts_meta_max_1 DESC
                      Sort Method: quicksort 
@@ -1007,7 +981,6 @@ FROM :TEST_TABLE m1
                            ->  Hash
                                  ->  Append
                                        ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m3
-                                             Filter: (device_id = 3)
                                              ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
                                                    Filter: (device_id = 3)
                                        ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m3
@@ -1032,7 +1005,6 @@ FROM :TEST_TABLE m1
          ->  Merge Append
                Sort Key: m2."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                     Filter: (device_id = 2)
                      ->  Sort
                            Sort Key: compress_hyper_X_X_chunk_1._ts_meta_min_1, compress_hyper_X_X_chunk_1._ts_meta_max_1
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
@@ -1043,7 +1015,6 @@ FROM :TEST_TABLE m1
                ->  Merge Append
                      Sort Key: m1."time"
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m1
-                           Filter: (device_id = 1)
                            ->  Sort
                                  Sort Key: compress_hyper_X_X_chunk._ts_meta_min_1, compress_hyper_X_X_chunk._ts_meta_max_1
                                  ->  Seq Scan on compress_hyper_X_X_chunk
@@ -1143,7 +1114,6 @@ LIMIT 100;
                ->  Hash
                      ->  Append
                            ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk m2
-                                 Filter: (device_id = 2)
                                  ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
                                        Filter: (device_id = 2)
                            ->  Index Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk m2
@@ -1236,7 +1206,6 @@ PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=3598.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=2000.00 loops=1)
-               Filter: (device_id = 1)
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=2.00 loops=1)
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 16

--- a/tsl/test/sql/include/columnar_index_scan_query.sql
+++ b/tsl/test/sql/include/columnar_index_scan_query.sql
@@ -213,6 +213,10 @@ SET enable_partitionwise_aggregate = off;
 -- WHERE mixes segmentby and non-segmentby column
 :PREFIX SELECT device, count(*) FROM metrics WHERE device = 'd1' AND value > 10 GROUP BY device ORDER BY device;
 
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 


### PR DESCRIPTION
A WHERE clause like `dev NOT IN (SELECT ...)` puts a SubPlan filter
on the ColumnarScan that the columnar pushdown does not push to the
compressed scan.  The old check looked at the Vars in the qual and
approved the ColumnarIndexScan optimization, which then dropped the
filter and returned wrong results.

Track in `columnar_scan_filter_pushdown` whether every clause was
pushed without recheck.  When it was, skip those clauses on the
ColumnarScan's plan.qual so the compressed scan is the only place
they get enforced.  For partial chunks this also removes the
redundant Filter that used to appear next to the compressed Index
Cond, and keeps the ColumnarIndexScan optimization applicable.

ColumnarIndexScan now treats any remaining clause on plan.qual as
"must be rechecked" and skips the optimization.

Fixes #9907
