### PR TITLE
Fix incremental refresh null cap

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -1151,11 +1151,30 @@ continuous_agg_split_refresh_window(ContinuousAgg *cagg, InternalTimeRange *orig
 				 NameStr(cagg->data.user_view_name));
 			return NIL;
 		}
-		/* range_end is exclusive; subtract 1 to get the last internal value in the chunk,
-		 * then find the end of the bucket that contains it. */
-		refresh_window.end = cagg_next_bucket_start(slice->fd.range_end - 1,
-													refresh_window.type,
-													cagg->bucket_function);
+		/*
+		 * Cap the window end at the next bucket boundary after the actual
+		 * maximum data value in the hypertable, not the chunk's range_end.
+		 *
+		 * invalidation_threshold_compute() uses
+		 * ts_hypertable_get_open_dim_max_value() for the same reason.  Using
+		 * the same value here keeps single-pass and incremental refresh
+		 * behaviour consistent.
+		 */
+		bool maxval_isnull;
+		int64 maxval = ts_hypertable_get_open_dim_max_value(ht, 0, &maxval_isnull);
+
+		if (maxval_isnull)
+		{
+			elog(DEBUG1,
+				 "no data in hypertable for continuous aggregate \"%s.%s\", falling back to "
+				 "single batch processing",
+				 NameStr(cagg->data.user_view_schema),
+				 NameStr(cagg->data.user_view_name));
+			return NIL;
+		}
+
+		refresh_window.end =
+			cagg_next_bucket_start(maxval, refresh_window.type, cagg->bucket_function);
 		refresh_window.end_isnull = false;
 	}
 

--- a/tsl/test/expected/cagg_policy_incremental.out
+++ b/tsl/test/expected/cagg_policy_incremental.out
@@ -1430,6 +1430,108 @@ LOG:  statement: RESET client_min_messages;
 DROP TABLE end_null_data CASCADE;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_12_106_chunk
