### PR TITLE
Refactor process_utility to reduce reliance on compressed_chunk_id

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1935,7 +1935,7 @@ chunk_scan_context_add_chunk(ChunkScanCtx *scanctx, ChunkStub *stub)
 }
 
 TM_Result
-ts_chunk_lock_for_creating_compressed_chunk(int32 chunk_id, int32 *compressed_chunk_id)
+ts_chunk_lock_for_creating_compressed_chunk(Chunk *chunk)
 {
 	ScanIterator iterator;
 	bool found = false;
@@ -1947,7 +1947,7 @@ ts_chunk_lock_for_creating_compressed_chunk(int32 chunk_id, int32 *compressed_ch
 	};
 
 	iterator = ts_scan_iterator_create(CHUNK, RowShareLock, CurrentMemoryContext);
-	ts_chunk_scan_iterator_set_chunk_id(&iterator, chunk_id);
+	ts_chunk_scan_iterator_set_chunk_id(&iterator, chunk->fd.id);
 	iterator.ctx.tuplock = &tuplock;
 
 	ts_scanner_foreach(&iterator)
@@ -1955,11 +1955,16 @@ ts_chunk_lock_for_creating_compressed_chunk(int32 chunk_id, int32 *compressed_ch
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		lockresult = ti->lockresult;
 
-		if (lockresult == TM_Ok && compressed_chunk_id)
+		/*
+		 * Refresh the chunk's status from the locked tuple so the caller can
+		 * recheck whether the chunk was compressed concurrently.
+		 */
+		if (lockresult == TM_Ok)
 		{
 			bool isnull;
-			Datum value = slot_getattr(ti->slot, Anum_chunk_compressed_chunk_id, &isnull);
-			*compressed_chunk_id = isnull ? INVALID_CHUNK_ID : DatumGetInt32(value);
+			Datum value = slot_getattr(ti->slot, Anum_chunk_status, &isnull);
+			Assert(!isnull);
+			chunk->fd.status = DatumGetInt32(value);
 		}
 		found = true;
 	}
@@ -1968,7 +1973,7 @@ ts_chunk_lock_for_creating_compressed_chunk(int32 chunk_id, int32 *compressed_ch
 
 	if (!found)
 	{
-		elog(ERROR, "chunk with ID %d does not exist", chunk_id);
+		elog(ERROR, "chunk with ID %d does not exist", chunk->fd.id);
 	}
 
 	return lockresult;
@@ -3130,10 +3135,11 @@ ts_chunk_exists_with_compression(int32 hypertable_id)
 	init_scan_by_hypertable_id(&iterator, hypertable_id);
 	ts_scanner_foreach(&iterator)
 	{
-		bool isnull_chunk_id =
-			slot_attisnull(ts_scan_iterator_slot(&iterator), Anum_chunk_compressed_chunk_id);
+		bool status_isnull;
+		Datum status =
+			slot_getattr(ts_scan_iterator_slot(&iterator), Anum_chunk_status, &status_isnull);
 
-		if (!isnull_chunk_id)
+		if (!status_isnull && ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED))
 		{
 			found = true;
 			break;
@@ -3141,57 +3147,6 @@ ts_chunk_exists_with_compression(int32 hypertable_id)
 	}
 	ts_scan_iterator_close(&iterator);
 	return found;
-}
-
-static void
-init_scan_by_compressed_chunk_id(ScanIterator *iterator, int32 compressed_chunk_id)
-{
-	iterator->ctx.index =
-		catalog_get_index(ts_catalog_get(), CHUNK, CHUNK_COMPRESSED_CHUNK_ID_INDEX);
-	ts_scan_iterator_scan_key_init(iterator,
-								   Anum_chunk_compressed_chunk_id_idx_compressed_chunk_id,
-								   BTEqualStrategyNumber,
-								   F_INT4EQ,
-								   Int32GetDatum(compressed_chunk_id));
-}
-
-Chunk *
-ts_chunk_get_compressed_chunk_parent(const Chunk *chunk)
-{
-	ScanIterator iterator = ts_scan_iterator_create(CHUNK, AccessShareLock, CurrentMemoryContext);
-	Oid parent_id = InvalidOid;
-
-	init_scan_by_compressed_chunk_id(&iterator, chunk->fd.id);
-
-	ts_scanner_foreach(&iterator)
-	{
-		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
-		Datum datum;
-		bool isnull;
-
-		Assert(!OidIsValid(parent_id));
-		datum = slot_getattr(ti->slot, Anum_chunk_id, &isnull);
-
-		if (!isnull)
-		{
-			parent_id = DatumGetObjectId(datum);
-		}
-	}
-
-	if (OidIsValid(parent_id))
-	{
-		return ts_chunk_get_by_id(parent_id, true);
-	}
-
-	return NULL;
-}
-
-bool
-ts_chunk_contains_compressed_data(const Chunk *chunk)
-{
-	Chunk *parent_chunk = ts_chunk_get_compressed_chunk_parent(chunk);
-
-	return parent_chunk != NULL;
 }
 
 List *

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -212,7 +212,6 @@ extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_tha
 extern TSDLLEXPORT Chunk *
 ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc, const char *schema_name,
 									 const char *table_name, Oid chunk_table_relid, bool *created);
-extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_unordered(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_partial(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_compressed(const Chunk *chunk);
@@ -222,7 +221,6 @@ extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(const Chunk
 																	 ChunkOperation cmd,
 																	 bool throw_error);
 
-extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(const Chunk *chunk);
 extern TSDLLEXPORT ChunkCompressionStatus ts_chunk_get_compression_status(int32 chunk_id);
 extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT Datum ts_chunk_status_text(PG_FUNCTION_ARGS);
@@ -236,8 +234,7 @@ extern Chunk *ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti
 												 const ChunkStub *stub,
 												 const ScanTupLock *slice_lock);
 
-extern TM_Result ts_chunk_lock_for_creating_compressed_chunk(int32 chunk_id,
-															 int32 *compressed_chunk_id);
+extern TM_Result ts_chunk_lock_for_creating_compressed_chunk(Chunk *chunk);
 extern ScanIterator ts_chunk_scan_iterator_create(MemoryContext result_mcxt);
 extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -178,8 +178,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 
 			DEBUG_WAITPOINT("insert_create_compressed");
 
-			lockres = ts_chunk_lock_for_creating_compressed_chunk(chunk->fd.id,
-																  &chunk->fd.compressed_chunk_id);
+			lockres = ts_chunk_lock_for_creating_compressed_chunk(chunk);
 
 			/*
 			 * Since the locking function blocks and follows the update chain,
@@ -191,15 +190,14 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 				   "compressed chunk. Lock result %d",
 				   lockres);
 
-			/* recheck whether compressed chunk exists after acquiring the lock */
-			if (!chunk->fd.compressed_chunk_id)
+			/* recheck whether the chunk got compressed after acquiring the lock */
+			if (!ts_chunk_is_compressed(chunk))
 			{
 				Hypertable *compressed_ht =
 					ts_hypertable_get_by_id(ctr->hypertable->fd.compressed_hypertable_id);
 				Chunk *compressed_chunk =
 					ts_cm_functions->compression_chunk_create(compressed_ht, chunk);
 				ts_chunk_set_compressed_chunk(chunk, compressed_chunk->fd.id);
-				chunk->fd.compressed_chunk_id = compressed_chunk->fd.id;
 				created_compressed_chunk = true;
 
 				/* mark chunk as partial unless completely new chunk */

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -57,6 +57,7 @@
 #include "partitioning.h"
 #include "planner/planner.h"
 #include "sort_transform.h"
+#include "ts_catalog/compression_settings.h"
 #include "utils.h"
 
 #include "compat/compat.h"
@@ -1744,26 +1745,18 @@ replace_modify_hypertable_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 			/* Check for DML on chunk directly */
 			if (!ht)
 			{
-				Chunk *chunk = ts_chunk_get_by_relid(rte->relid, false);
-				if (!chunk)
+				/*
+				 * For operations on internal compressed chunks we block modifications
+				 * if the chunk belongs to a frozen chunk.
+				 * Direct modifications of uncompressed chunks is intercepted by chunk
+				 * tuple routing.
+				 * In all other cases of direct modification of chunks we dont interfere
+				 * and do not add a ModifyHypertable node.
+				 */
+				Oid uncompressed_relid = ts_relation_get_uncompressed_relid(rte->relid);
+				if (OidIsValid(uncompressed_relid))
 				{
-					/* Not a hypertable or chunk, continue */
-					new_pathlist = lappend(new_pathlist, path);
-					continue;
-				}
-
-				ht = ts_hypertable_get_by_id(chunk->fd.hypertable_id);
-				if (ht->fd.compression_state == HypertableInternalCompressionTable)
-				{
-					/*
-					 * For operations on internal compressed chunks we block modifications
-					 * if the chunk belongs to a frozen chunk.
-					 * Direct modifications of uncompressed chunks is intercepted by chunk
-					 * tuple routing.
-					 * In all other cases of direct modification of chunks we dont interfere
-					 * and do not add a ModifyHypertable node.
-					 */
-					Chunk *uncompressed = ts_chunk_get_compressed_chunk_parent(chunk);
+					Chunk *uncompressed = ts_chunk_get_by_relid(uncompressed_relid, true);
 					if (ts_chunk_is_frozen(uncompressed))
 					{
 						ereport(ERROR,
@@ -1775,6 +1768,16 @@ replace_modify_hypertable_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 					new_pathlist = lappend(new_pathlist, path);
 					continue;
 				}
+
+				int32 hypertable_id = ts_chunk_get_hypertable_id_by_reloid(rte->relid);
+				if (hypertable_id == INVALID_HYPERTABLE_ID)
+				{
+					/* Not a hypertable or chunk, continue */
+					new_pathlist = lappend(new_pathlist, path);
+					continue;
+				}
+
+				ht = ts_hypertable_get_by_id(hypertable_id);
 			}
 
 			switch (mt->operation)

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -867,24 +867,15 @@ process_copy(ProcessUtilityArgs *args)
 
 		if (!ht)
 		{
-			Chunk *chunk = ts_chunk_get_by_relid(relid, false);
-
-			/* target is neither hypertable nor chunk so let postgres handle it */
-			if (!chunk)
+			/*
+			 * For operations on internal compressed chunks we block modifications
+			 * if the chunk belongs to a frozen chunk otherwise let postgres handle it.
+			 * Uncompressed frozen chunks are intercepted as part of tuple routing.
+			 */
+			Oid uncompressed_relid = ts_relation_get_uncompressed_relid(relid);
+			if (OidIsValid(uncompressed_relid))
 			{
-				ts_cache_release(&hcache);
-				return DDL_CONTINUE;
-			}
-
-			ht = ts_hypertable_get_by_id(chunk->fd.hypertable_id);
-			if (ht->fd.compression_state == HypertableInternalCompressionTable)
-			{
-				/*
-				 * For operations on internal compressed chunks we block modifications
-				 * if the chunk belongs to a frozen chunk otherwise let postgres handle it.
-				 * Uncompressed frozen chunks are intercepted as part of tuple routing.
-				 */
-				Chunk *uncompressed = ts_chunk_get_compressed_chunk_parent(chunk);
+				Chunk *uncompressed = ts_chunk_get_by_relid(uncompressed_relid, true);
 				if (ts_chunk_is_frozen(uncompressed))
 				{
 					ereport(ERROR,
@@ -896,6 +887,16 @@ process_copy(ProcessUtilityArgs *args)
 				ts_cache_release(&hcache);
 				return DDL_CONTINUE;
 			}
+
+			/* target is neither hypertable nor chunk so let postgres handle it */
+			int32 hypertable_id = ts_chunk_get_hypertable_id_by_reloid(relid);
+			if (hypertable_id == INVALID_HYPERTABLE_ID)
+			{
+				ts_cache_release(&hcache);
+				return DDL_CONTINUE;
+			}
+
+			ht = ts_hypertable_get_by_id(hypertable_id);
 		}
 	}
 
@@ -1154,13 +1155,13 @@ add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
 	ctx->chunk_rels = lappend(ctx->chunk_rels, chunk_vacuum_rel);
 
 	/* If we have a compressed chunk make sure to analyze it as well */
-	if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+	if (ts_chunk_is_compressed(chunk))
 	{
-		Chunk *comp_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, false);
+		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
 		/* Compressed chunk might be missing due to concurrent operations */
-		if (comp_chunk)
+		if (OidIsValid(compressed_relid))
 		{
-			chunk_vacuum_rel = makeVacuumRelation(NULL, comp_chunk->table_id, NIL);
+			chunk_vacuum_rel = makeVacuumRelation(NULL, compressed_relid, NIL);
 			ctx->chunk_rels = lappend(ctx->chunk_rels, chunk_vacuum_rel);
 		}
 	}
@@ -1565,17 +1566,18 @@ process_truncate(ProcessUtilityArgs *args)
 							ts_continuous_agg_invalidate_chunk(ht, chunk);
 						}
 						/* Truncate the compressed chunk too */
-						if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+						if (ts_chunk_is_compressed(chunk))
 						{
-							Chunk *compressed_chunk =
-								ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, false);
-							if (compressed_chunk != NULL)
+							Oid compressed_relid =
+								ts_relation_get_compressed_relid(chunk->table_id);
+							if (OidIsValid(compressed_relid))
 							{
 								/* Create list item into the same context of the list. */
 								oldctx = MemoryContextSwitchTo(parsetreectx);
-								rv = makeRangeVar(NameStr(compressed_chunk->fd.schema_name),
-												  NameStr(compressed_chunk->fd.table_name),
-												  -1);
+								char *schema_name =
+									get_namespace_name(get_rel_namespace(compressed_relid));
+								char *table_name = get_rel_name(compressed_relid);
+								rv = makeRangeVar(schema_name, table_name, -1);
 								MemoryContextSwitchTo(oldctx);
 								list_changed = true;
 							}
@@ -1712,7 +1714,7 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 		{
 			Hypertable *ht;
 
-			if (ts_chunk_contains_compressed_data(chunk))
+			if (ts_relation_is_compressed_chunk_relation(chunk->table_id))
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1723,13 +1725,13 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 
 			/* if cascade is enabled, delete the compressed chunk with cascade too. Otherwise
 			 *  it would be blocked if there are dependent objects */
-			if (stmt->behavior == DROP_CASCADE && chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+			if (stmt->behavior == DROP_CASCADE && ts_chunk_is_compressed(chunk))
 			{
-				Chunk *compressed_chunk =
-					ts_chunk_get_by_id_with_slice_lock(chunk->fd.compressed_chunk_id,
-													   AccessExclusiveLock,
-													   &slice_lock,
-													   false);
+				Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
+				Chunk *compressed_chunk = ts_chunk_get_by_relid_locked(compressed_relid,
+																	   AccessExclusiveLock,
+																	   &slice_lock,
+																	   false);
 				/* The chunk may have been delete by a CASCADE */
 				if (compressed_chunk != NULL)
 				{
@@ -4762,14 +4764,7 @@ process_altertable_end_index(Node *parsetree, CollectedCommand *cmd)
 static void
 process_altertable_chunk_propagate_to_compressed(AlterTableCmd *cmd, Oid relid)
 {
-	Chunk *chunk = ts_chunk_get_by_relid(relid, false);
-
-	if (chunk == NULL)
-	{
-		return;
-	}
-
-	if (ts_chunk_contains_compressed_data(chunk))
+	if (ts_relation_is_compressed_chunk_relation(relid))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -4778,12 +4773,12 @@ process_altertable_chunk_propagate_to_compressed(AlterTableCmd *cmd, Oid relid)
 						 "instead.")));
 	}
 
-	/* set tablespace for compressed chunk */
-	if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
-	{
-		Chunk *compressed_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
+	Oid compressed_relid = ts_relation_get_compressed_relid(relid);
 
-		AlterTableInternal(compressed_chunk->table_id, list_make1(cmd), false);
+	/* set tablespace for compressed chunk */
+	if (OidIsValid(compressed_relid))
+	{
+		AlterTableInternal(compressed_relid, list_make1(cmd), false);
 	}
 }
 

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -504,6 +504,41 @@ ts_relation_get_uncompressed_relid(Oid compress_relid)
 }
 
 /*
+ * Get the OID of the relation holding the compressed data given the OID of the
+ * uncompressed relation.
+ *
+ * Returns InvalidOid if relid is not compressed.
+ */
+TSDLLEXPORT Oid
+ts_relation_get_compressed_relid(Oid relid)
+{
+	if (!OidIsValid(relid))
+	{
+		return InvalidOid;
+	}
+
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
+	init_scan_by_relid(&iterator, relid);
+
+	Oid compress_relid = InvalidOid;
+	ts_scanner_start_scan(&iterator.ctx);
+	TupleInfo *ti = ts_scanner_next(&iterator.ctx);
+	if (ti)
+	{
+		bool isnull;
+		Datum datum = slot_getattr(ti->slot, Anum_compression_settings_compress_relid, &isnull);
+		if (!isnull)
+		{
+			compress_relid = DatumGetObjectId(datum);
+		}
+	}
+	ts_scan_iterator_close(&iterator);
+
+	return compress_relid;
+}
+
+/*
  * Delete entries matching the non-compressed relation.
  */
 TSDLLEXPORT bool

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -144,6 +144,8 @@ TSDLLEXPORT CompressionSettings *ts_compression_settings_get(Oid relid);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get_by_compress_relid(Oid relid);
 TSDLLEXPORT bool ts_relation_is_compressed_chunk_relation(Oid relid);
 TSDLLEXPORT Oid ts_relation_get_uncompressed_relid(Oid compress_relid);
+TSDLLEXPORT Oid ts_relation_get_compressed_relid(Oid relid);
+
 TSDLLEXPORT CompressionSettings *ts_compression_settings_materialize(const CompressionSettings *src,
 																	 Oid relid, Oid compress_relid);
 TSDLLEXPORT bool ts_compression_settings_delete(Oid relid);

--- a/tsl/src/chunk_merge.c
+++ b/tsl/src/chunk_merge.c
@@ -715,7 +715,8 @@ merge_relinfos(RelationMergeInfo *relinfos, int nrelids, int mergeindex, LOCKMOD
 	}
 
 	stats->relid = result_minfo->relid;
-	stats->chunk_id = result_minfo->chunk->fd.id;
+	/* Compressed relinfos carry no Chunk */
+	stats->chunk_id = result_minfo->chunk ? result_minfo->chunk->fd.id : INVALID_CHUNK_ID;
 
 	Oid tablespace = result_rel->rd_rel->reltablespace;
 	struct VacuumCutoffs *merged_cutoffs = &result_minfo->cutoffs;
@@ -838,8 +839,7 @@ relock_rel(const Relation hyper_rel, RelationMergeInfo *rmi, LOCKMODE lockmode)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-				 errmsg("chunk \"%s\" was removed concurrently",
-						NameStr(rmi->chunk->fd.table_name))));
+				 errmsg("chunk \"%s\" was removed concurrently", get_rel_name(rmi->relid))));
 	}
 
 	/* Re-lock toast tables, heap swap expects it */
