### PR TITLE
Handle wrong user-supplied input in bloom1_hash function

### DIFF
--- a/tsl/src/compression/batch_metadata_builder_bloom1.c
+++ b/tsl/src/compression/batch_metadata_builder_bloom1.c
@@ -903,10 +903,14 @@ bloom1_hash(PG_FUNCTION_ARGS)
 		TupleDesc tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
 
 		num_columns = tupdesc->natts;
-		Ensure(num_columns <= MAX_BLOOM_FILTER_COLUMNS,
-			   "composite bloom filter supports at most %d columns, got %d",
-			   MAX_BLOOM_FILTER_COLUMNS,
-			   num_columns);
+		if (num_columns > MAX_BLOOM_FILTER_COLUMNS)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("composite bloom filter supports at most %d columns, got %d",
+							MAX_BLOOM_FILTER_COLUMNS,
+							num_columns)));
+		}
 
 		for (int i = 0; i < num_columns; i++)
 		{

--- a/tsl/test/expected/compress_bloom_sparse_debug.out
+++ b/tsl/test/expected/compress_bloom_sparse_debug.out
@@ -230,3 +230,6 @@ SELECT _timescaledb_functions.bloom1_contains(NULL, pg_catalog.record_in(null::c
 -----------------
  f
 
+-- The hash function is callable by user, so must return proper error
+SELECT _timescaledb_functions.bloom1_hash(ROW(1, 2, 3, 4, 5, 6, 7, 8, 9));
+ERROR:  composite bloom filter supports at most 8 columns, got 9

--- a/tsl/test/sql/compress_bloom_sparse_debug.sql
+++ b/tsl/test/sql/compress_bloom_sparse_debug.sql
@@ -166,3 +166,8 @@ SELECT _timescaledb_functions.bloom1_contains('\xd098c885f08468eb8916751d947f248
 -- both args NULL but second arg obfuscated through record_in
 SELECT _timescaledb_functions.bloom1_contains(NULL, pg_catalog.record_in(null::cstring, 23::oid, 12::int4));
 
+
+-- The hash function is callable by user, so must return proper error
+SELECT _timescaledb_functions.bloom1_hash(ROW(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+


### PR DESCRIPTION
We can't use Ensure to verify the user-supplied arguments.

Disable-check: force-changelog-file