+-- Test: null end_offset — incremental and single-pass refresh set the same threshold.
+--
+-- A 3-day bucket is used so bucket boundaries are clearly distinct from both the
+-- chunk boundaries and the raw data timestamp, making any mismatch obvious.
+--
+-- Setup (1-month chunk interval ≈ 30 days from Unix epoch):
+--   data point    : 2024-01-05 12:00 UTC  (noon, not on any bucket boundary)
+--   chunk range   : [2023-12-19 00:00, 2024-01-18 00:00) UTC
+--   data bucket   : time_bucket('3 days', data) = 2024-01-03 → [Jan 03, Jan 06)
+--   threshold set by 1-pass refresh: cagg_next_bucket_start(data) = 2024-01-06 00:00 UTC
+--
+-- Before the fix the split function capped the window at chunk_end (Jan 18 UTC)
+-- instead of max-data's next bucket (Jan 06).  With buckets_per_batch=1 (batch_size
+-- = 3 days), that produces ten 3-day batches over the 30-day chunk:
+--   [Dec 19, Dec 22) ... [Jan 03, Jan 06) ... [Jan 15, Jan 18) → [Jan 15, INF)
+-- Newest-first processing:
+--   batch [Jan 15, INF): max_refresh → threshold = Jan 06 (from max data)
+--   batch [Jan 12, Jan 15): Jan 15 > Jan 06 → threshold advances to Jan 15
+-- The remaining older batches don't advance it further, so the final threshold is
+-- Jan 15 — 9 days past the value set by the single-pass refresh.
+--
+-- After the fix the window is capped at Jan 06, producing six 3-day batches:
+--   [Dec 19, Dec 22)  [Dec 22, Dec 25)  [Dec 25, Dec 28)
+--   [Dec 28, Dec 31)  [Dec 31, Jan 03)  [Jan 03, Jan 06) → [Jan 03, INF)
+-- Newest-first processing:
+--   batch [Jan 03, INF): max_refresh → threshold = Jan 06 (from max data)
+--   batch [Dec 31, Jan 03): Jan 03 < Jan 06 → no change  ← FIXED
+-- Final threshold = Jan 06, matching single-pass exactly.
+--
+-- Two separate hypertables (identical data) keep the thresholds independent so the
+-- run order cannot mask a discrepancy.
+CREATE TABLE threshold_sp_data (time TIMESTAMPTZ NOT NULL, val INT);
+SELECT FROM create_hypertable('threshold_sp_data', by_range('time', INTERVAL '1 month'));
+--
+
+CREATE TABLE threshold_inc_data (time TIMESTAMPTZ NOT NULL, val INT);
+SELECT FROM create_hypertable('threshold_inc_data', by_range('time', INTERVAL '1 month'));
+--
+
+INSERT INTO threshold_sp_data  VALUES ('2024-01-05 12:00:00+00', 1);
+INSERT INTO threshold_inc_data VALUES ('2024-01-05 12:00:00+00', 1);
+CREATE MATERIALIZED VIEW threshold_sp_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('3 days', time) AS bucket, count(*) AS cnt
+FROM threshold_sp_data GROUP BY 1 WITH NO DATA;
+CREATE MATERIALIZED VIEW threshold_inc_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('3 days', time) AS bucket, count(*) AS cnt
+FROM threshold_inc_data GROUP BY 1 WITH NO DATA;
+SELECT add_continuous_aggregate_policy('threshold_sp_cagg',
+    start_offset => NULL, end_offset => NULL,
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 0   -- single-pass
+) AS sp_job \gset
+SELECT add_continuous_aggregate_policy('threshold_inc_cagg',
+    start_offset => NULL, end_offset => NULL,
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1   -- incremental: one 3-day batch at a time
+) AS inc_job \gset
+CALL run_job(:sp_job);
+CALL run_job(:inc_job);
+-- Both must equal 2024-01-06 00:00:00+00 = cagg_next_bucket_start(MAX(data) = Jan 05 12:00).
+-- Before the fix incremental_threshold was 2024-01-15 00:00:00+00 (9 days too far).
+SELECT
+    _timescaledb_functions.to_timestamp(t1.watermark) AS singlepass_threshold,
+    _timescaledb_functions.to_timestamp(t2.watermark) AS incremental_threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold t1
+JOIN _timescaledb_catalog.continuous_aggs_invalidation_threshold t2
+  ON true
+WHERE t1.hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'threshold_sp_cagg')
+  AND t2.hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'threshold_inc_cagg');
+     singlepass_threshold     |    incremental_threshold     
+------------------------------+------------------------------
+ Sat Jan 06 00:00:00 2024 UTC | Sat Jan 06 00:00:00 2024 UTC
+
+DROP TABLE threshold_sp_data CASCADE;
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_109_chunk
+-- Test: null end_offset on an empty hypertable hits the maxval_isnull branch and
+-- falls back to single-pass without error.  The DEBUG1 message confirms the path.
+TRUNCATE threshold_inc_data;
+SET client_min_messages TO DEBUG1;
+CALL run_job(:inc_job);
+LOG:  statement: CALL run_job(1012);
+DEBUG:  Executing policy_refresh_continuous_aggregate with parameters {"end_offset": null, "start_offset": null, "buckets_per_batch": 1, "mat_hypertable_id": 16}
+DEBUG:  begin "threshold_inc_cagg" in window [ Mon Nov 24 00:00:00 4714 UTC BC, infinity ] internal [ -210866803200000000, 9223372036854775807 ] minimum [ Mon Nov 24 00:00:00 4714 UTC BC ]
+DEBUG:  START IS NULL "threshold_inc_cagg" in window [ Mon Nov 24 00:00:00 4714 UTC BC, infinity ] internal [ -210866803200000000, 9223372036854775807 ] minimum [ Mon Nov 24 00:00:00 4714 UTC BC ]
+DEBUG:  no min slice range start for continuous aggregate "public.threshold_inc_cagg", falling back to single batch processing
+DEBUG:  refreshing continuous aggregate "threshold_inc_cagg" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+DEBUG:  hypertable 14 existing watermark >= new invalidation threshold 1704499200000000 -210866803200000000
+LOG:  continuous aggregate refresh (individual invalidation) on "threshold_inc_cagg" in window [ Tue Nov 25 00:00:00 4714 UTC BC, Sat Jan 06 00:00:00 2024 UTC ]
+LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_16"
+LOG:  inserted 0 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_16"
+RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
+DROP TABLE threshold_inc_data CASCADE;
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_16_110_chunk
 DROP TABLE sparse_data CASCADE;
 NOTICE:  drop cascades to 6 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_98_chunk

--- a/tsl/test/sql/cagg_policy_incremental.sql
+++ b/tsl/test/sql/cagg_policy_incremental.sql
@@ -873,6 +873,97 @@ RESET client_min_messages;
 
 DROP TABLE end_null_data CASCADE;
 