@@ -1234,9 +1234,9 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 		 * order below, because the compressed relations need to be in the
 		 * same order.
 		 */
-		if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		if (ts_chunk_is_compressed(chunk))
 		{
-			Oid crelid = ts_chunk_get_relid(chunk->fd.compressed_chunk_id, false);
+			Oid crelid = ts_relation_get_compressed_relid(chunk->table_id);
 			Relation crel = table_open(crelid, lockmode);
 			rellocks = append_rellock(rellocks, crel, lockmode, merge_cxt);
 			table_close(crel, NoLock);
@@ -1355,19 +1355,12 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 		 * Fill in the compressed mergerelinfo array here after final sort of
 		 * rels so that the two arrays have the same order.
 		 */
-		if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		if (ts_chunk_is_compressed(chunk))
 		{
 			RelationMergeInfo *crelinfo = &crelinfos[i];
-			Chunk *cchunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
-			/*
-			 * Allocate on merge_cxt to survive transaction end in
-			 * concurrent mode.
-			 */
-			MemoryContext old_mcxt = MemoryContextSwitchTo(merge_cxt);
-			crelinfo->chunk = ts_chunk_copy(cchunk);
-			MemoryContextSwitchTo(old_mcxt);
-
-			crelinfo->relid = crelinfo->chunk->table_id;
+			/* Merging the compressed relation only needs its relid, not a full Chunk. */
+			crelinfo->chunk = NULL;
+			crelinfo->relid = ts_relation_get_compressed_relid(chunk->table_id);
 			crelinfo->rel = table_open(crelinfo->relid, lockmode);
 			crelinfo->isresult = relinfos[i].isresult;
 			crelinfo->iscompressed_rel = true;
@@ -1395,7 +1388,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 		const CompressionSettings *result_settings = NULL;
 		const Chunk *result_chunk = relinfos[mergeindex].chunk;
 
-		if (result_chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
+		if (ts_chunk_is_compressed(result_chunk))
 		{
 			result_settings = ts_compression_settings_get(result_chunk->table_id);
 		}
@@ -1405,7 +1398,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 			const Chunk *chunk = relinfos[i].chunk;
 			const CompressionSettings *settings;
 
-			if (i == mergeindex || chunk->fd.compressed_chunk_id == INVALID_CHUNK_ID)
+			if (i == mergeindex || !ts_chunk_is_compressed(chunk))
 			{
 				continue;
 			}

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -314,7 +314,7 @@ find_chunk_to_merge_into(Hypertable *ht, Chunk *current_chunk)
 	/* If there is no previous adjacent chunk along the time dimension or
 	 * if it hasn't been compressed yet, we can't merge.
 	 */
-	if (!previous_chunk || !OidIsValid(previous_chunk->fd.compressed_chunk_id))
+	if (!previous_chunk || !ts_chunk_is_compressed(previous_chunk))
 	{
 		return NULL;
 	}
@@ -633,7 +633,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 		elog(ERROR, "hypertable and chunk do not match");
 	}
 
-	if (uncompressed_chunk->fd.compressed_chunk_id == INVALID_CHUNK_ID)
+	if (!ts_chunk_is_compressed(uncompressed_chunk))
 	{
 		ts_cache_release(&hcache);
 		ereport((if_compressed ? NOTICE : ERROR),
@@ -736,7 +736,7 @@ is_chunk_orderby_nonnullable(CompressionSettings *settings)
 }
 
 static bool
-recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
+recompress_chunk_impl(Chunk *chunk, bool recompress)
 {
 	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
 	bool recompressed = false;
@@ -792,7 +792,7 @@ recompress_chunk_impl(Chunk *chunk, Oid *uncompressed_chunk_id, bool recompress)
 				 NameStr(chunk->fd.schema_name),
 				 NameStr(chunk->fd.table_name));
 		}
-		*uncompressed_chunk_id = recompress_chunk_segmentwise_impl(chunk, nullable_orderby);
+		recompress_chunk_segmentwise_impl(chunk, nullable_orderby);
 		recompressed = true;
 	}
 	else
@@ -892,25 +892,25 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 Datum
 tsl_compress_chunk(PG_FUNCTION_ARGS)
 {
-	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	Oid uncompressed_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_not_compressed = PG_ARGISNULL(1) ? true : PG_GETARG_BOOL(1);
 	bool recompress = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();
-	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
+	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_relid, true);
 	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 
-	uncompressed_chunk_id = tsl_compress_chunk_wrapper(chunk, if_not_compressed, recompress);
+	uncompressed_relid = tsl_compress_chunk_wrapper(chunk, if_not_compressed, recompress);
 
-	PG_RETURN_OID(uncompressed_chunk_id);
+	PG_RETURN_OID(uncompressed_relid);
 }
 
 Oid
 tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress)
 {
-	Oid uncompressed_chunk_id = chunk->table_id;
+	Oid uncompressed_relid = chunk->table_id;
 
 	if (ts_chunk_is_frozen(chunk))
 	{
@@ -920,19 +920,19 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 						NameStr(chunk->fd.schema_name),
 						NameStr(chunk->fd.table_name)),
 				 errhint("Use _timescaledb_functions.unfreeze_chunk to unfreeze.")));
