### PR TITLE
Fix wrong allocation size for chunk column stats data

### DIFF
--- a/src/ts_catalog/chunk_column_stats.h
+++ b/src/ts_catalog/chunk_column_stats.h
@@ -24,7 +24,7 @@ typedef struct ChunkRangeSpace
 } ChunkRangeSpace;
 
 #define CHUNKRANGESPACE_SIZE(num_columns)                                                          \
-	(sizeof(ChunkRangeSpace) + (sizeof(NameData) * (num_columns)))
+	(sizeof(ChunkRangeSpace) + (sizeof(FormData_chunk_column_stats) * (num_columns)))
 
 extern ChunkRangeSpace *ts_chunk_column_stats_range_space_scan(int32 hypertable_id, Oid ht_reloid,
 															   MemoryContext mctx);

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -775,3 +775,17 @@ SELECT * FROM attno WHERE id = 1 AND start > '2025-02-02T11:53:28Z'::date ORDER 
   1 | Thu Jan 01 00:01:00 2026 PST
   1 | Thu Jan 01 00:06:00 2026 PST
 
+-- Test for wrong allocation size of chunk stats storage
+CREATE TABLE sensor_readings(measured_at timestamptz NOT NULL, temperature int, humidity int);
+SELECT create_hypertable('sensor_readings', 'measured_at');
+       create_hypertable       
+-------------------------------
+ (10,public,sensor_readings,t)
+
+SELECT enable_chunk_skipping('sensor_readings', 'temperature');
+ enable_chunk_skipping 
+-----------------------
+ (17,t)
+
+RESET timescaledb.enable_chunk_skipping;
+RESET timescaledb.enable_chunk_skipping;

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -351,3 +351,12 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('attno') ch;
 
 SELECT * FROM attno WHERE id = 1 AND start > '2025-02-02T11:53:28Z'::date ORDER BY start;
 
+
+-- Test for wrong allocation size of chunk stats storage
+CREATE TABLE sensor_readings(measured_at timestamptz NOT NULL, temperature int, humidity int);
+SELECT create_hypertable('sensor_readings', 'measured_at');
+SELECT enable_chunk_skipping('sensor_readings', 'temperature');
+RESET timescaledb.enable_chunk_skipping;
+
+
+RESET timescaledb.enable_chunk_skipping;


### PR DESCRIPTION
Triggers an AddressSanitizer failure.

Disable-check: force-changelog-file