### PR TITLE
Block unsafe updates of unique columns on compressed chunks

### DIFF
--- a/.unreleased/pr_10003
+++ b/.unreleased/pr_10003
@@ -1,0 +1,1 @@
+Fixes: #10003 Block unsafe updates of unique columns on compressed chunks

--- a/src/chunk_tuple_routing.h
+++ b/src/chunk_tuple_routing.h
@@ -32,6 +32,16 @@ typedef struct ChunkTupleRouting
 	ChunkInsertState *cis;
 
 	SharedCounters *counters; /* shared counters for the current statement */
+
+	/*
+	 * Cached ON CONFLICT DO UPDATE unique-column check. The check is statement-constant,
+	 * so it runs once on the first compressed-chunk route and is reused for every later row.
+	 * conflict_update_col is the attribute number of a changed unique column to report,
+	 * or InvalidAttrNumber when no unique column changes. AttrNumber is only used for error
+	 * reporting.
+	 */
+	bool conflict_update_col_checked;
+	AttrNumber conflict_update_col;
 } ChunkTupleRouting;
 
 ChunkTupleRouting *ts_chunk_tuple_routing_create(EState *estate, Hypertable *ht,

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -336,6 +336,42 @@ ts_indexing_relation_has_primary_or_unique_index(Relation htrel)
 	return result;
 }
 
+/*
+ * Collect the heap attribute numbers covered by any valid unique index
+ * (PRIMARY KEY included) on the relation. Returns a Bitmapset of raw attribute
+ * numbers, or NULL when the relation has no usable unique index.
+ *
+ * We do not use RelationGetIndexAttrBitmap(INDEX_ATTR_BITMAP_KEY): it leaves out
+ * partial and expression unique indexes, whose columns we still need to cover.
+ */
+TSDLLEXPORT Bitmapset *
+ts_indexing_relation_get_unique_columns(Relation rel)
+{
+	Bitmapset *unique_columns = NULL;
+	ListCell *lc;
+
+	foreach (lc, RelationGetIndexList(rel))
+	{
+		Relation index_rel = index_open(lfirst_oid(lc), AccessShareLock);
+		Form_pg_index index = index_rel->rd_index;
+
+		if (index->indisunique && index->indislive && index->indisvalid)
+		{
+			for (int i = 0; i < index->indnkeyatts; i++)
+			{
+				AttrNumber attno = index->indkey.values[i];
+				if (attno != 0)
+				{
+					unique_columns = bms_add_member(unique_columns, attno);
+				}
+			}
+		}
+		index_close(index_rel, AccessShareLock);
+	}
+
+	return unique_columns;
+}
+
 /* create the index on the root table of a hypertable.
  * based on postgres CREATE INDEX
  * https://github.com/postgres/postgres/blob/ebfe20dc706bd3238a9bdf3b44cd8f82337e86a8/src/backend/tcop/utility.c#L1291-L1374

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <postgres.h>
+#include <nodes/bitmapset.h>
 #include <nodes/parsenodes.h>
 #include <nodes/pg_list.h>
 
@@ -23,5 +24,6 @@ extern TSDLLEXPORT Oid ts_indexing_find_clustered_index(Oid table_relid);
 extern void ts_indexing_mark_as_valid(Oid index_id);
 extern bool ts_indexing_mark_as_invalid(Oid index_id);
 extern bool TSDLLEXPORT ts_indexing_relation_has_primary_or_unique_index(Relation htrel);
+extern TSDLLEXPORT Bitmapset *ts_indexing_relation_get_unique_columns(Relation rel);
 extern TSDLLEXPORT bool ts_indexing_compare(Oid index1, Oid index2);
 extern TSDLLEXPORT Datum ts_index_matches(PG_FUNCTION_ARGS);

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -76,6 +76,7 @@
 #include "cross_module_fn.h"
 #include "guc.h"
 #include "hypertable_cache.h"
+#include "indexing.h"
 #include "modify_hypertable.h"
 #include "nodes/chunk_append/chunk_append.h"
 #include "utils.h"
@@ -2250,6 +2251,7 @@ ExecOnConflictUpdate(ModifyTableContext *context,
 static void fireASTriggers(ModifyTableState *node);
 static void fireBSTriggers(ModifyTableState *node);
 static void checkDMLOnFrozenChunk(ResultRelInfo *resultRelInfo);
+static void error_on_compressed_unique_conflict_update(ChunkTupleRouting *ctr);
 
 /* ----------------------------------------------------------------
  *	   ExecModifyTable
@@ -2465,6 +2467,7 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 
 			/* Find or create the insert state matching the point */
 			ctr->cis = ts_chunk_tuple_routing_find_chunk(ctr, point);
+			error_on_compressed_unique_conflict_update(ctr);
 			bool update_counter = ctr->cis->onConflictAction == ONCONFLICT_UPDATE;
 			ts_chunk_tuple_routing_decompress_for_insert(ctr->cis, ctr->root_rri, hypertable_slot, ctr->estate, update_counter);
 			MemoryContextSwitchTo(oldctx);
@@ -2946,6 +2949,107 @@ static void checkDMLOnFrozenChunk(ResultRelInfo *resultRelInfo)
 				 errmsg("cannot update/delete rows from chunk \"%s\" as it is frozen",
 						get_rel_name(resultRelInfo->ri_RelationDesc->rd_id))));
 	}