-		return uncompressed_chunk_id;
+		return uncompressed_relid;
 	}
 
 	write_logical_replication_msg_compression_start();
 
 	if (ts_chunk_needs_compression(chunk))
 	{
-		uncompressed_chunk_id = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+		uncompressed_relid = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
 	}
 	else if (recompress || ts_chunk_needs_recompression(chunk))
 	{
 		/* Try in-memory recompression first and then fall back to decompress/recompress */
-		bool recompressed = recompress_chunk_impl(chunk, &uncompressed_chunk_id, recompress);
+		bool recompressed = recompress_chunk_impl(chunk, recompress);
 		if (!recompressed)
 		{
 			/* TODO: move away from manual decompression/compression */
@@ -954,13 +954,13 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 	}
 
 	write_logical_replication_msg_compression_end();
-	return uncompressed_chunk_id;
+	return uncompressed_relid;
 }
 
 Datum
 tsl_decompress_chunk(PG_FUNCTION_ARGS)
 {
-	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	Oid uncompressed_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_compressed = PG_ARGISNULL(1) ? true : PG_GETARG_BOOL(1);
 	int32 chunk_id;
 
@@ -968,7 +968,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
-	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
+	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_relid, true);
 	chunk_id = uncompressed_chunk->fd.id;
 
 	Hypertable *ht = ts_hypertable_get_by_id(uncompressed_chunk->fd.hypertable_id);
