### PR TITLE
Properly validate the user-supplied bloom filter object

### DIFF
--- a/tsl/src/compression/batch_metadata_builder_bloom1.c
+++ b/tsl/src/compression/batch_metadata_builder_bloom1.c
@@ -1223,6 +1223,7 @@ bloom1_contains_hash(Datum bloom_datum, uint64 hash)
 	const uint32 num_bits = 8 * VARSIZE_ANY_EXHDR(bloom);
 
 	/* Validate bloom structure */
+	CheckCompressedData(num_bits != 0);
 	CheckCompressedData(num_bits == (1ULL << pg_leftmost_one_pos32(num_bits)));
 	CheckCompressedData(num_bits >= 64);
 

--- a/tsl/test/expected/compress_bloom_sparse_debug.out
+++ b/tsl/test/expected/compress_bloom_sparse_debug.out
@@ -161,6 +161,8 @@ select _timescaledb_functions.bloom1_contains('\xffffffffffffffff'::_timescaledb
 ERROR:  the argument type bit lacks an extended hash function
 select _timescaledb_functions.bloom1_contains_any('\xffffffffffffffff'::_timescaledb_internal.bloom1, array[1::bit]) ;
 ERROR:  the argument type bit lacks an extended hash function
+select _timescaledb_functions.bloom1_contains(_timescaledb_functions.bloom1in('\x'::cstring), 1);
+ERROR:  the compressed data is corrupt
 \set ON_ERROR_STOP 1
 -- Test that the "contains" function cope with different source chunks.
 create table detoaster(ts int, tag text) with (tsdb.hypertable,

--- a/tsl/test/sql/compress_bloom_sparse_debug.sql
+++ b/tsl/test/sql/compress_bloom_sparse_debug.sql
@@ -115,6 +115,8 @@ select _timescaledb_functions.bloom1_contains('\xffffffffffffffff'::_timescaledb
 
 select _timescaledb_functions.bloom1_contains_any('\xffffffffffffffff'::_timescaledb_internal.bloom1, array[1::bit]) ;
 
+select _timescaledb_functions.bloom1_contains(_timescaledb_functions.bloom1in('\x'::cstring), 1);
+
 \set ON_ERROR_STOP 1
 
 


### PR DESCRIPTION
We didn't handle empty object which is invalid

Disable-check: force-changelog-file