### PR TITLE
Ignore NOT VALID NOT NULL constraints

### DIFF
--- a/.unreleased/constraints-not-valid
+++ b/.unreleased/constraints-not-valid
@@ -1,0 +1,1 @@
+Fixes: #9984 Fix handling of NOT VALID NOT NULL constraint for query optimization

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -1159,7 +1159,16 @@ ca_get_relation_constraints(Oid relationObjectId, Index varno, bool include_notn
 			{
 				Form_pg_attribute att = TupleDescAttr(relation->rd_att, i - 1);
 
+				/*
+				 * A NOT VALID NOT NULL constraint (PG18) sets attnotnull but
+				 * existing rows may still be NULL, so don't use it here.
+				 */
+#if PG18_GE
+				CompactAttribute *catt = TupleDescCompactAttr(relation->rd_att, i - 1);
+				if (catt->attnullability == ATTNULLABLE_VALID && !att->attisdropped)
+#else
 				if (att->attnotnull && !att->attisdropped)
+#endif
 				{
 					NullTest *ntest = makeNode(NullTest);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -2197,9 +2197,31 @@ ts_is_time_bucket_function(Expr *node)
 	return false;
 }
 
+/*
+ * Report whether a column cannot contain NULLs.
+ *
+ * On PG18 a NOT NULL constraint can be NOT VALID: attnotnull is set but
+ * existing rows may still be NULL, so we only trust a valid constraint. The
+ * validity is not on the pg_attribute tuple, so read it from the descriptor.
+ */
 bool
 ts_get_attnotnull(Oid relid, AttrNumber attno)
 {
+#if PG18_GE
+	Relation rel = try_relation_open(relid, AccessShareLock);
+	if (rel == NULL)
+	{
+		return false;
+	}
+	bool result = false;
+	if (attno >= 1 && attno <= rel->rd_att->natts)
+	{
+		const CompactAttribute *att = TupleDescCompactAttr(rel->rd_att, attno - 1);
+		result = att->attnullability == ATTNULLABLE_VALID;
+	}
+	relation_close(rel, AccessShareLock);
+	return result;
+#else
 	HeapTuple tp = SearchSysCache2(ATTNUM, ObjectIdGetDatum(relid), Int16GetDatum(attno));
 	if (!HeapTupleIsValid(tp))
 	{
@@ -2209,4 +2231,5 @@ ts_get_attnotnull(Oid relid, AttrNumber attno)
 	bool result = att_tup->attnotnull;
 	ReleaseSysCache(tp);
 	return result;
+#endif
 }

--- a/tsl/test/expected/constraints_not_valid.out
+++ b/tsl/test/expected/constraints_not_valid.out
@@ -1,0 +1,105 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- A NOT VALID NOT NULL constraint must not exclude chunks from an IS NULL query.
+create table nn(ts timestamptz not null, v int);
+select create_hypertable('nn', by_range('ts', interval '1 day'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+insert into nn
+select '2024-01-01'::timestamptz + (i || ' min')::interval,
+       case when i % 10 = 0 then null else i end
+from generate_series(1, 5000) i;
+insert into nn
+select '2024-01-03'::timestamptz + (i || ' min')::interval,
+       case when i % 10 = 0 then null else i end
+from generate_series(1, 5000) i;
+create index on nn (v);
+analyze nn;
+alter table nn add constraint v_nn not null v not valid;
+set plan_cache_mode = force_generic_plan;
+prepare q(timestamptz) as select count(*) from nn where ts >= $1 and v is null;
+-- the NULL rows must still be found
+explain (analyze, buffers off, costs off, summary off, timing off)
+execute q('2024-01-01');
+--- QUERY PLAN ---
+ Finalize Aggregate (actual rows=1.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on nn (actual rows=6.00 loops=1)
+         Chunks excluded during startup: 0
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_nn_v_idx on _hyper_1_1_chunk (actual rows=95.00 loops=1)
+                     Index Cond: (v IS NULL)
+                     Filter: (ts >= $1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_nn_v_idx on _hyper_1_2_chunk (actual rows=144.00 loops=1)
+                     Index Cond: (v IS NULL)
+                     Filter: (ts >= $1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_nn_v_idx on _hyper_1_3_chunk (actual rows=239.00 loops=1)
+                     Index Cond: (v IS NULL)
+                     Filter: (ts >= $1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_nn_v_idx on _hyper_1_4_chunk (actual rows=261.00 loops=1)
+                     Index Cond: (v IS NULL)
+                     Filter: (ts >= $1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Index Scan using _hyper_1_5_chunk_nn_v_idx on _hyper_1_5_chunk (actual rows=144.00 loops=1)
+                     Index Cond: (v IS NULL)
+                     Filter: (ts >= $1)
+         ->  Partial Aggregate (actual rows=1.00 loops=1)
+               ->  Index Scan using _hyper_1_6_chunk_nn_v_idx on _hyper_1_6_chunk (actual rows=117.00 loops=1)
+                     Index Cond: (v IS NULL)
+                     Filter: (ts >= $1)
+
+execute q('2024-01-01');
+ count 
+-------
+  1000
+
+execute q('2024-01-01');
+ count 
+-------
+  1000
+
+deallocate q;
+drop table nn;
+-- SkipScan must still return the NULL group when a NOT VALID NOT NULL constraint allows NULLs.
+create table sk(time int not null, dev int);
+select create_hypertable('sk', by_range('time', 100), create_default_indexes => false);
+ create_hypertable 
+-------------------
+ (2,t)
+
+insert into sk
+select i, case when i % 7 = 0 then null else i % 4 end
+from generate_series(1, 50) i;
+create index on sk(dev);
+analyze sk;
+alter table sk add constraint dev_nn not null dev not valid;
+set timescaledb.debug_skip_scan_info to true;
+set enable_seqscan to off;
+-- the NULL group must still be returned
+explain (analyze, buffers off, costs off, timing off, summary off)
+select distinct dev from sk order by dev;
+INFO:  SkipScan used on _hyper_2_7_chunk_sk_dev_idx(dev NULLS LAST)
+--- QUERY PLAN ---
+ Unique (actual rows=5.00 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_2_7_chunk (actual rows=5.00 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_sk_dev_idx on _hyper_2_7_chunk (actual rows=5.00 loops=1)
+               Index Cond: (dev > NULL::integer)
+
+select distinct dev from sk order by dev;
+INFO:  SkipScan used on _hyper_2_7_chunk_sk_dev_idx(dev NULLS LAST)
+ dev 
+-----
+   0
+   1
+   2
+   3
+    
+
+reset timescaledb.debug_skip_scan_info;
+reset enable_seqscan;
+drop table sk;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -229,6 +229,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))
        merge_append_partially_compressed.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "18"))
+  list(APPEND TEST_FILES constraints_not_valid.sql)
+endif()
+
 set(SOLO_TESTS
     # This interferes with other tests since it reloads the config to increase
     # log level.

--- a/tsl/test/sql/constraints_not_valid.sql
+++ b/tsl/test/sql/constraints_not_valid.sql
@@ -1,0 +1,57 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- A NOT VALID NOT NULL constraint must not exclude chunks from an IS NULL query.
+create table nn(ts timestamptz not null, v int);
+select create_hypertable('nn', by_range('ts', interval '1 day'));
+insert into nn
+select '2024-01-01'::timestamptz + (i || ' min')::interval,
+       case when i % 10 = 0 then null else i end
+from generate_series(1, 5000) i;
+insert into nn
+select '2024-01-03'::timestamptz + (i || ' min')::interval,
+       case when i % 10 = 0 then null else i end
+from generate_series(1, 5000) i;
+
+create index on nn (v);
+analyze nn;
+
+alter table nn add constraint v_nn not null v not valid;
+
+set plan_cache_mode = force_generic_plan;
+prepare q(timestamptz) as select count(*) from nn where ts >= $1 and v is null;
+
+-- the NULL rows must still be found
+explain (analyze, buffers off, costs off, summary off, timing off)
+execute q('2024-01-01');
+
+execute q('2024-01-01');
+execute q('2024-01-01');
+
+deallocate q;
+drop table nn;
+
+-- SkipScan must still return the NULL group when a NOT VALID NOT NULL constraint allows NULLs.
+create table sk(time int not null, dev int);
+select create_hypertable('sk', by_range('time', 100), create_default_indexes => false);
+insert into sk
+select i, case when i % 7 = 0 then null else i % 4 end
+from generate_series(1, 50) i;
+create index on sk(dev);
+analyze sk;
+
+alter table sk add constraint dev_nn not null dev not valid;
+
+set timescaledb.debug_skip_scan_info to true;
+set enable_seqscan to off;
+
+-- the NULL group must still be returned
+explain (analyze, buffers off, costs off, timing off, summary off)
+select distinct dev from sk order by dev;
+
+select distinct dev from sk order by dev;
+
+reset timescaledb.debug_skip_scan_info;
+reset enable_seqscan;
+drop table sk;


### PR DESCRIPTION
A NOT NULL constraint added as NOT VALID in PostgreSQL 18 marks a column
as not null even though existing rows may still be NULL. We must not rely
on such a constraint when optimizing queries.

Stop using these constraints for chunk exclusion and for the SkipScan and
compression optimizations, so queries that look for NULL values return the
correct results.

Fixes #9926