@@ -986,7 +986,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 		ereport((if_compressed ? NOTICE : ERROR),
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s\" is not converted to columnstore",
-						get_rel_name(uncompressed_chunk_id))));
+						get_rel_name(uncompressed_relid))));
 
 		PG_RETURN_NULL();
 	}
@@ -1001,7 +1001,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 	 */
 	ts_chunk_column_stats_reset_by_chunk_id(chunk_id);
 
-	PG_RETURN_OID(uncompressed_chunk_id);
+	PG_RETURN_OID(uncompressed_relid);
 }
 
 static bool
@@ -1147,9 +1147,9 @@ extern Datum
 tsl_get_compressed_chunk_index_for_recompression(PG_FUNCTION_ARGS)
 {
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
-	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	Oid uncompressed_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 
-	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
+	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_relid, true);
 
 	Oid index_oid = get_compressed_chunk_index_for_recompression(uncompressed_chunk);
 
@@ -1166,9 +1166,14 @@ tsl_get_compressed_chunk_index_for_recompression(PG_FUNCTION_ARGS)
 static Oid
 get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 {
-	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
+	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
+	if (!OidIsValid(compressed_relid))
+	{
+		return InvalidOid;
+	}
+
 	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
-	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, AccessShareLock);
+	Relation compressed_chunk_rel = table_open(compressed_relid, AccessShareLock);
 
 	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
 

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -80,18 +80,18 @@ static void try_updating_chunk_status(Chunk *uncompressed_chunk, Relation uncomp
  * that are affected by the addition of newer data. The existing
  * compressed chunk will not be recreated but modified in place.
  *
- * 0 uncompressed_chunk_id REGCLASS
+ * 0 uncompressed_relid REGCLASS
  * 1 if_not_compressed BOOL = false
  */
 Datum
 tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 {
-	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	Oid uncompressed_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_not_compressed = PG_ARGISNULL(1) ? true : PG_GETARG_BOOL(1);
 
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
-	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
+	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_relid, true);
 	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 
 	if (!ts_chunk_is_partial(chunk))
@@ -113,7 +113,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 							"enable it by first setting "
 							"timescaledb.enable_segmentwise_recompression to on")));
 		}
