### PR TITLE
Refactor code to reduce reliance on compressed_chunk_id

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2991,9 +2991,9 @@ chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool detach)
 		ts_chunk_rewrite_delete(relid, false);
 	}
 
-	if (form.compressed_chunk_id != INVALID_CHUNK_ID)
+	if (ts_flags_are_set_32(DatumGetInt32(form.status), CHUNK_STATUS_COMPRESSED))
 	{
-		Chunk *compressed_chunk = ts_chunk_get_by_id(form.compressed_chunk_id, false);
+		Oid compressed_relid = ts_relation_get_compressed_relid(relid);
 
 		if (OidIsValid(relid))
 		{
@@ -3001,11 +3001,11 @@ chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool detach)
 		}
 
 		/* The chunk may have been deleted by a CASCADE */
-		if (compressed_chunk != NULL)
+		if (OidIsValid(compressed_relid))
 		{
 			/* Plain drop without preserving catalog row because this is the compressed
 			 * chunk */
-			ts_chunk_drop(compressed_chunk, behavior, DEBUG1);
+			ts_chunk_drop_by_relid(compressed_relid, behavior, DEBUG1);
 		}
 	}
 	else if (OidIsValid(relid))
@@ -3823,6 +3823,32 @@ ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level)
 
 	/* Evict the chunk stats from the shared memory */
 	ts_stats_chunk_evict(chunk->table_id);
+}
+
+void
+ts_chunk_drop_by_relid(Oid relid, DropBehavior behavior, int32 log_level)
+{
+	ObjectAddress objaddr = {
+		.classId = RelationRelationId,
+		.objectId = relid,
+	};
+
+	const char *schema_name = get_namespace_name(get_rel_namespace(relid));
+	const char *table_name = get_rel_name(relid);
+
+	if (log_level >= 0)
+	{
+		elog(log_level, "dropping chunk %s.%s", schema_name, table_name);
+	}
+
+	/* Remove the chunk from the chunk table */
+	ts_chunk_delete_by_relid_and_relname(relid, schema_name, table_name, behavior);
+
+	/* Drop the table */
+	performDeletion(&objaddr, behavior, 0);
+
+	/* Evict the chunk stats from the shared memory */
+	ts_stats_chunk_evict(relid);
 }
 
 static void

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -206,6 +206,7 @@ extern TSDLLEXPORT bool ts_chunk_is_frozen(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id);
 extern TSDLLEXPORT bool ts_chunk_clear_compressed_chunk(Chunk *chunk);
 extern TSDLLEXPORT void ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level);
+extern TSDLLEXPORT void ts_chunk_drop_by_relid(Oid relid, DropBehavior behavior, int32 log_level);
 extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than,
 												 int32 log_level, Oid time_type, Oid arg_type,
 												 bool older_newer);

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -195,9 +195,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 			{
 				Hypertable *compressed_ht =
 					ts_hypertable_get_by_id(ctr->hypertable->fd.compressed_hypertable_id);
-				Chunk *compressed_chunk =
-					ts_cm_functions->compression_chunk_create(compressed_ht, chunk);
-				ts_chunk_set_compressed_chunk(chunk, compressed_chunk->fd.id);
+				ts_cm_functions->compression_chunk_create(compressed_ht, chunk);
 				created_compressed_chunk = true;
 
 				/* mark chunk as partial unless completely new chunk */

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -138,7 +138,7 @@ typedef struct CrossModuleFunctions
 								TupleTableSlot *slot);
 	void (*compressor_flush)(RowCompressor *compressor, BulkWriter *bulk_writer);
 	void (*compressor_close)(RowCompressor *compressor, BulkWriter *bulk_writer);
-	Chunk *(*compression_chunk_create)(Hypertable *ht, Chunk *src_chunk);
+	void (*compression_chunk_create)(Hypertable *ht, Chunk *src_chunk);
 
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1728,14 +1728,11 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 			if (stmt->behavior == DROP_CASCADE && ts_chunk_is_compressed(chunk))
 			{
 				Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
-				Chunk *compressed_chunk = ts_chunk_get_by_relid_locked(compressed_relid,
-																	   AccessExclusiveLock,
-																	   &slice_lock,
-																	   false);
 				/* The chunk may have been delete by a CASCADE */
-				if (compressed_chunk != NULL)
+				if (OidIsValid(compressed_relid))
 				{
-					ts_chunk_drop(compressed_chunk, stmt->behavior, DEBUG1);
+					LockRelationOid(compressed_relid, AccessExclusiveLock);
+					ts_chunk_drop_by_relid(compressed_relid, stmt->behavior, DEBUG1);
 				}
 			}
 

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -189,24 +189,24 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+----------------+---------------------+--------+-----------
-  2 |             2 | _timescaledb_internal | new_chunk_name |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id |      schema_name      |   table_name   | status | osm_chunk 
+----+---------------+-----------------------+----------------+--------+-----------
+  2 |             2 | _timescaledb_internal | new_chunk_name |      0 | f
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+----------------+---------------------+--------+-----------
-  2 |             2 | public      | new_chunk_name |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id | schema_name |   table_name   | status | osm_chunk 
+----+---------------+-------------+----------------+--------+-----------
+  2 |             2 | public      | new_chunk_name |      0 | f
 
 -- Test that we cannot rename chunk columns
 \set ON_ERROR_STOP 0
@@ -634,11 +634,11 @@ SELECT * from _timescaledb_catalog.hypertable;
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
  12 | public      | my_table   | new_associated_schema  | _hyper_12               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+--------------------+---------------------+--------+-----------
- 24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     |      0 | f
- 25 |            12 | new_associated_schema | _hyper_12_25_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk from _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |     table_name     | status | osm_chunk 
+----+---------------+-----------------------+--------------------+--------+-----------
+ 24 |            12 | new_associated_schema | _hyper_12_24_chunk |      0 | f
+ 25 |            12 | new_associated_schema | _hyper_12_25_chunk |      0 | f
 
 DROP TABLE my_table;
 -- test renaming unique constraints/indexes

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -505,13 +505,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
 ----+-------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
  10 | test_schema | test_migrate | _timescaledb_internal  | _hyper_10               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-select id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+--------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     |      0 | f
-  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |                     |      0 | f
-  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |                     |      0 | f
- 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |                     |      0 | f
+select id, hypertable_id, schema_name, table_name, status, osm_chunk from _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |     table_name     | status | osm_chunk 
+----+---------------+-----------------------+--------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |      0 | f
+  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |      0 | f
+  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |      0 | f
+ 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |      0 | f
 
 select * from test_schema.test_migrate;
            time           | temp 

--- a/test/expected/drop_owned-15.out
+++ b/test/expected/drop_owned-15.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | status | osm_chunk 
+----+---------------+-------------+------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_owned-16.out
+++ b/test/expected/drop_owned-16.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | status | osm_chunk 
+----+---------------+-------------+------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_owned-17.out
+++ b/test/expected/drop_owned-17.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | status | osm_chunk 
+----+---------------+-------------+------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_owned-18.out
+++ b/test/expected/drop_owned-18.out
@@ -26,11 +26,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
@@ -38,10 +38,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 ----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |      0 | f
 
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
@@ -49,9 +49,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | status | osm_chunk 
+----+---------------+-------------+------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -31,11 +31,11 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | test1      | chunk_schema1          | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+---------------+------------------+---------------------+--------+-----------
-  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     |      0 | f
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |  schema_name  |    table_name    | status | osm_chunk 
+----+---------------+---------------+------------------+--------+-----------
+  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |      0 | f
+  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |      0 | f
 
 RESET ROLE;
 --drop the associated schema. We drop the extra schema to show we can
@@ -52,18 +52,18 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
   1 | hypertable_schema | test1      | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
   2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+---------------+------------------+---------------------+--------+-----------
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |  schema_name  |    table_name    | status | osm_chunk 
+----+---------------+---------------+------------------+--------+-----------
+  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |      0 | f
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
 
 RESET ROLE;
 --dropping the internal schema should not work
@@ -80,9 +80,9 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | status 
 ----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | status | osm_chunk 
+----+---------------+-------------+------------+--------+-----------
 
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 

--- a/test/expected/insert-15.out
+++ b/test/expected/insert-15.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert-16.out
+++ b/test/expected/insert-16.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert-17.out
+++ b/test/expected/insert-17.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert-18.out
+++ b/test/expected/insert-18.out
@@ -154,13 +154,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |      0 | f
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -229,23 +229,23 @@ SELECT * FROM "1dim_neg";
    19 | 21.2
    20 | 21.2
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+-------------------+---------------------+--------+-----------
-  1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     |      0 | f
-  2 |             1 | one_Partition         | _hyper_1_2_chunk  |                     |      0 | f
-  3 |             1 | one_Partition         | _hyper_1_3_chunk  |                     |      0 | f
-  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |                     |      0 | f
-  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |                     |      0 | f
-  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |                     |      0 | f
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |                     |      0 | f
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |                     |      0 | f
- 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |                     |      0 | f
- 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |                     |      0 | f
- 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |                     |      0 | f
- 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |                     |      0 | f
- 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |                     |      0 | f
- 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name     | status | osm_chunk 
+----+---------------+-----------------------+-------------------+--------+-----------
+  1 |             1 | one_Partition         | _hyper_1_1_chunk  |      0 | f
+  2 |             1 | one_Partition         | _hyper_1_2_chunk  |      0 | f
+  3 |             1 | one_Partition         | _hyper_1_3_chunk  |      0 | f
+  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |      0 | f
+  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |      0 | f
+  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |      0 | f
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |      0 | f
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |      0 | f
+ 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |      0 | f
+ 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |      0 | f
+ 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |      0 | f
+ 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |      0 | f
+ 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |      0 | f
+ 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |      0 | f
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;
  id | chunk_id | dimension_id |     range_start     |      range_end      

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -39,13 +39,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 ----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |      0 | f
 
 SELECT * FROM test.show_subtables('"two_Partitions"');
                  Child                  | Tablespace 
@@ -78,9 +78,9 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 ----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------
   1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_functions   | calculate_chunk_interval |                 0 |                 0 |                          |      0
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | status | osm_chunk 
-----+---------------+-------------+------------+---------------------+--------+-----------
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name | status | osm_chunk 
+----+---------------+-------------+------------+--------+-----------
 
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -96,12 +96,12 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257987600000000000, 'dev1', 1.5, 2),
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     |      0 | f
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     |      0 | f
-  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |      0 | f
+  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |      0 | f
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;
 CREATE OR REPLACE FUNCTION test_trigger()

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -101,15 +101,15 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk WHERE id = 2;
 
 -- Test that we cannot rename chunk columns
 \set ON_ERROR_STOP 0
@@ -385,7 +385,7 @@ ALTER SCHEMA my_associated_schema RENAME TO new_associated_schema;
 INSERT INTO my_table (date, quantity) VALUES ('2018-08-10T23:00:00+00:00', 20);
 -- Make sure the schema name is changed in both catalog tables
 SELECT * from _timescaledb_catalog.hypertable;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk from _timescaledb_catalog.chunk;
 
 DROP TABLE my_table;
 

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -274,7 +274,7 @@ select create_hypertable('test_schema.test_migrate', 'time', migrate_data => tru
 
 --there should be two new chunks
 select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
-select id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk from _timescaledb_catalog.chunk;
+select id, hypertable_id, schema_name, table_name, status, osm_chunk from _timescaledb_catalog.chunk;
 select * from test_schema.test_migrate;
 --main table should now be empty
 select * from only test_schema.test_migrate;

--- a/test/sql/drop_owned.sql.in
+++ b/test/sql/drop_owned.sql.in
@@ -18,18 +18,18 @@ SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
 INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 DROP TABLE  hypertable_schema.superuser;
 
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT chunk_id, id AS dimension_slice_id, format('constraint_%s', id)::name AS constraint_name FROM _timescaledb_catalog.dimension_slice ORDER BY chunk_id, dimension_slice_id;

--- a/test/sql/drop_schema.sql
+++ b/test/sql/drop_schema.sql
@@ -22,7 +22,7 @@ INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 INSERT INTO hypertable_schema.test2 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 RESET ROLE;
 --drop the associated schema. We drop the extra schema to show we can
@@ -33,11 +33,11 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 --show that the metadata for the table using the dropped schema is
 --changed. The other table is not affected.
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 RESET ROLE;
 --dropping the internal schema should not work
@@ -50,7 +50,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT chunk_id, id AS dimension_slice_id, format('constraint_%s', id)::name AS constraint_name FROM _timescaledb_catalog.dimension_slice ORDER BY chunk_id, dimension_slice_id;

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -8,7 +8,7 @@ SET enable_seqscan TO off;
 
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 SELECT * FROM ONLY "two_Partitions";

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -55,7 +55,7 @@ INSERT INTO "1dim_neg" VALUES (19, 21.2);
 INSERT INTO "1dim_neg" VALUES (20, 21.2);
 SELECT * FROM "1dim_pre1970";
 SELECT * FROM "1dim_neg";
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 
 

--- a/test/sql/truncate.sql
+++ b/test/sql/truncate.sql
@@ -7,7 +7,7 @@
 \o
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 SELECT * FROM test.show_subtables('"two_Partitions"');
 SELECT * FROM "two_Partitions";
 
@@ -15,7 +15,7 @@ SET client_min_messages = WARNING;
 TRUNCATE "two_Partitions";
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -27,7 +27,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;
 

--- a/test/sql/updates/post.sparse_index.sql
+++ b/test/sql/updates/post.sparse_index.sql
@@ -9,18 +9,16 @@
 -- NULL values during upgrades, however.
 
 SELECT
-    schema_name || '.' || table_name AS chunk
-FROM _timescaledb_catalog.chunk
-WHERE id = (
-    SELECT compressed_chunk_id
-    FROM _timescaledb_catalog.chunk
-    WHERE hypertable_id = (
-        SELECT id
-        FROM _timescaledb_catalog.hypertable
-        WHERE table_name = 'bloom'
-    )
-    LIMIT 1
+    cs.compress_relid::text AS chunk
+FROM _timescaledb_catalog.chunk ch
+JOIN _timescaledb_catalog.compression_settings cs
+    ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+WHERE ch.hypertable_id = (
+    SELECT id
+    FROM _timescaledb_catalog.hypertable
+    WHERE table_name = 'bloom'
 )
+LIMIT 1
 \gset
 
 -- This test checks that the bloom sparse indexes survive the upgrade, so only

--- a/test/sql/updates/setup.sparse_index.sql
+++ b/test/sql/updates/setup.sparse_index.sql
@@ -40,18 +40,16 @@ VACUUM FULL ANALYZE bloom;
 SELECT * FROM _timescaledb_catalog.compression_settings;
 
 SELECT
-    schema_name || '.' || table_name AS chunk
-FROM _timescaledb_catalog.chunk
-WHERE id = (
-    SELECT compressed_chunk_id
-    FROM _timescaledb_catalog.chunk
-    WHERE hypertable_id = (
-        SELECT id
-        FROM _timescaledb_catalog.hypertable
-        WHERE table_name = 'bloom'
-    )
-    LIMIT 1
+    cs.compress_relid::text AS chunk
+FROM _timescaledb_catalog.chunk ch
+JOIN _timescaledb_catalog.compression_settings cs
+    ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+WHERE ch.hypertable_id = (
+    SELECT id
+    FROM _timescaledb_catalog.hypertable
+    WHERE table_name = 'bloom'
 )
+LIMIT 1
 \gset
 
 \d+ :chunk

--- a/tsl/src/chunk_split.c
+++ b/tsl/src/chunk_split.c
@@ -1175,8 +1175,6 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 		Hypertable *ht_compressed = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
 		new_compressed_chunk =
 			create_compress_chunk(ht_compressed, new_chunk, InvalidOid, false, NULL);
-		ts_trigger_create_all_on_chunk(new_compressed_chunk);
-		ts_chunk_set_compressed_chunk(new_chunk, new_compressed_chunk->fd.id);
 	}
 
 	CommandCounterIncrement();

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -483,8 +483,6 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 		/* create compressed chunk and a new table */
 		compress_ht_chunk =
 			create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, InvalidOid, false, NULL);
-		/* Associate compressed chunk with main chunk. */
-		ts_chunk_set_compressed_chunk(cxt.srcht_chunk, compress_ht_chunk->fd.id);
 		new_compressed_chunk = true;
 		ereport(DEBUG1,
 				(errmsg("new columnstore chunk \"%s.%s\" created",
@@ -607,7 +605,6 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 												CACHE_FLAG_NONE,
 												&hcache);
 	Hypertable *compressed_hypertable;
-	Chunk *compressed_chunk;
 
 	ts_hypertable_permissions_check(uncompressed_hypertable->main_table_relid, GetUserId());
 
@@ -646,7 +643,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	write_logical_replication_msg_decompression_start();
 
 	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk, CHUNK_DECOMPRESS, true);
-	compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
+	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
 
 	ereport(DEBUG1,
 			(errmsg("acquiring locks for converting to rowstore \"%s.%s\"",
@@ -671,7 +668,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	 *       operations.
 	 */
 	LockRelationOid(uncompressed_chunk->table_id, ExclusiveLock);
-	LockRelationOid(compressed_chunk->table_id, ExclusiveLock);
+	LockRelationOid(compressed_relid, ExclusiveLock);
 
 	/* acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
@@ -693,7 +690,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	/* Throw error if chunk has invalid status for operation */
 	ts_chunk_validate_chunk_status_for_operation(chunk_state_after_lock, CHUNK_DECOMPRESS, true);
 
-	decompress_chunk(compressed_chunk->table_id, uncompressed_chunk->table_id);
+	decompress_chunk(compressed_relid, uncompressed_chunk->table_id);
 
 	/* Delete the compressed chunk */
 	ts_compression_chunk_size_delete(uncompressed_chunk->fd.id);
@@ -711,8 +708,8 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	 * this call makes the lock on the chunk explicit.
 	 */
 	LockRelationOid(uncompressed_chunk->table_id, AccessExclusiveLock);
-	LockRelationOid(compressed_chunk->table_id, AccessExclusiveLock);
-	ts_chunk_drop(compressed_chunk, DROP_RESTRICT, -1);
+	LockRelationOid(compressed_relid, AccessExclusiveLock);
+	ts_chunk_drop_by_relid(compressed_relid, DROP_RESTRICT, -1);
 	ts_cache_release(&hcache);
 	write_logical_replication_msg_decompression_end();
 }
@@ -861,6 +858,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 	 * CreateCommandTag can handle to avoid spurious printouts.
 	 */
 	EventTriggerAlterTableStart(create_dummy_query());
+	chunk_was_compressed = ts_chunk_is_compressed(cxt.srcht_chunk);
 	/* Create compressed chunk using existing table */
 	compress_ht_chunk =
 		create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, chunk_table, false, NULL);
@@ -875,8 +873,6 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 										  numrows_post_compression,
 										  0);
 
-	chunk_was_compressed = ts_chunk_is_compressed(cxt.srcht_chunk);
-	ts_chunk_set_compressed_chunk(cxt.srcht_chunk, compress_ht_chunk->fd.id);
 	if (!chunk_was_compressed && ts_table_has_tuples(cxt.srcht_chunk->table_id, AccessShareLock))
 	{
 		/* The chunk was not compressed before it had the compressed chunk
@@ -1186,17 +1182,15 @@ get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 	return index_oid;
 }
 
-Chunk *
+void
 tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk)
 {
 	/* Create a new compressed chunk */
-	return create_compress_chunk(
-		compressed_ht,
-		src_chunk,
-		InvalidOid,
-		ts_guc_enable_direct_compress_auto_segmentby, /* skip_segmentby_default
-													   */
-		NULL);
+	create_compress_chunk(compressed_ht,
+						  src_chunk,
+						  InvalidOid,
+						  ts_guc_enable_direct_compress_auto_segmentby, /* skip_segmentby_default */
+						  NULL);
 }
 
 Datum

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -18,7 +18,7 @@ extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_rebuild_columnstore(PG_FUNCTION_ARGS);
 extern Datum tsl_rebuild_sparse_index(PG_FUNCTION_ARGS);
 extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress);
-extern Chunk *tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk);
+extern void tsl_compression_chunk_create(Hypertable *compressed_ht, Chunk *src_chunk);
 
 extern Datum tsl_get_compressed_chunk_index_for_recompression(
 	PG_FUNCTION_ARGS); // arg is oid of uncompressed chunk

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1144,7 +1144,6 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 	CompressionSettings *settings =
 		ts_compression_settings_get_by_compress_relid(old_compressed_relid);
 	Chunk *src_chunk = ts_chunk_get_by_relid(settings->fd.relid, true);
