### PR TITLE
Show warning when downgrading and block upgrading when firstlast indexes are present

### DIFF
--- a/.unreleased/pr_9967
+++ b/.unreleased/pr_9967
@@ -1,0 +1,1 @@
+Fixes: #9967 Block upgrade after downgrade with firstlast indexes present

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -11,6 +11,28 @@ BEGIN
 END;
 $$;
 
+-- Block the update if any firstlast sparse indexes exist. This could only
+-- happen when downgrading and then upgrading again. Under this circumstance
+-- the firstlast sparse index might not be consistent for any chunks that
+-- were recompressed while the extension was downgraded.
+DO $$
+DECLARE
+  affected text;
+BEGIN
+  SELECT string_agg(DISTINCT relid::text, ', ')
+  INTO affected
+  FROM _timescaledb_catalog.compression_settings
+  WHERE compress_relid IS NOT NULL AND index @> '[{"type": "firstlast"}]';
+
+  IF affected IS NOT NULL THEN
+    RAISE EXCEPTION 'cannot upgrade because firstlast sparse indexes exist'
+      USING
+        DETAIL = format('The following chunks have firstlast sparse indexes: %s', affected),
+        HINT = 'Recompress the chunks with firstlast indexes before upgrading.';
+  END IF;
+END
+$$;
+
 -- Rename legacy chunk-side constraints to the names the new code recomputes:
 -- FKs use the parent's name; unique/PK/exclusion/trigger use the deterministic
 -- "<chunk_id>_<parent>" form

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,4 +1,22 @@
 
+-- Warn about firstlast indexes when downgrading.
+DO $$
+DECLARE
+  affected text;
+BEGIN
+  SELECT string_agg(DISTINCT relid::text, ', ')
+  INTO affected
+  FROM _timescaledb_catalog.compression_settings
+  WHERE index @> '[{"type": "firstlast"}]';
+
+  IF affected IS NOT NULL THEN
+    RAISE WARNING 'Before upgrading again you have to recompress chunks with firstlast indexes.'
+      USING
+        DETAIL = format('The following chunk use firstlast sparse indexes: %s', affected);
+  END IF;
+END
+$$;
+
 DROP VIEW IF EXISTS _timescaledb_catalog.chunk_constraint;
 DROP FUNCTION IF EXISTS _timescaledb_functions.chunk_constraint_add_table_constraint( integer, name, name);
 


### PR DESCRIPTION
You can rebuild  chunks with firstlast index like so:

```
DO $$
DECLARE
  chunk regclass;
  BEGIN
    FOR chunk IN
      SELECT relid FROM _timescaledb_catalog.compression_settings
      WHERE compress_relid IS NOT NULL AND index @> '[{"type": "firstlast"}]'
    LOOP
      PERFORM compress_chunk(chunk,recompress:=true);
      COMMIT;
    END LOOP;
END
$$;