-		CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk_id);
+		CompressionSettings *settings = ts_compression_settings_get(uncompressed_relid);
 		if (!settings->fd.orderby)
 		{
 			ereport(ERROR,
@@ -131,10 +131,10 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 				 NameStr(chunk->fd.schema_name),
 				 NameStr(chunk->fd.table_name));
 		}
-		uncompressed_chunk_id = recompress_chunk_segmentwise_impl(chunk, nullable_orderby);
+		recompress_chunk_segmentwise_impl(chunk, nullable_orderby);
 	}
 
-	PG_RETURN_OID(uncompressed_chunk_id);
+	PG_RETURN_OID(uncompressed_relid);
 }
 
 static RecompressContext *
@@ -240,11 +240,11 @@ free_chunk_recompress_ctx(RecompressContext *recompress_ctx)
 	pfree(recompress_ctx);
 }
 
-Oid
+void
 recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 								  bool fullrecompress /* do full decompress/compress segmentwise */)
 {
-	Oid uncompressed_chunk_id = uncompressed_chunk->table_id;
+	Oid uncompressed_relid = uncompressed_chunk->table_id;
 
 	/*
 	 * only proceed if status in (3, 9, 11)
@@ -264,7 +264,6 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 	}
 
 	/* need it to find the segby cols from the catalog */
-	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
 	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
 
 	/* We should not do segment-wise recompression with empty orderby, see #7748
@@ -281,13 +280,13 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 	/* lock both chunks, compressed and uncompressed */
 	Relation uncompressed_chunk_rel =
 		table_open(uncompressed_chunk->table_id, recompression_lockmode);
-	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, recompression_lockmode);
+	Relation compressed_chunk_rel = table_open(settings->fd.compress_relid, recompression_lockmode);
 
 	bool has_unique_constraints =
 		ts_indexing_relation_has_primary_or_unique_index(uncompressed_chunk_rel);
 	int count;
 	LOCKTAG locktag;