+}
+
+/*
+ * Find a column changed by the ON CONFLICT DO UPDATE SET clause that is part of
+ * a unique constraint, or InvalidAttrNumber when none changes. The result only
+ * depends on the statement, not on the routed row.
+ */
+static AttrNumber
+conflict_update_changed_unique_col(ModifyTable *mt, Relation rel)
+{
+	/* Columns covered by any unique index (PRIMARY KEY included). */
+	Bitmapset *unique_columns = ts_indexing_relation_get_unique_columns(rel);
+
+	if (unique_columns == NULL)
+		return InvalidAttrNumber;
+
+	/*
+	 * onConflictSet holds the SET expressions; its non-junk entries correspond
+	 * in order to the target column numbers in onConflictCols.
+	 */
+	ListCell *col_cell = list_head(mt->onConflictCols);
+	ListCell *set_cell;
+	foreach (set_cell, mt->onConflictSet)
+	{
+		TargetEntry *tle = lfirst_node(TargetEntry, set_cell);
+
+		if (tle->resjunk)
+			continue;
+		if (col_cell == NULL)
+			break;
+
+		AttrNumber attno = lfirst_int(col_cell);
+		col_cell = lnext(mt->onConflictCols, col_cell);
+
+		if (!bms_is_member(attno, unique_columns))
+			continue;
+
+		/*
+		 * Allow the no-op "SET col = excluded.col". Planning rewrites the
+		 * excluded Var's varno to INNER_VAR, but varnosyn/varattnosyn still
+		 * carry the original reference to the excluded pseudo-relation.
+		 */
+		Expr *expr = tle->expr;
+		if (IsA(expr, RelabelType))
+			expr = ((RelabelType *) expr)->arg;
+		if (IsA(expr, Var))
+		{
+			Var *var = (Var *) expr;
+			if (var->varnosyn == mt->exclRelRTI && var->varattnosyn == attno)
+				continue;
+		}
+
+		return attno;
+	}
+
+	return InvalidAttrNumber;
+}
+
+/*
+ * Reject INSERT ... ON CONFLICT DO UPDATE on a compressed chunk when the SET
+ * clause changes a column that is part of a unique constraint.
+ *
+ * Like a plain UPDATE of a unique column, this could move a row onto a key held
+ * by a row that is still compressed and therefore invisible to the unique
+ * indexes, silently introducing a duplicate. Setting a key column to its own
+ * excluded value (SET col = excluded.col) does not change the value and stays
+ * allowed, as that is a common UPSERT idiom.
+ */
+static void
+error_on_compressed_unique_conflict_update(ChunkTupleRouting *ctr)
+{
+	ChunkInsertState *cis = ctr->cis;
+	ModifyTable *mt = ctr->mht_state ? ctr->mht_state->mt : NULL;
+
+	if (mt == NULL || cis->onConflictAction != ONCONFLICT_UPDATE || !cis->chunk_compressed)
+		return;
+
+	/* Result relation and ON CONFLICT columns share the root relation's attribute space. */
+	Relation rel = ctr->root_rri->ri_RelationDesc;
+
+	/*
+	 * The check is statement-constant but reaching it requires a compressed
+	 * target chunk, so compute it on the first such row and reuse it after that
+	 * instead of reopening every index per row.
+	 */
+	if (!ctr->conflict_update_col_checked)
+	{
+		ctr->conflict_update_col = conflict_update_changed_unique_col(mt, rel);
+		ctr->conflict_update_col_checked = true;
+	}
+
+	if (ctr->conflict_update_col == InvalidAttrNumber)
+		return;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("cannot update column \"%s\" of a compressed chunk",
+					get_attname(RelationGetRelid(rel), ctr->conflict_update_col, false)),
+			 errdetail("ON CONFLICT DO UPDATE cannot change a column that is part of a unique "
+					   "constraint on a compressed chunk."),
+			 errhint("Decompress the chunk before running this statement.")));
 }
 
 

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -9,6 +9,8 @@
 #include <access/tableam.h>
 #include <access/valid.h>
 #include <catalog/pg_am.h>
+#include <executor/executor.h>
+#include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
 #include <optimizer/optimizer.h>
 #include <parser/parse_coerce.h>
@@ -77,6 +79,10 @@ static void process_predicates(Chunk *ch, CompressionSettings *settings, List *p
 static Relation find_matching_index(Relation comp_chunk_rel, List **index_filters,
 									List **heap_filters);
 static tuple_filtering_constraints *get_batch_keys_for_unique_constraints(Relation relation);
+static bool decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chunk,
+												 List *predicates, EState *estate, bool has_joins);
+static bool decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk *chunk,
+													  EState *estate, bool has_joins);
 static BatchFilter *make_batchfilter(char *column_name, StrategyNumber strategy, Oid collation,
 									 RegProcedure opcode, Const *value, bool is_null_check,
 									 bool is_null, bool is_array_op);
@@ -551,6 +557,249 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 
 	CommandCounterIncrement();
 	table_close(in_rel, NoLock);
