### PR TITLE
Kill Postgres harder in fuzzer workflow

### DIFF
--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -265,7 +265,12 @@ jobs:
       if: steps.repro.outputs.found == 'true'
       run: |
         set -xeu
-        pkill -U "$(id -u)" postgres || true
+
+        # PG can get stuck in background worker termination after an
+        # AddressSanitizer failure (upstream bug), so we have to kill it
+        # forcefully.
+        killall -9 postgres || true
+
         sleep 2
 
     - name: Restore clean PostgreSQL build

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -301,7 +301,10 @@ jobs:
         export PATH=$HOME/$PG_INSTALL_DIR/bin:$PATH
 
         export PGDATA=verify_db
-        export PGPORT=5433
+
+        PGPORT=$(( 6600 + $RANDOM % 100 ))
+        export PGPORT
+
         export PGDATABASE=postgres
 
         initdb


### PR DESCRIPTION
It can get stuck after address sanitizer failure due to an upstream bug with race condition in terminating the background workers. This leads to repro failure.


The upstream bug: https://www.postgresql.org/message-id/flat/CALzhyqxD2_0HGn4zz5agovrGF5hsGebUw8SUK%2BJdTpXxd9nsyQ%40mail.gmail.com