-	SET_LOCKTAG_RELATION(locktag, MyDatabaseId, uncompressed_chunk_id);
+	SET_LOCKTAG_RELATION(locktag, MyDatabaseId, uncompressed_relid);
 
 	/*
 	 * Recompression does not block inserts but it can interfere with
@@ -313,7 +312,7 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 			table_close(uncompressed_chunk_rel, NoLock);
 			table_close(compressed_chunk_rel, NoLock);
 
-			PG_RETURN_OID(uncompressed_chunk_id);
+			return;
 		}
 	}
 
@@ -745,8 +744,6 @@ finish:
 
 	table_close(uncompressed_chunk_rel, NoLock);
 	table_close(compressed_chunk_rel, NoLock);
-
-	PG_RETURN_OID(uncompressed_chunk_id);
 }
 
 /*

--- a/tsl/src/compression/recompress.h
+++ b/tsl/src/compression/recompress.h
@@ -30,7 +30,7 @@ typedef struct RecompressContext
 
 extern Datum tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS);
 
-Oid recompress_chunk_segmentwise_impl(Chunk *chunk, bool fullrecompress);
+void recompress_chunk_segmentwise_impl(Chunk *chunk, bool fullrecompress);
 bool recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk);
 void rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force);
 

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -1205,7 +1205,7 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 	SortInfo sort_info =
 		build_sortinfo(root, chunk, chunk_rel, compression_info, root->query_pathkeys);
 
-	Assert(chunk->fd.compressed_chunk_id > 0);
+	Assert(ts_chunk_is_compressed(chunk));
 
 	List *uncompressed_table_pathlist = chunk_rel->pathlist;
 	List *uncompressed_table_parallel_pathlist = chunk_rel->partial_pathlist;

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -143,18 +143,9 @@ tsl_move_chunk(PG_FUNCTION_ARGS)
 						"are required")));
 	}
 
-	chunk = ts_chunk_get_by_relid(chunk_id, false);
-
-	if (NULL == chunk)
+	if (ts_relation_is_compressed_chunk_relation(chunk_id))
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("\"%s\" is not a chunk", get_rel_name(chunk_id))));
-	}
-
-	if (ts_chunk_contains_compressed_data(chunk))
-	{
-		Chunk *chunk_parent = ts_chunk_get_compressed_chunk_parent(chunk);
+		Oid uncompressed_relid = ts_relation_get_uncompressed_relid(chunk_id);
 
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -162,15 +153,24 @@ tsl_move_chunk(PG_FUNCTION_ARGS)
 				 errdetail("Chunk \"%s\" contains columnstore data for chunk \"%s\" and cannot be "
 						   "moved directly.",
 						   get_rel_name(chunk_id),
-						   get_rel_name(chunk_parent->table_id)),
+						   get_rel_name(uncompressed_relid)),
 				 errhint("Moving chunk \"%s\" will also move the columnstore data.",
-						 get_rel_name(chunk_parent->table_id))));
+						 get_rel_name(uncompressed_relid))));
+	}
+
+	chunk = ts_chunk_get_by_relid(chunk_id, false);
+
+	if (!chunk)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("\"%s\" is not a chunk", get_rel_name(chunk_id))));
 	}
 
 	/* If chunk is compressed move it by altering tablespace on both chunks */
 	if (ts_chunk_is_compressed(chunk))
 	{
-		CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+		Oid compressed_relid = ts_relation_get_compressed_relid(chunk_id);
 		AlterTableCmd cmd = { .type = T_AlterTableCmd,
 							  .subtype = AT_SetTableSpace,
 							  .name = get_tablespace_name(destination_tablespace) };
@@ -184,13 +184,13 @@ tsl_move_chunk(PG_FUNCTION_ARGS)
 		}
 
 		ts_alter_table_with_event_trigger(chunk_id, fcinfo->context, list_make1(&cmd), false);
