### PR TITLE
Support first/last(val, ord) in ColumnarIndexScan

### DIFF
--- a/.unreleased/pr_9980
+++ b/.unreleased/pr_9980
@@ -1,0 +1,1 @@
+Implements: #9980 Support first/last(val, ord) in ColumnarIndexScan

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
@@ -44,8 +44,10 @@ _columnar_index_scan_init(void)
  * Currently supported aggregates are min, max, first, and last.
  */
 static bool
-is_supported_aggregate(Aggref *aggref, Var **arg_var_out, const char **meta_type_out)
+is_supported_aggregate(Aggref *aggref, Var **arg_var_out, const char **meta_type_out,
+					   Var **orderby_var_out)
 {
+	*orderby_var_out = NULL;
 	if (aggref->args == NIL)
 	{
 		return false;
@@ -133,7 +135,7 @@ is_supported_aggregate(Aggref *aggref, Var **arg_var_out, const char **meta_type
 			*arg_var_out = var;
 			return true;
 		default:
-			/* Check for first()/last() with both args referencing same column */
+			/* Check for first()/last() */
 			if (!OidIsValid(ts_first_func_oid) || !OidIsValid(ts_last_func_oid))
 			{
 				ts_func_cache_init();
@@ -147,12 +149,30 @@ is_supported_aggregate(Aggref *aggref, Var **arg_var_out, const char **meta_type
 				}
 				TargetEntry *tle2 = castNode(TargetEntry, lsecond(aggref->args));
 				Node *arg2_expr = strip_implicit_coercions((Node *) tle2->expr);
-				if (!equal(var, arg2_expr))
+
+				if (equal(var, arg2_expr))
+				{
+					/* Same column: first(x,x) / last(x,x) */
+					*meta_type_out = (aggref->aggfnoid == ts_first_func_oid) ? "min" : "max";
+					*arg_var_out = var;
+					return true;
+				}
+
+				/* Different columns: first(x,y) / last(x,y) */
+				if (!IsA(arg2_expr, Var))
 				{
 					return false;
 				}
-				*meta_type_out = (aggref->aggfnoid == ts_first_func_oid) ? "min" : "max";
+
+				Var *arg2_var = castNode(Var, arg2_expr);
+				if (arg2_var->varattno <= 0)
+				{
+					return false;
+				}
+
 				*arg_var_out = var;
+				*orderby_var_out = arg2_var;
+				*meta_type_out = (aggref->aggfnoid == ts_first_func_oid) ? "first" : "last";
 				return true;
 			}
 			break;
@@ -337,13 +357,117 @@ validate_entries_walker(Node *node, void *context)
 		else
 		{
 			Var *arg_var = NULL;
+			Var *orderby_var = NULL;
 			const char *meta_type = NULL;
-			if (!is_supported_aggregate(aggref, &arg_var, &meta_type))
+			if (!is_supported_aggregate(aggref, &arg_var, &meta_type, &orderby_var))
 			{
 				return true;
 			}
 
-			if (arg_var->varattno == TableOidAttributeNumber)
+			if (orderby_var != NULL)
+			{
+				/*
+				 * Two-column first(value, orderby) or last(value, orderby).
+				 * The orderby column must be the first orderby column.
+				 */
+				char *orderby_col_name =
+					get_attname(ctx->uncompressed_relid, orderby_var->varattno, false);
+				int16 orderby_pos = ts_array_position(ctx->settings->fd.orderby, orderby_col_name);
+				if (orderby_pos != 1)
+				{
+					return true;
+				}
+
+				/*
+				 * first and last functions disregard NULL values.
+				 * Skip NULLABLE orderby columns as boundary values could be NULL.
+				 */
+				if (!ts_get_attnotnull(ctx->uncompressed_relid, orderby_var->varattno))
+				{
+					return true;
+				}
+
+				bool desc = ts_array_get_element_bool(ctx->settings->fd.orderby_desc, 1);
+				bool is_first_agg = (strcmp(meta_type, "first") == 0);
+
+				/*
+				 * Determine which metadata columns to use.
+				 */
+				const char *value_meta_type;
+				const char *orderby_meta_type;
+				/*
+				 * first(value, orderby) returns value's value at min(orderby).
+				 * If orderby is descending, min(orderby) value corresponds to the last metadata
+				 * column. Similar logic for last(value, orderby)
+				 */
+				if (is_first_agg)
+				{
+					value_meta_type = desc ? "last" : "first";
+					orderby_meta_type = "min";
+				}
+				else
+				{
+					value_meta_type = desc ? "first" : "last";
+					orderby_meta_type = "max";
+				}
+
+				/* Look up value column's firstlast metadata */
+				AttrNumber value_meta_attno =
+					compressed_column_metadata_attno(ctx->settings,
+													 ctx->uncompressed_relid,
+													 arg_var->varattno,
+													 ctx->compressed_relid,
+													 value_meta_type);
+				if (value_meta_attno == InvalidAttrNumber)
+				{
+					return true;
+				}
+
+				AttrNumber value_child_resno =
+					find_resno_by_compressed_attno(ctx->leaf_plan, value_meta_attno);
+				if (value_child_resno == InvalidAttrNumber)
+				{
+					return true;
+				}
+
+				/* Look up orderby column's min/max metadata */
+				AttrNumber orderby_meta_attno =
+					compressed_column_metadata_attno(ctx->settings,
+													 ctx->uncompressed_relid,
+													 orderby_var->varattno,
+													 ctx->compressed_relid,
+													 orderby_meta_type);
+				if (orderby_meta_attno == InvalidAttrNumber)
+				{
+					return true;
+				}
+
+				AttrNumber orderby_child_resno =
+					find_resno_by_compressed_attno(ctx->leaf_plan, orderby_meta_attno);
+				if (orderby_child_resno == InvalidAttrNumber)
+				{
+					return true;
+				}
+
+				/* Add value metadata output first, then orderby metadata.
+				 * The rewrite mutator consumes them in this order. */
+				add_scan_output(ctx,
+								value_child_resno,
+								ctx->uncompressed_scanrelid,
+								arg_var->varattno,
+								get_atttype(ctx->compressed_relid, value_meta_attno),
+								-1,
+								arg_var->varcollid);
+
+				add_scan_output(ctx,
+								orderby_child_resno,
+								ctx->uncompressed_scanrelid,
+								orderby_var->varattno,
+								get_atttype(ctx->compressed_relid, orderby_meta_attno),
+								-1,
+								orderby_var->varcollid);
+			}
+			else if (arg_var->varattno == TableOidAttributeNumber)
 			{
 				/*
 				 * tableoid is constant within a single chunk scan, so
@@ -495,24 +619,63 @@ rewrite_agg_tlist_mutator(Node *node, void *context)
 		Aggref *aggref = copyObject(orig);
 		TargetEntry *scan_tle = list_nth_node(TargetEntry, ctx->custom_scan_tlist, resno - 1);
 		Var *scan_var = castNode(Var, scan_tle->expr);
-		Var *new_arg = makeVar(OUTER_VAR,
-							   resno,
-							   scan_var->vartype,
-							   scan_var->vartypmod,
-							   scan_var->varcollid,
-							   0);
-		TargetEntry *new_arg_te = makeTargetEntry((Expr *) new_arg, 1, NULL, false);
 
 		if (list_length(aggref->args) == 2)
 		{
-			/* first/last: both args point to same metadata column */
-			Var *new_arg2 = copyObject(new_arg);
-			TargetEntry *new_arg_te2 = makeTargetEntry((Expr *) new_arg2, 2, NULL, false);
-			aggref->args = list_make2(new_arg_te, new_arg_te2);
+			TargetEntry *orig_te1 = linitial_node(TargetEntry, orig->args);
+			TargetEntry *orig_te2 = lsecond_node(TargetEntry, orig->args);
+			Node *orig_arg1 = strip_implicit_coercions((Node *) orig_te1->expr);
+			Node *orig_arg2 = strip_implicit_coercions((Node *) orig_te2->expr);
+
+			if (!equal(orig_arg1, orig_arg2))
+			{
+				/* Two-column first/last: arg1 → value metadata, arg2 → orderby metadata */
+				Var *new_arg1 = makeVar(OUTER_VAR,
+										resno,
+										scan_var->vartype,
+										scan_var->vartypmod,
+										scan_var->varcollid,
+										0);
+
+				AttrNumber resno2 = ctx->next_resno++;
+				TargetEntry *scan_tle2 =
+					list_nth_node(TargetEntry, ctx->custom_scan_tlist, resno2 - 1);
+				Var *scan_var2 = castNode(Var, scan_tle2->expr);
+				Var *new_arg2 = makeVar(OUTER_VAR,
+										resno2,
+										scan_var2->vartype,
+										scan_var2->vartypmod,
+										scan_var2->varcollid,
+										0);
+
+				aggref->args = list_make2(makeTargetEntry((Expr *) new_arg1, 1, NULL, false),
+										  makeTargetEntry((Expr *) new_arg2, 2, NULL, false));
+			}
+			else
+			{
+				/* Same column: both args point to same metadata column */
+				Var *new_arg = makeVar(OUTER_VAR,
+									   resno,
+									   scan_var->vartype,
+									   scan_var->vartypmod,
+									   scan_var->varcollid,
+									   0);
+
+				aggref->args =
+					list_make2(makeTargetEntry((Expr *) new_arg, 1, NULL, false),
+							   makeTargetEntry((Expr *) copyObject(new_arg), 2, NULL, false));
+			}
 		}
 		else
 		{
-			aggref->args = list_make1(new_arg_te);
+			/* min/max: single arg */
+			Var *new_arg = makeVar(OUTER_VAR,
+								   resno,
+								   scan_var->vartype,
+								   scan_var->vartypmod,
+								   scan_var->varcollid,
+								   0);
+			aggref->args = list_make1(makeTargetEntry((Expr *) new_arg, 1, NULL, false));
 		}
 
 		return (Node *) aggref;
@@ -527,6 +690,8 @@ rewrite_agg_tlist_mutator(Node *node, void *context)
  *   count(*)        → sum(_ts_meta_count)
  *   min(col)/max(col) → same aggfnoid, arg rewritten to metadata column
  *   first(col,col)/last(col,col) → same aggfnoid, both args rewritten
+ *   first(val,ord)/last(val,ord) → same aggfnoid, args rewritten to
+ *       value's firstlast metadata and orderby's min/max metadata
  *
  * Expressions that combine aggregates (e.g. 2*count(*), min(x)+max(y)) are
  * supported — the walker/mutator handles Var and Aggref nodes at any depth.

--- a/tsl/test/expected/columnar_index_scan-15.out
+++ b/tsl/test/expected/columnar_index_scan-15.out
@@ -16,22 +16,23 @@ CREATE TABLE metrics(
     device text,
     sensor text,
     value float,
-    value2 float
-) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
+    value2 float,
+    value3 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value), firstlast(value3)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
+('2025-01-01 00:01:00 PST', 'd1', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1, 40.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1, 290.0),
+('2025-01-01 00:01:00 PST', 'd2', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1, 60.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1, 310.0);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -111,6 +112,21 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -178,6 +194,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -194,6 +217,14 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -212,6 +243,14 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -226,6 +265,14 @@ SHOW timescaledb.enable_columnarindexscan;
  GroupAggregate
    Group Key: device
    Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   Filter: (first(value3, "time") > '5'::double precision)
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
@@ -277,6 +324,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -301,8 +355,44 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: device
@@ -333,9 +423,26 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -400,6 +507,25 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -420,6 +546,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          Group Key: device
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -500,8 +633,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Seq Scan on compress_hyper_2_2_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
 --- QUERY PLAN ---
  Aggregate
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
@@ -523,7 +669,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Seq Scan on compress_hyper_2_2_chunk
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -532,6 +678,14 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
@@ -767,13 +921,12 @@ SET enable_partitionwise_aggregate = off;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: m1.device
-   ->  Merge Join
-         Merge Cond: (m1.device = m2.device)
+   ->  Nested Loop
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
-         ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     Index Cond: (device = m1.device)
 
 \set PREFIX ''
 \set ECHO errors
@@ -905,6 +1058,37 @@ SHOW timescaledb.enable_columnarindexscan;
                      Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -1016,6 +1200,21 @@ SHOW timescaledb.enable_columnarindexscan;
                      Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
                      ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.device, metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -1054,6 +1253,21 @@ SHOW timescaledb.enable_columnarindexscan;
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -1094,6 +1308,25 @@ SHOW timescaledb.enable_columnarindexscan;
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -1122,6 +1355,22 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Partial HashAggregate
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
@@ -1209,6 +1458,21 @@ SHOW timescaledb.enable_columnarindexscan;
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -1251,6 +1515,67 @@ SHOW timescaledb.enable_columnarindexscan;
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -1264,6 +1589,21 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Partial HashAggregate
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
@@ -1313,9 +1653,42 @@ SHOW timescaledb.enable_columnarindexscan;
                            Group Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -1420,6 +1793,39 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                            Group Key: _hyper_1_1_chunk_1.device
                            ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: _hyper_1_1_chunk_1.device
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -1454,6 +1860,17 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Partial HashAggregate
                            Group Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -1586,6 +2003,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Partial Aggregate
                ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -1594,6 +2026,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Merge Append
+                       Sort Key: metrics."time"
+                       ->  Sort
+                             Sort Key: _hyper_1_1_chunk."time"
+                             ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                   ->  Seq Scan on compress_hyper_2_2_chunk
+                       ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -1618,7 +2065,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
@@ -1635,6 +2082,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
    Sort Key: metrics.device
@@ -2169,6 +2632,37 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -2304,6 +2798,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -2338,6 +2847,22 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -2374,6 +2899,23 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -2396,6 +2938,22 @@ SHOW timescaledb.enable_columnarindexscan;
  Finalize GroupAggregate
    Group Key: metrics.device
    Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
    ->  Merge Append
          Sort Key: metrics.device
          ->  Partial GroupAggregate
@@ -2502,6 +3060,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -2550,8 +3123,84 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -2614,9 +3263,42 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -2729,6 +3411,41 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                            ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                                  ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -2765,6 +3482,37 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      Group Key: device
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $1)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_4_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+   InitPlan 2 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -2908,6 +3656,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -2917,6 +3680,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Seq Scan on compress_hyper_2_2_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                ->  Seq Scan on compress_hyper_2_4_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_4_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -2944,7 +3723,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on compress_hyper_2_4_chunk
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -2961,6 +3740,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -3414,3 +4209,1796 @@ NOTICE:  using column "ts" as partitioning column
 -------
      6
 
+-- Test: nullable orderby column should NOT use ColumnarIndexScan for first/last(col, orderby)
+CREATE TABLE metrics_nullable_orderby(
+    time int NOT NULL,
+    priority int,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.orderby='priority',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+INSERT INTO metrics_nullable_orderby VALUES
+(1, 1, 'd1', 10.0),
+(2, 2, 'd1', 20.0),
+(3, 3, 'd1', 15.0),
+(4, 1, 'd2', 30.0),
+(5, 2, 'd2', 5.0),
+(6, NULL, 'd2', 99.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_nullable_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, priority) should NOT optimize because priority is nullable
+EXPLAIN (costs off) SELECT device, first(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- min/max should still optimize
+EXPLAIN (costs off) SELECT device, min(priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_5_7_chunk metrics_nullable_orderby
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- Test: multiple orderby columns, first/last only optimized for the first orderby column
+CREATE TABLE metrics_multi_orderby(
+    time timestamptz NOT NULL,
+    seq int NOT NULL,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc, seq asc',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_multi_orderby VALUES
+('2025-01-01 00:00:00 PST', 1, 'd1', 10.0),
+('2025-01-01 00:01:00 PST', 2, 'd1', 20.0),
+('2025-01-01 01:00:00 PST', 1, 'd1', 15.0),
+('2025-01-01 00:02:00 PST', 1, 'd2', 30.0),
+('2025-01-01 01:02:00 PST', 1, 'd2', 5.0),
+('2025-01-01 01:03:00 PST', 2, 'd2', 25.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_multi_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_9_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, time) should optimize (time is first orderby column)
+EXPLAIN (costs off) SELECT device, first(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- first/last(value, seq) should NOT optimize (seq is second orderby column)
+EXPLAIN (costs off) SELECT device, first(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- correctness check
+SET timescaledb.enable_columnarindexscan = off;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+SET timescaledb.enable_columnarindexscan = on;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+-- Repeat all queries with ASC orderby to test the DESC flip logic
+ALTER TABLE metrics SET (timescaledb.compress_orderby = 'time asc');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(decompress_chunk(c)) FROM show_chunks('metrics') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- get query plans
+\set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Append
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $1)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+   InitPlan 2 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last on column without firstlast sparse index (should not optimize)
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUPING SETS / ROLLUP / CUBE are not supported by ColumnarIndexScan
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY ROLLUP(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   Group Key: metrics.device
+   Group Key: ()
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY CUBE(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.sensor
+         Group Key: metrics.device, metrics.sensor
+         Group Key: metrics.device
+         Group Key: ()
+         ->  Merge Append
+               Sort Key: metrics.device, metrics.sensor
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY GROUPING SETS ((device), (sensor), ()) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.device
+         Hash Key: metrics.sensor
+         Group Key: ()
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- DISTINCT on a segmentby column (Agg with no Aggrefs)
+:PREFIX SELECT DISTINCT device FROM metrics ORDER BY device;
+--- QUERY PLAN ---
+ Unique
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- count(*) without GROUP BY
+:PREFIX SELECT count(*) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate only in HAVING (not in SELECT)
+:PREFIX SELECT device FROM metrics GROUP BY device HAVING min(value) > 10 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY ordinal position
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY 1 ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY () empty grouping
+:PREFIX SELECT count(*) FROM metrics GROUP BY ();
+--- QUERY PLAN ---
+ Aggregate
+   Group Key: ()
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate wrapped in COALESCE
+:PREFIX SELECT device, COALESCE(min(time), '2000-01-01'::timestamptz) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate above a JOIN (Agg not directly above ColumnarScan)
+:PREFIX SELECT m.device, min(m.time) FROM metrics m JOIN (VALUES ('d1'), ('d2')) AS d(device) ON m.device = d.device GROUP BY m.device ORDER BY m.device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m.device
+   ->  HashAggregate
+         Group Key: m.device
+         ->  Nested Loop
+               ->  Values Scan on "*VALUES*"
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+
+-- ordered-set aggregate (not supported)
+:PREFIX SELECT device, percentile_cont(0.5) WITHIN GROUP (ORDER BY value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- bool_and / bool_or (not supported)
+:PREFIX SELECT device, bool_and(value > 0), bool_or(value > 0) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- partition-wise aggregate
+SET enable_partitionwise_aggregate = on;
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SET enable_partitionwise_aggregate = off;
+-- Aggref inside a SubLink in the outer tlist (inner aggregate belongs to a separate Agg)
+:PREFIX SELECT device, count(*), (SELECT count(*) FROM (VALUES (1),(2),(3)) v(x) WHERE x::text < device) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+   SubPlan 1
+     ->  Aggregate
+           ->  Values Scan on "*VALUES*"
+                 Filter: ((column1)::text < metrics.device)
+
+-- HAVING with non-pushable expression on grouping columns
+:PREFIX SELECT device, sensor, min(time) FROM metrics GROUP BY device, sensor HAVING (device || sensor) LIKE 'd1%' ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device, compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device, compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+
+-- same Aggref referenced multiple times in tlist
+:PREFIX SELECT device, min(time), date_trunc('day', min(time)) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY column not in SELECT (appears only as resjunk in Agg tlist)
+:PREFIX SELECT count(*) FROM metrics GROUP BY device ORDER BY count(*);
+--- QUERY PLAN ---
+ Sort
+   Sort Key: (sum(compress_hyper_2_11_chunk._ts_meta_count))
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- WHERE mixes segmentby and non-segmentby column
+:PREFIX SELECT device, count(*) FROM metrics WHERE device = 'd1' AND value > 10 GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Append
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+
+-- HAVING with NOT around Aggref
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) <= '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING with Aggref IS NULL
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) IS NULL ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) IS NULL)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY with explicit collation (not a bare Var)
+:PREFIX SELECT device COLLATE "C", count(*) FROM metrics GROUP BY device COLLATE "C" ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: ((metrics.device)::text)
+   ->  Merge Append
+         Sort Key: ((metrics.device)::text) COLLATE "C"
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_1_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_3_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- self-join on the same hypertable
+:PREFIX SELECT m1.device, min(m1.time) FROM metrics m1 JOIN metrics m2 ON m1.device = m2.device GROUP BY m1.device ORDER BY m1.device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: m1.device
+   ->  Merge Join
+         Merge Cond: (m1.device = m2.device)
+         ->  Merge Append
+               Sort Key: m1.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1_1
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_2
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Materialize
+               ->  Merge Append
+                     Sort Key: m2.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m2_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -16,22 +16,23 @@ CREATE TABLE metrics(
     device text,
     sensor text,
     value float,
-    value2 float
-) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
+    value2 float,
+    value3 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value), firstlast(value3)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
+('2025-01-01 00:01:00 PST', 'd1', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1, 40.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1, 290.0),
+('2025-01-01 00:01:00 PST', 'd2', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1, 60.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1, 310.0);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -111,6 +112,21 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -178,6 +194,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -194,6 +217,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -212,6 +242,14 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -226,6 +264,14 @@ SHOW timescaledb.enable_columnarindexscan;
  GroupAggregate
    Group Key: device
    Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   Filter: (first(value3, "time") > '5'::double precision)
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
@@ -277,6 +323,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -301,8 +354,44 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: device
@@ -333,9 +422,26 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -398,6 +504,23 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -418,6 +541,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          Group Key: device
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -498,6 +628,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -505,6 +642,16 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Sort
+                 Sort Key: _hyper_1_1_chunk."time"
+                 ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                       ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -524,7 +671,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Seq Scan on compress_hyper_2_2_chunk
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -533,6 +680,14 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
@@ -767,13 +922,12 @@ SET enable_partitionwise_aggregate = off;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: m1.device
-   ->  Merge Join
-         Merge Cond: (m1.device = m2.device)
+   ->  Nested Loop
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
-         ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     Index Cond: (device = m1.device)
 
 \set PREFIX ''
 \set ECHO errors
@@ -905,6 +1059,37 @@ SHOW timescaledb.enable_columnarindexscan;
                      Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -1016,6 +1201,21 @@ SHOW timescaledb.enable_columnarindexscan;
                      Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
                      ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  Finalize HashAggregate
+         Group Key: metrics.device, metrics.sensor
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -1054,6 +1254,18 @@ SHOW timescaledb.enable_columnarindexscan;
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -1094,6 +1306,25 @@ SHOW timescaledb.enable_columnarindexscan;
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -1122,6 +1353,22 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Partial HashAggregate
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
@@ -1209,6 +1456,21 @@ SHOW timescaledb.enable_columnarindexscan;
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -1251,6 +1513,67 @@ SHOW timescaledb.enable_columnarindexscan;
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -1264,6 +1587,21 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Partial HashAggregate
                Group Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
 
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
@@ -1313,9 +1651,42 @@ SHOW timescaledb.enable_columnarindexscan;
                            Group Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -1414,6 +1785,33 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                            Group Key: _hyper_1_1_chunk_1.device
                            ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -1448,6 +1846,17 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Partial HashAggregate
                            Group Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -1582,6 +1991,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Partial Aggregate
                ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -1592,6 +2016,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                      ->  Seq Scan on compress_hyper_2_2_chunk
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Merge Append
+                       Sort Key: metrics."time"
+                       ->  Sort
+                             Sort Key: _hyper_1_1_chunk."time"
+                             ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                   ->  Seq Scan on compress_hyper_2_2_chunk
+                       ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -1618,7 +2057,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
@@ -1635,6 +2074,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
    Sort Key: metrics.device
@@ -2166,6 +2621,37 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -2301,6 +2787,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -2335,6 +2836,19 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -2371,6 +2885,23 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -2393,6 +2924,22 @@ SHOW timescaledb.enable_columnarindexscan;
  Finalize GroupAggregate
    Group Key: metrics.device
    Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
    ->  Merge Append
          Sort Key: metrics.device
          ->  Partial GroupAggregate
@@ -2499,6 +3046,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -2547,8 +3109,84 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -2611,9 +3249,42 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -2720,6 +3391,35 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                            ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                                  ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -2756,6 +3456,37 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      Group Key: device
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $1)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_4_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+   InitPlan 2 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -2901,6 +3632,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -2913,6 +3659,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_4_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -2942,7 +3704,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on compress_hyper_2_4_chunk
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -2959,6 +3721,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -3409,3 +4187,1785 @@ NOTICE:  using column "ts" as partitioning column
 -------
      6
 
+-- Test: nullable orderby column should NOT use ColumnarIndexScan for first/last(col, orderby)
+CREATE TABLE metrics_nullable_orderby(
+    time int NOT NULL,
+    priority int,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.orderby='priority',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+INSERT INTO metrics_nullable_orderby VALUES
+(1, 1, 'd1', 10.0),
+(2, 2, 'd1', 20.0),
+(3, 3, 'd1', 15.0),
+(4, 1, 'd2', 30.0),
+(5, 2, 'd2', 5.0),
+(6, NULL, 'd2', 99.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_nullable_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, priority) should NOT optimize because priority is nullable
+EXPLAIN (costs off) SELECT device, first(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- min/max should still optimize
+EXPLAIN (costs off) SELECT device, min(priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_5_7_chunk metrics_nullable_orderby
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- Test: multiple orderby columns, first/last only optimized for the first orderby column
+CREATE TABLE metrics_multi_orderby(
+    time timestamptz NOT NULL,
+    seq int NOT NULL,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc, seq asc',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_multi_orderby VALUES
+('2025-01-01 00:00:00 PST', 1, 'd1', 10.0),
+('2025-01-01 00:01:00 PST', 2, 'd1', 20.0),
+('2025-01-01 01:00:00 PST', 1, 'd1', 15.0),
+('2025-01-01 00:02:00 PST', 1, 'd2', 30.0),
+('2025-01-01 01:02:00 PST', 1, 'd2', 5.0),
+('2025-01-01 01:03:00 PST', 2, 'd2', 25.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_multi_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_9_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, time) should optimize (time is first orderby column)
+EXPLAIN (costs off) SELECT device, first(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- first/last(value, seq) should NOT optimize (seq is second orderby column)
+EXPLAIN (costs off) SELECT device, first(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- correctness check
+SET timescaledb.enable_columnarindexscan = off;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+SET timescaledb.enable_columnarindexscan = on;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+-- Repeat all queries with ASC orderby to test the DESC flip logic
+ALTER TABLE metrics SET (timescaledb.compress_orderby = 'time asc');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(decompress_chunk(c)) FROM show_chunks('metrics') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- get query plans
+\set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $1)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             Vectorized Filter: ("time" IS NOT NULL)
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+   InitPlan 2 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last on column without firstlast sparse index (should not optimize)
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUPING SETS / ROLLUP / CUBE are not supported by ColumnarIndexScan
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY ROLLUP(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   Group Key: metrics.device
+   Group Key: ()
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY CUBE(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.sensor
+         Group Key: metrics.device, metrics.sensor
+         Group Key: metrics.device
+         Group Key: ()
+         ->  Merge Append
+               Sort Key: metrics.device, metrics.sensor
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY GROUPING SETS ((device), (sensor), ()) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.device
+         Hash Key: metrics.sensor
+         Group Key: ()
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- DISTINCT on a segmentby column (Agg with no Aggrefs)
+:PREFIX SELECT DISTINCT device FROM metrics ORDER BY device;
+--- QUERY PLAN ---
+ Unique
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- count(*) without GROUP BY
+:PREFIX SELECT count(*) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate only in HAVING (not in SELECT)
+:PREFIX SELECT device FROM metrics GROUP BY device HAVING min(value) > 10 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY ordinal position
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY 1 ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY () empty grouping
+:PREFIX SELECT count(*) FROM metrics GROUP BY ();
+--- QUERY PLAN ---
+ Aggregate
+   Group Key: ()
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate wrapped in COALESCE
+:PREFIX SELECT device, COALESCE(min(time), '2000-01-01'::timestamptz) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate above a JOIN (Agg not directly above ColumnarScan)
+:PREFIX SELECT m.device, min(m.time) FROM metrics m JOIN (VALUES ('d1'), ('d2')) AS d(device) ON m.device = d.device GROUP BY m.device ORDER BY m.device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m.device
+   ->  HashAggregate
+         Group Key: m.device
+         ->  Nested Loop
+               ->  Values Scan on "*VALUES*"
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+
+-- ordered-set aggregate (not supported)
+:PREFIX SELECT device, percentile_cont(0.5) WITHIN GROUP (ORDER BY value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- bool_and / bool_or (not supported)
+:PREFIX SELECT device, bool_and(value > 0), bool_or(value > 0) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- partition-wise aggregate
+SET enable_partitionwise_aggregate = on;
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SET enable_partitionwise_aggregate = off;
+-- Aggref inside a SubLink in the outer tlist (inner aggregate belongs to a separate Agg)
+:PREFIX SELECT device, count(*), (SELECT count(*) FROM (VALUES (1),(2),(3)) v(x) WHERE x::text < device) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+   SubPlan 1
+     ->  Aggregate
+           ->  Values Scan on "*VALUES*"
+                 Filter: ((column1)::text < metrics.device)
+
+-- HAVING with non-pushable expression on grouping columns
+:PREFIX SELECT device, sensor, min(time) FROM metrics GROUP BY device, sensor HAVING (device || sensor) LIKE 'd1%' ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device, compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device, compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+
+-- same Aggref referenced multiple times in tlist
+:PREFIX SELECT device, min(time), date_trunc('day', min(time)) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY column not in SELECT (appears only as resjunk in Agg tlist)
+:PREFIX SELECT count(*) FROM metrics GROUP BY device ORDER BY count(*);
+--- QUERY PLAN ---
+ Sort
+   Sort Key: (sum(compress_hyper_2_11_chunk._ts_meta_count))
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- WHERE mixes segmentby and non-segmentby column
+:PREFIX SELECT device, count(*) FROM metrics WHERE device = 'd1' AND value > 10 GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (hashed SubPlan 1))
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+
+-- HAVING with NOT around Aggref
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) <= '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING with Aggref IS NULL
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) IS NULL ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) IS NULL)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY with explicit collation (not a bare Var)
+:PREFIX SELECT device COLLATE "C", count(*) FROM metrics GROUP BY device COLLATE "C" ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: ((metrics.device)::text)
+   ->  Merge Append
+         Sort Key: ((metrics.device)::text) COLLATE "C"
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_1_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_3_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- self-join on the same hypertable
+:PREFIX SELECT m1.device, min(m1.time) FROM metrics m1 JOIN metrics m2 ON m1.device = m2.device GROUP BY m1.device ORDER BY m1.device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: m1.device
+   ->  Merge Join
+         Merge Cond: (m1.device = m2.device)
+         ->  Merge Append
+               Sort Key: m1.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1_1
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_2
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Materialize
+               ->  Merge Append
+                     Sort Key: m2.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m2_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -16,22 +16,23 @@ CREATE TABLE metrics(
     device text,
     sensor text,
     value float,
-    value2 float
-) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
+    value2 float,
+    value3 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value), firstlast(value3)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
+('2025-01-01 00:01:00 PST', 'd1', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1, 40.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1, 290.0),
+('2025-01-01 00:01:00 PST', 'd2', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1, 60.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1, 310.0);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -111,6 +112,21 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -178,6 +194,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -194,6 +217,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -212,6 +242,14 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -226,6 +264,14 @@ SHOW timescaledb.enable_columnarindexscan;
  GroupAggregate
    Group Key: device
    Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   Filter: (first(value3, "time") > '5'::double precision)
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
@@ -277,6 +323,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -301,8 +354,44 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: device
@@ -333,9 +422,26 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -398,6 +504,23 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -418,6 +541,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          Group Key: device
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -498,6 +628,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -505,6 +642,16 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Sort
+                 Sort Key: _hyper_1_1_chunk."time"
+                 ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                       ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -524,7 +671,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Seq Scan on compress_hyper_2_2_chunk
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -533,6 +680,14 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
@@ -767,13 +922,12 @@ SET enable_partitionwise_aggregate = off;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: m1.device
-   ->  Merge Join
-         Merge Cond: (m1.device = m2.device)
+   ->  Nested Loop
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
-         ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     Index Cond: (device = m1.device)
 
 \set PREFIX ''
 \set ECHO errors
@@ -903,6 +1057,43 @@ SHOW timescaledb.enable_columnarindexscan;
 
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -1052,6 +1243,24 @@ SHOW timescaledb.enable_columnarindexscan;
                      Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
                      ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -1090,6 +1299,18 @@ SHOW timescaledb.enable_columnarindexscan;
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -1130,6 +1351,25 @@ SHOW timescaledb.enable_columnarindexscan;
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -1162,6 +1402,22 @@ SHOW timescaledb.enable_columnarindexscan;
                Group Key: _hyper_1_1_chunk.device
                ->  Sort
                      Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- HAVING
@@ -1268,6 +1524,24 @@ SHOW timescaledb.enable_columnarindexscan;
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -1325,8 +1599,99 @@ SHOW timescaledb.enable_columnarindexscan;
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -1401,9 +1766,48 @@ SHOW timescaledb.enable_columnarindexscan;
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -1520,6 +1924,33 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                                  Sort Key: _hyper_1_1_chunk_1.device
                                  ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -1557,6 +1988,17 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Sort
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -1694,6 +2136,24 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Partial Aggregate
                ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -1707,6 +2167,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Sort
                Sort Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Merge Append
+                       Sort Key: metrics."time"
+                       ->  Sort
+                             Sort Key: _hyper_1_1_chunk."time"
+                             ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                   ->  Seq Scan on compress_hyper_2_2_chunk
+                       ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -1733,7 +2208,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -1753,6 +2228,25 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -1845,21 +2339,18 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 -- aggregate only in HAVING (not in SELECT)
 :PREFIX SELECT device FROM metrics GROUP BY device HAVING min(value) > 10 ORDER BY device;
 --- QUERY PLAN ---
- Finalize GroupAggregate
-   Group Key: metrics.device
-   Filter: (min(metrics.value) > '10'::double precision)
-   ->  Merge Append
-         Sort Key: metrics.device
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Sort
-                           Sort Key: compress_hyper_2_2_chunk.device
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (min(metrics.value) > '10'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
                            ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Sort
-                     Sort Key: _hyper_1_1_chunk.device
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- GROUP BY ordinal position
@@ -2106,21 +2597,18 @@ SET enable_partitionwise_aggregate = off;
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
- Finalize GroupAggregate
-   Group Key: metrics.device
-   Filter: (min(metrics.value) <= '10'::double precision)
-   ->  Merge Append
-         Sort Key: metrics.device
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Sort
-                           Sort Key: compress_hyper_2_2_chunk.device
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (min(metrics.value) <= '10'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
                            ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Sort
-                     Sort Key: _hyper_1_1_chunk.device
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- HAVING with Aggref IS NULL
@@ -2328,6 +2816,37 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -2463,6 +2982,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -2497,6 +3031,19 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -2533,6 +3080,23 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -2555,6 +3119,22 @@ SHOW timescaledb.enable_columnarindexscan;
  Finalize GroupAggregate
    Group Key: metrics.device
    Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
    ->  Merge Append
          Sort Key: metrics.device
          ->  Partial GroupAggregate
@@ -2661,6 +3241,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -2709,8 +3304,84 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -2773,9 +3444,42 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -2882,6 +3586,35 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                            ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                                  ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -2918,6 +3651,35 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      Group Key: device
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_4_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+   InitPlan 2
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -3063,6 +3825,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -3075,6 +3852,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_4_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -3104,7 +3897,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on compress_hyper_2_4_chunk
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -3121,6 +3914,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -3571,3 +4380,1783 @@ NOTICE:  using column "ts" as partitioning column
 -------
      6
 
+-- Test: nullable orderby column should NOT use ColumnarIndexScan for first/last(col, orderby)
+CREATE TABLE metrics_nullable_orderby(
+    time int NOT NULL,
+    priority int,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.orderby='priority',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+INSERT INTO metrics_nullable_orderby VALUES
+(1, 1, 'd1', 10.0),
+(2, 2, 'd1', 20.0),
+(3, 3, 'd1', 15.0),
+(4, 1, 'd2', 30.0),
+(5, 2, 'd2', 5.0),
+(6, NULL, 'd2', 99.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_nullable_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, priority) should NOT optimize because priority is nullable
+EXPLAIN (costs off) SELECT device, first(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- min/max should still optimize
+EXPLAIN (costs off) SELECT device, min(priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_5_7_chunk metrics_nullable_orderby
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- Test: multiple orderby columns, first/last only optimized for the first orderby column
+CREATE TABLE metrics_multi_orderby(
+    time timestamptz NOT NULL,
+    seq int NOT NULL,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc, seq asc',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_multi_orderby VALUES
+('2025-01-01 00:00:00 PST', 1, 'd1', 10.0),
+('2025-01-01 00:01:00 PST', 2, 'd1', 20.0),
+('2025-01-01 01:00:00 PST', 1, 'd1', 15.0),
+('2025-01-01 00:02:00 PST', 1, 'd2', 30.0),
+('2025-01-01 01:02:00 PST', 1, 'd2', 5.0),
+('2025-01-01 01:03:00 PST', 2, 'd2', 25.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_multi_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_9_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, time) should optimize (time is first orderby column)
+EXPLAIN (costs off) SELECT device, first(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- first/last(value, seq) should NOT optimize (seq is second orderby column)
+EXPLAIN (costs off) SELECT device, first(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- correctness check
+SET timescaledb.enable_columnarindexscan = off;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+SET timescaledb.enable_columnarindexscan = on;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+-- Repeat all queries with ASC orderby to test the DESC flip logic
+ALTER TABLE metrics SET (timescaledb.compress_orderby = 'time asc');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(decompress_chunk(c)) FROM show_chunks('metrics') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- get query plans
+\set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+   InitPlan 2
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last on column without firstlast sparse index (should not optimize)
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUPING SETS / ROLLUP / CUBE are not supported by ColumnarIndexScan
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY ROLLUP(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   Group Key: metrics.device
+   Group Key: ()
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY CUBE(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.sensor
+         Group Key: metrics.device, metrics.sensor
+         Group Key: metrics.device
+         Group Key: ()
+         ->  Merge Append
+               Sort Key: metrics.device, metrics.sensor
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY GROUPING SETS ((device), (sensor), ()) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.device
+         Hash Key: metrics.sensor
+         Group Key: ()
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- DISTINCT on a segmentby column (Agg with no Aggrefs)
+:PREFIX SELECT DISTINCT device FROM metrics ORDER BY device;
+--- QUERY PLAN ---
+ Unique
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- count(*) without GROUP BY
+:PREFIX SELECT count(*) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate only in HAVING (not in SELECT)
+:PREFIX SELECT device FROM metrics GROUP BY device HAVING min(value) > 10 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY ordinal position
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY 1 ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY () empty grouping
+:PREFIX SELECT count(*) FROM metrics GROUP BY ();
+--- QUERY PLAN ---
+ Aggregate
+   Group Key: ()
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate wrapped in COALESCE
+:PREFIX SELECT device, COALESCE(min(time), '2000-01-01'::timestamptz) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate above a JOIN (Agg not directly above ColumnarScan)
+:PREFIX SELECT m.device, min(m.time) FROM metrics m JOIN (VALUES ('d1'), ('d2')) AS d(device) ON m.device = d.device GROUP BY m.device ORDER BY m.device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m.device
+   ->  HashAggregate
+         Group Key: m.device
+         ->  Nested Loop
+               ->  Values Scan on "*VALUES*"
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+
+-- ordered-set aggregate (not supported)
+:PREFIX SELECT device, percentile_cont(0.5) WITHIN GROUP (ORDER BY value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- bool_and / bool_or (not supported)
+:PREFIX SELECT device, bool_and(value > 0), bool_or(value > 0) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- partition-wise aggregate
+SET enable_partitionwise_aggregate = on;
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SET enable_partitionwise_aggregate = off;
+-- Aggref inside a SubLink in the outer tlist (inner aggregate belongs to a separate Agg)
+:PREFIX SELECT device, count(*), (SELECT count(*) FROM (VALUES (1),(2),(3)) v(x) WHERE x::text < device) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+   SubPlan 1
+     ->  Aggregate
+           ->  Values Scan on "*VALUES*"
+                 Filter: ((column1)::text < metrics.device)
+
+-- HAVING with non-pushable expression on grouping columns
+:PREFIX SELECT device, sensor, min(time) FROM metrics GROUP BY device, sensor HAVING (device || sensor) LIKE 'd1%' ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device, compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device, compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+
+-- same Aggref referenced multiple times in tlist
+:PREFIX SELECT device, min(time), date_trunc('day', min(time)) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY column not in SELECT (appears only as resjunk in Agg tlist)
+:PREFIX SELECT count(*) FROM metrics GROUP BY device ORDER BY count(*);
+--- QUERY PLAN ---
+ Sort
+   Sort Key: (sum(compress_hyper_2_11_chunk._ts_meta_count))
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- WHERE mixes segmentby and non-segmentby column
+:PREFIX SELECT device, count(*) FROM metrics WHERE device = 'd1' AND value > 10 GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+
+-- HAVING with NOT around Aggref
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) <= '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING with Aggref IS NULL
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) IS NULL ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) IS NULL)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY with explicit collation (not a bare Var)
+:PREFIX SELECT device COLLATE "C", count(*) FROM metrics GROUP BY device COLLATE "C" ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: ((metrics.device)::text)
+   ->  Merge Append
+         Sort Key: ((metrics.device)::text) COLLATE "C"
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_1_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_3_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- self-join on the same hypertable
+:PREFIX SELECT m1.device, min(m1.time) FROM metrics m1 JOIN metrics m2 ON m1.device = m2.device GROUP BY m1.device ORDER BY m1.device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: m1.device
+   ->  Merge Join
+         Merge Cond: (m1.device = m2.device)
+         ->  Merge Append
+               Sort Key: m1.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1_1
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_2
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Materialize
+               ->  Merge Append
+                     Sort Key: m2.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m2_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -16,22 +16,23 @@ CREATE TABLE metrics(
     device text,
     sensor text,
     value float,
-    value2 float
-) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
+    value2 float,
+    value3 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value), firstlast(value3)');
 NOTICE:  using column "time" as partitioning column
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
+('2025-01-01 00:01:00 PST', 'd1', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1, 40.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1, 290.0),
+('2025-01-01 00:01:00 PST', 'd2', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1, 60.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1, 310.0);
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
              compress_chunk             
@@ -111,6 +112,21 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -178,6 +194,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device, sensor
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -194,6 +217,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -212,6 +242,14 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
                Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+               Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -226,6 +264,14 @@ SHOW timescaledb.enable_columnarindexscan;
  GroupAggregate
    Group Key: device
    Filter: (min(value) < '25'::double precision)
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   Filter: (first(value3, "time") > '5'::double precision)
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
@@ -277,6 +323,13 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -301,8 +354,44 @@ SHOW timescaledb.enable_columnarindexscan;
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: device
@@ -333,9 +422,26 @@ SHOW timescaledb.enable_columnarindexscan;
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -398,6 +504,23 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                      ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: device
+   ->  Append
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                           Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -418,6 +541,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          Group Key: device
          ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+         ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -498,6 +628,13 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
          ->  Seq Scan on compress_hyper_2_2_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -505,6 +642,16 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
    ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Sort
+                 Sort Key: _hyper_1_1_chunk."time"
+                 ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                       ->  Seq Scan on compress_hyper_2_2_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -524,7 +671,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Seq Scan on compress_hyper_2_2_chunk
                Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -533,6 +680,14 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_1_1_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+         ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: _hyper_1_1_chunk.device
@@ -769,13 +924,12 @@ SET enable_partitionwise_aggregate = off;
 --- QUERY PLAN ---
  GroupAggregate
    Group Key: m1.device
-   ->  Merge Join
-         Merge Cond: (m1.device = m2.device)
+   ->  Nested Loop
          ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1
                ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
-         ->  Materialize
-               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
-                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2
+               ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                     Index Cond: (device = m1.device)
 
 \set PREFIX ''
 \set ECHO errors
@@ -905,6 +1059,43 @@ SHOW timescaledb.enable_columnarindexscan;
 
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -1054,6 +1245,24 @@ SHOW timescaledb.enable_columnarindexscan;
                      Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
                      ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device, compress_hyper_2_2_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.sensor
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -1092,6 +1301,18 @@ SHOW timescaledb.enable_columnarindexscan;
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -1132,6 +1353,25 @@ SHOW timescaledb.enable_columnarindexscan;
                            ->  Seq Scan on _hyper_1_1_chunk
                                  Filter: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Sort
+         Sort Key: metrics.device
+         ->  Append
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                 Index Cond: (device = ANY ('{d1,d2}'::text[]))
+               ->  Partial GroupAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Sort
+                           Sort Key: _hyper_1_1_chunk.device
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -1164,6 +1404,22 @@ SHOW timescaledb.enable_columnarindexscan;
                Group Key: _hyper_1_1_chunk.device
                ->  Sort
                      Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- HAVING
@@ -1270,6 +1526,24 @@ SHOW timescaledb.enable_columnarindexscan;
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -1327,8 +1601,99 @@ SHOW timescaledb.enable_columnarindexscan;
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -1403,9 +1768,48 @@ SHOW timescaledb.enable_columnarindexscan;
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -1522,6 +1926,33 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                                  Sort Key: _hyper_1_1_chunk_1.device
                                  ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk
+                                 Filter: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Seq Scan on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                                 Filter: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -1559,6 +1990,17 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Sort
                            Sort Key: _hyper_1_1_chunk.device
                            ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial Aggregate
+               ->  Seq Scan on _hyper_1_1_chunk
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -1696,6 +2138,24 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Partial Aggregate
                ->  Seq Scan on _hyper_1_1_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -1709,6 +2169,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Sort
                Sort Key: _hyper_1_1_chunk.device
                ->  Seq Scan on _hyper_1_1_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Merge Append
+                       Sort Key: metrics."time"
+                       ->  Sort
+                             Sort Key: _hyper_1_1_chunk."time"
+                             ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                                   ->  Seq Scan on compress_hyper_2_2_chunk
+                       ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -1735,7 +2210,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: (value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -1755,6 +2230,25 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_2_chunk.device
+                           ->  Seq Scan on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk.device
+                     ->  Seq Scan on _hyper_1_1_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -1849,21 +2343,18 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 -- aggregate only in HAVING (not in SELECT)
 :PREFIX SELECT device FROM metrics GROUP BY device HAVING min(value) > 10 ORDER BY device;
 --- QUERY PLAN ---
- Finalize GroupAggregate
-   Group Key: metrics.device
-   Filter: (min(metrics.value) > '10'::double precision)
-   ->  Merge Append
-         Sort Key: metrics.device
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Sort
-                           Sort Key: compress_hyper_2_2_chunk.device
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (min(metrics.value) > '10'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
                            ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Sort
-                     Sort Key: _hyper_1_1_chunk.device
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- GROUP BY ordinal position
@@ -2110,21 +2601,18 @@ SET enable_partitionwise_aggregate = off;
 -- HAVING with NOT around Aggref
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
 --- QUERY PLAN ---
- Finalize GroupAggregate
-   Group Key: metrics.device
-   Filter: (min(metrics.value) <= '10'::double precision)
-   ->  Merge Append
-         Sort Key: metrics.device
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
-                     ->  Sort
-                           Sort Key: compress_hyper_2_2_chunk.device
+ Sort
+   Sort Key: metrics.device
+   ->  Finalize HashAggregate
+         Group Key: metrics.device
+         Filter: (min(metrics.value) <= '10'::double precision)
+         ->  Append
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
                            ->  Seq Scan on compress_hyper_2_2_chunk
-         ->  Partial GroupAggregate
-               Group Key: _hyper_1_1_chunk.device
-               ->  Sort
-                     Sort Key: _hyper_1_1_chunk.device
+               ->  Partial HashAggregate
+                     Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- HAVING with Aggref IS NULL
@@ -2332,6 +2820,37 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 --- QUERY PLAN ---
@@ -2467,6 +2986,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 --- QUERY PLAN ---
@@ -2501,6 +3035,19 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = 'd1'::text)
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
@@ -2537,6 +3084,23 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
                            Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
 
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 --- QUERY PLAN ---
@@ -2559,6 +3123,22 @@ SHOW timescaledb.enable_columnarindexscan;
  Finalize GroupAggregate
    Group Key: metrics.device
    Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
    ->  Merge Append
          Sort Key: metrics.device
          ->  Partial GroupAggregate
@@ -2665,6 +3245,21 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
 --- QUERY PLAN ---
@@ -2713,8 +3308,84 @@ SHOW timescaledb.enable_columnarindexscan;
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -2777,9 +3448,42 @@ SHOW timescaledb.enable_columnarindexscan;
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 --- QUERY PLAN ---
@@ -2886,6 +3590,35 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                            ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                                  ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
@@ -2922,6 +3655,35 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      Group Key: device
                      ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
                            ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_4_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+   InitPlan 2
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_2_chunk compress_hyper_2_2_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_4_chunk compress_hyper_2_4_chunk_1
 
 -- currently unoptimized queries
 -- count on dimension column (could be optimized but currently is not)
@@ -3067,6 +3829,21 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Seq Scan on compress_hyper_2_4_chunk
 
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
 --- QUERY PLAN ---
@@ -3079,6 +3856,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
          ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_2_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_4_chunk
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -3108,7 +3901,7 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Seq Scan on compress_hyper_2_4_chunk
                            Filter: (_ts_meta_v2_max_value > '10'::double precision)
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -3125,6 +3918,22 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
                      ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
 
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_2_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_2_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_4_chunk_device_sensor__ts_meta_v2_last_tim_idx on compress_hyper_2_4_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
    Group Key: metrics.device
@@ -3577,3 +4386,1785 @@ NOTICE:  using column "ts" as partitioning column
 -------
      6
 
+-- Test: nullable orderby column should NOT use ColumnarIndexScan for first/last(col, orderby)
+CREATE TABLE metrics_nullable_orderby(
+    time int NOT NULL,
+    priority int,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.orderby='priority',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+INSERT INTO metrics_nullable_orderby VALUES
+(1, 1, 'd1', 10.0),
+(2, 2, 'd1', 20.0),
+(3, 3, 'd1', 15.0),
+(4, 1, 'd2', 30.0),
+(5, 2, 'd2', 5.0),
+(6, NULL, 'd2', 99.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_nullable_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, priority) should NOT optimize because priority is nullable
+EXPLAIN (costs off) SELECT device, first(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_5_7_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_5_7_chunk
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- min/max should still optimize
+EXPLAIN (costs off) SELECT device, min(priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_5_7_chunk metrics_nullable_orderby
+         ->  Index Scan using compress_hyper_6_8_chunk_device__ts_meta_v2_first_priority__idx on compress_hyper_6_8_chunk
+
+-- Test: multiple orderby columns, first/last only optimized for the first orderby column
+CREATE TABLE metrics_multi_orderby(
+    time timestamptz NOT NULL,
+    seq int NOT NULL,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc, seq asc',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_multi_orderby VALUES
+('2025-01-01 00:00:00 PST', 1, 'd1', 10.0),
+('2025-01-01 00:01:00 PST', 2, 'd1', 20.0),
+('2025-01-01 01:00:00 PST', 1, 'd1', 15.0),
+('2025-01-01 00:02:00 PST', 1, 'd2', 30.0),
+('2025-01-01 01:02:00 PST', 1, 'd2', 5.0),
+('2025-01-01 01:03:00 PST', 2, 'd2', 25.0);
+SELECT compress_chunk(c) FROM show_chunks('metrics_multi_orderby') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_7_9_chunk
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, time) should optimize (time is first orderby column)
+EXPLAIN (costs off) SELECT device, first(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: device
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_7_9_chunk metrics_multi_orderby
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- first/last(value, seq) should NOT optimize (seq is second orderby column)
+EXPLAIN (costs off) SELECT device, first(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+EXPLAIN (costs off) SELECT device, last(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: _hyper_7_9_chunk.device
+   ->  Custom Scan (ColumnarScan) on _hyper_7_9_chunk
+         ->  Index Scan using compress_hyper_8_10_chunk_device__ts_meta_v2_last_time__ts__idx on compress_hyper_8_10_chunk
+
+-- correctness check
+SET timescaledb.enable_columnarindexscan = off;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+SET timescaledb.enable_columnarindexscan = on;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+ device | first | last 
+--------+-------+------
+ d1     |    10 |   15
+ d2     |    30 |   25
+
+-- Repeat all queries with ASC orderby to test the DESC flip logic
+ALTER TABLE metrics SET (timescaledb.compress_orderby = 'time asc');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(decompress_chunk(c)) FROM show_chunks('metrics') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+
+-- get query plans
+\set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for test diff
+SHOW timescaledb.enable_columnarindexscan;
+ timescaledb.enable_columnarindexscan 
+--------------------------------------
+ on
+
+-- simple query with count without grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with count with grouping
+:PREFIX SELECT device, count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with multiple count with grouping
+:PREFIX SELECT device, count(*), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 max aggregate that can use optimization
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 min aggregate that can use optimization
+:PREFIX SELECT sensor, min(time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- simple query with 1 first aggregate that can use optimization
+:PREFIX SELECT device, first(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with 1 last aggregate that can use optimization
+:PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- explicit index columns dont prevent optimization
+:PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT sensor, min(value), max(value) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column
+:PREFIX SELECT sensor, min(time), max(time), first(time,time), last(time,time) FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns
+:PREFIX SELECT sensor, min(time), min(value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- same aggregate on multiple columns but different order
+:PREFIX SELECT sensor, min(value), min(time), sensor  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT sensor, first(time,time), last(time,time), first(value, value), last(value, value)  FROM metrics GROUP BY sensor ORDER BY sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- test multiple group by columns
+:PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- filter on segmentby allows optimization
+:PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+
+-- HAVING on segmentby (pushed down to lower scan)
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: ((device = ANY ('{d1,d2}'::text[])) AND (sensor = 'B'::text))
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ANY ('{d1,d2}'::text[]))
+
+-- HAVING with aggregate function
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '20'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) < '25'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (first(metrics.value3, metrics."time") > '5'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics."time") > 'Wed Jan 01 00:30:00 2025 PST'::timestamp with time zone)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- tableoid doesnt prevent optimization
+:PREFIX SELECT tableoid, device, max(time) FROM metrics GROUP BY device, tableoid;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.tableoid
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: device, tableoid
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), min(tableoid) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column use optimization
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same column with first/last
+:PREFIX SELECT device, min(time), first(time, time), last(time, time), max(time) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- segmentby column at end of targetlist
+:PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on different columns use optimization
+:PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on same non-time column use optimization
+:PREFIX SELECT device, min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- multiple aggregates on multiple columns
+:PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- expression on aggregates
+:PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with sort
+:PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with subquery (SubqueryScan)
+:PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Subquery Scan on sub
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test with CTE (also uses SubqueryScan)
+:PREFIX WITH agg_data AS (
+    SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- test parallel queries (not supported with ColumnarIndexScan)
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+ set_config 
+------------
+ on
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+ set_config 
+------------
+ off
+
+-- test with UNION ALL (Append node)
+:PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, min(time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device
+UNION ALL
+SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
+--- QUERY PLAN ---
+ Incremental Sort
+   Sort Key: metrics.device, (min(metrics."time")), (max(metrics."time"))
+   Presorted Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Finalize GroupAggregate
+               Group Key: metrics.device
+               ->  Merge Append
+                     Sort Key: metrics.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Finalize GroupAggregate
+               Group Key: metrics_1.device
+               ->  Merge Append
+                     Sort Key: metrics_1.device
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Partial GroupAggregate
+                           Group Key: device
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  Append
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                       Index Cond: (device = 'd1'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                       Index Cond: (device = 'd1'::text)
+         ->  Finalize GroupAggregate
+               ->  Append
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+                     ->  Partial GroupAggregate
+                           ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                 ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+                                       Index Cond: (device = 'd2'::text)
+
+-- test WINDOW functions
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device
+   ->  WindowAgg
+         ->  Sort
+               Sort Key: (max(metrics."time"))
+               ->  Finalize GroupAggregate
+                     Group Key: metrics.device
+                     ->  Merge Append
+                           Sort Key: metrics.device
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           ->  Partial GroupAggregate
+                                 Group Key: device
+                                 ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                                       ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ WindowAgg
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time" DESC
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time" DESC
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+   InitPlan 2
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics metrics_1
+                 Order: metrics_1."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1
+                             ->  Seq Scan on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk_1."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1
+                             ->  Seq Scan on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+-- currently unoptimized queries
+-- count on dimension column (could be optimized but currently is not)
+:PREFIX SELECT count(time) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with segmentby column
+:PREFIX SELECT count(device) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- count with other columns
+:PREFIX SELECT count(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- group by on non-segmentby prevents optimization
+:PREFIX SELECT max(time) FROM metrics GROUP BY value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, max(time) FROM metrics GROUP BY device,value;
+--- QUERY PLAN ---
+ Finalize HashAggregate
+   Group Key: metrics.device, metrics.value
+   ->  Append
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_1_chunk.device, _hyper_1_1_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial HashAggregate
+               Group Key: _hyper_1_3_chunk.device, _hyper_1_3_chunk.value
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- unsupported aggregates on any column
+:PREFIX SELECT avg(value) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT string_agg(device, ',') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate on segmentby column does not use optimization
+:PREFIX SELECT device, min(sensor) FROM metrics GROUP BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate on column without metadata
+:PREFIX SELECT min(value2) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with FILTER clause
+:PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregates with DISTINCT
+:PREFIX SELECT count(DISTINCT device) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
+--- QUERY PLAN ---
+ Result
+   InitPlan 1
+     ->  Limit
+           ->  Custom Scan (ChunkAppend) on metrics
+                 Order: metrics."time"
+                 ->  Sort
+                       Sort Key: _hyper_1_1_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                             ->  Seq Scan on compress_hyper_2_11_chunk
+                 ->  Sort
+                       Sort Key: _hyper_1_3_chunk."time"
+                       ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                             ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregates with ORDER
+:PREFIX SELECT min(value ORDER BY time) FROM metrics;
+--- QUERY PLAN ---
+ Aggregate
+   ->  Sort
+         Sort Key: metrics."time"
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- WHERE clause on non-segmentby column
+:PREFIX SELECT count(*) FROM metrics WHERE value > 10;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- first/last on column without firstlast sparse index (should not optimize)
+:PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUPING SETS / ROLLUP / CUBE are not supported by ColumnarIndexScan
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY ROLLUP(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  GroupAggregate
+         Group Key: metrics.device, metrics.sensor
+         Group Key: metrics.device
+         Group Key: ()
+         ->  Merge Append
+               Sort Key: metrics.device, metrics.sensor
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY CUBE(device, sensor) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.sensor
+         Group Key: metrics.device, metrics.sensor
+         Group Key: metrics.device
+         Group Key: ()
+         ->  Merge Append
+               Sort Key: metrics.device, metrics.sensor
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+:PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY GROUPING SETS ((device), (sensor), ()) ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: metrics.device, metrics.sensor
+   ->  MixedAggregate
+         Hash Key: metrics.device
+         Hash Key: metrics.sensor
+         Group Key: ()
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- DISTINCT on a segmentby column (Agg with no Aggrefs)
+:PREFIX SELECT DISTINCT device FROM metrics ORDER BY device;
+--- QUERY PLAN ---
+ Unique
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- count(*) without GROUP BY
+:PREFIX SELECT count(*) FROM metrics;
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Append
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate only in HAVING (not in SELECT)
+:PREFIX SELECT device FROM metrics GROUP BY device HAVING min(value) > 10 ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) > '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY ordinal position
+:PREFIX SELECT device, min(time) FROM metrics GROUP BY 1 ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY () empty grouping
+:PREFIX SELECT count(*) FROM metrics GROUP BY ();
+--- QUERY PLAN ---
+ Aggregate
+   Group Key: ()
+   ->  Append
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- aggregate wrapped in COALESCE
+:PREFIX SELECT device, COALESCE(min(time), '2000-01-01'::timestamptz) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- aggregate above a JOIN (Agg not directly above ColumnarScan)
+:PREFIX SELECT m.device, min(m.time) FROM metrics m JOIN (VALUES ('d1'), ('d2')) AS d(device) ON m.device = d.device GROUP BY m.device ORDER BY m.device;
+--- QUERY PLAN ---
+ Sort
+   Sort Key: m.device
+   ->  HashAggregate
+         Group Key: m.device
+         ->  Nested Loop
+               ->  Values Scan on "*VALUES*"
+               ->  Append
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                                 Index Cond: (device = "*VALUES*".column1)
+
+-- ordered-set aggregate (not supported)
+:PREFIX SELECT device, percentile_cont(0.5) WITHIN GROUP (ORDER BY value) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+               ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+               ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- bool_and / bool_or (not supported)
+:PREFIX SELECT device, bool_and(value > 0), bool_or(value > 0) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_1_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: _hyper_1_3_chunk.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- partition-wise aggregate
+SET enable_partitionwise_aggregate = on;
+:PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+SET enable_partitionwise_aggregate = off;
+-- Aggref inside a SubLink in the outer tlist (inner aggregate belongs to a separate Agg)
+:PREFIX SELECT device, count(*), (SELECT count(*) FROM (VALUES (1),(2),(3)) v(x) WHERE x::text < device) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+   SubPlan 1
+     ->  Aggregate
+           ->  Values Scan on "*VALUES*"
+                 Filter: ((column1)::text < metrics.device)
+
+-- HAVING with non-pushable expression on grouping columns
+:PREFIX SELECT device, sensor, min(time) FROM metrics GROUP BY device, sensor HAVING (device || sensor) LIKE 'd1%' ORDER BY device, sensor;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device, metrics.sensor
+   ->  Merge Append
+         Sort Key: metrics.device, metrics.sensor
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device, compress_hyper_2_11_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+         ->  Partial GroupAggregate
+               Group Key: device, sensor
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device, compress_hyper_2_12_chunk.sensor
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+                                 Filter: ((device || sensor) ~~ 'd1%'::text)
+
+-- same Aggref referenced multiple times in tlist
+:PREFIX SELECT device, min(time), date_trunc('day', min(time)) FROM metrics GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY column not in SELECT (appears only as resjunk in Agg tlist)
+:PREFIX SELECT count(*) FROM metrics GROUP BY device ORDER BY count(*);
+--- QUERY PLAN ---
+ Sort
+   Sort Key: (sum(compress_hyper_2_11_chunk._ts_meta_count))
+   ->  Finalize GroupAggregate
+         Group Key: metrics.device
+         ->  Merge Append
+               Sort Key: metrics.device
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Partial GroupAggregate
+                     Group Key: device
+                     ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- WHERE mixes segmentby and non-segmentby column
+:PREFIX SELECT device, count(*) FROM metrics WHERE device = 'd1' AND value > 10 GROUP BY device ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   ->  Append
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+         ->  Partial GroupAggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Vectorized Filter: (value > '10'::double precision)
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = 'd1'::text)
+                           Filter: (_ts_meta_v2_max_value > '10'::double precision)
+
+-- WHERE with a SubPlan on a segmentby column (not pushable, must not be dropped)
+:PREFIX SELECT count(*) FROM metrics WHERE device NOT IN (SELECT 'd' || g FROM generate_series(1,1) g);
+--- QUERY PLAN ---
+ Finalize Aggregate
+   ->  Custom Scan (ChunkAppend) on metrics
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_11_chunk
+                     SubPlan 1
+                       ->  Function Scan on generate_series g
+         ->  Partial Aggregate
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     Filter: (NOT (ANY (device = (hashed SubPlan 1).col1)))
+                     ->  Seq Scan on compress_hyper_2_12_chunk
+
+:PREFIX SELECT count(*) FROM metrics WHERE device IN (SELECT 'd' || g FROM generate_series(1,2) g);
+--- QUERY PLAN ---
+ Aggregate
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
+                     Sort Key: (('d'::text || (g.g)::text))
+                     ->  Function Scan on generate_series g
+         ->  Append
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+                           Index Cond: (device = ('d'::text || (g.g)::text))
+
+-- HAVING with NOT around Aggref
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING NOT (min(value) > 10) ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) <= '10'::double precision)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- HAVING with Aggref IS NULL
+:PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) IS NULL ORDER BY device;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: metrics.device
+   Filter: (min(metrics.value) IS NULL)
+   ->  Merge Append
+         Sort Key: metrics.device
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: device
+               ->  Custom Scan (ColumnarIndexScan) on _hyper_1_3_chunk metrics
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+
+-- GROUP BY with explicit collation (not a bare Var)
+:PREFIX SELECT device COLLATE "C", count(*) FROM metrics GROUP BY device COLLATE "C" ORDER BY 1;
+--- QUERY PLAN ---
+ Finalize GroupAggregate
+   Group Key: ((metrics.device)::text)
+   ->  Merge Append
+         Sort Key: ((metrics.device)::text) COLLATE "C"
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_1_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_11_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_11_chunk
+         ->  Partial GroupAggregate
+               Group Key: (_hyper_1_3_chunk.device)::text
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk
+                     ->  Sort
+                           Sort Key: compress_hyper_2_12_chunk.device COLLATE "C"
+                           ->  Seq Scan on compress_hyper_2_12_chunk
+
+-- self-join on the same hypertable
+:PREFIX SELECT m1.device, min(m1.time) FROM metrics m1 JOIN metrics m2 ON m1.device = m2.device GROUP BY m1.device ORDER BY m1.device;
+--- QUERY PLAN ---
+ GroupAggregate
+   Group Key: m1.device
+   ->  Merge Join
+         Merge Cond: (m1.device = m2.device)
+         ->  Merge Append
+               Sort Key: m1.device
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m1_1
+                     ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m1_2
+                     ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk
+         ->  Materialize
+               ->  Merge Append
+                     Sort Key: m2.device
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk m2_1
+                           ->  Index Scan using compress_hyper_2_11_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_11_chunk compress_hyper_2_11_chunk_1
+                     ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk m2_2
+                           ->  Index Scan using compress_hyper_2_12_chunk_device_sensor__ts_meta_v2_first_t_idx on compress_hyper_2_12_chunk compress_hyper_2_12_chunk_1
+
+\set PREFIX ''
+\set ECHO errors
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  timescaledb.enable_columnarindexscan 
+ --------------------------------------
+- off
++ on
+ 
+  device | count 

--- a/tsl/test/sql/columnar_index_scan.sql.in
+++ b/tsl/test/sql/columnar_index_scan.sql.in
@@ -19,22 +19,23 @@ CREATE TABLE metrics(
     device text,
     sensor text,
     value float,
-    value2 float
-) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value)');
+    value2 float,
+    value3 float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc',tsdb.segmentby='device,sensor',tsdb.index='minmax(value), firstlast(value3)');
 
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1),
-('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1),
-('2025-01-01 00:00:00 PST', 'd2', 'A', 10.0, 10.1),
-('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1),
-('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1),
-('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1),
-('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1),
-('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1);
+('2025-01-01 00:01:00 PST', 'd1', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd1', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd1', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd1', 'B', 4.0, 4.1, 40.0),
+('2025-01-01 01:30:00 PST', 'd1', 'B', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd1', 'B', 29.0, 29.1, 290.0),
+('2025-01-01 00:01:00 PST', 'd2', 'A', 10.0, 10.1, 100.0),
+('2025-01-01 01:00:00 PST', 'd2', 'A', 20.0, 20.1, 200.0),
+('2025-01-01 02:00:00 PST', 'd2', 'A', 15.0, 15.1, 150.0),
+('2025-01-01 00:30:00 PST', 'd2', 'C', 6.0, 6.1, 60.0),
+('2025-01-01 01:30:00 PST', 'd2', 'C', 25.0, 25.1, 250.0),
+('2025-01-01 02:30:00 PST', 'd2', 'C', 31.0, 31.1, 310.0);
 
 -- Compress all chunks
 SELECT compress_chunk(c) FROM show_chunks('metrics') c;
@@ -67,9 +68,9 @@ SET timescaledb.enable_columnarindexscan = on;
 
 -- make initial chunk partial
 INSERT INTO metrics VALUES
-('2025-01-01 00:00:00 PST', 'd1', 'A', 1.0, 1.1),
-('2025-01-01 00:00:00 PST', 'd3', 'A', 50.0, 50.1),
-('2025-01-01 00:00:00 PST', 'd3', 'B', 52.0, 52.1);
+('2025-01-01 00:00:00 PST', 'd1', 'A', 1.0, 1.1, 11.0),
+('2025-01-01 00:00:00 PST', 'd3', 'A', 50.0, 50.1, 500.0),
+('2025-01-01 00:00:00 PST', 'd3', 'B', 52.0, 52.1, 520.0);
 
 -- second run with hypertable with 1 partial chunk
 
@@ -99,10 +100,10 @@ SET timescaledb.enable_columnarindexscan = on;
 
 -- create a second chunk
 INSERT INTO metrics VALUES
-('2025-02-01 00:00:00 PST', 'd1', 'A', 100.0, 100.1),
-('2025-02-01 01:00:00 PST', 'd1', 'B', 200.0, 200.1),
-('2025-02-01 00:00:00 PST', 'd2', 'A', 150.0, 150.1),
-('2025-02-01 01:00:00 PST', 'd2', 'C', 250.0, 250.1);
+('2025-02-01 00:00:00 PST', 'd1', 'A', 100.0, 100.1, 1000.0),
+('2025-02-01 01:00:00 PST', 'd1', 'B', 200.0, 200.1, 2000.0),
+('2025-02-01 00:00:00 PST', 'd2', 'A', 150.0, 150.1, 1500.0),
+('2025-02-01 01:00:00 PST', 'd2', 'C', 250.0, 250.1, 2500.0);
 
 SELECT compress_chunk(c) FROM show_chunks('metrics') c LIMIT 1 OFFSET 1;
 
@@ -153,4 +154,90 @@ SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY sensor, device) g;
 SET timescaledb.enable_columnarindexscan = on;
 SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY device, sensor) g;
 SELECT count(*) FROM (SELECT count(*) FROM metrics GROUP BY sensor, device) g;
+
+\set ECHO all
+-- Test: nullable orderby column should NOT use ColumnarIndexScan for first/last(col, orderby)
+CREATE TABLE metrics_nullable_orderby(
+    time int NOT NULL,
+    priority int,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.orderby='priority',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+
+INSERT INTO metrics_nullable_orderby VALUES
+(1, 1, 'd1', 10.0),
+(2, 2, 'd1', 20.0),
+(3, 3, 'd1', 15.0),
+(4, 1, 'd2', 30.0),
+(5, 2, 'd2', 5.0),
+(6, NULL, 'd2', 99.0);
+
+SELECT compress_chunk(c) FROM show_chunks('metrics_nullable_orderby') c;
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, priority) should NOT optimize because priority is nullable
+EXPLAIN (costs off) SELECT device, first(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+EXPLAIN (costs off) SELECT device, last(value, priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+-- min/max should still optimize
+EXPLAIN (costs off) SELECT device, min(priority) FROM metrics_nullable_orderby GROUP BY device ORDER BY device;
+
+-- Test: multiple orderby columns, first/last only optimized for the first orderby column
+CREATE TABLE metrics_multi_orderby(
+    time timestamptz NOT NULL,
+    seq int NOT NULL,
+    device text,
+    value float
+) WITH (tsdb.hypertable,tsdb.orderby='time desc, seq asc',tsdb.segmentby='device',tsdb.index='firstlast("value")');
+
+INSERT INTO metrics_multi_orderby VALUES
+('2025-01-01 00:00:00 PST', 1, 'd1', 10.0),
+('2025-01-01 00:01:00 PST', 2, 'd1', 20.0),
+('2025-01-01 01:00:00 PST', 1, 'd1', 15.0),
+('2025-01-01 00:02:00 PST', 1, 'd2', 30.0),
+('2025-01-01 01:02:00 PST', 1, 'd2', 5.0),
+('2025-01-01 01:03:00 PST', 2, 'd2', 25.0);
+
+SELECT compress_chunk(c) FROM show_chunks('metrics_multi_orderby') c;
+
+SET timescaledb.enable_columnarindexscan = on;
+-- first/last(value, time) should optimize (time is first orderby column)
+EXPLAIN (costs off) SELECT device, first(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+EXPLAIN (costs off) SELECT device, last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+-- first/last(value, seq) should NOT optimize (seq is second orderby column)
+EXPLAIN (costs off) SELECT device, first(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+EXPLAIN (costs off) SELECT device, last(value, seq) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+
+-- correctness check
+SET timescaledb.enable_columnarindexscan = off;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+SET timescaledb.enable_columnarindexscan = on;
+SELECT device, first(value, time), last(value, time) FROM metrics_multi_orderby GROUP BY device ORDER BY device;
+
+-- Repeat all queries with ASC orderby to test the DESC flip logic
+ALTER TABLE metrics SET (timescaledb.compress_orderby = 'time asc');
+SELECT compress_chunk(decompress_chunk(c)) FROM show_chunks('metrics') c;
+
+-- get query plans
+\set PREFIX 'EXPLAIN (costs off)'
+\set ECHO all
+SET timescaledb.enable_columnarindexscan = on;
+\ir :TEST_QUERY_NAME
+
+\set PREFIX ''
+\set ECHO errors
+
+-- get query results with columnar index scan disabled
+SET timescaledb.enable_columnarindexscan = off;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+-- get query results with columnar index scan enabled
+SET timescaledb.enable_columnarindexscan = on;
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+\o
+
+-- compare optimized vs non-optimized results
+:DIFF_CMD
 

--- a/tsl/test/sql/include/columnar_index_scan_query.sql
+++ b/tsl/test/sql/include/columnar_index_scan_query.sql
@@ -26,6 +26,10 @@ SHOW timescaledb.enable_columnarindexscan;
 -- simple query with 1 last aggregate that can use optimization
 :PREFIX SELECT device, last(time, time) FROM metrics GROUP BY device ORDER BY device;
 
+-- simple query with first/last(value3, time) that can use optimization
+:PREFIX SELECT first(value3, time) FROM metrics GROUP BY device ORDER BY device;
+:PREFIX SELECT last(value3, time) FROM metrics GROUP BY device ORDER BY device;
+
 -- explicit index columns dont prevent optimization
 :PREFIX SELECT sensor, min(value) FROM metrics GROUP BY sensor ORDER BY sensor;
 
@@ -45,18 +49,22 @@ SHOW timescaledb.enable_columnarindexscan;
 
 -- test multiple group by columns
 :PREFIX SELECT device, sensor, max(time) FROM metrics GROUP BY device,sensor ORDER BY device,sensor;
+:PREFIX SELECT device, sensor, first(value3, time), last(value3, time) FROM metrics GROUP BY device, sensor ORDER BY device, sensor;
 
 -- filter on segmentby allows optimization
 :PREFIX SELECT device, min(time) FROM metrics WHERE device IN ('d1','d2') GROUP BY device;
 :PREFIX SELECT device, min(time) FROM metrics WHERE device =ANY(ARRAY['d1','d2']) AND sensor='B' GROUP BY device;
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device;
 
 -- HAVING on segmentby (pushed down to lower scan)
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING device IN ('d1','d2');
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device,sensor HAVING device =ANY(ARRAY['d1','d2']) AND sensor='B';
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING device IN ('d1','d2') ORDER BY device;
 
 -- HAVING with aggregate function
 :PREFIX SELECT device, min(value) FROM metrics GROUP BY device HAVING min(value) > 20;
 :PREFIX SELECT device, max(value) FROM metrics GROUP BY device HAVING min(value) < 25;
+:PREFIX SELECT device, first(value3, time) FROM metrics GROUP BY device HAVING first(value3, time) > 5 ORDER BY device;
 
 -- HAVING
 :PREFIX SELECT device, min(time) FROM metrics GROUP BY device HAVING min(time) > '2025-01-01 00:30:00 PST';
@@ -73,6 +81,7 @@ SHOW timescaledb.enable_columnarindexscan;
 
 -- segmentby column at end of targetlist
 :PREFIX SELECT first(time, time), last(time, time), device FROM metrics GROUP BY device;
+:PREFIX SELECT first(value3, time), last(value3, time), device FROM metrics GROUP BY device ORDER BY device;
 
 -- multiple aggregates on different columns use optimization
 :PREFIX SELECT device, min(time), max(value) FROM metrics GROUP BY device;
@@ -83,20 +92,32 @@ SHOW timescaledb.enable_columnarindexscan;
 -- multiple aggregates on multiple columns
 :PREFIX SELECT device, min(time), max(time), min(value), max(value) FROM metrics GROUP BY device;
 
+-- first/last(value3,time) mixed with other columnar index scan aggregates
+:PREFIX SELECT device, first(value3, time), last(value3, time), count(*) FROM metrics GROUP BY device ORDER BY device;
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
+:PREFIX SELECT device, first(value3, time), last(value3, time), min(value), max(value) FROM metrics GROUP BY device ORDER BY device;
+:PREFIX SELECT device, first(value3, time), last(value3, time), first(time, time), last(time, time) FROM metrics GROUP BY device ORDER BY device;
+
 -- expression on aggregates
 :PREFIX SELECT device, max(time), min(time), max(time) - min(time)  FROM metrics GROUP BY device;
+:PREFIX SELECT device, last(value3, time) - first(value3, time) FROM metrics GROUP BY device ORDER BY device;
 
 -- test with sort
 :PREFIX SELECT device, sensor, first(time,time), last(time,time) from metrics group by device, sensor order by 1,2;
 
 -- test with subquery (SubqueryScan)
 :PREFIX SELECT * FROM (SELECT device, min(time), max(time) FROM metrics GROUP BY device) sub ORDER BY device;
-
 :PREFIX SELECT mx, mn, device FROM (SELECT device, min(time) mn, max(time) mx FROM metrics GROUP BY device) sub ORDER BY device;
+:PREFIX SELECT * FROM (SELECT device, first(value3, time), last(value3, time) FROM metrics GROUP BY device) sub ORDER BY device;
 
 -- test with CTE (also uses SubqueryScan)
 :PREFIX WITH agg_data AS (
     SELECT device, min(time) as min_time, max(time) as max_time FROM metrics GROUP BY device
+)
+SELECT * FROM agg_data ORDER BY device;
+
+:PREFIX WITH agg_data AS (
+    SELECT device, first(value3, time) as fv, last(value3, time) as lv FROM metrics GROUP BY device
 )
 SELECT * FROM agg_data ORDER BY device;
 
@@ -115,9 +136,17 @@ ORDER BY device;
 UNION ALL
 SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 
+:PREFIX SELECT device, first(value3, time) FROM metrics WHERE device = 'd1' GROUP BY device
+UNION ALL
+SELECT device, first(value3, time) FROM metrics WHERE device = 'd2' GROUP BY device
+ORDER BY device;
+
 -- test WINDOW functions
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY max(time)) from metrics GROUP BY device ORDER BY device;
 :PREFIX SELECT device, max(time), lead(device) OVER (PARTITION BY device) from metrics GROUP BY device ORDER BY device;
+
+-- first/last(value3,time) without GROUP BY
+:PREFIX SELECT first(value3, time), last(value3, time) FROM metrics;
 
 -- currently unoptimized queries
 
@@ -147,9 +176,11 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 -- aggregates with FILTER clause
 :PREFIX SELECT count(*) FILTER(WHERE device='dev 1') FROM metrics;
 :PREFIX SELECT min(value) FILTER(WHERE device='dev 1') FROM metrics;
+:PREFIX SELECT device, first(value3, time) FILTER(WHERE sensor = 'A') FROM metrics GROUP BY device ORDER BY device;
 
 -- aggregates with DISTINCT
 :PREFIX SELECT count(DISTINCT device) FROM metrics;
+:PREFIX SELECT first(DISTINCT value3, time) FROM metrics;
 
 -- aggregates with ORDER
 :PREFIX SELECT min(value ORDER BY time) FROM metrics;
@@ -157,9 +188,12 @@ SELECT device, max(time), min(time) FROM metrics GROUP BY device ORDER BY 1,2,3;
 -- WHERE clause on non-segmentby column
 :PREFIX SELECT count(*) FROM metrics WHERE value > 10;
 
--- first/last with different arg1 and arg2
+-- first/last on column without firstlast sparse index (should not optimize)
 :PREFIX SELECT first(value, time) FROM metrics GROUP BY device ORDER BY device;
 :PREFIX SELECT last(value, time) FROM metrics GROUP BY device ORDER BY device;
+
+-- first/last where arg2 is NOT the orderby column (should not optimize)
+:PREFIX SELECT device, first(time, value3) FROM metrics GROUP BY device ORDER BY device;
 
 -- GROUPING SETS / ROLLUP / CUBE are not supported by ColumnarIndexScan
 :PREFIX SELECT device, sensor, count(*) FROM metrics GROUP BY ROLLUP(device, sensor) ORDER BY device, sensor;


### PR DESCRIPTION
Optimize two-column first(value, orderby) and
last(value, orderby) aggregates using compressed
batch metadata. Requires the value column to have a
firstlast sparse index, the orderby column to be the
first orderby column with firstlast sparse kind and
a NOT NULL constraint.

The value is read from the batch's firstlast metadata
while the orderby is read from the batch's min/max
metadata.
