### PR TITLE
Small refactor of compression_settings

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4336,6 +4336,15 @@ Datum
 ts_chunk_drop_single_chunk(PG_FUNCTION_ARGS)
 {
 	Oid chunk_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	if (ts_relation_is_compressed_chunk_relation(chunk_relid))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("dropping compressed chunks not supported"),
+				 errhint("Please drop the corresponding chunk on the uncompressed hypertable "
+						 "instead.")));
+	}
+
 	char *chunk_table_name = get_rel_name(chunk_relid);
 	char *chunk_schema_name = get_namespace_name(get_rel_namespace(chunk_relid));
 	ScanTupLock tuplock = {
@@ -4351,15 +4360,6 @@ ts_chunk_drop_single_chunk(PG_FUNCTION_ARGS)
 															   true);
 	Assert(ch != NULL);
 	ts_chunk_validate_chunk_status_for_operation(ch, CHUNK_DROP, true /*throw_error */);
-
-	if (ts_chunk_contains_compressed_data(ch))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("dropping compressed chunks not supported"),
-				 errhint("Please drop the corresponding chunk on the uncompressed hypertable "
-						 "instead.")));
-	}
 
 	/* do not drop any chunk dependencies */
 	ts_chunk_drop(ch, DROP_RESTRICT, LOG);

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -326,34 +326,40 @@ compression_settings_fill_from_tuple(CompressionSettings *settings, TupleInfo *t
 }
 
 static void
-compression_settings_iterator_init(ScanIterator *iterator, Oid relid, bool by_compress_relid)
+init_scan_by_relid(ScanIterator *iterator, Oid relid)
 {
-	int indexid =
-		by_compress_relid ? COMPRESSION_SETTINGS_COMPRESS_RELID_IDX : COMPRESSION_SETTINGS_PKEY;
-	iterator->ctx.index = catalog_get_index(ts_catalog_get(), COMPRESSION_SETTINGS, indexid);
+	iterator->ctx.index =
+		catalog_get_index(ts_catalog_get(), COMPRESSION_SETTINGS, COMPRESSION_SETTINGS_PKEY);
 	ts_scan_iterator_scan_key_init(iterator,
-								   by_compress_relid ?
-									   Anum_compression_settings_compress_relid_idx_relid :
-									   Anum_compression_settings_pkey_relid,
+								   Anum_compression_settings_pkey_relid,
 								   BTEqualStrategyNumber,
 								   F_OIDEQ,
 								   ObjectIdGetDatum(relid));
 }
 
+static void
+init_scan_by_compress_relid(ScanIterator *iterator, Oid compress_relid)
+{
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(),
+											COMPRESSION_SETTINGS,
+											COMPRESSION_SETTINGS_COMPRESS_RELID_IDX);
+	ts_scan_iterator_scan_key_init(iterator,
+								   Anum_compression_settings_compress_relid_idx_relid,
+								   BTEqualStrategyNumber,
+								   F_OIDEQ,
+								   ObjectIdGetDatum(compress_relid));
+}
+
 /*
- * Get compression settings for a relation.
- *
- * When 'by_compress_relid' is false, the 'relid' refers to the "main"
- * relation being compressed. When it is true the 'relid' refers to the
- * relation containing the associated compressed data.
+ * Get the compression settings for the relation referred to by 'relid'.
  */
-static CompressionSettings *
-compression_settings_get(Oid relid, bool by_compress_relid)
+TSDLLEXPORT CompressionSettings *
+ts_compression_settings_get(Oid relid)
 {
 	CompressionSettings *settings = NULL;
 	ScanIterator iterator =
 		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
-	compression_settings_iterator_init(&iterator, relid, by_compress_relid);
+	init_scan_by_relid(&iterator, relid);
 
 	ts_scanner_start_scan(&iterator.ctx);
 	TupleInfo *ti = ts_scanner_next(&iterator.ctx);
@@ -369,39 +375,97 @@ compression_settings_get(Oid relid, bool by_compress_relid)
 }
 
 /*
- * Get the compression settings for the relation referred to by 'relid'.
- */
-TSDLLEXPORT CompressionSettings *
-ts_compression_settings_get(Oid relid)
-{
-	return compression_settings_get(relid, false);
-}
-
-/*
  * Get the compression settings for a relation given its associated compressed
  * relation.
- *
- * Ideally, settings should only be looked up by "primary key", i.e., the
- * non-compressed chunk's 'relid', and in that case this function wouldn't be
- * needed. It might be possible to remove this function in the future.
  */
 TSDLLEXPORT CompressionSettings *
-ts_compression_settings_get_by_compress_relid(Oid relid)
+ts_compression_settings_get_by_compress_relid(Oid compress_relid)
 {
-	CompressionSettings *settings = compression_settings_get(relid, true);
-	Ensure(settings, "compression settings not found for %s", get_rel_name(relid));
+	CompressionSettings *settings = NULL;
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
+	init_scan_by_compress_relid(&iterator, compress_relid);
+
+	ts_scanner_start_scan(&iterator.ctx);
+	TupleInfo *ti = ts_scanner_next(&iterator.ctx);
+	if (!ti)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("compression settings not found for relation \"%s\"",
+						get_rel_name(compress_relid))));
+	}
+
+	settings = palloc0(sizeof(CompressionSettings));
+	compression_settings_fill_from_tuple(settings, ti);
+	ts_scan_iterator_close(&iterator);
 	return settings;
 }
 
 /*
- * Delete compression settings for a relation.
- *
- * When 'by_compress_relid' is false, the 'relid' refers to the "main"
- * relation being compressed. When it is true the 'relid' refers to the
- * relation containing the associated compressed data.
+ * Check whether 'relid' is the relation holding the compressed data of a
+ * compressed chunk.
  */