-		ts_alter_table_with_event_trigger(settings->fd.compress_relid,
+		ts_alter_table_with_event_trigger(compressed_relid,
 										  fcinfo->context,
 										  list_make1(&cmd),
 										  false);
 		/* move indexes on original and compressed chunk */
 		ts_chunk_index_move_all(chunk_id, index_destination_tablespace);
-		ts_chunk_index_move_all(settings->fd.compress_relid, index_destination_tablespace);
+		ts_chunk_index_move_all(compressed_relid, index_destination_tablespace);
 	}
 	else
 	{

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -919,3 +919,19 @@ FROM show_chunks('segwise_uaf_scankeys') c; -- should not segfault
 
 RESET maintenance_work_mem;
 DROP TABLE segwise_uaf_scankeys;
+-- get_compressed_chunk_index_for_recompression on an uncompressed chunk
+-- returns NULL instead of raising an internal error
+CREATE TABLE uncompressed_index (time timestamptz not null, a int);
+SELECT create_hypertable('uncompressed_index', 'time');
+        create_hypertable         
+----------------------------------
+ (31,public,uncompressed_index,t)
+
+INSERT INTO uncompressed_index VALUES ('2024-01-01', 1);
+SELECT _timescaledb_functions.get_compressed_chunk_index_for_recompression(c)
+FROM show_chunks('uncompressed_index') c;
+ get_compressed_chunk_index_for_recompression 
+----------------------------------------------
+ 
+
+DROP TABLE uncompressed_index;

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -590,4 +590,13 @@ FROM show_chunks('segwise_uaf_scankeys') c; -- should not segfault
 RESET maintenance_work_mem;
 DROP TABLE segwise_uaf_scankeys;
 
+-- get_compressed_chunk_index_for_recompression on an uncompressed chunk
+-- returns NULL instead of raising an internal error
+CREATE TABLE uncompressed_index (time timestamptz not null, a int);
+SELECT create_hypertable('uncompressed_index', 'time');
+INSERT INTO uncompressed_index VALUES ('2024-01-01', 1);
+SELECT _timescaledb_functions.get_compressed_chunk_index_for_recompression(c)
+FROM show_chunks('uncompressed_index') c;
+DROP TABLE uncompressed_index;
+
 


### PR DESCRIPTION
Using oid directly in process_utility allows us to skip some
catalog scans we would otherwise do when instantiating Chunk
object.

Disable-check: force-changelog-file