### PR TITLE
Fix wrong results when filtering a date column to a timestamptz value

### DIFF
--- a/.unreleased/date-timestamptz-comparison
+++ b/.unreleased/date-timestamptz-comparison
@@ -1,0 +1,1 @@
+Fixes: #9976 Fix wrong results when comparing a date column to a timestamptz value

--- a/src/nodes/chunk_append/transform.c
+++ b/src/nodes/chunk_append/transform.c
@@ -4,12 +4,14 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
+#include <access/stratnum.h>
 #include <catalog/pg_namespace.h>
 #include <catalog/pg_type.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
 #include <optimizer/optimizer.h>
 #include <utils/lsyscache.h>
+#include <utils/typcache.h>
 
 #include "nodes/chunk_append/transform.h"
 #include "utils.h"
@@ -78,6 +80,31 @@ ts_transform_cross_datatype_comparison(Expr *clause)
 		{
 			source_type = left_type;
 			target_type = right_type;
+		}
+
+		/*
+		 * Casting the TIMESTAMPTZ side down to DATE rounds it down to midnight.
+		 * Since midnight is the smallest time of the day the comparison only
+		 * stays equivalent for "date > value" and "date <= value". For the
+		 * other operators the dropped time-of-day would change the result, so
+		 * we leave them untransformed.
+		 */
+		if (target_type == DATEOID)
+		{
+			TypeCacheEntry *tce = lookup_type_cache(TIMESTAMPTZOID, TYPECACHE_BTREE_OPFAMILY);
+			int strategy = get_op_opfamily_strategy(op->opno, tce->btree_opf);
+
+			if (IsA(linitial(op->args), Var))
+			{
+				if (strategy != BTGreaterStrategyNumber && strategy != BTLessEqualStrategyNumber)
+				{
+					return clause;
+				}
+			}
+			else if (strategy != BTLessStrategyNumber && strategy != BTGreaterEqualStrategyNumber)
+			{
+				return clause;
+			}
 		}
 
 		opno = ts_get_operator(opname, PG_CATALOG_NAMESPACE, target_type, target_type);

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -616,6 +616,29 @@ ts_transform_time_bucket_comparison(Expr *node)
 	}
 
 	/*
+	 * The value and the time_bucket() input column can have different time types
+	 * (e.g. a TIMESTAMPTZ bucket compared against a DATE constant). DATE counts
+	 * days while TIMESTAMP/TIMESTAMPTZ count microseconds, so we convert the value
+	 * to the input type before reading its integral value below. Converting down
+	 * to DATE would drop the time-of-day and change the result, so we skip it.
+	 */
+	if (tbqual.value->consttype != tbqual.tb.timetype &&
+		IS_TIMESTAMP_TYPE(tbqual.value->consttype) && IS_TIMESTAMP_TYPE(tbqual.tb.timetype))
+	{
+		Oid timetype = tbqual.tb.timetype;
+		Oid castfunc = ts_get_cast_func(tbqual.value->consttype, timetype);
+
+		if (timetype == DATEOID || !OidIsValid(castfunc))
+		{
+			return NULL;
+		}
+
+		/* TIMESTAMP and TIMESTAMPTZ are both 8-byte pass-by-value. */
+		Datum converted = OidFunctionCall1(castfunc, tbqual.value->constvalue);
+		tbqual.value = makeConst(timetype, -1, InvalidOid, sizeof(int64), converted, false, true);
+	}
+
+	/*
 	 * The qual is an expression <time_bucket OP value> or <value OP time_bucket>. Convert the value
 	 * to integral time format.
 	 */

--- a/test/expected/append-15.out
+++ b/test/expected/append-15.out
@@ -590,10 +590,12 @@ reset enable_material;
 --- QUERY PLAN ---
  Custom Scan (ChunkAppend) on metrics_date (actual rows=1440.00 loops=1)
    Order: metrics_date."time"
-   Chunks excluded during startup: 3
+   Chunks excluded during startup: 2
    ->  Index Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288.00 loops=1)
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=0.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -590,10 +590,12 @@ reset enable_material;
 --- QUERY PLAN ---
  Custom Scan (ChunkAppend) on metrics_date (actual rows=1440.00 loops=1)
    Order: metrics_date."time"
-   Chunks excluded during startup: 3
+   Chunks excluded during startup: 2
    ->  Index Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288.00 loops=1)
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=0.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -590,10 +590,12 @@ reset enable_material;
 --- QUERY PLAN ---
  Custom Scan (ChunkAppend) on metrics_date (actual rows=1440.00 loops=1)
    Order: metrics_date."time"