-	Chunk *old_compressed_chunk = ts_chunk_get_by_relid(old_compressed_relid, true);
 	Hypertable *ht = ts_hypertable_get_by_id(src_chunk->fd.hypertable_id);
 	Hypertable *compress_ht = ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
 
@@ -1175,8 +1174,8 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 	Ensure(CheckRelationOidLockedByMe(old_compressed_relid, AccessExclusiveLock, false),
 		   "compressed chunk \"%s\".\"%s\" must have AccessExclusiveLock "
 		   "to apply segmentby",
-		   NameStr(old_compressed_chunk->fd.schema_name),
-		   NameStr(old_compressed_chunk->fd.table_name));
+		   get_namespace_name(get_rel_namespace(old_compressed_relid)),
+		   get_rel_name(old_compressed_relid));
 
 	settings->fd.segmentby = analyze_and_get_segmentby(settings, old_compressor);
 
@@ -1208,7 +1207,6 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 	/* Create before drop. We must update settings first to point to the new chunk. */
 	Chunk *new_compressed_chunk =
 		create_compress_chunk(compress_ht, src_chunk, InvalidOid, false, settings);
-	ts_chunk_set_compressed_chunk(src_chunk, new_compressed_chunk->fd.id);
 
 	/* Initialize the new bulk writer and compressor against the new compressed relation */
 	Relation out_rel = table_open(new_compressed_chunk->table_id, RowExclusiveLock);
@@ -1245,7 +1243,7 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 
 	tsl_compressor_close(old_compressor, old_bulk_writer);
 
-	ts_chunk_drop(old_compressed_chunk, DROP_RESTRICT, -1);
+	ts_chunk_drop_by_relid(old_compressed_relid, DROP_RESTRICT, -1);
 
 	tuplesort_performsort(new_compressor.sort_state);
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -981,6 +981,9 @@ create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id,
 							  compress_chunk->table_id,
 							  tablespace_oid);
 
+	/* Associate the source chunk with the new compressed chunk. */
+	ts_chunk_set_compressed_chunk(src_chunk, compress_chunk->fd.id);
+
 	return compress_chunk;
 }
 

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -933,21 +933,18 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 		return false;
 	}
 
-	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
-	Ensure(compressed_chunk != NULL,
-		   "compressed chunk not found for chunk \"%s\"",
-		   get_rel_name(uncompressed_chunk->table_id));
-
 	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
-	Ensure(settings != NULL,
-		   "compression settings not found for chunk \"%s\"",
+	Oid compressed_relid = settings->fd.compress_relid;
+
+	Ensure(settings && OidIsValid(compressed_relid),
+		   "compressed chunk not found for chunk \"%s\"",
 		   get_rel_name(uncompressed_chunk->table_id));
 
 	Ensure(settings->fd.orderby, "empty order by, cannot recompress in-memory");
 
 	LOCKMODE lockmode = ExclusiveLock;
 	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, lockmode);
-	Relation compressed_chunk_rel = table_open(compressed_chunk->table_id, lockmode);
+	Relation compressed_chunk_rel = table_open(compressed_relid, lockmode);
 
 	CompressionSettings *new_settings = resolve_recompression_settings(uncompressed_chunk);
 
@@ -999,8 +996,8 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	table_close(new_compressed_chunk_rel, NoLock);
 
 	LockRelationOid(uncompressed_chunk->table_id, AccessExclusiveLock);
-	LockRelationOid(compressed_chunk->table_id, AccessExclusiveLock);
-	ts_chunk_drop(compressed_chunk, DROP_RESTRICT, -1);
+	LockRelationOid(compressed_relid, AccessExclusiveLock);
+	ts_chunk_drop_by_relid(compressed_relid, DROP_RESTRICT, -1);
 	if (ts_chunk_clear_status(uncompressed_chunk, CHUNK_STATUS_COMPRESSED_UNORDERED))
 	{
 		ereport(DEBUG1,
@@ -1008,7 +1005,6 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 						NameStr(uncompressed_chunk->fd.schema_name),
 						NameStr(uncompressed_chunk->fd.table_name))));
 	}
-	ts_chunk_set_compressed_chunk(uncompressed_chunk, new_compressed_chunk->fd.id);
 
 	/* recompress successful */
 	return true;
@@ -1831,22 +1827,20 @@ rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
 		return;
 	}
 
-	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
+	Oid compressed_relid = chunk_settings->fd.compress_relid;
 
 	/* Step 2: initialize builders and decompressor */
-	Relation compressed_rel = table_open(compressed_chunk->table_id, RowExclusiveLock);
+	Relation compressed_rel = table_open(compressed_relid, RowExclusiveLock);
 	Relation uncompressed_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
 	TupleDesc compressed_desc = RelationGetDescr(compressed_rel);
 
 	bool *repl = palloc0(sizeof(bool) * compressed_desc->natts);
-	List *builders = create_sparse_index_builders(uncompressed_rel,
-												  compressed_chunk->table_id,
-												  added_indexes,
-												  repl);
+	List *builders =
+		create_sparse_index_builders(uncompressed_rel, compressed_relid, added_indexes, repl);
 
 	RowDecompressor decompressor = build_decompressor(compressed_desc,
 													  RelationGetDescr(uncompressed_rel),
-													  compressed_chunk->table_id,
+													  compressed_relid,
 													  uncompressed_chunk->table_id);
 
 	/* Step 3: scan, decompress, populate, update */

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -2382,14 +2382,7 @@ columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Ch
 	 * Ensure we do not grab a slice lock because that will assign a transaction ID that could
 	 * unnecessarily block other operations.
 	 */
-	const Chunk *compressed_chunk = ts_chunk_get_by_relid_locked(info->settings->fd.compress_relid,
-																 AccessShareLock,
-																 NULL,
-																 true);
-	ts_add_baserel_cache_entry_for_chunk(info->settings->fd.compress_relid,
-										 ts_planner_get_hypertable(compressed_chunk
-																	   ->hypertable_relid,
-																   CACHE_FLAG_NONE));
+	LockRelationOid(info->settings->fd.compress_relid, AccessShareLock);
 
 	expand_planner_arrays(root, 1);
 	info->compressed_rte = columnar_scan_make_rte(info->settings->fd.compress_relid,

--- a/tsl/test/expected/cagg_usage-15.out
+++ b/tsl/test/expected/cagg_usage-15.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_16_chunk |            0 |        
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_16_chunk |            0
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,15 +452,15 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
@@ -471,14 +471,14 @@ SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestampt
 -- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
@@ -489,12 +489,12 @@ SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestampt
 -- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_19_chunk |            0
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-16.out
+++ b/tsl/test/expected/cagg_usage-16.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_16_chunk |            0 |        
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_16_chunk |            0
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,15 +452,15 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
@@ -471,14 +471,14 @@ SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestampt
 -- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
@@ -489,12 +489,12 @@ SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestampt
 -- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_19_chunk |            0
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-17.out
+++ b/tsl/test/expected/cagg_usage-17.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_16_chunk |            0 |        
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_16_chunk |            0
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,15 +452,15 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
@@ -471,14 +471,14 @@ SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestampt
 -- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
@@ -489,12 +489,12 @@ SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestampt
 -- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_19_chunk |            0
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/cagg_usage-18.out
+++ b/tsl/test/expected/cagg_usage-18.out
@@ -432,16 +432,16 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_16_chunk |            0 |        
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_16_chunk |            0
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should also remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestamptz);
@@ -452,15 +452,15 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_17_chunk |            0 |        
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_17_chunk |            0
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestamptz);
@@ -471,14 +471,14 @@ SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestampt
 -- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_18_chunk |            0 |        
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_18_chunk |            0
+ _hyper_11_19_chunk |            0
 
 -- dropping chunk should remove the catalog data
 SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestamptz);
@@ -489,12 +489,12 @@ SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestampt
 -- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_11_19_chunk |            0 |        
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_11_19_chunk |            0
 
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -11,8 +11,6 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
-   LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
 ;
 CREATE TABLE sample_table (
        time TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -31,18 +31,18 @@ SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> 
 
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     |      0 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     |      0 | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     |      0 | f
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     |      0 | f
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     |      0 | f
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk |                     |      0 | f
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk |                     |      0 | f
-  9 |             3 | _timescaledb_internal | _hyper_3_9_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | status | osm_chunk 
+----+---------------+-----------------------+------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |      0 | f
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |      0 | f
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk |      0 | f
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk |      0 | f
+  9 |             3 | _timescaledb_internal | _hyper_3_9_chunk |      0 | f
 
 \set ON_ERROR_STOP 0
 -- Cannot merge chunks from different hypertables

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1289,13 +1289,13 @@ ORDER BY 2,3;
 CREATE TABLE test_multicon(time timestamptz not null unique, a int);
 SELECT hypertable_id as htid FROM create_hypertable('test_multicon', 'time', chunk_time_interval => interval '1 day') \gset
 insert into test_multicon values ('2020-01-02 01:00'::timestamptz, 1);
-SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.status, c.osm_chunk,
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.status, c.osm_chunk,
 ds.chunk_id, ds.id AS dimension_slice_id, format('constraint_%s', ds.id)::name AS constraint_name FROM
 _timescaledb_catalog.chunk c, _timescaledb_catalog.dimension_slice ds WHERE c.hypertable_id = :htid
 AND ds.chunk_id = c.id;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | status | osm_chunk | chunk_id | dimension_slice_id | constraint_name 
-----+---------------+-----------------------+--------------------+---------------------+--------+-----------+----------+--------------------+-----------------
- 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |                     |      0 | f         |       31 |                 28 | constraint_28
+ id | hypertable_id |      schema_name      |     table_name     | status | osm_chunk | chunk_id | dimension_slice_id | constraint_name 
+----+---------------+-----------------------+--------------------+--------+-----------+----------+--------------------+-----------------
+ 31 |            19 | _timescaledb_internal | _hyper_19_31_chunk |      0 | f         |       31 |                 28 | constraint_28
 
 \c :TEST_DBNAME :ROLE_SUPERUSER ;
 UPDATE _timescaledb_catalog.chunk SET osm_chunk = true WHERE hypertable_id = :htid;

--- a/tsl/test/expected/columnar_scan_cost.out
+++ b/tsl/test/expected/columnar_scan_cost.out
@@ -320,10 +320,11 @@ select count(compress_chunk(x)) from show_chunks('lastmax') x;
      1
 
 vacuum freeze analyze lastmax;
-select schema_name || '.' || table_name chunk, 'c' column from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'lastmax') limit 1)
+select cs.compress_relid::regclass chunk, 'c' column from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'lastmax') limit 1
 \gset
 set timescaledb.restoring to true;
 alter table :chunk drop column _ts_meta_max_1;

--- a/tsl/test/expected/compress_bloom_hash.out
+++ b/tsl/test/expected/compress_bloom_hash.out
@@ -26,10 +26,11 @@ select count(compress_chunk(x)) from show_chunks('hashes') x;
      1
 
 vacuum full analyze hashes;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'hashes') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'hashes') limit 1
 \gset
 \pset format unaligned
 \pset expanded on

--- a/tsl/test/expected/compress_bloom_hash_1.out
+++ b/tsl/test/expected/compress_bloom_hash_1.out
@@ -26,10 +26,11 @@ select count(compress_chunk(x)) from show_chunks('hashes') x;
      1
 
 vacuum full analyze hashes;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'hashes') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'hashes') limit 1
 \gset
 \pset format unaligned
 \pset expanded on

