### PR TITLE
Block inheriting from a hypertable with ALTER TABLE INHERIT

### DIFF
--- a/.unreleased/pr_9982
+++ b/.unreleased/pr_9982
@@ -1,0 +1,1 @@
+Fixes: #9982 Reject ALTER TABLE ... INHERIT when the parent is a hypertable

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -4921,6 +4921,23 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 				}
 				break;
 			}
+			case AT_AddInherit:
+			{
+				/* A plain table cannot inherit from a hypertable, since the
+				 * child would not be a chunk and its rows would be hidden from
+				 * queries on the hypertable. */
+				RangeVar *parent = castNode(RangeVar, cmd->def);
+				Oid parent_relid = RangeVarGetRelid(parent, NoLock, true);
+
+				if (OidIsValid(parent_relid) && ts_is_hypertable(parent_relid))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("cannot inherit from hypertable \"%s\"",
+									get_rel_name(parent_relid))));
+				}
+				break;
+			}
 
 			case AT_SetRelOptions:
 			{

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -60,6 +60,10 @@ CREATE TABLE PUBLIC."Hyper_Child" () INHERITS ("Hypertable_1");
 ERROR:  hypertables do not support inheritance
 CREATE TABLE PUBLIC."Hyper_Child" (extra int) INHERITS (PUBLIC."Hypertable_1", PUBLIC."Parent");
 ERROR:  hypertables do not support inheritance
+-- a plain table cannot inherit from a hypertable
+CREATE TABLE PUBLIC."Inherit_Child" (LIKE "Hypertable_1");
+ALTER TABLE PUBLIC."Inherit_Child" INHERIT "Hypertable_1";
+ERROR:  cannot inherit from hypertable "Hypertable_1"
 \set ON_ERROR_STOP 1
 CREATE TABLE PUBLIC."Child" () INHERITS ("Parent");
 \set ON_ERROR_STOP 0

--- a/test/sql/ddl_errors.sql
+++ b/test/sql/ddl_errors.sql
@@ -53,6 +53,9 @@ ALTER TABLE _timescaledb_internal._hyper_1_1_chunk INHERIT "Parent";
 ALTER TABLE _timescaledb_internal._hyper_1_1_chunk NO INHERIT "Parent";
 CREATE TABLE PUBLIC."Hyper_Child" () INHERITS ("Hypertable_1");
 CREATE TABLE PUBLIC."Hyper_Child" (extra int) INHERITS (PUBLIC."Hypertable_1", PUBLIC."Parent");
+-- a plain table cannot inherit from a hypertable
+CREATE TABLE PUBLIC."Inherit_Child" (LIKE "Hypertable_1");
+ALTER TABLE PUBLIC."Inherit_Child" INHERIT "Hypertable_1";
 \set ON_ERROR_STOP 1
 
 CREATE TABLE PUBLIC."Child" () INHERITS ("Parent");


### PR DESCRIPTION
Hypertable children that are not actual chunks will not be included
in queries when using our hypertable expansion.

Fixes: #9975
