### PR TITLE
Fix COPY WHERE into a hypertable with dropped columns

### DIFF
--- a/.unreleased/pr_9983
+++ b/.unreleased/pr_9983
@@ -1,0 +1,1 @@
+Fixes: #9977 Fix COPY WHERE into a hypertable with dropped columns

--- a/src/copy.c
+++ b/src/copy.c
@@ -1098,6 +1098,19 @@ copyfrom(CopyChunkState *ccstate, ParseState *pstate, Hypertable *ht, MemoryCont
 
 		ExecStoreVirtualTuple(myslot);
 
+		/*
+		 * Apply the WHERE clause before the tuple is converted to the chunk
+		 * layout. The chunk can have different physical layout.
+		 */
+		if (qualexpr != NULL)
+		{
+			econtext->ecxt_scantuple = myslot;
+			if (!ExecQual(qualexpr, econtext))
+			{
+				continue;
+			}
+		}
+
 		/* Calculate the tuple's point in the N-dimensional hyperspace */
 		point = ts_hyperspace_calculate_point(ht->space, myslot);
 
@@ -1187,15 +1200,6 @@ copyfrom(CopyChunkState *ccstate, ParseState *pstate, Hypertable *ht, MemoryCont
 				 */
 				ExecCopySlot(batchslot, myslot);
 				myslot = batchslot;
-			}
-		}
-
-		if (qualexpr != NULL)
-		{
-			econtext->ecxt_scantuple = myslot;
-			if (!ExecQual(qualexpr, econtext))
-			{
-				continue;
 			}
 		}
 

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -678,6 +678,41 @@ SELECT * FROM table_with_layout_change ORDER BY time, value7;
     5 |    724
     6 |    725
 
+-- COPY WHERE into a hypertable whose chunks have dropped columns
+COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'null' WHERE value7 > 800;
+SELECT * FROM table_with_layout_change ORDER BY time, value7;
+ time | value7 
+------+--------
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    722
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    721
+    2 |    850
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    723
+    3 |    860
+    4 |    700
+    4 |    700
+    4 |    726
+    5 |    700
+    5 |    724
+    6 |    725
+
 -- verify check constraints work
 CREATE TABLE test_check(a INT, b TIMESTAMPTZ);
 ALTER TABLE test_check ADD CONSTRAINT c1 CHECK (a > 7);

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -545,6 +545,15 @@ COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'n
 
 SELECT * FROM table_with_layout_change ORDER BY time, value7;
 
+-- COPY WHERE into a hypertable whose chunks have dropped columns
+COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'null' WHERE value7 > 800;
+850,2
+727,1
+860,3
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value7;
+
 -- verify check constraints work
 CREATE TABLE test_check(a INT, b TIMESTAMPTZ);
 ALTER TABLE test_check ADD CONSTRAINT c1 CHECK (a > 7);


### PR DESCRIPTION
COPY with a WHERE clause could fail with an attribute number error when
the target hypertable had dropped columns.

Evaluate the WHERE clause before converting to chunk layout, since the
chunk layout may differ from hypertable layout.

Fixes #9977