--- a/tsl/test/expected/compress_bloom_sparse-15.out
+++ b/tsl/test/expected/compress_bloom_sparse-15.out
@@ -38,10 +38,11 @@ select * from settings;
  _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_2_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "value", "source": "default"}, {"type": "bloom", "column": "u", "source": "default"}, {"type": "minmax", "column": "ts", "source": "default"}, {"type": "minmax", "column": "x", "source": "orderby"}, {"type": "firstlast", "column": "x", "source": "orderby"}]
 
 vacuum full analyze bloom;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bloom') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bloom') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
           Column          |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -563,10 +564,11 @@ select count(compress_chunk(x)) from show_chunks('badtable') x;
      1
 
 vacuum full analyze badtable;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -621,10 +623,11 @@ select * from settings;
 
 vacuum full analyze badtable;
 -- Verify that we actually got the bloom filter index.
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/tsl/test/expected/compress_bloom_sparse-16.out
+++ b/tsl/test/expected/compress_bloom_sparse-16.out
@@ -38,10 +38,11 @@ select * from settings;
  _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_2_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "value", "source": "default"}, {"type": "bloom", "column": "u", "source": "default"}, {"type": "minmax", "column": "ts", "source": "default"}, {"type": "minmax", "column": "x", "source": "orderby"}, {"type": "firstlast", "column": "x", "source": "orderby"}]
 
 vacuum full analyze bloom;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bloom') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bloom') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
           Column          |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -563,10 +564,11 @@ select count(compress_chunk(x)) from show_chunks('badtable') x;
      1
 
 vacuum full analyze badtable;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -621,10 +623,11 @@ select * from settings;
 
 vacuum full analyze badtable;
 -- Verify that we actually got the bloom filter index.
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/tsl/test/expected/compress_bloom_sparse-17.out
+++ b/tsl/test/expected/compress_bloom_sparse-17.out
@@ -38,10 +38,11 @@ select * from settings;
  _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_2_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "value", "source": "default"}, {"type": "bloom", "column": "u", "source": "default"}, {"type": "minmax", "column": "ts", "source": "default"}, {"type": "minmax", "column": "x", "source": "orderby"}, {"type": "firstlast", "column": "x", "source": "orderby"}]
 
 vacuum full analyze bloom;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bloom') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bloom') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
           Column          |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -563,10 +564,11 @@ select count(compress_chunk(x)) from show_chunks('badtable') x;
      1
 
 vacuum full analyze badtable;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -621,10 +623,11 @@ select * from settings;
 
 vacuum full analyze badtable;
 -- Verify that we actually got the bloom filter index.
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/tsl/test/expected/compress_bloom_sparse-18.out
+++ b/tsl/test/expected/compress_bloom_sparse-18.out
@@ -38,10 +38,11 @@ select * from settings;
  _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal.compress_hyper_2_2_chunk | {}        | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "value", "source": "default"}, {"type": "bloom", "column": "u", "source": "default"}, {"type": "minmax", "column": "ts", "source": "default"}, {"type": "minmax", "column": "x", "source": "orderby"}, {"type": "firstlast", "column": "x", "source": "orderby"}]
 
 vacuum full analyze bloom;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bloom') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bloom') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
           Column          |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -563,10 +564,11 @@ select count(compress_chunk(x)) from show_chunks('badtable') x;
      1
 
 vacuum full analyze badtable;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -621,10 +623,11 @@ select * from settings;
 
 vacuum full analyze badtable;
 -- Verify that we actually got the bloom filter index.
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/tsl/test/expected/compress_bloom_sparse_debug.out
+++ b/tsl/test/expected/compress_bloom_sparse_debug.out
@@ -32,10 +32,11 @@ create or replace function ts_bloom1_debug_info(in _timescaledb_internal.bloom1,
     out detoasted_bytes int, out bits_total int, out bits_set int,
     out estimated_elements int)
 as :TSL_MODULE_PATHNAME, 'ts_bloom1_debug_info' language c immutable parallel safe;
-select schema_name || '.' || table_name chunk, 'c' column from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test') limit 1)
+select cs.compress_relid::regclass chunk, 'c' column from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test') limit 1
 \gset
 with col as (
     select _ts_meta_count rows, _ts_meta_v2_bloomh_:column f, :column cc
@@ -176,12 +177,15 @@ select count(compress_chunk(x)) from show_chunks('detoaster') x;
 
 with chunks as (
   select
-    row_number() over (order by table_name) index,
-    schema_name || '.' || table_name chunk
-  from _timescaledb_catalog.chunk
-    where id in (select compressed_chunk_id from _timescaledb_catalog.chunk
-      where hypertable_id = (select id from _timescaledb_catalog.hypertable
-        where table_name = 'detoaster'))
+    row_number() over (order by cc.table_name) index,
+    cc.schema_name || '.' || cc.table_name chunk
+  from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+      on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    join _timescaledb_catalog.chunk cc
+      on cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
+  where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'detoaster')
 )
 select max(chunk) filter (where index = 1) chunk1,
     max(chunk) filter (where index = 2) chunk2

--- a/tsl/test/expected/compress_composite_bloom_debug.out
+++ b/tsl/test/expected/compress_composite_bloom_debug.out
@@ -181,13 +181,13 @@ CREATE TABLE composite_filter_ref AS SELECT * FROM composite_filter_test;
 -----------------------------------------------------------
 -- Verify Composite Bloom Column Exists
 -----------------------------------------------------------
-SELECT cc.schema_name || '.' || cc.table_name AS chunk
-FROM _timescaledb_catalog.chunk uc, timescaledb_information.chunks tc, _timescaledb_catalog.chunk cc
+SELECT cs.compress_relid AS chunk
+FROM _timescaledb_catalog.chunk uc, timescaledb_information.chunks tc, _timescaledb_catalog.compression_settings cs
 WHERE uc.table_name = tc.chunk_name
-  AND cc.id = uc.compressed_chunk_id
+  AND cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
   AND tc.hypertable_name = 'composite_filter_test'
   AND tc.is_compressed
-ORDER BY cc.table_name
+ORDER BY cs.compress_relid::text
 LIMIT 1
 \gset
 \echo 'Chunk: ' :chunk

--- a/tsl/test/expected/compress_firstlast_sparse.out
+++ b/tsl/test/expected/compress_firstlast_sparse.out
@@ -56,7 +56,8 @@ select count(compress_chunk(x)) from show_chunks('fl_basic') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
 \gset
 -- sorted by ts ASC: values are [10,20,30,40,50]
@@ -85,7 +86,8 @@ select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
 \gset
 select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
@@ -115,7 +117,8 @@ select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
 \gset
 -- first row (1,10), last row (5,50)
@@ -144,7 +147,8 @@ select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
 \gset
 select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
@@ -173,7 +177,8 @@ select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
 \gset
 select _ts_meta_v2_first_value, _ts_meta_v2_last_value,
@@ -202,7 +207,8 @@ select count(compress_chunk(x)) from show_chunks('fl_single') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
 \gset
 select _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -230,7 +236,8 @@ select count(compress_chunk(x)) from show_chunks('fl_multi') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
 \gset
 -- sorted: (1,5,x),(1,8,y),(2,1,z),(2,3,w),(3,2,v)
@@ -265,7 +272,8 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompres
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
 \gset
 select _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -476,7 +484,8 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_push_reco
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_push_recompress')
 order by ch.id
 limit 1

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -314,10 +314,11 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_
      1
 
 vacuum full analyze test_sparse_index;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -396,10 +397,11 @@ select count(compress_chunk(x)) from show_chunks('test_sparse_index') x;
      1
 
 vacuum full analyze test_sparse_index;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
         Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -474,10 +476,11 @@ select * from settings;
  test_sparse_index                      |                                                |           | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "minmax", "column": "ts_new", "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}, {"type": "firstlast", "column": "x", "source": "orderby"}]
  _timescaledb_internal._hyper_5_4_chunk | _timescaledb_internal.compress_hyper_6_6_chunk |           | {x}     | {f}          | {f}                | [{"type": "bloom", "column": "u", "source": "config"}, {"type": "minmax", "column": "ts_new", "source": "config"}, {"type": "minmax", "column": "x", "source": "orderby"}, {"type": "firstlast", "column": "x", "source": "orderby"}]
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
          Column         |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -506,10 +509,11 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_
 -------
      1
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
      Column     |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -540,10 +544,11 @@ select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_
 -------
      1
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
             Column            |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -577,10 +582,11 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_
      1
 
 vacuum full analyze test_sparse_index;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
        Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -612,10 +618,11 @@ select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_
      1
 
 vacuum full analyze test_sparse_index;
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
        Column        |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -667,10 +674,11 @@ select count(compress_chunk(x)) from show_chunks('test_drop_sparse') x;
 -------
      1
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_drop_sparse') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_drop_sparse') limit 1
 \gset
 -- Show columns before drop
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -770,10 +778,11 @@ select count(compress_chunk(x)) from show_chunks('test_drop_sparse2') x;
 -------
      1
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_drop_sparse2') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_drop_sparse2') limit 1
 \gset
 select * from test.show_columns_ext(:'chunk'::regclass);
             Column             |                 Type                  | Collation | Nullable | Default | Storage  | Stats target | Description 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -154,8 +154,8 @@ numrows_frozen_immediately | 1
 \x
 select  ch1.id, ch1.schema_name, ch1.table_name ,  ch2.table_name as compress_table
 from
-_timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2
-where ch1.compressed_chunk_id = ch2.id;
+_timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass;
  id |      schema_name      |    table_name    |      compress_table      
 ----+-----------------------+------------------+--------------------------
   2 | _timescaledb_internal | _hyper_1_2_chunk | compress_hyper_2_5_chunk
@@ -317,9 +317,9 @@ select tableoid::regclass, count(*) from conditions group by tableoid order by t
  tableoid | count 
 ----------+-------
 
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 SELECT count(*) from :CHUNK_NAME;
  count 
 -------
@@ -479,8 +479,8 @@ and map.chunk_id = ch1.id;
 -------
      0
 
---make sure  compressed_chunk_id  is reset to NULL
-select ch1.compressed_chunk_id IS NULL
+--make sure the chunk is no longer linked to a compressed chunk
+select NOT EXISTS (SELECT 1 FROM _timescaledb_catalog.compression_settings cs WHERE cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass AND cs.compress_relid IS NOT NULL)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
  ?column? 
 ----------
@@ -1178,9 +1178,9 @@ SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples 
 
 SELECT compch.table_name  as "STAT_COMP_CHUNK_NAME"
 FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
-       , _timescaledb_catalog.chunk compch
+       , _timescaledb_catalog.chunk compch, _timescaledb_catalog.compression_settings cs
   WHERE ht.table_name = 'stattest' AND ch.hypertable_id = ht.id
-        AND compch.id = ch.compressed_chunk_id AND ch.compressed_chunk_id > 0  \gset
+        AND cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass AND cs.compress_relid = format('%I.%I', compch.schema_name, compch.table_name)::regclass  \gset
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
 SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
  relpages | reltuples 
@@ -1343,7 +1343,7 @@ SET reltuples = 0, relpages = 0
     _timescaledb_catalog.chunk ch,
     _timescaledb_catalog.hypertable ht
   WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id
