### PR TITLE
Properly check the compressed data header in recv function

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -2963,10 +2963,8 @@ tsl_compressed_data_recv(PG_FUNCTION_ARGS)
 
 	header.compression_algorithm = pq_getmsgbyte(buf);
 
-	if (header.compression_algorithm >= _END_COMPRESSION_ALGORITHMS)
-	{
-		elog(ERROR, "invalid compression algorithm %d", header.compression_algorithm);
-	}
+	CheckCompressedData(header.compression_algorithm > 0 &&
+						header.compression_algorithm < _END_COMPRESSION_ALGORITHMS);
 
 	return definitions[header.compression_algorithm].compressed_data_recv(buf);
 }

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -2119,6 +2119,11 @@ CREATE TABLE base_uuids AS SELECT row_number() OVER() as rn, u as item FROM uuid
 DROP TABLE base_uuids;
 RESET timescaledb.enable_uuid_compression;
 DROP table uuid_set;
+-- Corrupt compressed data with zero header
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.compressed_data_in('AA=='::cstring);
+ERROR:  the compressed data is corrupt
+\set ON_ERROR_STOP 1
 -----------------------------------------------
 -- Interesting corrupt data found by fuzzing --
 -----------------------------------------------

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -498,6 +498,13 @@ DROP TABLE base_uuids;
 RESET timescaledb.enable_uuid_compression;
 DROP table uuid_set;
 
+
+-- Corrupt compressed data with zero header
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.compressed_data_in('AA=='::cstring);
+\set ON_ERROR_STOP 1
+
+
 -----------------------------------------------
 -- Interesting corrupt data found by fuzzing --
 -----------------------------------------------


### PR DESCRIPTION
Zero compression algorithm is invalid.

Disable-check: force-changelog-file