-   Chunks excluded during startup: 3
+   Chunks excluded during startup: 2
    ->  Index Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288.00 loops=1)
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=0.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints

--- a/test/expected/append-18.out
+++ b/test/expected/append-18.out
@@ -590,10 +590,12 @@ reset enable_material;
 --- QUERY PLAN ---
  Custom Scan (ChunkAppend) on metrics_date (actual rows=1440.00 loops=1)
    Order: metrics_date."time"
-   Chunks excluded during startup: 3
+   Chunks excluded during startup: 2
    ->  Index Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk (actual rows=1152.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk (actual rows=288.00 loops=1)
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk (actual rows=0.00 loops=1)
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints

--- a/test/expected/qual_filtering.out
+++ b/test/expected/qual_filtering.out
@@ -80,6 +80,69 @@ WHERE d >= '2026-02-01' AND d < '2026-03-01'::timestamp;
     28
 
 RESET timescaledb.enable_qual_filtering;
+-- A date column compared to a '<' timestamptz constant keeps the boundary day.
+SET timezone TO 'UTC';
+CREATE TABLE qual_filter_date_tz(d date NOT NULL);
+SELECT create_hypertable('qual_filter_date_tz', 'd',
+    chunk_time_interval => INTERVAL '1 day');
+        create_hypertable         
+----------------------------------
+ (3,public,qual_filter_date_tz,t)
+
+INSERT INTO qual_filter_date_tz
+SELECT generate_series('2024-03-08'::date, '2024-03-12'::date, '1 day');
+-- Mar 8, 9 and 10 match.
+SELECT d FROM qual_filter_date_tz
+WHERE d < '2024-03-10 12:00:00+00'::timestamptz ORDER BY d;
+     d      
+------------
+ 03-08-2024
+ 03-09-2024
+ 03-10-2024
+
+DROP TABLE qual_filter_date_tz;
+RESET timezone;
+-- A date constant against a timestamptz time_bucket is converted to timestamptz.
+SET timezone TO 'UTC';
+CREATE TABLE qual_filter_tb(ts timestamptz NOT NULL);
+SELECT create_hypertable('qual_filter_tb', 'ts',
+    chunk_time_interval => INTERVAL '1 day');
+      create_hypertable      
+-----------------------------
+ (4,public,qual_filter_tb,t)
+
+INSERT INTO qual_filter_tb
+SELECT generate_series('2024-03-01'::timestamptz, '2024-03-20'::timestamptz, '1 day');
+-- Both count the 9 buckets before March 10.
+SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10'::date;
+ count 
+-------
+     9
+
+SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10'::timestamptz;
+ count 
+-------
+     9
+
+DROP TABLE qual_filter_tb;
+-- A timestamptz constant against a date time_bucket is not transformed.
+CREATE TABLE qual_filter_tb_date(d date NOT NULL);
+SELECT create_hypertable('qual_filter_tb_date', 'd',
+    chunk_time_interval => INTERVAL '1 day');
+        create_hypertable         
+----------------------------------
+ (5,public,qual_filter_tb_date,t)
+
+INSERT INTO qual_filter_tb_date
+SELECT generate_series('2024-03-01'::date, '2024-03-20'::date, '1 day');
+SELECT count(*) FROM qual_filter_tb_date
+WHERE time_bucket('1 day', d) < '2024-03-10 12:00:00+00'::timestamptz;
+ count 
+-------
+    10
+
+DROP TABLE qual_filter_tb_date;
+RESET timezone;
 -- Cleanup
 DROP TABLE qual_filter_tz;
 DROP TABLE qual_filter_date;
@@ -91,7 +154,7 @@ SELECT create_hypertable('qual_filter_ops', 'ts',
     chunk_time_interval => INTERVAL '7 days');
       create_hypertable       
 ------------------------------
- (3,public,qual_filter_ops,t)
+ (6,public,qual_filter_ops,t)
 
 INSERT INTO qual_filter_ops
 SELECT t, extract(day from t)::int

--- a/test/sql/qual_filtering.sql
+++ b/test/sql/qual_filtering.sql
@@ -60,6 +60,42 @@ SELECT count(*) FROM qual_filter_date
 WHERE d >= '2026-02-01' AND d < '2026-03-01'::timestamp;
 RESET timescaledb.enable_qual_filtering;
 
+-- A date column compared to a '<' timestamptz constant keeps the boundary day.
+SET timezone TO 'UTC';
+CREATE TABLE qual_filter_date_tz(d date NOT NULL);
+SELECT create_hypertable('qual_filter_date_tz', 'd',
+    chunk_time_interval => INTERVAL '1 day');
+INSERT INTO qual_filter_date_tz
+SELECT generate_series('2024-03-08'::date, '2024-03-12'::date, '1 day');
+-- Mar 8, 9 and 10 match.
+SELECT d FROM qual_filter_date_tz
+WHERE d < '2024-03-10 12:00:00+00'::timestamptz ORDER BY d;
+DROP TABLE qual_filter_date_tz;
+RESET timezone;
+
+-- A date constant against a timestamptz time_bucket is converted to timestamptz.
+SET timezone TO 'UTC';
+CREATE TABLE qual_filter_tb(ts timestamptz NOT NULL);
+SELECT create_hypertable('qual_filter_tb', 'ts',
+    chunk_time_interval => INTERVAL '1 day');
+INSERT INTO qual_filter_tb
+SELECT generate_series('2024-03-01'::timestamptz, '2024-03-20'::timestamptz, '1 day');
+-- Both count the 9 buckets before March 10.
+SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10'::date;
+SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10'::timestamptz;
+DROP TABLE qual_filter_tb;
+
+-- A timestamptz constant against a date time_bucket is not transformed.
+CREATE TABLE qual_filter_tb_date(d date NOT NULL);
+SELECT create_hypertable('qual_filter_tb_date', 'd',
+    chunk_time_interval => INTERVAL '1 day');
+INSERT INTO qual_filter_tb_date
+SELECT generate_series('2024-03-01'::date, '2024-03-20'::date, '1 day');
+SELECT count(*) FROM qual_filter_tb_date
+WHERE time_bucket('1 day', d) < '2024-03-10 12:00:00+00'::timestamptz;
+DROP TABLE qual_filter_tb_date;
+RESET timezone;
+
 -- Cleanup
 DROP TABLE qual_filter_tz;
 DROP TABLE qual_filter_date;

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -1061,6 +1061,35 @@ select * from date_table where ts <  CURRENT_DATE;
  01-02-2021
  01-01-2021
 
+-- A date column vs a timestamptz constant is only vectorized for '>' and '<='.
+select * from date_table where ts >  '2021-01-02 12:00:00+00'::timestamptz;
+     ts     
+------------
+ 01-03-2021
+
+select * from date_table where ts <= '2021-01-02 12:00:00+00'::timestamptz;
+     ts     
+------------
+ 01-02-2021
+ 01-01-2021
+
+set timescaledb.debug_require_vector_qual to 'forbid';
+select * from date_table where ts =  '2021-01-02 12:00:00+00'::timestamptz;
+ ts 
+----
+
+select * from date_table where ts <  '2021-01-02 12:00:00+00'::timestamptz;
+     ts     
+------------
+ 01-02-2021
+ 01-01-2021
+
+select * from date_table where ts >= '2021-01-02 12:00:00+00'::timestamptz;
+     ts     
+------------
+ 01-03-2021
+
+set timescaledb.debug_require_vector_qual to 'require';
 -- Text columns.
 create table text_table(ts int, d int);
 select create_hypertable('text_table', 'ts');

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -414,6 +414,15 @@ select * from date_table where ts <= '2021-01-02';
 select * from date_table where ts <  '2021-01-02';
 select * from date_table where ts <  CURRENT_DATE;
 
+-- A date column vs a timestamptz constant is only vectorized for '>' and '<='.
+select * from date_table where ts >  '2021-01-02 12:00:00+00'::timestamptz;
+select * from date_table where ts <= '2021-01-02 12:00:00+00'::timestamptz;
+set timescaledb.debug_require_vector_qual to 'forbid';
+select * from date_table where ts =  '2021-01-02 12:00:00+00'::timestamptz;
+select * from date_table where ts <  '2021-01-02 12:00:00+00'::timestamptz;
+select * from date_table where ts >= '2021-01-02 12:00:00+00'::timestamptz;
+set timescaledb.debug_require_vector_qual to 'require';
+
 -- Text columns.
 create table text_table(ts int, d int);
 select create_hypertable('text_table', 'ts');


### PR DESCRIPTION
The comparison was rewritten by casting the timestamptz to a date, which
drops the time of day and can change the result.
This is correct only for "date > value" and "date <= value". For the other
operators we now keep the original comparison.

This affected vectorized filtering and chunk exclusion.

Fixes: #9976