+}
+
+/*
+ * Find the SET expression that produces the new value for a result-relation
+ * column in an UPDATE. The new values live in the ModifyTable subplan's
+ * targetlist; its non-junk entries correspond one-to-one (and in order) to the
+ * result relation's update column numbers. Returns NULL if the column is not
+ * updated.
+ */
+static Expr *
+find_update_set_expr(ModifyTable *mt, AttrNumber target_attno)
+{
+	List *update_colnos = linitial(mt->updateColnosLists);
+	List *subplan_tlist = outerPlan(mt)->targetlist;
+	ListCell *col_cell = list_head(update_colnos);
+	ListCell *tl_cell;
+
+	foreach (tl_cell, subplan_tlist)
+	{
+		TargetEntry *tle = lfirst_node(TargetEntry, tl_cell);
+
+		if (tle->resjunk)
+		{
+			continue;
+		}
+
+		if (col_cell == NULL)
+		{
+			break;
+		}
+
+		if (lfirst_int(col_cell) == target_attno)
+		{
+			return tle->expr;
+		}
+
+		col_cell = lnext(update_colnos, col_cell);
+	}
+
+	return NULL;
+}
+
+/*
+ * Build an equality predicate "chunk_col = <new value>" for a changed unique key
+ * column, or NULL when its new value cannot be used to prune batches.
+ *
+ * The column must be a segmentby column or have minmax sparse index.
+ */
+static OpExpr *
+build_changed_key_filter(CompressionSettings *settings, Relation rel, Oid chunk_relid,
+						 AttrNumber attno, ModifyTable *mt, PlannerInfo *root)
+{
+	char *colname = get_attname(RelationGetRelid(rel), attno, false);
+	AttrNumber chunk_attno = get_attnum(chunk_relid, colname);
+
+	if (!ts_array_is_member(settings->fd.segmentby, colname) &&
+		(compressed_column_metadata_attno(settings,
+										  chunk_relid,
+										  chunk_attno,
+										  settings->fd.compress_relid,
+										  "min") == InvalidAttrNumber ||
+		 compressed_column_metadata_attno(settings,
+										  chunk_relid,
+										  chunk_attno,
+										  settings->fd.compress_relid,
+										  "max") == InvalidAttrNumber))
+	{
+		return NULL;
+	}
+
+	/* The new value has to be derivable before the scan. */
+	Expr *setexpr = find_update_set_expr(mt, attno);
+	if (setexpr == NULL)
+	{
+		return NULL;
+	}
+
+	Node *folded = estimate_expression_value(root, copyObject((Node *) setexpr));
+	if (!IsA(folded, Const))
+	{
+		return NULL;
+	}
+
+	Const *value = castNode(Const, folded);
+
+	/* Currently we dont support filtering on NULL values. */
+	if (value->constisnull)
+	{
+		return NULL;
+	}
+
+	Oid eq_opr = lookup_type_cache(value->consttype, TYPECACHE_EQ_OPR)->eq_opr;
+	if (!OidIsValid(eq_opr))
+	{
+		return NULL;
+	}
+
+	Var *var = makeVar(1, chunk_attno, value->consttype, value->consttypmod, value->constcollid, 0);
+	OpExpr *op = (OpExpr *) make_opclause(eq_opr,
+										  BOOLOID,
+										  false,
+										  (Expr *) var,
+										  (Expr *) value,
+										  InvalidOid,
+										  value->constcollid);
+	op->opfuncid = get_opcode(eq_opr);
+	return op;
+}
+
+/*
+ * Support UPDATEs that change columns covered by a unique constraint on a
+ * compressed chunk.
+ *
+ * The regular UPDATE decompression only decompresses the batches matching the
+ * statement's WHERE clause. A row that the UPDATE moves to a new unique key
+ * could collide with a row that is still compressed and therefore invisible to
+ * the unique indexes. To let those indexes detect the conflict we decompress,
+ * up front, the batches that could hold a row with the new key value.
+ *
+ * This only works when the new key value can be derived before the scan (a
+ * constant) and the changed unique columns can prune which batches to
+ * decompress. Anything we cannot derive that way is rejected, because staying
+ * correct would otherwise require decompressing the whole chunk.
+ */
+static bool
+decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk *chunk,
+										  EState *estate, bool has_joins)
+{
+	ModifyTable *mt = ht_state->mt;
+
+	if (mt->operation != CMD_UPDATE)
+	{
+		return false;
+	}
+
+	ModifyTableState *mtstate =
+		linitial_node(ModifyTableState, castNode(CustomScanState, ht_state)->custom_ps);
+	ResultRelInfo *relinfo = mtstate->resultRelInfo;
+	Relation rel = relinfo->ri_RelationDesc;
+	Bitmapset *updated_columns = ExecGetUpdatedCols(relinfo, estate);
+
+	if (bms_is_empty(updated_columns))
+	{
+		return false;
+	}
+
+	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+	Oid chunk_relid = chunk->table_id;
+	bool batches_decompressed = false;
+
+	/*
+	 * Root used for constant folding of the SET expressions. Forwarding the
+	 * bound parameters lets us derive a value for "SET col = $1" style updates.
+	 */
+	PlannerGlobal glob = { .boundParams = estate->es_param_list_info };
+	PlannerInfo root = { .glob = &glob };
+
+	ListCell *lc;
+	foreach (lc, RelationGetIndexList(rel))
+	{
+		Relation index_rel = index_open(lfirst_oid(lc), AccessShareLock);
+
+		/* PRIMARY KEY indexes also have indisunique set */
+		if (!index_rel->rd_index->indisunique || !index_rel->rd_index->indislive ||
+			!index_rel->rd_index->indisvalid)
+		{
+			index_close(index_rel, AccessShareLock);
+			continue;
+		}
+
+		/*
+		 * Build equality predicates from the new values of the changed key
+		 * columns. We only use a column when its new value is a constant and it
+		 * can prune batches (a segmentby or orderby column); one such column is
+		 * enough, since decompressing the batches matching it yields a superset
+		 * of the conflicting rows for this constraint.
+		 */
+		bool key_updated = false;
+		char *changed_col = NULL;
+		List *predicates = NIL;
+		for (int i = 0; i < index_rel->rd_index->indnkeyatts; i++)
+		{
+			AttrNumber attno = index_rel->rd_index->indkey.values[i];
+
+			if (attno == 0 ||
+				!bms_is_member(attno - FirstLowInvalidHeapAttributeNumber, updated_columns))
+			{
+				continue;
+			}
+
+			key_updated = true;
+			if (changed_col == NULL)
+			{
+				changed_col = get_attname(RelationGetRelid(rel), attno, false);
+			}
+
+			OpExpr *filter = build_changed_key_filter(settings, rel, chunk_relid, attno, mt, &root);
+			if (filter != NULL)
+			{
+				predicates = lappend(predicates, filter);
+			}
+		}
+
+		/*
+		 * A key expression or partial-index predicate that depends on a changed
+		 * column also changes which rows the constraint covers, but cannot be
+		 * turned into a batch filter.
+		 */
+		Bitmapset *referenced = NULL;
+		pull_varattnos((Node *) RelationGetIndexExpressions(index_rel), 1, &referenced);
+		pull_varattnos((Node *) RelationGetIndexPredicate(index_rel), 1, &referenced);
+		bool expr_or_pred_updated = bms_overlap(referenced, updated_columns);
+
+		index_close(index_rel, AccessShareLock);
+
+		if (!key_updated && !expr_or_pred_updated)
+		{
+			/* this constraint's key does not change */
+			continue;
+		}
+
+		if (expr_or_pred_updated || predicates == NIL)
+		{
+			if (changed_col == NULL)
+			{
+				AttrNumber off = bms_next_member(bms_intersect(referenced, updated_columns), -1) +
+								 FirstLowInvalidHeapAttributeNumber;
+				changed_col = get_attname(RelationGetRelid(rel), off, false);
+			}
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot update column \"%s\" of a compressed chunk", changed_col),
+					 errdetail("The conflicting rows cannot be determined without decompressing "
+							   "the whole chunk."),
+					 errhint("Decompress the chunk before running this update.")));
+		}
+
+		/* Decompress the batches that could hold a row with the new key value. */
+		batches_decompressed |=
+			decompress_batches_for_update_delete(ht_state, chunk, predicates, estate, has_joins);
+	}
+
+	return batches_decompressed;
 }
 
 /*
@@ -1519,6 +1768,18 @@ decompress_chunk_walker(PlanState *ps, struct decompress_chunk_context *ctx)
 																			ps->state,
 																			ctx->has_joins);
 				ctx->batches_decompressed |= batches_decompressed;
+
+				/*
+				 * For UPDATEs that change a unique key column, also decompress
+				 * the batches that could hold a row with the new key value so
+				 * the unique indexes can detect a conflict (or reject the
+				 * statement when that cannot be derived).
+				 */
+				ctx->batches_decompressed |=
+					decompress_unique_update_conflict_batches(ctx->ht_state,
+															  current_chunk,
+															  ps->state,
+															  ctx->has_joins);
 
 				/* This is a workaround specifically for bitmap heap scans:
 				 * during node initialization, initialize the scan state with the active snapshot

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -189,15 +189,18 @@ insert into foo_join select generate_series(0,40, 10), 222;
 update foo
 set b = newval
 from foo_join where foo.a = foo_join.a;
+ERROR:  cannot update column "b" of a compressed chunk
 update foo
 set b = newval
 from foo_join where foo.a = foo_join.a and foo_join.a > 10;
+ERROR:  cannot update column "b" of a compressed chunk
 --here the chunk gets excluded , so succeeds --
 update foo
 set b = newval
 from foo_join where foo.a = foo_join.a and foo.a > 20;
 update foo
 set b = (select f1.newval from foo_join f1 left join lateral (select newval as newval2 from  foo_join2 f2 where f1.a= f2.a ) subq on true limit 1);
+ERROR:  cannot update column "b" of a compressed chunk
 --upsert test --
 insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
@@ -205,21 +208,20 @@ do update set b = excluded.b;
 SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
-  3 | 111 | 20 |   
  10 |  12 | 12 | 12
- 20 | 111 | 20 |   
+ 20 |  11 | 20 |   
  30 | 111 | 40 |   
 
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b + 12;
+ERROR:  cannot update column "b" of a compressed chunk
 SELECT * from foo ORDER BY a,b;
  a  |  b  | c  | d  
 ----+-----+----+----
-  3 | 111 | 20 |   
- 10 |  24 | 12 | 12
- 20 | 111 | 20 |   
+ 10 |  12 | 12 | 12
+ 20 |  11 | 20 |   
  30 | 111 | 40 |   
 
 update _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -734,3 +734,260 @@ SELECT * FROM test_i7672 t ORDER BY t;
  Wed Jan 01 00:00:00 2025 PST | d1
  Wed Jan 01 00:00:00 2025 PST | d2
 
+-- UPDATE of a unique constraint column on a compressed chunk
+-- a single chunk holds all rows so conflicts stay within the chunk
+CREATE TABLE comp_update_unique(time timestamptz NOT NULL, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_unique', 'time', chunk_time_interval => INTERVAL '10 years');
+     table_name     
+--------------------
+ comp_update_unique
+
+ALTER TABLE comp_update_unique SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_unique VALUES
+('2020-01-01','d1',0.1),
+('2020-01-01','d2',0.2),
+('2020-01-02','d1',0.3);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_unique') c;
+ count 
+-------
+     1
+
+-- updating a non-unique column is allowed
+UPDATE comp_update_unique SET value = 1.0 WHERE device = 'd1';
+SELECT * FROM comp_update_unique ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |     1
+ Wed Jan 01 00:00:00 2020 PST | d2     |   0.2
+ Thu Jan 02 00:00:00 2020 PST | d1     |     1
+
+-- updating the segmentby unique column to a free value works; the new segment
+-- is decompressed up front so the unique index is enforced
+UPDATE comp_update_unique SET device = 'd3' WHERE device = 'd1' AND time = '2020-01-02';
+SELECT * FROM comp_update_unique ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |     1
+ Wed Jan 01 00:00:00 2020 PST | d2     |   0.2
+ Thu Jan 02 00:00:00 2020 PST | d3     |     1
+
+-- updating the orderby unique column (time) within the chunk works
+UPDATE comp_update_unique SET time = '2020-01-03' WHERE device = 'd2';
+SELECT * FROM comp_update_unique ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |     1
+ Thu Jan 02 00:00:00 2020 PST | d3     |     1
+ Fri Jan 03 00:00:00 2020 PST | d2     |   0.2
+
+-- a new value that is not constant cannot be derived and is rejected
+\set ON_ERROR_STOP 0
+UPDATE comp_update_unique SET device = device || '_x' WHERE device = 'd1';
+ERROR:  cannot update column "device" of a compressed chunk
+\set ON_ERROR_STOP 1
+DROP TABLE comp_update_unique;
+-- setting a unique segmentby column to NULL cannot prune batches and is rejected
+CREATE TABLE comp_update_null(time timestamptz NOT NULL, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_null', 'time', chunk_time_interval => INTERVAL '10 years');
+    table_name    
+------------------
+ comp_update_null
+
+ALTER TABLE comp_update_null SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_null VALUES ('2020-01-01','d1',0.1),('2020-01-01','d2',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_null') c;
+ count 
+-------
+     1
+
+\set ON_ERROR_STOP 0
+UPDATE comp_update_null SET device = NULL WHERE device = 'd1' AND time = '2020-01-01';
+ERROR:  cannot update column "device" of a compressed chunk
+\set ON_ERROR_STOP 1
+SELECT * FROM comp_update_null ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |   0.1
+ Wed Jan 01 00:00:00 2020 PST | d2     |   0.2
+
+DROP TABLE comp_update_null;
+-- updating a unique column into a value that already exists in a row that is
+-- still compressed (a different segment) must be rejected as a unique violation
+CREATE TABLE comp_update_conflict(time timestamptz NOT NULL, device text, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_conflict', 'time', chunk_time_interval => INTERVAL '10 years');
+      table_name      
+----------------------
+ comp_update_conflict
+
+ALTER TABLE comp_update_conflict SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_conflict VALUES ('2020-01-01','d1'),('2020-01-01','d2');
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_conflict') c;
+ count 
+-------
+     1
+
+-- (2020-01-01,d2) is in the d2 segment and stays compressed; moving the d1 row
+-- onto it must still be detected as a conflict
+\set ON_ERROR_STOP 0
+UPDATE comp_update_conflict SET device = 'd2' WHERE device = 'd1';
+ERROR:  duplicate key value violates unique constraint "23_comp_update_conflict_time_device_key"
+\set ON_ERROR_STOP 1
+SELECT * FROM comp_update_conflict ORDER BY time, device;
+             time             | device 
+------------------------------+--------
+ Wed Jan 01 00:00:00 2020 PST | d1
+ Wed Jan 01 00:00:00 2020 PST | d2
+
+DROP TABLE comp_update_conflict;
+-- a dropped column shifts attribute numbers; the constant value is still derived
+CREATE TABLE comp_update_dropped(time timestamptz NOT NULL, junk int, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_dropped', 'time', chunk_time_interval => INTERVAL '10 years');
+     table_name      
+---------------------
+ comp_update_dropped
+
+ALTER TABLE comp_update_dropped DROP COLUMN junk;
+ALTER TABLE comp_update_dropped SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_dropped VALUES ('2020-01-01','d1',0.1),('2020-01-01','d2',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_dropped') c;
+ count 
+-------
+     1
+
+UPDATE comp_update_dropped SET device = 'd3' WHERE device = 'd1';
+SELECT * FROM comp_update_dropped ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d2     |   0.2
+ Wed Jan 01 00:00:00 2020 PST | d3     |   0.1
+
+DROP TABLE comp_update_dropped;
+-- a unique column that is neither segmentby nor orderby cannot prune batches and is rejected
+CREATE TABLE comp_update_noprune(time timestamptz NOT NULL, device text, tag text, value float, UNIQUE(time, device, tag));
+SELECT table_name FROM create_hypertable('comp_update_noprune', 'time', chunk_time_interval => INTERVAL '10 years');
+     table_name      
+---------------------
+ comp_update_noprune
+
+ALTER TABLE comp_update_noprune SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+WARNING:  column "tag" should be used for segmenting or ordering
+INSERT INTO comp_update_noprune VALUES ('2020-01-01','d1','a',0.1),('2020-01-01','d2','b',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_noprune') c;
+ count 
+-------
+     1
+
+-- updating tag (not segmentby, not orderby) cannot be pruned to specific batches
+\set ON_ERROR_STOP 0
+UPDATE comp_update_noprune SET tag = 'z' WHERE device = 'd1';
+ERROR:  cannot update column "tag" of a compressed chunk
+\set ON_ERROR_STOP 1
+DROP TABLE comp_update_noprune;
+-- two unique indexes: only the index whose key changes is decompressed
+CREATE TABLE comp_update_multi(time timestamptz NOT NULL, a text, b int, UNIQUE(time, a), UNIQUE(time, b));
+SELECT table_name FROM create_hypertable('comp_update_multi', 'time', chunk_time_interval => INTERVAL '10 years');
+    table_name     
+-------------------
+ comp_update_multi
+
+ALTER TABLE comp_update_multi SET (timescaledb.compress, timescaledb.compress_segmentby='a', timescaledb.compress_orderby='time, b');
+INSERT INTO comp_update_multi VALUES ('2020-01-01','a1',1),('2020-01-01','a2',2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_multi') c;
+ count 
+-------
+     1
+
+-- a is segmentby (UNIQUE(time,a)); b has min/max metadata (UNIQUE(time,b)); both prunable
+UPDATE comp_update_multi SET a = 'a3' WHERE a = 'a1';
+UPDATE comp_update_multi SET b = 9 WHERE a = 'a2';
+SELECT * FROM comp_update_multi ORDER BY time, a;
+             time             | a  | b 
+------------------------------+----+---
+ Wed Jan 01 00:00:00 2020 PST | a2 | 9
+ Wed Jan 01 00:00:00 2020 PST | a3 | 1
+
+DROP TABLE comp_update_multi;
+-- updating the time column across a chunk boundary is row movement and stays unsupported
+CREATE TABLE comp_update_move(time timestamptz NOT NULL, device text, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_move', 'time', chunk_time_interval => INTERVAL '1 day');
+    table_name    
+------------------
+ comp_update_move
+
+ALTER TABLE comp_update_move SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_move VALUES ('2020-01-01','d1'),('2020-01-05','d1');
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_move') c;
+ count 
+-------
+     2
+
+\set ON_ERROR_STOP 0
+UPDATE comp_update_move SET time = '2020-01-05' WHERE time = '2020-01-01';
+ERROR:  new row for relation "_hyper_27_31_chunk" violates check constraint "constraint_16"
+\set ON_ERROR_STOP 1
+DROP TABLE comp_update_move;
+-- UPSERT (INSERT ... ON CONFLICT DO UPDATE) on compressed chunks
+CREATE TABLE comp_upsert(time timestamptz NOT NULL, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_upsert', 'time');
+ table_name  
+-------------
+ comp_upsert
+
+ALTER TABLE comp_upsert SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',0.1),('2020-01-01','d2',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_upsert') c;
+ count 
+-------
+     1
+
+-- positive: ON CONFLICT DO UPDATE of a non-unique column resolves against compressed data
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',9.9)
+  ON CONFLICT (time, device) DO UPDATE SET value = excluded.value;
+SELECT * FROM comp_upsert ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |   9.9
+ Wed Jan 01 00:00:00 2020 PST | d2     |   0.2
+
+-- positive: setting the conflict key columns to their own excluded value is a no-op and allowed
+INSERT INTO comp_upsert VALUES ('2020-01-01','d2',7.7)
+  ON CONFLICT (time, device) DO UPDATE SET device = excluded.device, value = excluded.value;
+SELECT * FROM comp_upsert ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |   9.9
+ Wed Jan 01 00:00:00 2020 PST | d2     |   7.7
+
+-- positive: an insert that does not conflict is added normally
+INSERT INTO comp_upsert VALUES ('2020-01-01','d3',0.3)
+  ON CONFLICT (time, device) DO UPDATE SET value = excluded.value;
+SELECT * FROM comp_upsert ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |   9.9
+ Wed Jan 01 00:00:00 2020 PST | d2     |   7.7
+ Wed Jan 01 00:00:00 2020 PST | d3     |   0.3
+
+-- negative: ON CONFLICT DO UPDATE that changes a unique column is rejected
+-- (it could move a row onto a key held by a still-compressed row, see #9978)
+\set ON_ERROR_STOP 0
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',1.1)
+  ON CONFLICT (time, device) DO UPDATE SET device = 'd9';
+ERROR:  cannot update column "device" of a compressed chunk
+\set ON_ERROR_STOP 1
+SELECT * FROM comp_upsert ORDER BY time, device;
+             time             | device | value 
+------------------------------+--------+-------
+ Wed Jan 01 00:00:00 2020 PST | d1     |   9.9
+ Wed Jan 01 00:00:00 2020 PST | d2     |   7.7
+ Wed Jan 01 00:00:00 2020 PST | d3     |   0.3
+
+-- negative: with DML decompression disabled the conflict check cannot run
+SET timescaledb.enable_dml_decompression = false;
+\set ON_ERROR_STOP 0
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',5.5)
+  ON CONFLICT (time, device) DO UPDATE SET value = excluded.value;
+ERROR:  inserting into compressed chunk with unique constraints disabled
+\set ON_ERROR_STOP 1
+RESET timescaledb.enable_dml_decompression;
+DROP TABLE comp_upsert;

--- a/tsl/test/sql/compression_conflicts.sql
+++ b/tsl/test/sql/compression_conflicts.sql
@@ -546,3 +546,147 @@ ON CONFLICT DO NOTHING;
 
 SELECT * FROM test_i7672 t ORDER BY t;
 
+-- UPDATE of a unique constraint column on a compressed chunk
+-- a single chunk holds all rows so conflicts stay within the chunk
+CREATE TABLE comp_update_unique(time timestamptz NOT NULL, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_unique', 'time', chunk_time_interval => INTERVAL '10 years');
+ALTER TABLE comp_update_unique SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_unique VALUES
+('2020-01-01','d1',0.1),
+('2020-01-01','d2',0.2),
+('2020-01-02','d1',0.3);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_unique') c;
+
+-- updating a non-unique column is allowed
+UPDATE comp_update_unique SET value = 1.0 WHERE device = 'd1';
+SELECT * FROM comp_update_unique ORDER BY time, device;
+
+-- updating the segmentby unique column to a free value works; the new segment
+-- is decompressed up front so the unique index is enforced
+UPDATE comp_update_unique SET device = 'd3' WHERE device = 'd1' AND time = '2020-01-02';
+SELECT * FROM comp_update_unique ORDER BY time, device;
+
+-- updating the orderby unique column (time) within the chunk works
+UPDATE comp_update_unique SET time = '2020-01-03' WHERE device = 'd2';
+SELECT * FROM comp_update_unique ORDER BY time, device;
+
+-- a new value that is not constant cannot be derived and is rejected
+\set ON_ERROR_STOP 0
+UPDATE comp_update_unique SET device = device || '_x' WHERE device = 'd1';
+\set ON_ERROR_STOP 1
+
+DROP TABLE comp_update_unique;
+
+-- setting a unique segmentby column to NULL cannot prune batches and is rejected
+CREATE TABLE comp_update_null(time timestamptz NOT NULL, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_null', 'time', chunk_time_interval => INTERVAL '10 years');
+ALTER TABLE comp_update_null SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_null VALUES ('2020-01-01','d1',0.1),('2020-01-01','d2',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_null') c;
+\set ON_ERROR_STOP 0
+UPDATE comp_update_null SET device = NULL WHERE device = 'd1' AND time = '2020-01-01';
+\set ON_ERROR_STOP 1
+SELECT * FROM comp_update_null ORDER BY time, device;
+DROP TABLE comp_update_null;
+
+-- updating a unique column into a value that already exists in a row that is
+-- still compressed (a different segment) must be rejected as a unique violation
+CREATE TABLE comp_update_conflict(time timestamptz NOT NULL, device text, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_conflict', 'time', chunk_time_interval => INTERVAL '10 years');
+ALTER TABLE comp_update_conflict SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_conflict VALUES ('2020-01-01','d1'),('2020-01-01','d2');
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_conflict') c;
+-- (2020-01-01,d2) is in the d2 segment and stays compressed; moving the d1 row
+-- onto it must still be detected as a conflict
+\set ON_ERROR_STOP 0
+UPDATE comp_update_conflict SET device = 'd2' WHERE device = 'd1';
+\set ON_ERROR_STOP 1
+SELECT * FROM comp_update_conflict ORDER BY time, device;
+DROP TABLE comp_update_conflict;
+
+-- a dropped column shifts attribute numbers; the constant value is still derived
+CREATE TABLE comp_update_dropped(time timestamptz NOT NULL, junk int, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_dropped', 'time', chunk_time_interval => INTERVAL '10 years');
+ALTER TABLE comp_update_dropped DROP COLUMN junk;
+ALTER TABLE comp_update_dropped SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_dropped VALUES ('2020-01-01','d1',0.1),('2020-01-01','d2',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_dropped') c;
+UPDATE comp_update_dropped SET device = 'd3' WHERE device = 'd1';
+SELECT * FROM comp_update_dropped ORDER BY time, device;
+DROP TABLE comp_update_dropped;
+
+-- a unique column that is neither segmentby nor orderby cannot prune batches and is rejected
+CREATE TABLE comp_update_noprune(time timestamptz NOT NULL, device text, tag text, value float, UNIQUE(time, device, tag));
+SELECT table_name FROM create_hypertable('comp_update_noprune', 'time', chunk_time_interval => INTERVAL '10 years');
+ALTER TABLE comp_update_noprune SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby='time');
+INSERT INTO comp_update_noprune VALUES ('2020-01-01','d1','a',0.1),('2020-01-01','d2','b',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_noprune') c;
+-- updating tag (not segmentby, not orderby) cannot be pruned to specific batches
+\set ON_ERROR_STOP 0
+UPDATE comp_update_noprune SET tag = 'z' WHERE device = 'd1';
+\set ON_ERROR_STOP 1
+DROP TABLE comp_update_noprune;
+
+-- two unique indexes: only the index whose key changes is decompressed
+CREATE TABLE comp_update_multi(time timestamptz NOT NULL, a text, b int, UNIQUE(time, a), UNIQUE(time, b));
+SELECT table_name FROM create_hypertable('comp_update_multi', 'time', chunk_time_interval => INTERVAL '10 years');
+ALTER TABLE comp_update_multi SET (timescaledb.compress, timescaledb.compress_segmentby='a', timescaledb.compress_orderby='time, b');
+INSERT INTO comp_update_multi VALUES ('2020-01-01','a1',1),('2020-01-01','a2',2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_multi') c;
+-- a is segmentby (UNIQUE(time,a)); b has min/max metadata (UNIQUE(time,b)); both prunable
+UPDATE comp_update_multi SET a = 'a3' WHERE a = 'a1';
+UPDATE comp_update_multi SET b = 9 WHERE a = 'a2';
+SELECT * FROM comp_update_multi ORDER BY time, a;
+DROP TABLE comp_update_multi;
+
+-- updating the time column across a chunk boundary is row movement and stays unsupported
+CREATE TABLE comp_update_move(time timestamptz NOT NULL, device text, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_update_move', 'time', chunk_time_interval => INTERVAL '1 day');
+ALTER TABLE comp_update_move SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_update_move VALUES ('2020-01-01','d1'),('2020-01-05','d1');
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_update_move') c;
+\set ON_ERROR_STOP 0
+UPDATE comp_update_move SET time = '2020-01-05' WHERE time = '2020-01-01';
+\set ON_ERROR_STOP 1
+DROP TABLE comp_update_move;
+
+-- UPSERT (INSERT ... ON CONFLICT DO UPDATE) on compressed chunks
+CREATE TABLE comp_upsert(time timestamptz NOT NULL, device text, value float, UNIQUE(time, device));
+SELECT table_name FROM create_hypertable('comp_upsert', 'time');
+ALTER TABLE comp_upsert SET (timescaledb.compress, timescaledb.compress_segmentby='device');
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',0.1),('2020-01-01','d2',0.2);
+SELECT count(compress_chunk(c)) FROM show_chunks('comp_upsert') c;
+
+-- positive: ON CONFLICT DO UPDATE of a non-unique column resolves against compressed data
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',9.9)
+  ON CONFLICT (time, device) DO UPDATE SET value = excluded.value;
+SELECT * FROM comp_upsert ORDER BY time, device;
+
+-- positive: setting the conflict key columns to their own excluded value is a no-op and allowed
+INSERT INTO comp_upsert VALUES ('2020-01-01','d2',7.7)
+  ON CONFLICT (time, device) DO UPDATE SET device = excluded.device, value = excluded.value;
+SELECT * FROM comp_upsert ORDER BY time, device;
+
+-- positive: an insert that does not conflict is added normally
+INSERT INTO comp_upsert VALUES ('2020-01-01','d3',0.3)
+  ON CONFLICT (time, device) DO UPDATE SET value = excluded.value;
+SELECT * FROM comp_upsert ORDER BY time, device;
+
+-- negative: ON CONFLICT DO UPDATE that changes a unique column is rejected
+-- (it could move a row onto a key held by a still-compressed row, see #9978)
+\set ON_ERROR_STOP 0
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',1.1)
+  ON CONFLICT (time, device) DO UPDATE SET device = 'd9';
+\set ON_ERROR_STOP 1
+SELECT * FROM comp_upsert ORDER BY time, device;
+
+-- negative: with DML decompression disabled the conflict check cannot run
+SET timescaledb.enable_dml_decompression = false;
+\set ON_ERROR_STOP 0
+INSERT INTO comp_upsert VALUES ('2020-01-01','d1',5.5)
+  ON CONFLICT (time, device) DO UPDATE SET value = excluded.value;
+\set ON_ERROR_STOP 1
+RESET timescaledb.enable_dml_decompression;
+
+DROP TABLE comp_upsert;
+


### PR DESCRIPTION
An UPDATE on a compressed chunk only decompresses the rows that match the
statement. Rows in batches that do not match stay compressed, so the unique
indexes on the chunk cannot see them. Changing a column that is part of a
unique constraint could therefore create duplicate values that go unnoticed
because the conflicting row is still compressed.

Reject such an UPDATE with a clear error and point the user at decompressing
the chunk first. Updates to columns that are not part of a unique constraint
keep working as before.

Fixes #9978