-static bool
-compression_settings_delete(Oid relid, bool by_compress_relid)
+TSDLLEXPORT bool
+ts_relation_is_compressed_chunk_relation(Oid compress_relid)
+{
+	if (!OidIsValid(compress_relid))
+	{
+		return false;
+	}
+
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
+	init_scan_by_compress_relid(&iterator, compress_relid);
+
+	ts_scanner_start_scan(&iterator.ctx);
+	bool found = ts_scanner_next(&iterator.ctx) != NULL;
+	ts_scan_iterator_close(&iterator);
+
+	return found;
+}
+
+/*
+ * Get the OID of the uncompressed relation given the OID of the relation
+ * holding its compressed data.
+ *
+ * Returns InvalidOid if 'compress_relid' is not the compressed-data relation
+ * of any compressed chunk.
+ */
+TSDLLEXPORT Oid
+ts_relation_get_uncompressed_relid(Oid compress_relid)
+{
+	if (!OidIsValid(compress_relid))
+	{
+		return InvalidOid;
+	}
+
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
+	init_scan_by_compress_relid(&iterator, compress_relid);
+
+	Oid relid = InvalidOid;
+	ts_scanner_start_scan(&iterator.ctx);
+	TupleInfo *ti = ts_scanner_next(&iterator.ctx);
+	if (ti)
+	{
+		bool isnull;
+		Datum datum = slot_getattr(ti->slot, Anum_compression_settings_relid, &isnull);
+		if (!isnull)
+		{
+			relid = DatumGetObjectId(datum);
+		}
+	}
+	ts_scan_iterator_close(&iterator);
+
+	return relid;
+}
+
+/*
+ * Delete entries matching the non-compressed relation.
+ */
+TSDLLEXPORT bool
+ts_compression_settings_delete(Oid relid)
 {
 	if (!OidIsValid(relid))
 	{
@@ -411,7 +475,7 @@ compression_settings_delete(Oid relid, bool by_compress_relid)
 	int count = 0;
 	ScanIterator iterator =
 		ts_scan_iterator_create(COMPRESSION_SETTINGS, RowExclusiveLock, CurrentMemoryContext);
-	compression_settings_iterator_init(&iterator, relid, by_compress_relid);
+	init_scan_by_relid(&iterator, relid);
 
 	ts_scanner_foreach(&iterator)
 	{
@@ -423,21 +487,28 @@ compression_settings_delete(Oid relid, bool by_compress_relid)
 }
 
 /*
- * Delete entries matching the non-compressed relation.
- */
-TSDLLEXPORT bool
-ts_compression_settings_delete(Oid relid)
-{
-	return compression_settings_delete(relid, false);
-}
-
-/*
  * Delete entries matching a compressed relation.
  */
 TSDLLEXPORT bool
 ts_compression_settings_delete_by_compress_relid(Oid relid)
 {
-	return compression_settings_delete(relid, true);
+	if (!OidIsValid(relid))
+	{
+		return false;
+	}
+
+	int count = 0;
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_SETTINGS, RowExclusiveLock, CurrentMemoryContext);
+	init_scan_by_compress_relid(&iterator, relid);
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+		count++;
+	}
+	return count > 0;
 }
 
 /*

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -142,6 +142,8 @@ ts_compression_settings_create(Oid relid, Oid compress_relid, ArrayType *segment
 							   ArrayType *orderby_nullsfirst, Jsonb *sparse_index);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get(Oid relid);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get_by_compress_relid(Oid relid);
+TSDLLEXPORT bool ts_relation_is_compressed_chunk_relation(Oid relid);
+TSDLLEXPORT Oid ts_relation_get_uncompressed_relid(Oid compress_relid);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_materialize(const CompressionSettings *src,
 																	 Oid relid, Oid compress_relid);
 TSDLLEXPORT bool ts_compression_settings_delete(Oid relid);

--- a/tsl/src/chunk_split.c
+++ b/tsl/src/chunk_split.c
@@ -1235,11 +1235,10 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 			.noncompressed_tupdesc = CreateTupleDescCopy(RelationGetDescr(srcrel)),
 		};
 
-		csplit_relations[0] = (SplitRelationInfo){ .relid = compress_settings->fd.compress_relid,
-												   .chunk_id = chunk->fd.compressed_chunk_id,
-												   .heap_swap = true };
+		csplit_relations[0] =
+			(SplitRelationInfo){ .relid = compress_settings->fd.compress_relid, .heap_swap = true };
 		csplit_relations[1] = (SplitRelationInfo){ .relid = new_compressed_chunk->table_id,
-												   .chunk_id = new_chunk->fd.compressed_chunk_id,
+												   .chunk_id = new_compressed_chunk->fd.id,
 												   .heap_swap = false };
 
 		Relation compressed_rel =


### PR DESCRIPTION
Replace functions with by_compress_relid arguments with clearly
named variants that are less error prone.
Also adds new function
ts_relation_is_compressed_chunk_relation(Oid) to allow checking
whether a relation is a compressed chunk relation.

Disable-check: force-changelog-file
Disable-check: approval-count