### PR TITLE
Only check for dumps in fuzzer workflow if we have a repro

### DIFF
--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -342,7 +342,7 @@ jobs:
         sudo journalctl --system -q --facility=kern --grep "Killed process" || true
 
     - name: Stack trace
-      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      if: always() && steps.collectlogs.outputs.coredumps == 'true' && steps.repro.outputs.found == 'true'
       run: |
         sudo coredumpctl gdb <<<"
           set verbose on


### PR DESCRIPTION
Otherwise we might pick an unrelated core dump existing on the runner machine.