-        AND ch.compressed_chunk_id > 0 );
+        AND format('%I.%I', ch.schema_name, ch.table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SET timezone TO 'America/Los_Angeles';
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE has been run
@@ -1448,12 +1448,12 @@ SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
 
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
- chunk_name | chunk_status | comp_id 
-------------+--------------+---------
+ chunk_name | chunk_status 
+------------+--------------
 
 SELECT "time", cnt  FROM cagg_expr ORDER BY time LIMIT 5;
              time             | cnt  
@@ -1474,14 +1474,14 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
-     chunk_name     | chunk_status | comp_id 
---------------------+--------------+---------
- _hyper_13_64_chunk |            1 |      66
- _hyper_13_65_chunk |            1 |      67
+     chunk_name     | chunk_status 
+--------------------+--------------
+ _hyper_13_64_chunk |            1
+ _hyper_13_65_chunk |            1
 
 SELECT count(*) FROM metrics;
  count 
@@ -2440,10 +2440,10 @@ ERROR:  chunk "_hyper_47_102_chunk" is already converted to columnstore
 \set ON_ERROR_STOP 1
 ALTER TABLE compress_chunk_test SET (timescaledb.compress_segmentby='device');
 NOTICE:  updated compression settings will only apply to future compressions
-SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
- compressed_chunk_id 
----------------------
-                 103
+SELECT compress_relid from _timescaledb_catalog.compression_settings cs INNER JOIN _timescaledb_catalog.chunk ch ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+                  compress_relid                   
+---------------------------------------------------
+ _timescaledb_internal.compress_hyper_48_103_chunk
 
 -- changing compression settings will not recompress the chunk by default
 SELECT compress_chunk(:'CHUNK');
@@ -2458,11 +2458,11 @@ SELECT compress_chunk(:'CHUNK', recompress := true);
 -------------------------------------------
  _timescaledb_internal._hyper_47_102_chunk
 
--- compressed_chunk_id should be different now
-SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
- compressed_chunk_id 
----------------------
-                 104
+-- compressed chunk should be different now
+SELECT compress_relid from _timescaledb_catalog.compression_settings cs INNER JOIN _timescaledb_catalog.chunk ch ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+                  compress_relid                   
+---------------------------------------------------
+ _timescaledb_internal.compress_hyper_48_104_chunk
 
 --test partial handling
 INSERT INTO compress_chunk_test SELECT '2020-01-01', 'c3po', 3.14;
@@ -2472,11 +2472,11 @@ SELECT compress_chunk(:'CHUNK');
 -------------------------------------------
  _timescaledb_internal._hyper_47_102_chunk
 
--- compressed_chunk_id should not have changed
-SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
- compressed_chunk_id 
----------------------
-                 104
+-- compressed chunk should not have changed
+SELECT compress_relid from _timescaledb_catalog.compression_settings cs INNER JOIN _timescaledb_catalog.chunk ch ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+                  compress_relid                   
+---------------------------------------------------
+ _timescaledb_internal.compress_hyper_48_104_chunk
 
 -- should return no rows
 SELECT * FROM ONLY :CHUNK;
@@ -2639,9 +2639,9 @@ SELECT ch1.id "CHUNK_ID"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'hyper_85'
 ORDER BY ch1.id
 LIMIT 1 \gset
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
  _ts_meta_count 
 ----------------
@@ -2664,9 +2664,9 @@ SELECT ch1.id "CHUNK_ID"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'hyper_85'
 ORDER BY ch1.id
 LIMIT 1 \gset
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
  _ts_meta_count 
 ----------------
@@ -2693,9 +2693,9 @@ SELECT ch1.id "CHUNK_ID"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'hyper_85'
 ORDER BY ch1.id
 LIMIT 1 \gset
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
  _ts_meta_count 
 ----------------

--- a/tsl/test/expected/compression_allocation.out
+++ b/tsl/test/expected/compression_allocation.out
@@ -28,9 +28,10 @@ SELECT ch1.id "CHUNK_ID"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'vector_overalloc'
 ORDER BY ch1.id
 LIMIT 1 \gset
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
+  AND uncompressed.id = :'CHUNK_ID' \gset
 -- Confirm we have multiple batches
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 ASC;
  _ts_meta_count 

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -67,13 +67,13 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
 ------------------+--------------+-------------
  _hyper_1_1_chunk | 32 kB        | 40 kB
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
- id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | status | osm_chunk 
-----+---------------+-----------------------+--------------------------+---------------------+--------+-----------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 |      1 | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                     |      0 | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                     |      0 | f
-  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     |      0 | f
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
+ id | hypertable_id |      schema_name      |        table_name        | status | osm_chunk 
+----+---------------+-----------------------+--------------------------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |      1 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |      0 | f
 
 -- TEST 4 --
 --cannot set another policy
@@ -327,8 +327,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE TABLE test2 (timec timestamptz NOT NULL, i integer ,
       b bigint, t text);
@@ -451,14 +453,14 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 \set ON_ERROR_STOP 0
 -- call compress_chunk when status is not unordered
 SELECT compress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:107: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
+psql:include/recompress_basic.sql:109: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_14_62_chunk
 
 -- This will succeed and compress the chunk for the test below.
 SELECT compress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:110: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
+psql:include/recompress_basic.sql:112: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_14_62_chunk
@@ -567,7 +569,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:186: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:188: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_bools.out
+++ b/tsl/test/expected/compression_bools.out
@@ -123,7 +123,7 @@ WHERE
 -- check the compression algorithm for the compressed chunks
 CREATE TABLE compressed_chunks AS
 SELECT
-	format('%I.%I', comp.schema_name, comp.table_name)::regclass as compressed_chunk,
+	cs.compress_relid as compressed_chunk,
 	ccs.compressed_heap_size,
 	ccs.compressed_toast_size,
 	ccs.compressed_index_size,
@@ -133,10 +133,10 @@ FROM
 	show_chunks('t') c
 	INNER JOIN _timescaledb_catalog.chunk cat
 		ON (c = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
-	INNER JOIN _timescaledb_catalog.chunk comp
-		ON (cat.compressed_chunk_id = comp.id)
+	INNER JOIN _timescaledb_catalog.compression_settings cs
+		ON (cs.relid = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
 	INNER JOIN _timescaledb_catalog.compression_chunk_size ccs
-		ON (comp.id = ccs.compressed_chunk_id);
+		ON (ccs.chunk_id = cat.id);
 CREATE TABLE compression_info (compressed_chunk regclass, result text, compressed_size int, num_rows int);
 DO $$
 DECLARE

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -198,7 +198,8 @@ INFO:  using tuplesort to scan rows from "_hyper_5_5_chunk" for converting to co
 SELECT format('%I.%I', i.schemaname, i.indexname) AS "COMPRESSED_CHUNK_INDEX"
 FROM pg_indexes i
 JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name AND i.tablename = cc.table_name
-JOIN _timescaledb_catalog.chunk uc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk uc ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name) = :'CHUNK'
 LIMIT 1 \gset
 -- after compression no data should be in uncompressed chunk
@@ -544,8 +545,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id;
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass;
 CREATE TABLE compressed_ht (
        time TIMESTAMP WITH TIME ZONE NOT NULL,
        sensor_id INTEGER NOT NULL,

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -139,7 +139,8 @@ SELECT
 FROM _timescaledb_catalog.chunk comp_chunk
 INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (comp_chunk.hypertable_id = comp_hyper.id)
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-INNER JOIN _timescaledb_catalog.chunk uncomp_chunk ON (uncomp_chunk.compressed_chunk_id = comp_chunk.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
+INNER JOIN _timescaledb_catalog.chunk uncomp_chunk ON (cs.relid = format('%I.%I', uncomp_chunk.schema_name, uncomp_chunk.table_name)::regclass)
 WHERE uncomp_hyper.table_name like 'test1' ORDER BY comp_chunk.id LIMIT 1\gset
 -- ensure compression chunk cannot be moved directly
 SELECT tablename
@@ -338,7 +339,8 @@ SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
     comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (chunk.compressed_chunk_id = comp_chunk.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 --create a dependent object on the compressed chunk to test cascade behaviour
@@ -372,7 +374,8 @@ SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
     comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (chunk.compressed_chunk_id = comp_chunk.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
@@ -1914,7 +1917,7 @@ DECLARE
 BEGIN
   FOR chunk IN
   SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL
+    FROM _timescaledb_catalog.chunk WHERE status = 9 and format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL)
     ORDER BY id
   LOOP
     EXECUTE format('select decompress_chunk(''%s'');', chunk::text);

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -306,7 +306,7 @@ SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
 SELECT format('%I.%I', schemaname, indexname) AS "INDEXNAME"
 FROM pg_indexes i
 INNER JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name and i.tablename = cc.table_name
-INNER JOIN _timescaledb_catalog.chunk c ON (cc.id = c.compressed_chunk_id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 LIMIT 1 \gset
 DROP INDEX :INDEXNAME;
 -- Merging works without indexes on compressed chunks

--- a/tsl/test/expected/compression_nulls_and_defaults.out
+++ b/tsl/test/expected/compression_nulls_and_defaults.out
@@ -596,10 +596,11 @@ BEGIN
 		FROM
 			_timescaledb_catalog.chunk uncomp,
 			_timescaledb_catalog.chunk comp,
+			_timescaledb_catalog.compression_settings cs,
 			(SELECT show_chunks('codecov') as c) as x
 		WHERE
-			uncomp.compressed_chunk_id IS NOT NULL AND
-			comp.id = uncomp.compressed_chunk_id AND
+			cs.relid = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass AND
+			cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP
 		-- codecov to record coverage of 'tsl_compressed_data_info'

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -142,9 +142,10 @@ ORDER BY device_id DESC, time DESC;
 -- modify two chunks by adding sequence number to the segments
 -- and rebuild the index based on that column
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -164,9 +165,10 @@ CREATE INDEX ON :CHUNK_FULL_NAME (device_id, _ts_meta_sequence_num);
 SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id OFFSET 2 LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -402,9 +404,10 @@ ORDER BY time;
 
 -- modify two chunks by adding sequence number to the segments
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id LIMIT 1 \gset
 SET ROLE :ROLE_SUPERUSER;
 SET timescaledb.restoring TO ON;
@@ -418,9 +421,10 @@ DELETE FROM :CHUNK_FULL_NAME WHERE _ts_meta_sequence_num IS NULL;
 SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id OFFSET 3 LIMIT 1 \gset
 SET ROLE :ROLE_SUPERUSER;
 SET timescaledb.restoring TO ON;
@@ -512,9 +516,10 @@ SELECT compress_chunk(show_chunks('hyper'));
 
 VACUUM ANALYZE hyper;
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id LIMIT 1 \gset
 SET ROLE :ROLE_SUPERUSER;
 SELECT :'CHUNK_FULL_NAME'::regclass::oid as "CHUNK_OID" \gset

--- a/tsl/test/expected/compression_settings.out
+++ b/tsl/test/expected/compression_settings.out
@@ -248,7 +248,7 @@ SELECT * FROM chunk_settings;
 
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='bloom(value)');
 NOTICE:  updated compression settings will only apply to future compressions
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) ORDER BY id LIMIT 1 OFFSET 1\gset
 -- recompressing chunks should apply current hypertable settings
 SELECT compress_chunk(:'CHUNK', recompress:=true);
              compress_chunk             
@@ -276,7 +276,7 @@ SELECT * FROM settings;
 
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='');
 NOTICE:  updated compression settings will only apply to future compressions
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) ORDER BY id LIMIT 1 OFFSET 1\gset
 SELECT compress_chunk(:'CHUNK', recompress:=true);
              compress_chunk             
 ----------------------------------------

--- a/tsl/test/expected/compression_sorted_merge.out
+++ b/tsl/test/expected/compression_sorted_merge.out
@@ -1547,10 +1547,11 @@ SELECT count(compress_chunk(c)) FROM show_chunks('bsm_segby') c;
 -------
      1
 
-select schema_name || '.' || table_name chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bsm_segby') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bsm_segby') limit 1
 \gset
 -- Firstlast index is used with Batch Sorted Merge: correct result
 set timescaledb.debug_require_batch_sorted_merge = 'force';
@@ -1568,10 +1569,9 @@ set index = '[{"type": "minmax", "column": "name", "source": "orderby"}, {"type"
 where relid = 'bsm_segby'::regclass;
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "name", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bsm_segby') limit 1));
+where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
+    where hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bsm_segby') limit 1);
 create index compressed_index_minmax_firstlast on :chunk (grp, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_ts, _ts_meta_v2_last_ts);
 -- Correct result with Batch Sorted Merge
 set timescaledb.debug_require_batch_sorted_merge = 'force';
@@ -1592,10 +1592,9 @@ set index = '[{"type": "minmax", "column": "name", "source": "orderby"}, {"type"
 where relid = 'bsm_segby'::regclass;
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "name", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bsm_segby') limit 1));
+where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
+    where hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bsm_segby') limit 1);
 -- Correct result only when cannot use Batch Sorted Merge
 set timescaledb.debug_require_batch_sorted_merge = 'forbid';
 SELECT count(*) misorder FROM (

--- a/tsl/test/expected/compression_update_delete-15.out
+++ b/tsl/test/expected/compression_update_delete-15.out
@@ -14,8 +14,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE TABLE sample_table (
        time TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -1958,10 +1960,11 @@ AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
-AND ch1.compressed_chunk_id  = ch2.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
 ORDER BY ch2.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -14,8 +14,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE TABLE sample_table (
        time TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -1958,10 +1960,11 @@ AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
-AND ch1.compressed_chunk_id  = ch2.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
 ORDER BY ch2.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -14,8 +14,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE TABLE sample_table (
        time TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -1964,10 +1966,11 @@ AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
-AND ch1.compressed_chunk_id  = ch2.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
 ORDER BY ch2.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -14,8 +14,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE TABLE sample_table (
        time TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -1964,10 +1966,11 @@ AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
-AND ch1.compressed_chunk_id  = ch2.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
 ORDER BY ch2.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column

--- a/tsl/test/expected/compression_uuid.out
+++ b/tsl/test/expected/compression_uuid.out
@@ -154,7 +154,7 @@ NOTICE:  chunk "_hyper_3_26_chunk" is already converted to columnstore
 -- check the compression algorithm for the compressed chunks
 CREATE TABLE compressed_chunks AS
 SELECT
-	format('%I.%I', comp.schema_name, comp.table_name)::regclass as compressed_chunk,
+	cs.compress_relid as compressed_chunk,
 	ccs.compressed_heap_size,
 	ccs.compressed_toast_size,
 	ccs.compressed_index_size,
@@ -164,10 +164,10 @@ FROM
 	show_chunks('mixed_compressed') c
 	INNER JOIN _timescaledb_catalog.chunk cat
 		ON (c = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
-	INNER JOIN _timescaledb_catalog.chunk comp
-		ON (cat.compressed_chunk_id = comp.id)
+	INNER JOIN _timescaledb_catalog.compression_settings cs
+		ON (cs.relid = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
 	INNER JOIN _timescaledb_catalog.compression_chunk_size ccs
-		ON (comp.id = ccs.compressed_chunk_id);
+		ON (ccs.chunk_id = cat.id);
 CREATE TABLE compression_info (compressed_chunk regclass, result text, compressed_size int, num_rows int);
 DO $$
 DECLARE

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -3460,10 +3460,11 @@ BEGIN
 		FROM
 			_timescaledb_catalog.chunk uncomp,
 			_timescaledb_catalog.chunk comp,
+			_timescaledb_catalog.compression_settings cs,
 			(SELECT show_chunks('bool_table') as c UNION SELECT show_chunks('int_table') as c) as x
 		WHERE
-			uncomp.compressed_chunk_id IS NOT NULL AND
-			comp.id = uncomp.compressed_chunk_id AND
+			cs.relid = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass AND
+			cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP
 		FOR rec IN

--- a/tsl/test/expected/direct_compress_copy.out
+++ b/tsl/test/expected/direct_compress_copy.out
@@ -99,7 +99,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
          ->  Seq Scan on compress_hyper_2_18_chunk (actual rows=3.00 loops=1)
    ->  Seq Scan on _hyper_1_16_chunk (actual rows=2041.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
       9
@@ -116,7 +116,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
    ->  Seq Scan on compress_hyper_2_20_chunk (actual rows=3.00 loops=1)
 
 -- status should be 9
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
       1
@@ -133,7 +133,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
    ->  Seq Scan on compress_hyper_2_22_chunk (actual rows=3.00 loops=1)
 
 -- status should be 11
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
       3
@@ -151,7 +151,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
  Custom Scan (ColumnarScan) on _hyper_1_23_chunk (actual rows=50.00 loops=1)
    ->  Seq Scan on compress_hyper_2_24_chunk (actual rows=10.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
  count 
@@ -169,7 +169,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 --- QUERY PLAN ---
  Seq Scan on _hyper_1_25_chunk (actual rows=1.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
 
@@ -185,7 +185,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 --- QUERY PLAN ---
  Seq Scan on _hyper_1_26_chunk (actual rows=1.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
 
@@ -200,7 +200,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
  Custom Scan (ColumnarScan) on _hyper_1_27_chunk (actual rows=1.00 loops=1)
    ->  Seq Scan on compress_hyper_2_28_chunk (actual rows=1.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
       3

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -239,7 +239,7 @@ SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, ti
 ------------------------------+------------------------------
  Wed Jan 01 00:00:00 2025 PST | Sat Jan 04 02:00:00 2025 PST
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 desc limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
  _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
@@ -282,7 +282,7 @@ SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, ti
 ------------------------------+------------------------------
  Wed Jan 01 00:00:00 2025 PST | Tue Jan 07 02:00:00 2025 PST
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 desc limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
 -- should not see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
  _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
@@ -315,7 +315,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
  Custom Scan (ColumnarScan) on _hyper_1_33_chunk (actual rows=50.00 loops=1)
    ->  Seq Scan on compress_hyper_2_34_chunk (actual rows=10.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
  count 
@@ -345,7 +345,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
    ->  Custom Scan (ColumnarScan) on _hyper_1_37_chunk (actual rows=5042.00 loops=1)
          ->  Seq Scan on compress_hyper_2_38_chunk (actual rows=8.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 desc limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
 -- should see overlapping batches per device
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, device from :COMPRESSED_CHUNK order by 4, 2;
  _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        | device 
@@ -382,7 +382,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
    ->  Custom Scan (ColumnarScan) on _hyper_1_41_chunk (actual rows=2522.00 loops=1)
          ->  Seq Scan on compress_hyper_2_42_chunk (actual rows=4.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_min_2, _ts_meta_max_2 from :COMPRESSED_CHUNK order by 2, 4;
  _ts_meta_count | _ts_meta_min_1 | _ts_meta_max_1 |        _ts_meta_min_2        |        _ts_meta_max_2        
@@ -409,7 +409,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 --- QUERY PLAN ---
  Seq Scan on _hyper_1_43_chunk (actual rows=101.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
 
@@ -425,7 +425,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
 --- QUERY PLAN ---
  Seq Scan on _hyper_1_44_chunk (actual rows=101.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
 
@@ -440,7 +440,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
  Custom Scan (ColumnarScan) on _hyper_1_45_chunk (actual rows=101.00 loops=1)
    ->  Seq Scan on compress_hyper_2_46_chunk (actual rows=1.00 loops=1)
 
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
  status 
 --------
       3

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -626,7 +626,6 @@ from _timescaledb_catalog.compression_chunk_size ccs \gset
 create view compression_size_fraction as
 select
     ccs.chunk_id,
-    ccs.compressed_chunk_id,
     round(ccs.uncompressed_heap_size::numeric / :total_uncompressed_heap_size, 1) as uncompressed_heap_size_fraction,
     ccs.uncompressed_toast_size::numeric as uncompressed_toast_size_fraction,
     round(ccs.uncompressed_index_size::numeric / :total_uncompressed_index_size, 1) as uncompressed_index_size_fraction,
@@ -651,9 +650,9 @@ set timescaledb.enable_merge_multidim_chunks = true;
 ---
 begin;
 select * from compression_size_fraction;
- chunk_id | compressed_chunk_id | uncompressed_heap_size_fraction | uncompressed_toast_size_fraction | uncompressed_index_size_fraction | compressed_heap_size_fraction | compressed_toast_size_fraction | compressed_index_size_fraction | numrows_pre_compression_fraction | numrows_post_compression_fraction | numrows_frozen_immediately_fraction 
-----------+---------------------+---------------------------------+----------------------------------+----------------------------------+-------------------------------+--------------------------------+--------------------------------+----------------------------------+-----------------------------------+-------------------------------------
-        1 |                  17 |                             1.0 |                                0 |                              1.0 |                           1.0 |                            1.0 |                            1.0 |                              1.0 |                               1.0 |                                 1.0
+ chunk_id | uncompressed_heap_size_fraction | uncompressed_toast_size_fraction | uncompressed_index_size_fraction | compressed_heap_size_fraction | compressed_toast_size_fraction | compressed_index_size_fraction | numrows_pre_compression_fraction | numrows_post_compression_fraction | numrows_frozen_immediately_fraction 
+----------+---------------------------------+----------------------------------+----------------------------------+-------------------------------+--------------------------------+--------------------------------+----------------------------------+-----------------------------------+-------------------------------------
+        1 |                             1.0 |                                0 |                              1.0 |                           1.0 |                            1.0 |                            1.0 |                              1.0 |                               1.0 |                                 1.0
 
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  count  |   sum   |     round     
@@ -714,9 +713,9 @@ call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_
 -- Final merge, involving the two compressed chunks 1 and 2. The stats
 -- should also be merged.
 select * from compression_size_fraction;
- chunk_id | compressed_chunk_id | uncompressed_heap_size_fraction | uncompressed_toast_size_fraction | uncompressed_index_size_fraction | compressed_heap_size_fraction | compressed_toast_size_fraction | compressed_index_size_fraction | numrows_pre_compression_fraction | numrows_post_compression_fraction | numrows_frozen_immediately_fraction 
-----------+---------------------+---------------------------------+----------------------------------+----------------------------------+-------------------------------+--------------------------------+--------------------------------+----------------------------------+-----------------------------------+-------------------------------------
-        1 |                  17 |                             1.0 |                                0 |                              1.0 |                           1.0 |                            1.0 |                            1.0 |                              1.0 |                               1.0 |                                 1.0
+ chunk_id | uncompressed_heap_size_fraction | uncompressed_toast_size_fraction | uncompressed_index_size_fraction | compressed_heap_size_fraction | compressed_toast_size_fraction | compressed_index_size_fraction | numrows_pre_compression_fraction | numrows_post_compression_fraction | numrows_frozen_immediately_fraction 
+----------+---------------------------------+----------------------------------+----------------------------------+-------------------------------+--------------------------------+--------------------------------+----------------------------------+-----------------------------------+-------------------------------------
+        1 |                             1.0 |                                0 |                              1.0 |                           1.0 |                            1.0 |                            1.0 |                              1.0 |                               1.0 |                                 1.0
 
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  count  |   sum   |     round     
@@ -735,9 +734,9 @@ select * from partitions;
 
 call merge_chunks(ARRAY['_timescaledb_internal._hyper_1_3_chunk', '_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_2_chunk']);
 select * from compression_size_fraction;
- chunk_id | compressed_chunk_id | uncompressed_heap_size_fraction | uncompressed_toast_size_fraction | uncompressed_index_size_fraction | compressed_heap_size_fraction | compressed_toast_size_fraction | compressed_index_size_fraction | numrows_pre_compression_fraction | numrows_post_compression_fraction | numrows_frozen_immediately_fraction 
-----------+---------------------+---------------------------------+----------------------------------+----------------------------------+-------------------------------+--------------------------------+--------------------------------+----------------------------------+-----------------------------------+-------------------------------------
-        1 |                  17 |                             1.0 |                                0 |                              1.0 |                           1.0 |                            1.0 |                            1.0 |                              1.0 |                               1.0 |                                 1.0
+ chunk_id | uncompressed_heap_size_fraction | uncompressed_toast_size_fraction | uncompressed_index_size_fraction | compressed_heap_size_fraction | compressed_toast_size_fraction | compressed_index_size_fraction | numrows_pre_compression_fraction | numrows_post_compression_fraction | numrows_frozen_immediately_fraction 
+----------+---------------------------------+----------------------------------+----------------------------------+-------------------------------+--------------------------------+--------------------------------+----------------------------------+-----------------------------------+-------------------------------------
+        1 |                             1.0 |                                0 |                              1.0 |                           1.0 |                            1.0 |                            1.0 |                              1.0 |                               1.0 |                                 1.0
 
 select count(*), sum(device), round(sum(temp)::numeric, 4) from mergeme;
  count  |   sum   |     round     

--- a/tsl/test/expected/rebuild_columnstore_tests.out
+++ b/tsl/test/expected/rebuild_columnstore_tests.out
@@ -10,7 +10,8 @@ SELECT
     cc.schema_name || '.' || cc.table_name AS compressed_chunk,
     _timescaledb_functions.chunk_status_text((uc.schema_name || '.' || uc.table_name)::regclass) AS status
 FROM _timescaledb_catalog.chunk uc
-LEFT JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+LEFT JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+LEFT JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h ON uc.hypertable_id = h.id;
 SET timescaledb.enable_direct_compress_insert = true;
 -- Test 1: Rebuild fully compressed (ordered) chunk

--- a/tsl/test/expected/rebuild_sparse_index.out
+++ b/tsl/test/expected/rebuild_sparse_index.out
@@ -10,7 +10,8 @@ RETURNS TABLE(attname name, typname name) AS $$
     WHERE a.attrelid = (
         SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass
         FROM _timescaledb_catalog.chunk uc
-        JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+        JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+        JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
         WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass
     )
     AND a.attname LIKE '_ts_meta_%'
@@ -239,7 +240,8 @@ DECLARE
 BEGIN
     SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass INTO compressed_relid
     FROM _timescaledb_catalog.chunk uc
-    JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+    JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+    JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
     WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass;
 
     SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY a.attname) INTO col_list
@@ -273,11 +275,13 @@ SELECT compress_chunk(:'ichunk2');
 
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
 \o :ORIGINAL
 SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
@@ -355,11 +359,13 @@ SELECT compress_chunk(:'ichunk2');
 -- re-fetch compressed chunk names after recompress
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
 \o :ORIGINAL
 SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
@@ -431,7 +437,8 @@ SELECT compress_chunk(:'ichunk1');
 
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 ALTER TABLE rsi_integrity SET (
     timescaledb.compress,
@@ -535,7 +542,8 @@ SELECT compress_chunk(:'ichunk1');
 
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 ALTER TABLE rsi_integrity SET (
     timescaledb.compress,

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -15,8 +15,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE OR REPLACE VIEW compression_rowcnt_view AS
 select ccs.numrows_pre_compression, ccs.numrows_post_compression,
@@ -811,9 +813,9 @@ SELECT compress_chunk(c) FROM show_chunks('segwise_no_overlap') c;
  _timescaledb_internal._hyper_27_29_chunk
 
 -- Locate the compressed chunk for the metadata check.
-SELECT cc.schema_name || '.' || cc.table_name AS comp_table_segwise
+SELECT cs.compress_relid AS comp_table_segwise
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc      ON cc.id = uc.compressed_chunk_id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h  ON h.id  = uc.hypertable_id
 WHERE h.table_name = 'segwise_no_overlap' \gset
 -- Resulting batches: must be at most adjacent on series_id, never

--- a/tsl/test/expected/recompression_integrity_tests.out
+++ b/tsl/test/expected/recompression_integrity_tests.out
@@ -51,11 +51,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -77,11 +76,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_1_1_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -93,14 +91,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                    recompression_status                    
-------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=3, new_chunk_id=5
+                                                              recompression_status                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_2_3_chunk, new_chunk=_timescaledb_internal.compress_hyper_2_5_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -156,11 +154,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -182,11 +179,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_3_6_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -198,14 +194,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                    recompression_status                     
--------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=8, new_chunk_id=10
+                                                              recompression_status                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_4_8_chunk, new_chunk=_timescaledb_internal.compress_hyper_4_10_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -262,11 +258,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -288,11 +283,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_5_11_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -304,14 +298,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=12, new_chunk_id=13
+                                                               recompression_status                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_6_12_chunk, new_chunk=_timescaledb_internal.compress_hyper_6_13_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -369,11 +363,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -395,11 +388,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_7_14_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -411,14 +403,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=16, new_chunk_id=18
+                                                               recompression_status                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_8_16_chunk, new_chunk=_timescaledb_internal.compress_hyper_8_18_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -474,11 +466,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -508,11 +499,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_9_19_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -528,14 +518,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=20, new_chunk_id=21
+                                                                recompression_status                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_10_20_chunk, new_chunk=_timescaledb_internal.compress_hyper_10_21_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD

--- a/tsl/test/expected/recompression_integrity_unordered.out
+++ b/tsl/test/expected/recompression_integrity_unordered.out
@@ -55,11 +55,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -89,11 +88,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_1_1_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -109,14 +107,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                    recompression_status                    
-------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=2, new_chunk_id=3
+                                                              recompression_status                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_2_2_chunk, new_chunk=_timescaledb_internal.compress_hyper_2_3_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -179,11 +177,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -213,11 +210,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_3_4_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -235,14 +231,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                    recompression_status                    
-------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=5, new_chunk_id=6
+                                                              recompression_status                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_4_5_chunk, new_chunk=_timescaledb_internal.compress_hyper_4_6_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -307,11 +303,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -341,11 +336,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_5_7_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -363,14 +357,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                    recompression_status                    
-------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=8, new_chunk_id=9
+                                                              recompression_status                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_6_8_chunk, new_chunk=_timescaledb_internal.compress_hyper_6_9_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -417,11 +411,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -452,11 +445,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_7_10_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -473,14 +465,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=11, new_chunk_id=12
+                                                               recompression_status                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_8_11_chunk, new_chunk=_timescaledb_internal.compress_hyper_8_12_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -520,11 +512,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -553,11 +544,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_9_13_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -575,14 +565,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=14, new_chunk_id=15
+                                                                recompression_status                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_10_14_chunk, new_chunk=_timescaledb_internal.compress_hyper_10_15_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -606,11 +596,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -638,11 +627,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_9_13_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -660,14 +648,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=15, new_chunk_id=16
+                                                                recompression_status                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_10_15_chunk, new_chunk=_timescaledb_internal.compress_hyper_10_16_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD
@@ -691,11 +679,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 \gset
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -723,11 +710,10 @@ SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
  _timescaledb_internal._hyper_9_13_chunk
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 \set COMPRESSED_CHUNK_NAME :NEW_COMPRESSED_CHUNK_NAME
@@ -745,14 +731,14 @@ LIMIT 1 \gset
 \o
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
-                     recompression_status                     
---------------------------------------------------------------
- SUCCESS: New chunk created, old_chunk_id=16, new_chunk_id=17
+                                                                recompression_status                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ SUCCESS: New chunk created, old_chunk=_timescaledb_internal.compress_hyper_10_16_chunk, new_chunk=_timescaledb_internal.compress_hyper_10_17_chunk
 
 -- Compare result using diff to validate integrity of recompressed data
 :DIFF_CMD

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -691,11 +691,11 @@ order by time;
  Sun Jan 07 09:03:11 2024 PST |      1 |   21 |       21
  Wed Jan 10 02:04:12 2024 PST |      1 |   17 |       32
 
-select table_name, status, compressed_chunk_id
+select table_name, status
 from _timescaledb_catalog.chunk where table_name = '_hyper_1_3_chunk';
-    table_name    | status | compressed_chunk_id 
-------------------+--------+---------------------
- _hyper_1_3_chunk |      9 |                  15
+    table_name    | status 
+------------------+--------
+ _hyper_1_3_chunk |      9
 
 analyze _timescaledb_internal._hyper_1_3_chunk;
 truncate chunk_summary_before_split;
@@ -734,13 +734,13 @@ select * from chunk_info;
  _hyper_1_7_chunk  | heap |      5760 | constraint_11 | (("time" >= 'Wed Dec 27 16:00:00 2023 PST'::timestamp with time zone) AND ("time" < 'Wed Jan 03 16:00:00 2024 PST'::timestamp with time zone))
  _hyper_1_8_chunk  | heap |     28800 | constraint_13 | (("time" >= 'Fri Jan 05 16:00:00 2024 PST'::timestamp with time zone) AND ("time" < 'Sun Jan 07 08:00:00 2024 PST'::timestamp with time zone))
 
-select table_name, status, compressed_chunk_id
+select table_name, status
 from _timescaledb_catalog.chunk
 where table_name in ('_hyper_1_3_chunk', '_hyper_1_16_chunk');
-    table_name     | status | compressed_chunk_id 
--------------------+--------+---------------------
- _hyper_1_16_chunk |      9 |                  17
- _hyper_1_3_chunk  |      9 |                  15
+    table_name     | status 
+-------------------+--------
+ _hyper_1_16_chunk |      9
+ _hyper_1_3_chunk  |      9
 
 -- Check that the non-compressed data rows ended up in separate partitions
 select *

--- a/tsl/test/expected/uncompressed_size.out
+++ b/tsl/test/expected/uncompressed_size.out
@@ -19,11 +19,11 @@ SELECT compress_chunk(chunk) FROM show_chunks('t2') AS chunk;
 ----------------------------------------
  _timescaledb_internal._hyper_3_2_chunk
 
-SELECT ccs.compressed_chunk_id, l.relation_size, l.index_size, l.total_size FROM _timescaledb_catalog.compression_chunk_size ccs JOIN _timescaledb_catalog.chunk ch ON ch.id=ccs.compressed_chunk_id JOIN LATERAL (SELECT * FROM _timescaledb_functions.estimate_uncompressed_size(format('%I.%I',ch.schema_name,ch.table_name))) l ON true;
- compressed_chunk_id | relation_size | index_size | total_size 
----------------------+---------------+------------+------------
-                   3 |       5980000 |    2000000 |    7980000
-                   4 |       5520000 |    2000000 |    7520000
+SELECT cs.compress_relid, l.relation_size, l.index_size, l.total_size FROM _timescaledb_catalog.compression_chunk_size ccs JOIN _timescaledb_catalog.chunk uc ON uc.id=ccs.chunk_id JOIN _timescaledb_catalog.compression_settings cs ON cs.relid=format('%I.%I',uc.schema_name,uc.table_name)::regclass JOIN LATERAL (SELECT * FROM _timescaledb_functions.estimate_uncompressed_size(cs.compress_relid)) l ON true;
+                 compress_relid                 | relation_size | index_size | total_size 
+------------------------------------------------+---------------+------------+------------
+ _timescaledb_internal.compress_hyper_2_3_chunk |       5980000 |    2000000 |    7980000
+ _timescaledb_internal.compress_hyper_4_4_chunk |       5520000 |    2000000 |    7520000
 
 -- test NULL compression does not error and returns NULL
 INSERT INTO t1 SELECT '2026-01-01'::timestamptz + format('%s ms', i)::interval, NULL, NULL FROM generate_series(1, 3000) i;

--- a/tsl/test/expected/vacuum.out
+++ b/tsl/test/expected/vacuum.out
@@ -284,10 +284,10 @@ LIMIT 1;
 ANALYZE cagg_analyze_view;
 SELECT count(*) > 0 AS compression_chunk_analyzed
 FROM pg_stat_all_tables s
-JOIN _timescaledb_catalog.chunk c
-  ON c.table_name = s.relname AND c.schema_name = s.schemaname
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.compress_relid = s.relid
 JOIN _timescaledb_catalog.chunk parent
-  ON parent.compressed_chunk_id = c.id
+  ON cs.relid = format('%I.%I', parent.schema_name, parent.table_name)::regclass
 WHERE parent.hypertable_id = (SELECT mat_hypertable_id
                               FROM _timescaledb_catalog.continuous_agg
                               WHERE user_view_name = 'cagg_analyze_view')

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -116,22 +116,22 @@ count
 step s3_select_on_compressed_chunk: 
     DO $$
     DECLARE
-      hyper_id int;
-      chunk_id int;
+      comp_chunk regclass;
     BEGIN
-      SELECT h.compressed_hypertable_id, c.compressed_chunk_id 
-      INTO hyper_id, chunk_id
-      FROM _timescaledb_catalog.hypertable h 
-      INNER JOIN _timescaledb_catalog.chunk c  
-      ON h.id = c.hypertable_id 
-      WHERE h.table_name = 'sensor_data' 
-      AND c.compressed_chunk_id IS NOT NULL;
-      EXECUTE format('SELECT * 
-        FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
-        WHERE sensor_id = 40 
-        AND temperature IS NOT NULL;', 
-        hyper_id, 
-        chunk_id);
+      SELECT cs.compress_relid
+      INTO comp_chunk
+      FROM _timescaledb_catalog.hypertable h
+      INNER JOIN _timescaledb_catalog.chunk c
+      ON h.id = c.hypertable_id
+      INNER JOIN _timescaledb_catalog.compression_settings cs
+      ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
+      WHERE h.table_name = 'sensor_data'
+      AND cs.compress_relid IS NOT NULL;
+      EXECUTE format('SELECT *
+        FROM %s
+        WHERE sensor_id = 40
+        AND temperature IS NOT NULL;',
+        comp_chunk);
     END;
     $$;
 

--- a/tsl/test/isolation/expected/compression_recompress.out
+++ b/tsl/test/isolation/expected/compression_recompress.out
@@ -111,7 +111,7 @@ step s2_insert_do_nothing: <... completed>
 
 starting permutation: s1_show_chunk_state s2_begin s2_insert_do_nothing s1_begin s1_recompress_chunk s2_insert_do_nothing s2_wait_for_finish s2_commit s1_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -153,7 +153,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -167,7 +167,7 @@ count
 
 starting permutation: s1_show_chunk_state s2_begin s2_insert_do_nothing s1_begin s1_recompress_chunk s2_insert_existing_do_nothing s2_wait_for_finish s2_commit s1_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -211,7 +211,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -225,7 +225,7 @@ count
 
 starting permutation: s1_show_chunk_state s2_begin s2_insert_do_nothing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -256,7 +256,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -270,7 +270,7 @@ count
 
 starting permutation: s1_show_chunk_state s2_begin s2_insert_existing_do_nothing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -303,7 +303,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -326,7 +326,7 @@ recompress
          1
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -348,7 +348,7 @@ step s1_insert_for_recompression:
    ORDER BY time;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -381,7 +381,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -395,7 +395,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_upsert s1_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -428,7 +428,7 @@ step s1_commit:
 
 step s2_upsert: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -449,7 +449,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_upsert_existing s1_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -484,7 +484,7 @@ step s1_commit:
 
 step s2_upsert_existing: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -505,7 +505,7 @@ count
 
 starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_upsert s2_wait_for_finish s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -540,7 +540,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -564,7 +564,7 @@ step s3_release_exclusive_lock:
 
 starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_upsert_existing s2_wait_for_finish s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -601,7 +601,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -625,7 +625,7 @@ step s3_release_exclusive_lock:
 
 starting permutation: s1_show_chunk_state s2_begin s2_upsert s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -656,7 +656,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -677,7 +677,7 @@ count
 
 starting permutation: s1_show_chunk_state s2_begin s2_upsert_existing s1_recompress_chunk s2_wait_for_finish s2_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -710,7 +710,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -750,7 +750,7 @@ step s1_insert_for_recompression:
    ORDER BY time;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -783,7 +783,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -804,7 +804,7 @@ count
 
 starting permutation: s1_show_chunk_state s3_begin s1_begin s3_delete_uncompressed s1_recompress_chunk s2_insert_do_nothing s3_rollback s1_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -846,7 +846,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -860,7 +860,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_delete_compressed s1_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -891,7 +891,7 @@ step s1_commit:
 
 step s2_delete_compressed: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -905,7 +905,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_delete_uncompressed s1_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -936,7 +936,7 @@ step s1_commit:
 
 step s2_delete_uncompressed: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -969,7 +969,7 @@ step s1_insert_for_recompression:
    ORDER BY time;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1000,7 +1000,7 @@ step s1_commit:
 
 step s2_delete_recompressed: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1014,7 +1014,7 @@ count
 
 starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_delete_compressed s2_wait_for_finish s1_commit s1_show_chunk_state s3_release_exclusive_lock
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1047,7 +1047,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1064,7 +1064,7 @@ step s3_release_exclusive_lock:
 
 starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_delete_uncompressed s1_commit s1_show_chunk_state s3_release_exclusive_lock
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1095,7 +1095,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1135,7 +1135,7 @@ step s1_insert_for_recompression:
    ORDER BY time;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1162,7 +1162,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1179,7 +1179,7 @@ step s3_release_exclusive_lock:
 
 starting permutation: s1_show_chunk_state s2_begin s2_delete_uncompressed s1_recompress_chunk s2_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1207,7 +1207,7 @@ step s2_commit:
 step s1_recompress_chunk: <... completed>
 ERROR:  aborting recompression due to concurrent updates on uncompressed data, retrying with next policy run
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1221,7 +1221,7 @@ count
 
 starting permutation: s1_show_chunk_state s2_begin s2_delete_compressed s1_recompress_chunk s2_commit s1_show_chunk_state
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1248,7 +1248,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1281,7 +1281,7 @@ step s1_insert_for_recompression:
    ORDER BY time;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1309,7 +1309,7 @@ step s2_commit:
 step s1_recompress_chunk: <... completed>
 ERROR:  aborting recompression due to concurrent updates on compressed data, retrying with next policy run
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1323,7 +1323,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_update_compressed s1_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1354,7 +1354,7 @@ step s1_commit:
 
 step s2_update_compressed: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1375,7 +1375,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s1_recompress_chunk s2_update_uncompressed s1_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1406,7 +1406,7 @@ step s1_commit:
 
 step s2_update_uncompressed: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1465,7 +1465,7 @@ step s1_commit:
 
 step s2_update_recompressed: <... completed>
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1486,7 +1486,7 @@ count
 
 starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_update_compressed s2_wait_for_finish s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1519,7 +1519,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1543,7 +1543,7 @@ step s3_release_exclusive_lock:
 
 starting permutation: s1_show_chunk_state s3_block_exclusive_lock s1_begin s1_recompress_chunk s2_update_uncompressed s1_commit s1_show_chunk_state s2_show_updated_count s3_release_exclusive_lock
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1574,7 +1574,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1636,7 +1636,7 @@ step s1_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1660,7 +1660,7 @@ step s3_release_exclusive_lock:
 
 starting permutation: s1_show_chunk_state s2_begin s2_update_uncompressed s1_recompress_chunk s2_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1688,7 +1688,7 @@ step s2_commit:
 step s1_recompress_chunk: <... completed>
 ERROR:  aborting recompression due to concurrent updates on uncompressed data, retrying with next policy run
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1709,7 +1709,7 @@ count
 
 starting permutation: s1_show_chunk_state s2_begin s2_update_compressed s1_recompress_chunk s2_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1736,7 +1736,7 @@ step s2_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1776,7 +1776,7 @@ step s1_insert_for_recompression:
    ORDER BY time;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1804,7 +1804,7 @@ step s2_commit:
 step s1_recompress_chunk: <... completed>
 ERROR:  aborting recompression due to concurrent updates on compressed data, retrying with next policy run
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1825,7 +1825,7 @@ count
 
 starting permutation: s1_show_chunk_state s1_begin s3_begin s1_recompress_chunk s3_recompress_chunk s1_commit s3_commit s1_show_chunk_state s2_show_updated_count
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status
@@ -1868,7 +1868,7 @@ step s3_commit:
 	COMMIT;
 
 step s1_show_chunk_state: 
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 
 status

--- a/tsl/test/isolation/expected/deadlock_recompress_chunk.out
+++ b/tsl/test/isolation/expected/deadlock_recompress_chunk.out
@@ -16,8 +16,9 @@ step lock_after_decompress:
       chunk regclass;
     BEGIN
       SELECT format('%I.%I', c.schema_name, c.table_name)::regclass INTO chunk
-      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c
-      WHERE p.compressed_chunk_id = c.id
+      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c, _timescaledb_catalog.compression_settings cs
+      WHERE cs.relid = format('%I.%I', p.schema_name, p.table_name)::regclass
+      AND cs.compress_relid = format('%I.%I', c.schema_name, c.table_name)::regclass
       AND format('%I.%I', p.schema_name, p.table_name)::regclass = show_chunks;
       EXECUTE format('LOCK TABLE %s IN EXCLUSIVE MODE', chunk);
     END;

--- a/tsl/test/isolation/specs/compression_merge_race.spec
+++ b/tsl/test/isolation/specs/compression_merge_race.spec
@@ -127,22 +127,22 @@ step "s3_count_chunks_post_compression" {
 step "s3_select_on_compressed_chunk" {
     DO $$
     DECLARE
-      hyper_id int;
-      chunk_id int;
+      comp_chunk regclass;
     BEGIN
-      SELECT h.compressed_hypertable_id, c.compressed_chunk_id 
-      INTO hyper_id, chunk_id
-      FROM _timescaledb_catalog.hypertable h 
-      INNER JOIN _timescaledb_catalog.chunk c  
-      ON h.id = c.hypertable_id 
-      WHERE h.table_name = 'sensor_data' 
-      AND c.compressed_chunk_id IS NOT NULL;
-      EXECUTE format('SELECT * 
-        FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
-        WHERE sensor_id = 40 
-        AND temperature IS NOT NULL;', 
-        hyper_id, 
-        chunk_id);
+      SELECT cs.compress_relid
+      INTO comp_chunk
+      FROM _timescaledb_catalog.hypertable h
+      INNER JOIN _timescaledb_catalog.chunk c
+      ON h.id = c.hypertable_id
+      INNER JOIN _timescaledb_catalog.compression_settings cs
+      ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
+      WHERE h.table_name = 'sensor_data'
+      AND cs.compress_relid IS NOT NULL;
+      EXECUTE format('SELECT *
+        FROM %s
+        WHERE sensor_id = 40
+        AND temperature IS NOT NULL;',
+        comp_chunk);
     END;
     $$;
 }

--- a/tsl/test/isolation/specs/compression_recompress.spec
+++ b/tsl/test/isolation/specs/compression_recompress.spec
@@ -78,7 +78,7 @@ step "s1_decompress" {
 }
 
 step "s1_show_chunk_state" {
-   SELECT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+   SELECT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
    SELECT count(*) FROM sensor_data;
 }
 

--- a/tsl/test/isolation/specs/deadlock_recompress_chunk.spec
+++ b/tsl/test/isolation/specs/deadlock_recompress_chunk.spec
@@ -51,8 +51,9 @@ step "lock_after_decompress" {
       chunk regclass;
     BEGIN
       SELECT format('%I.%I', c.schema_name, c.table_name)::regclass INTO chunk
-      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c
-      WHERE p.compressed_chunk_id = c.id
+      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c, _timescaledb_catalog.compression_settings cs
+      WHERE cs.relid = format('%I.%I', p.schema_name, p.table_name)::regclass
+      AND cs.compress_relid = format('%I.%I', c.schema_name, c.table_name)::regclass
       AND format('%I.%I', p.schema_name, p.table_name)::regclass = show_chunks;
       EXECUTE format('LOCK TABLE %s IN EXCLUSIVE MODE', chunk);
     END;

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -63,10 +63,11 @@ UPDATE metrics_compressed SET v3 = 42 WHERE device_id=1 AND time > '2000-01-01' 
 -- used to be different before 2.15 with all metadata columns at the back. We
 -- had cases where new code broke with this layout, but this was not detected by
 -- the tests since they all use the modern layout.
-select schema_name || '.' || table_name chunk, 'c' column from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'metrics_compressed') order by id limit 1)
+select cs.compress_relid::regclass chunk, 'c' column from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'metrics_compressed') order by ch.id limit 1
 \gset
 
 set role :ROLE_SUPERUSER;

--- a/tsl/test/sql/cagg_usage.sql.in
+++ b/tsl/test/sql/cagg_usage.sql.in
@@ -295,7 +295,7 @@ SELECT * FROM cagg4;
 -- should return 4 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
@@ -306,7 +306,7 @@ SELECT drop_chunks('metrics', older_than => '2000-01-01 00:00:00-02'::timestampt
 -- should return 3 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id AND h.table_name = 'metrics'
 ORDER BY 1;
@@ -317,7 +317,7 @@ SELECT drop_chunks('metrics', older_than => '2000-01-13 00:00:00-02'::timestampt
 -- should return 2 chunks
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
@@ -328,7 +328,7 @@ SELECT drop_chunks('metrics', older_than => '2000-01-25 00:00:00-02'::timestampt
 -- should return 1 chunk
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -13,8 +13,6 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
-   LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
 ;
 
 CREATE TABLE sample_table (

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -26,7 +26,7 @@ SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> 
 -- This creates chunks 7 - 9 on second hypertable.
 INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
 
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk;
 
 \set ON_ERROR_STOP 0
 

--- a/tsl/test/sql/columnar_scan_cost.sql
+++ b/tsl/test/sql/columnar_scan_cost.sql
@@ -190,10 +190,11 @@ select count(compress_chunk(x)) from show_chunks('lastmax') x;
 
 vacuum freeze analyze lastmax;
 
-select schema_name || '.' || table_name chunk, 'c' column from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'lastmax') limit 1)
+select cs.compress_relid::regclass chunk, 'c' column from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'lastmax') limit 1
 \gset
 
 set timescaledb.restoring to true;

--- a/tsl/test/sql/compress_bloom_hash.sql
+++ b/tsl/test/sql/compress_bloom_hash.sql
@@ -26,10 +26,11 @@ select 1,
 select count(compress_chunk(x)) from show_chunks('hashes') x;
 vacuum full analyze hashes;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'hashes') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'hashes') limit 1
 \gset
 
 \pset format unaligned

--- a/tsl/test/sql/compress_bloom_sparse.sql.in
+++ b/tsl/test/sql/compress_bloom_sparse.sql.in
@@ -31,10 +31,11 @@ select count(compress_chunk(x)) from show_chunks('bloom') x;
 select * from settings;
 vacuum full analyze bloom;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bloom') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bloom') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -288,10 +289,11 @@ select count(compress_chunk(x)) from show_chunks('badtable') x;
 
 vacuum full analyze badtable;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -324,10 +326,11 @@ select * from settings;
 vacuum full analyze badtable;
 
 -- Verify that we actually got the bloom filter index.
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'badtable') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'badtable') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);

--- a/tsl/test/sql/compress_bloom_sparse_debug.sql
+++ b/tsl/test/sql/compress_bloom_sparse_debug.sql
@@ -35,10 +35,11 @@ create or replace function ts_bloom1_debug_info(in _timescaledb_internal.bloom1,
     out estimated_elements int)
 as :TSL_MODULE_PATHNAME, 'ts_bloom1_debug_info' language c immutable parallel safe;
 
-select schema_name || '.' || table_name chunk, 'c' column from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test') limit 1)
+select cs.compress_relid::regclass chunk, 'c' column from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test') limit 1
 \gset
 
 with col as (
@@ -132,12 +133,15 @@ select count(compress_chunk(x)) from show_chunks('detoaster') x;
 
 with chunks as (
   select
-    row_number() over (order by table_name) index,
-    schema_name || '.' || table_name chunk
-  from _timescaledb_catalog.chunk
-    where id in (select compressed_chunk_id from _timescaledb_catalog.chunk
-      where hypertable_id = (select id from _timescaledb_catalog.hypertable
-        where table_name = 'detoaster'))
+    row_number() over (order by cc.table_name) index,
+    cc.schema_name || '.' || cc.table_name chunk
+  from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+      on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    join _timescaledb_catalog.chunk cc
+      on cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
+  where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'detoaster')
 )
 select max(chunk) filter (where index = 1) chunk1,
     max(chunk) filter (where index = 2) chunk2

--- a/tsl/test/sql/compress_composite_bloom_debug.sql
+++ b/tsl/test/sql/compress_composite_bloom_debug.sql
@@ -131,13 +131,13 @@ CREATE TABLE composite_filter_ref AS SELECT * FROM composite_filter_test;
 -----------------------------------------------------------
 -- Verify Composite Bloom Column Exists
 -----------------------------------------------------------
-SELECT cc.schema_name || '.' || cc.table_name AS chunk
-FROM _timescaledb_catalog.chunk uc, timescaledb_information.chunks tc, _timescaledb_catalog.chunk cc
+SELECT cs.compress_relid AS chunk
+FROM _timescaledb_catalog.chunk uc, timescaledb_information.chunks tc, _timescaledb_catalog.compression_settings cs
 WHERE uc.table_name = tc.chunk_name
-  AND cc.id = uc.compressed_chunk_id
+  AND cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
   AND tc.hypertable_name = 'composite_filter_test'
   AND tc.is_compressed
-ORDER BY cc.table_name
+ORDER BY cs.compress_relid::text
 LIMIT 1
 \gset
 

--- a/tsl/test/sql/compress_firstlast_sparse.sql
+++ b/tsl/test/sql/compress_firstlast_sparse.sql
@@ -40,7 +40,8 @@ select count(compress_chunk(x)) from show_chunks('fl_basic') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
 \gset
 
@@ -62,7 +63,8 @@ select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
 \gset
 
@@ -85,7 +87,8 @@ select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
 \gset
 
@@ -107,7 +110,8 @@ select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
 \gset
 
@@ -129,7 +133,8 @@ select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
 \gset
 
@@ -151,7 +156,8 @@ select count(compress_chunk(x)) from show_chunks('fl_single') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
 \gset
 
@@ -172,7 +178,8 @@ select count(compress_chunk(x)) from show_chunks('fl_multi') x;
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
 \gset
 
@@ -197,7 +204,8 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompres
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
 \gset
 
@@ -327,7 +335,8 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_push_reco
 
 select ch.schema_name || '.' || ch.table_name as compressed_chunk
 from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.chunk uc on ch.id = uc.compressed_chunk_id
+inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_push_recompress')
 order by ch.id
 limit 1

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -259,10 +259,11 @@ select * from settings;
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
 vacuum full analyze test_sparse_index;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -295,10 +296,11 @@ from generate_series(1, 10000) x;
 select count(compress_chunk(x)) from show_chunks('test_sparse_index') x;
 vacuum full analyze test_sparse_index;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -328,10 +330,11 @@ alter table test_sparse_index rename value to value_new;
 alter table test_sparse_index rename ts to ts_new;
 select * from settings;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -344,10 +347,11 @@ alter table test_sparse_index set (timescaledb.compress,
 
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -362,10 +366,11 @@ alter table test_sparse_index set (timescaledb.compress,
 
 select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -380,10 +385,11 @@ alter table test_sparse_index set (timescaledb.compress,
 select count(compress_chunk(x, recompress:=true)) from show_chunks('test_sparse_index') x;
 vacuum full analyze test_sparse_index;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -397,10 +403,11 @@ alter table test_sparse_index reset (timescaledb.compress_segmentby,
 select count(compress_chunk(decompress_chunk(x))) from show_chunks('test_sparse_index') x;
 vacuum full analyze test_sparse_index;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_sparse_index') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_sparse_index') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);
@@ -428,10 +435,11 @@ select * from settings;
 
 select count(compress_chunk(x)) from show_chunks('test_drop_sparse') x;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_drop_sparse') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_drop_sparse') limit 1
 \gset
 
 -- Show columns before drop
@@ -472,10 +480,11 @@ select * from settings;
 
 select count(compress_chunk(x)) from show_chunks('test_drop_sparse2') x;
 
-select schema_name || '.' || table_name chunk from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'test_drop_sparse2') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'test_drop_sparse2') limit 1
 \gset
 
 select * from test.show_columns_ext(:'chunk'::regclass);

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -53,8 +53,8 @@ order by chunk_id;
 \x
 select  ch1.id, ch1.schema_name, ch1.table_name ,  ch2.table_name as compress_table
 from
-_timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2
-where ch1.compressed_chunk_id = ch2.id;
+_timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass;
 
 \set ON_ERROR_STOP 0
 --cannot compress the chunk the second time around
@@ -155,9 +155,9 @@ SELECT compress_chunk(ch, true) FROM show_chunks('conditions') ch ORDER BY ch::t
 
 select tableoid::regclass, count(*) from conditions group by tableoid order by tableoid;
 
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 
 SELECT count(*) from :CHUNK_NAME;
 SELECT count(*) from :COMPRESSED_CHUNK_NAME;
@@ -205,8 +205,8 @@ _timescaledb_catalog.compression_chunk_size map
 where ch1.hypertable_id = ht.id and ht.table_name like 'conditions'
 and map.chunk_id = ch1.id;
 
---make sure  compressed_chunk_id  is reset to NULL
-select ch1.compressed_chunk_id IS NULL
+--make sure the chunk is no longer linked to a compressed chunk
+select NOT EXISTS (SELECT 1 FROM _timescaledb_catalog.compression_settings cs WHERE cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass AND cs.compress_relid IS NOT NULL)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'conditions';
 
 -- test plans get invalidated when chunks get compressed
@@ -535,9 +535,9 @@ SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples 
 
 SELECT compch.table_name  as "STAT_COMP_CHUNK_NAME"
 FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
-       , _timescaledb_catalog.chunk compch
+       , _timescaledb_catalog.chunk compch, _timescaledb_catalog.compression_settings cs
   WHERE ht.table_name = 'stattest' AND ch.hypertable_id = ht.id
-        AND compch.id = ch.compressed_chunk_id AND ch.compressed_chunk_id > 0  \gset
+        AND cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass AND cs.compress_relid = format('%I.%I', compch.schema_name, compch.table_name)::regclass  \gset
 
 -- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
 SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
@@ -616,7 +616,7 @@ SET reltuples = 0, relpages = 0
     _timescaledb_catalog.chunk ch,
     _timescaledb_catalog.hypertable ht
   WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id
-        AND ch.compressed_chunk_id > 0 );
+        AND format('%I.%I', ch.schema_name, ch.table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 SET timezone TO 'America/Los_Angeles';
@@ -684,7 +684,7 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
@@ -696,7 +696,7 @@ INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10
 SELECT count(compress_chunk(ch)) FROM show_chunks('metrics') ch;
 SELECT
    c.table_name as chunk_name,
-   c.status as chunk_status, c.compressed_chunk_id as comp_id
+   c.status as chunk_status
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
@@ -1075,20 +1075,20 @@ SELECT compress_chunk(:'CHUNK', false);
 \set ON_ERROR_STOP 1
 
 ALTER TABLE compress_chunk_test SET (timescaledb.compress_segmentby='device');
-SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+SELECT compress_relid from _timescaledb_catalog.compression_settings cs INNER JOIN _timescaledb_catalog.chunk ch ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
 -- changing compression settings will not recompress the chunk by default
 SELECT compress_chunk(:'CHUNK');
 -- unless we specify recompress := true
 SELECT compress_chunk(:'CHUNK', recompress := true);
--- compressed_chunk_id should be different now
-SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+-- compressed chunk should be different now
+SELECT compress_relid from _timescaledb_catalog.compression_settings cs INNER JOIN _timescaledb_catalog.chunk ch ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
 
 --test partial handling
 INSERT INTO compress_chunk_test SELECT '2020-01-01', 'c3po', 3.14;
 -- should result in merging uncompressed data into compressed chunk
 SELECT compress_chunk(:'CHUNK');
--- compressed_chunk_id should not have changed
-SELECT compressed_chunk_id from _timescaledb_catalog.chunk ch INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
+-- compressed chunk should not have changed
+SELECT compress_relid from _timescaledb_catalog.compression_settings cs INNER JOIN _timescaledb_catalog.chunk ch ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass INNER JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id AND ht.table_name='compress_chunk_test';
 -- should return no rows
 SELECT * FROM ONLY :CHUNK;
 
@@ -1201,9 +1201,9 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 ORDER BY ch1.id
 LIMIT 1 \gset
 
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
 ROLLBACK;
@@ -1218,9 +1218,9 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 ORDER BY ch1.id
 LIMIT 1 \gset
 
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
 ROLLBACK;
@@ -1236,9 +1236,9 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 ORDER BY ch1.id
 LIMIT 1 \gset
 
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass AND uncompressed.id = :'CHUNK_ID' \gset
 
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 DESC;
 

--- a/tsl/test/sql/compression_allocation.sql
+++ b/tsl/test/sql/compression_allocation.sql
@@ -24,9 +24,10 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 ORDER BY ch1.id
 LIMIT 1 \gset
 
-select  compressed.schema_name|| '.' || compressed.table_name as "COMPRESSED_CHUNK_NAME"
-from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.chunk compressed
-where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'CHUNK_ID' \gset
+select  cs.compress_relid as "COMPRESSED_CHUNK_NAME"
+from _timescaledb_catalog.chunk uncompressed, _timescaledb_catalog.compression_settings cs
+where cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
+  AND uncompressed.id = :'CHUNK_ID' \gset
 
 -- Confirm we have multiple batches
 SELECT _ts_meta_count FROM :COMPRESSED_CHUNK_NAME ORDER BY device, _ts_meta_min_1 ASC;

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -53,7 +53,7 @@ CALL run_job(:compressjob_id);
 select chunk_name, pg_size_pretty(before_compression_total_bytes) before_total,
 pg_size_pretty( after_compression_total_bytes)  after_total
 from chunk_compression_stats('conditions') where compression_status like 'Compressed' order by chunk_name;
-SELECT id, hypertable_id, schema_name, table_name, compressed_chunk_id, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
+SELECT id, hypertable_id, schema_name, table_name, status, osm_chunk FROM _timescaledb_catalog.chunk ORDER BY id;
 
 -- TEST 4 --
 --cannot set another policy

--- a/tsl/test/sql/compression_bools.sql
+++ b/tsl/test/sql/compression_bools.sql
@@ -83,7 +83,7 @@ WHERE
 -- check the compression algorithm for the compressed chunks
 CREATE TABLE compressed_chunks AS
 SELECT
-	format('%I.%I', comp.schema_name, comp.table_name)::regclass as compressed_chunk,
+	cs.compress_relid as compressed_chunk,
 	ccs.compressed_heap_size,
 	ccs.compressed_toast_size,
 	ccs.compressed_index_size,
@@ -93,10 +93,10 @@ FROM
 	show_chunks('t') c
 	INNER JOIN _timescaledb_catalog.chunk cat
 		ON (c = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
-	INNER JOIN _timescaledb_catalog.chunk comp
-		ON (cat.compressed_chunk_id = comp.id)
+	INNER JOIN _timescaledb_catalog.compression_settings cs
+		ON (cs.relid = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
 	INNER JOIN _timescaledb_catalog.compression_chunk_size ccs
-		ON (comp.id = ccs.compressed_chunk_id);
+		ON (ccs.chunk_id = cat.id);
 
 CREATE TABLE compression_info (compressed_chunk regclass, result text, compressed_size int, num_rows int);
 

--- a/tsl/test/sql/compression_conflicts.sql
+++ b/tsl/test/sql/compression_conflicts.sql
@@ -151,7 +151,8 @@ SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_3') c
 SELECT format('%I.%I', i.schemaname, i.indexname) AS "COMPRESSED_CHUNK_INDEX"
 FROM pg_indexes i
 JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name AND i.tablename = cc.table_name
-JOIN _timescaledb_catalog.chunk uc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk uc ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name) = :'CHUNK'
 LIMIT 1 \gset
 
@@ -409,8 +410,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id;
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass;
 
 CREATE TABLE compressed_ht (
        time TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -101,7 +101,8 @@ SELECT
 FROM _timescaledb_catalog.chunk comp_chunk
 INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (comp_chunk.hypertable_id = comp_hyper.id)
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-INNER JOIN _timescaledb_catalog.chunk uncomp_chunk ON (uncomp_chunk.compressed_chunk_id = comp_chunk.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
+INNER JOIN _timescaledb_catalog.chunk uncomp_chunk ON (cs.relid = format('%I.%I', uncomp_chunk.schema_name, uncomp_chunk.table_name)::regclass)
 WHERE uncomp_hyper.table_name like 'test1' ORDER BY comp_chunk.id LIMIT 1\gset
 
 -- ensure compression chunk cannot be moved directly
@@ -235,7 +236,8 @@ SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
     comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (chunk.compressed_chunk_id = comp_chunk.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 
@@ -265,7 +267,8 @@ SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
     comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (chunk.compressed_chunk_id = comp_chunk.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 
@@ -924,7 +927,7 @@ DECLARE
 BEGIN
   FOR chunk IN
   SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk WHERE status = 9 and compressed_chunk_id IS NOT NULL
+    FROM _timescaledb_catalog.chunk WHERE status = 9 and format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL)
     ORDER BY id
   LOOP
     EXECUTE format('select decompress_chunk(''%s'');', chunk::text);

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -163,7 +163,7 @@ SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
 SELECT format('%I.%I', schemaname, indexname) AS "INDEXNAME"
 FROM pg_indexes i
 INNER JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name and i.tablename = cc.table_name
-INNER JOIN _timescaledb_catalog.chunk c ON (cc.id = c.compressed_chunk_id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 LIMIT 1 \gset
 
 

--- a/tsl/test/sql/compression_nulls_and_defaults.sql
+++ b/tsl/test/sql/compression_nulls_and_defaults.sql
@@ -277,10 +277,11 @@ BEGIN
 		FROM
 			_timescaledb_catalog.chunk uncomp,
 			_timescaledb_catalog.chunk comp,
+			_timescaledb_catalog.compression_settings cs,
 			(SELECT show_chunks('codecov') as c) as x
 		WHERE
-			uncomp.compressed_chunk_id IS NOT NULL AND
-			comp.id = uncomp.compressed_chunk_id AND
+			cs.relid = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass AND
+			cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP
 		-- codecov to record coverage of 'tsl_compressed_data_info'

--- a/tsl/test/sql/compression_sequence_num_removal.sql
+++ b/tsl/test/sql/compression_sequence_num_removal.sql
@@ -41,9 +41,10 @@ ORDER BY device_id DESC, time DESC;
 -- modify two chunks by adding sequence number to the segments
 -- and rebuild the index based on that column
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -65,9 +66,10 @@ SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id OFFSET 2 LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -128,9 +130,10 @@ ORDER BY time;
 
 -- modify two chunks by adding sequence number to the segments
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id LIMIT 1 \gset
 
 SET ROLE :ROLE_SUPERUSER;
@@ -146,9 +149,10 @@ SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id OFFSET 3 LIMIT 1 \gset
 
 SET ROLE :ROLE_SUPERUSER;
@@ -194,9 +198,10 @@ SELECT compress_chunk(show_chunks('hyper'));
 VACUUM ANALYZE hyper;
 
 SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
-AND ch1.compressed_chunk_id = comp_ch.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
 ORDER BY ch1.id LIMIT 1 \gset
 
 SET ROLE :ROLE_SUPERUSER;

--- a/tsl/test/sql/compression_settings.sql
+++ b/tsl/test/sql/compression_settings.sql
@@ -95,7 +95,7 @@ SELECT * FROM ht_settings;
 SELECT * FROM chunk_settings;
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='bloom(value)');
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) ORDER BY id LIMIT 1 OFFSET 1\gset
 
 -- recompressing chunks should apply current hypertable settings
 SELECT compress_chunk(:'CHUNK', recompress:=true);
@@ -105,7 +105,7 @@ SELECT * FROM settings;
 
 ALTER TABLE metrics SET (timescaledb.compress_orderby='"time" desc', timescaledb.compress_segmentby='d2', timescaledb.index='');
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL ORDER BY id LIMIT 1 OFFSET 1\gset
+SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) ORDER BY id LIMIT 1 OFFSET 1\gset
 SELECT compress_chunk(:'CHUNK', recompress:=true);
 SELECT * FROM settings;
 SELECT * FROM ht_settings;

--- a/tsl/test/sql/compression_sorted_merge.sql
+++ b/tsl/test/sql/compression_sorted_merge.sql
@@ -683,10 +683,11 @@ FROM generate_series(0,4379) g;
 
 SELECT count(compress_chunk(c)) FROM show_chunks('bsm_segby') c;
 
-select schema_name || '.' || table_name chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bsm_segby') limit 1)
+select cs.compress_relid::regclass chunk from _timescaledb_catalog.chunk ch
+    join _timescaledb_catalog.compression_settings cs
+        on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bsm_segby') limit 1
 \gset
 
 -- Firstlast index is used with Batch Sorted Merge: correct result
@@ -704,10 +705,9 @@ where relid = 'bsm_segby'::regclass;
 
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "name", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bsm_segby') limit 1));
+where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
+    where hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bsm_segby') limit 1);
 
 create index compressed_index_minmax_firstlast on :chunk (grp, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_ts, _ts_meta_v2_last_ts);
 
@@ -730,10 +730,9 @@ where relid = 'bsm_segby'::regclass;
 
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "name", "source": "orderby"}, {"type": "minmax", "column": "ts", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
-        where hypertable_id = (select id from _timescaledb_catalog.hypertable
-            where table_name = 'bsm_segby') limit 1));
+where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
+    where hypertable_id = (select id from _timescaledb_catalog.hypertable
+        where table_name = 'bsm_segby') limit 1);
 
 -- Correct result only when cannot use Batch Sorted Merge
 set timescaledb.debug_require_batch_sorted_merge = 'forbid';

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -16,8 +16,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 
 CREATE TABLE sample_table (
@@ -1158,10 +1160,11 @@ AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
 
 SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
-AND ch1.compressed_chunk_id  = ch2.id
+AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
 ORDER BY ch2.id LIMIT 1 \gset
 
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);

--- a/tsl/test/sql/compression_uuid.sql
+++ b/tsl/test/sql/compression_uuid.sql
@@ -103,7 +103,7 @@ SELECT compress_chunk(show_chunks('mixed_compressed'));
 -- check the compression algorithm for the compressed chunks
 CREATE TABLE compressed_chunks AS
 SELECT
-	format('%I.%I', comp.schema_name, comp.table_name)::regclass as compressed_chunk,
+	cs.compress_relid as compressed_chunk,
 	ccs.compressed_heap_size,
 	ccs.compressed_toast_size,
 	ccs.compressed_index_size,
@@ -113,10 +113,10 @@ FROM
 	show_chunks('mixed_compressed') c
 	INNER JOIN _timescaledb_catalog.chunk cat
 		ON (c = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
-	INNER JOIN _timescaledb_catalog.chunk comp
-		ON (cat.compressed_chunk_id = comp.id)
+	INNER JOIN _timescaledb_catalog.compression_settings cs
+		ON (cs.relid = format('%I.%I', cat.schema_name, cat.table_name)::regclass)
 	INNER JOIN _timescaledb_catalog.compression_chunk_size ccs
-		ON (comp.id = ccs.compressed_chunk_id);
+		ON (ccs.chunk_id = cat.id);
 
 CREATE TABLE compression_info (compressed_chunk regclass, result text, compressed_size int, num_rows int);
 

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -850,10 +850,11 @@ BEGIN
 		FROM
 			_timescaledb_catalog.chunk uncomp,
 			_timescaledb_catalog.chunk comp,
+			_timescaledb_catalog.compression_settings cs,
 			(SELECT show_chunks('bool_table') as c UNION SELECT show_chunks('int_table') as c) as x
 		WHERE
-			uncomp.compressed_chunk_id IS NOT NULL AND
-			comp.id = uncomp.compressed_chunk_id AND
+			cs.relid = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass AND
+			cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass AND
 			x.c = format('%I.%I', uncomp.schema_name, uncomp.table_name)::regclass
 	LOOP
 		FOR rec IN

--- a/tsl/test/sql/direct_compress_copy.sql
+++ b/tsl/test/sql/direct_compress_copy.sql
@@ -57,7 +57,7 @@ SET timescaledb.enable_direct_compress_copy = true;
 SET timescaledb.enable_direct_compress_copy_client_sorted = true;
 COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-01 + I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- simple test with compressed copy enabled and reversed order
@@ -67,7 +67,7 @@ SET timescaledb.enable_direct_compress_copy_client_sorted = true;
 COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-01 - I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 -- status should be 9
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- simple test with compressed copy enabled and no presorted
@@ -77,7 +77,7 @@ SET timescaledb.enable_direct_compress_copy_client_sorted = false;
 COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-01 - I minute" +"%Y-%m-%d %H:%M:%S,d1,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 -- status should be 11
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- test with segmentby
@@ -87,7 +87,7 @@ SET timescaledb.enable_direct_compress_copy = true;
 SET timescaledb.enable_direct_compress_copy_client_sorted = true;
 COPY metrics FROM PROGRAM 'seq 0 0.2 9.8 | sed -e ''s!.[0-9]$!!'' | xargs -II date -d "2025-01-01 - I minute" +"%Y-%m-%d %H:%M:%S,dI,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
 ROLLBACK;
@@ -100,7 +100,7 @@ COPY metrics FROM STDIN WITH (FORMAT CSV);
 2025-01-01,d1,0.3
 \.
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- test triggers prevent direct compress
@@ -112,7 +112,7 @@ COPY metrics FROM STDIN WITH (FORMAT CSV);
 2025-01-01,d1,0.3
 \.
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- test caggs with direct compress
@@ -123,7 +123,7 @@ COPY metrics FROM STDIN WITH (FORMAT CSV);
 2025-01-01,d1,0.3
 \.
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -118,7 +118,7 @@ INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interva
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 desc limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
 -- since the chunks are new status should be COMPRESSED, UNORDERED, PARTIAL and COMPRESSED, UNORDERED
@@ -134,7 +134,7 @@ INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interva
 INSERT INTO metrics SELECT '2025-01-05'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 desc limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
 -- should not see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
 -- since the chunks are new status should be COMPRESSED, UNORDERED, PARTIAL and COMPRESSED, UNORDERED
@@ -148,7 +148,7 @@ SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_client_sorted = true;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz - (i || ' minute')::interval, floor(i), i::float FROM generate_series(0.0,9.8,0.2) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
 -- since the chunks are new status should be COMPRESSED
@@ -163,7 +163,7 @@ SET timescaledb.enable_direct_compress_insert_client_sorted = false;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd'||i%2, i::float FROM generate_series(0,3000) i;
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd'||i%2, i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 desc limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
 -- should see overlapping batches per device
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, device from :COMPRESSED_CHUNK order by 4, 2;
 -- since the chunks are new status should be COMPRESSED, UNORDERED
@@ -178,7 +178,7 @@ SET timescaledb.enable_direct_compress_insert_client_sorted = false;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd'||i%3, i::float FROM generate_series(0,3000) i;
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz - (i || ' minute')::interval, 'd'||i%3, i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where compressed_chunk_id IS NULL order by 1 limit 1 \gset
+SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_min_2, _ts_meta_max_2 from :COMPRESSED_CHUNK order by 2, 4;
 -- since the chunks are new status should be COMPRESSED, UNORDERED
@@ -191,7 +191,7 @@ SET timescaledb.enable_direct_compress_insert = true;
 ALTER TABLE metrics ADD CONSTRAINT unique_time_device UNIQUE (time, device);
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- test triggers prevent direct compress
@@ -201,7 +201,7 @@ CREATE OR REPLACE FUNCTION test_trigger() RETURNS TRIGGER AS $$ BEGIN RETURN NEW
 CREATE TRIGGER metrics_trigger BEFORE INSERT OR UPDATE ON metrics FOR EACH ROW EXECUTE FUNCTION test_trigger();
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- test caggs with direct compress
@@ -210,7 +210,7 @@ SET timescaledb.enable_direct_compress_insert = true;
 CREATE MATERIALIZED VIEW metrics_cagg WITH (tsdb.continuous) AS SELECT time_bucket('1 hour', time) AS bucket, device, avg(value) AS avg_value FROM metrics GROUP BY bucket, device WITH NO DATA;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,100) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL;
+SELECT DISTINCT status FROM _timescaledb_catalog.chunk WHERE format('%I.%I', schema_name, table_name)::regclass IN (SELECT relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL);
 ROLLBACK;
 
 -- cagg + direct compress where the cagg time column is segmentby.

--- a/tsl/test/sql/include/chunk_utils_internal_orderedappend.sql
+++ b/tsl/test/sql/include/chunk_utils_internal_orderedappend.sql
@@ -40,7 +40,7 @@ ORDER BY 2,3;
 CREATE TABLE test_multicon(time timestamptz not null unique, a int);
 SELECT hypertable_id as htid FROM create_hypertable('test_multicon', 'time', chunk_time_interval => interval '1 day') \gset
 insert into test_multicon values ('2020-01-02 01:00'::timestamptz, 1);
-SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.compressed_chunk_id, c.status, c.osm_chunk,
+SELECT c.id, c.hypertable_id, c.schema_name, c.table_name, c.status, c.osm_chunk,
 ds.chunk_id, ds.id AS dimension_slice_id, format('constraint_%s', ds.id)::name AS constraint_name FROM
 _timescaledb_catalog.chunk c, _timescaledb_catalog.dimension_slice ds WHERE c.hypertable_id = :htid
 AND ds.chunk_id = c.id;

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -14,8 +14,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 
 CREATE TABLE test2 (timec timestamptz NOT NULL, i integer ,

--- a/tsl/test/sql/include/recompression_integrity_check.sql
+++ b/tsl/test/sql/include/recompression_integrity_check.sql
@@ -10,11 +10,10 @@ SELECT format('\! diff -u  --label "Compressed result" --label "Recompressed res
 
 -- Store initial compressed chunk info before recompression
 SELECT uncompressed.schema_name || '.' || uncompressed.table_name AS "OLD_CHUNK_NAME",
-        compressed.schema_name || '.' || compressed.table_name AS "OLD_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "OLD_CHUNK_ID"
+        cs.compress_relid::regclass::text AS "OLD_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.hypertable_id = (
           SELECT id
           FROM _timescaledb_catalog.hypertable
@@ -36,11 +35,10 @@ LIMIT 1 \gset
 SELECT compress_chunk(:'OLD_CHUNK_NAME', recompress := true);
 
 -- Get info for the new compressed chunk
-SELECT compressed.schema_name || '.' || compressed.table_name AS "NEW_COMPRESSED_CHUNK_NAME",
-        compressed.id AS "NEW_CHUNK_ID"
+SELECT cs.compress_relid::regclass::text AS "NEW_COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk uncompressed
-JOIN _timescaledb_catalog.chunk compressed
-  ON uncompressed.compressed_chunk_id = compressed.id
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.relid = format('%I.%I', uncompressed.schema_name, uncompressed.table_name)::regclass
 WHERE uncompressed.schema_name || '.' || uncompressed.table_name = :'OLD_CHUNK_NAME'
 LIMIT 1 \gset
 
@@ -55,10 +53,10 @@ LIMIT 1 \gset
 
 -- Check if a new chunk was created (this will show in the output)
 SELECT
-  CASE WHEN :'NEW_CHUNK_ID' IS NULL OR :'OLD_CHUNK_ID' = :'NEW_CHUNK_ID' THEN
+  CASE WHEN :'NEW_COMPRESSED_CHUNK_NAME' IS NULL OR :'OLD_COMPRESSED_CHUNK_NAME' = :'NEW_COMPRESSED_CHUNK_NAME' THEN
     'ERROR: Recompression did not create a new chunk'
   ELSE
-    'SUCCESS: New chunk created, old_chunk_id=' || :'OLD_CHUNK_ID' || ', new_chunk_id=' || :'NEW_CHUNK_ID'
+    'SUCCESS: New chunk created, old_chunk=' || :'OLD_COMPRESSED_CHUNK_NAME' || ', new_chunk=' || :'NEW_COMPRESSED_CHUNK_NAME'
   END AS recompression_status;
 
 -- Compare result using diff to validate integrity of recompressed data

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -327,7 +327,6 @@ from _timescaledb_catalog.compression_chunk_size ccs \gset
 create view compression_size_fraction as
 select
     ccs.chunk_id,
-    ccs.compressed_chunk_id,
     round(ccs.uncompressed_heap_size::numeric / :total_uncompressed_heap_size, 1) as uncompressed_heap_size_fraction,
     ccs.uncompressed_toast_size::numeric as uncompressed_toast_size_fraction,
     round(ccs.uncompressed_index_size::numeric / :total_uncompressed_index_size, 1) as uncompressed_index_size_fraction,

--- a/tsl/test/sql/rebuild_columnstore_tests.sql
+++ b/tsl/test/sql/rebuild_columnstore_tests.sql
@@ -12,7 +12,8 @@ SELECT
     cc.schema_name || '.' || cc.table_name AS compressed_chunk,
     _timescaledb_functions.chunk_status_text((uc.schema_name || '.' || uc.table_name)::regclass) AS status
 FROM _timescaledb_catalog.chunk uc
-LEFT JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+LEFT JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+LEFT JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h ON uc.hypertable_id = h.id;
 
 SET timescaledb.enable_direct_compress_insert = true;

--- a/tsl/test/sql/rebuild_sparse_index.sql
+++ b/tsl/test/sql/rebuild_sparse_index.sql
@@ -12,7 +12,8 @@ RETURNS TABLE(attname name, typname name) AS $$
     WHERE a.attrelid = (
         SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass
         FROM _timescaledb_catalog.chunk uc
-        JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+        JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+        JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
         WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass
     )
     AND a.attname LIKE '_ts_meta_%'
@@ -155,7 +156,8 @@ DECLARE
 BEGIN
     SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass INTO compressed_relid
     FROM _timescaledb_catalog.chunk uc
-    JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+    JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+    JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
     WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass;
 
     SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY a.attname) INTO col_list
@@ -183,12 +185,14 @@ SELECT compress_chunk(:'ichunk2');
 
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 
 SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
 
 \o :ORIGINAL
@@ -239,12 +243,14 @@ SELECT compress_chunk(:'ichunk2');
 -- re-fetch compressed chunk names after recompress
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 
 SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
 
 \o :ORIGINAL
@@ -293,7 +299,8 @@ SELECT compress_chunk(:'ichunk1');
 
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 
 ALTER TABLE rsi_integrity SET (
@@ -365,7 +372,8 @@ SELECT compress_chunk(:'ichunk1');
 
 SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc ON uc.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
+JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
 
 ALTER TABLE rsi_integrity SET (

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -17,8 +17,10 @@ SELECT
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
+   LEFT JOIN _timescaledb_catalog.compression_settings cs
+ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
    LEFT JOIN _timescaledb_catalog.chunk comp
-ON comp.id = c.compressed_chunk_id
+ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 
 CREATE OR REPLACE VIEW compression_rowcnt_view AS
@@ -490,9 +492,9 @@ FROM generate_series(1, 500) t;
 SELECT compress_chunk(c) FROM show_chunks('segwise_no_overlap') c;
 
 -- Locate the compressed chunk for the metadata check.
-SELECT cc.schema_name || '.' || cc.table_name AS comp_table_segwise
+SELECT cs.compress_relid AS comp_table_segwise
 FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.chunk cc      ON cc.id = uc.compressed_chunk_id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h  ON h.id  = uc.hypertable_id
 WHERE h.table_name = 'segwise_no_overlap' \gset
 

--- a/tsl/test/sql/split_chunk.sql
+++ b/tsl/test/sql/split_chunk.sql
@@ -437,7 +437,7 @@ select *
 from ONLY _timescaledb_internal._hyper_1_3_chunk
 order by time;
 
-select table_name, status, compressed_chunk_id
+select table_name, status
 from _timescaledb_catalog.chunk where table_name = '_hyper_1_3_chunk';
 analyze _timescaledb_internal._hyper_1_3_chunk;
 
@@ -457,7 +457,7 @@ call split_chunk('_timescaledb_internal._hyper_1_3_chunk');
 -- Check that the resulting chunks look OK and have the right access method
 select * from chunk_info;
 
-select table_name, status, compressed_chunk_id
+select table_name, status
 from _timescaledb_catalog.chunk
 where table_name in ('_hyper_1_3_chunk', '_hyper_1_16_chunk');
 

--- a/tsl/test/sql/uncompressed_size.sql
+++ b/tsl/test/sql/uncompressed_size.sql
@@ -15,7 +15,7 @@ SELECT compress_chunk(chunk) FROM show_chunks('t1') AS chunk;
 SELECT compress_chunk(chunk) FROM show_chunks('t2') AS chunk;
 
 
-SELECT ccs.compressed_chunk_id, l.relation_size, l.index_size, l.total_size FROM _timescaledb_catalog.compression_chunk_size ccs JOIN _timescaledb_catalog.chunk ch ON ch.id=ccs.compressed_chunk_id JOIN LATERAL (SELECT * FROM _timescaledb_functions.estimate_uncompressed_size(format('%I.%I',ch.schema_name,ch.table_name))) l ON true;
+SELECT cs.compress_relid, l.relation_size, l.index_size, l.total_size FROM _timescaledb_catalog.compression_chunk_size ccs JOIN _timescaledb_catalog.chunk uc ON uc.id=ccs.chunk_id JOIN _timescaledb_catalog.compression_settings cs ON cs.relid=format('%I.%I',uc.schema_name,uc.table_name)::regclass JOIN LATERAL (SELECT * FROM _timescaledb_functions.estimate_uncompressed_size(cs.compress_relid)) l ON true;
 
 -- test NULL compression does not error and returns NULL
 INSERT INTO t1 SELECT '2026-01-01'::timestamptz + format('%s ms', i)::interval, NULL, NULL FROM generate_series(1, 3000) i;

--- a/tsl/test/sql/vacuum.sql
+++ b/tsl/test/sql/vacuum.sql
@@ -218,10 +218,10 @@ ANALYZE cagg_analyze_view;
 
 SELECT count(*) > 0 AS compression_chunk_analyzed
 FROM pg_stat_all_tables s
-JOIN _timescaledb_catalog.chunk c
-  ON c.table_name = s.relname AND c.schema_name = s.schemaname
+JOIN _timescaledb_catalog.compression_settings cs
+  ON cs.compress_relid = s.relid
 JOIN _timescaledb_catalog.chunk parent
-  ON parent.compressed_chunk_id = c.id
+  ON cs.relid = format('%I.%I', parent.schema_name, parent.table_name)::regclass
 WHERE parent.hypertable_id = (SELECT mat_hypertable_id
                               FROM _timescaledb_catalog.continuous_agg
                               WHERE user_view_name = 'cagg_analyze_view')


### PR DESCRIPTION
The source of truth for chunk <-> compressed chunk link is
_timescaledb_catalog.compression_settings. This patch adjusts
the code to use that instead of compressed_chunk_id.

Disable-check: force-changelog-file