+-- Test: null end_offset — incremental and single-pass refresh set the same threshold.
+--
+-- A 3-day bucket is used so bucket boundaries are clearly distinct from both the
+-- chunk boundaries and the raw data timestamp, making any mismatch obvious.
+--
+-- Setup (1-month chunk interval ≈ 30 days from Unix epoch):
+--   data point    : 2024-01-05 12:00 UTC  (noon, not on any bucket boundary)
+--   chunk range   : [2023-12-19 00:00, 2024-01-18 00:00) UTC
+--   data bucket   : time_bucket('3 days', data) = 2024-01-03 → [Jan 03, Jan 06)
+--   threshold set by 1-pass refresh: cagg_next_bucket_start(data) = 2024-01-06 00:00 UTC
+--
+-- Before the fix the split function capped the window at chunk_end (Jan 18 UTC)
+-- instead of max-data's next bucket (Jan 06).  With buckets_per_batch=1 (batch_size
+-- = 3 days), that produces ten 3-day batches over the 30-day chunk:
+--   [Dec 19, Dec 22) ... [Jan 03, Jan 06) ... [Jan 15, Jan 18) → [Jan 15, INF)
+-- Newest-first processing:
+--   batch [Jan 15, INF): max_refresh → threshold = Jan 06 (from max data)
+--   batch [Jan 12, Jan 15): Jan 15 > Jan 06 → threshold advances to Jan 15
+-- The remaining older batches don't advance it further, so the final threshold is
+-- Jan 15 — 9 days past the value set by the single-pass refresh.
+--
+-- After the fix the window is capped at Jan 06, producing six 3-day batches:
+--   [Dec 19, Dec 22)  [Dec 22, Dec 25)  [Dec 25, Dec 28)
+--   [Dec 28, Dec 31)  [Dec 31, Jan 03)  [Jan 03, Jan 06) → [Jan 03, INF)
+-- Newest-first processing:
+--   batch [Jan 03, INF): max_refresh → threshold = Jan 06 (from max data)
+--   batch [Dec 31, Jan 03): Jan 03 < Jan 06 → no change  ← FIXED
+-- Final threshold = Jan 06, matching single-pass exactly.
+--
+-- Two separate hypertables (identical data) keep the thresholds independent so the
+-- run order cannot mask a discrepancy.
+CREATE TABLE threshold_sp_data (time TIMESTAMPTZ NOT NULL, val INT);
+SELECT FROM create_hypertable('threshold_sp_data', by_range('time', INTERVAL '1 month'));
+
+CREATE TABLE threshold_inc_data (time TIMESTAMPTZ NOT NULL, val INT);
+SELECT FROM create_hypertable('threshold_inc_data', by_range('time', INTERVAL '1 month'));
+
+INSERT INTO threshold_sp_data  VALUES ('2024-01-05 12:00:00+00', 1);
+INSERT INTO threshold_inc_data VALUES ('2024-01-05 12:00:00+00', 1);
+
+CREATE MATERIALIZED VIEW threshold_sp_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('3 days', time) AS bucket, count(*) AS cnt
+FROM threshold_sp_data GROUP BY 1 WITH NO DATA;
+
+CREATE MATERIALIZED VIEW threshold_inc_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = true) AS
+SELECT time_bucket('3 days', time) AS bucket, count(*) AS cnt
+FROM threshold_inc_data GROUP BY 1 WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('threshold_sp_cagg',
+    start_offset => NULL, end_offset => NULL,
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 0   -- single-pass
+) AS sp_job \gset
+
+SELECT add_continuous_aggregate_policy('threshold_inc_cagg',
+    start_offset => NULL, end_offset => NULL,
+    schedule_interval => INTERVAL '1 hour',
+    buckets_per_batch => 1   -- incremental: one 3-day batch at a time
+) AS inc_job \gset
+
+CALL run_job(:sp_job);
+CALL run_job(:inc_job);
+
+-- Both must equal 2024-01-06 00:00:00+00 = cagg_next_bucket_start(MAX(data) = Jan 05 12:00).
+-- Before the fix incremental_threshold was 2024-01-15 00:00:00+00 (9 days too far).
+SELECT
+    _timescaledb_functions.to_timestamp(t1.watermark) AS singlepass_threshold,
+    _timescaledb_functions.to_timestamp(t2.watermark) AS incremental_threshold
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold t1
+JOIN _timescaledb_catalog.continuous_aggs_invalidation_threshold t2
+  ON true
+WHERE t1.hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'threshold_sp_cagg')
+  AND t2.hypertable_id = (
+    SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+    WHERE user_view_name = 'threshold_inc_cagg');
+
+DROP TABLE threshold_sp_data CASCADE;
+
+-- Test: null end_offset on an empty hypertable hits the maxval_isnull branch and
+-- falls back to single-pass without error.  The DEBUG1 message confirms the path.
+TRUNCATE threshold_inc_data;
+SET client_min_messages TO DEBUG1;
+CALL run_job(:inc_job);
+RESET client_min_messages;
+
+DROP TABLE threshold_inc_data CASCADE;
+
 DROP TABLE sparse_data CASCADE;
 RESET timezone;
 


### PR DESCRIPTION
Fix null end capping in incremental refresh
    
 The split function capped the null refresh window end at the chunk's
 range_end, causing incremental refresh to generate empty batches beyond
 actual data and advance the invalidation threshold further than a
 single-pass refresh would.
 This fix uses ts_hypertable_get_open_dim_max_value instead for capping,
 matching the threshold computation in invalidation_threshold_compute.

 Disable-check: force-changelog-file