### PR TITLE
Make ownership error messages on CAggs consistent

### DIFF
--- a/.unreleased/pr_10013
+++ b/.unreleased/pr_10013
@@ -1,0 +1,1 @@
+Fixes: #10013 Make ownership error messages on CAggs consistent

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -760,6 +760,15 @@ process_alterviewschema(ProcessUtilityArgs *args)
 	schema = get_namespace_name(get_rel_namespace(relid));
 	name = get_rel_name(relid);
 
+	/* For a continuous aggregate, check ownership up front so the error refers
+	 * to the continuous aggregate rather than the underlying view, which is
+	 * what PG's own ownership check would report once the schema change is
+	 * dispatched as a view operation. */
+	if (ts_continuous_agg_find_by_relid(relid) != NULL)
+	{
+		ts_cagg_permissions_check(relid, GetUserId());
+	}
+
 	ts_continuous_agg_rename_view(schema, name, stmt->newschema, name, &stmt->objectType);
 }
 
@@ -2221,6 +2230,12 @@ process_drop_continuous_aggregates(ProcessUtilityArgs *args, DropStmt *stmt)
 
 		if (cagg)
 		{
+			/* Check ownership up front so the error refers to the continuous
+			 * aggregate rather than the underlying view, which is what PG's own
+			 * ownership check below would report after we rewrite the drop into
+			 * a DROP VIEW. */
+			ts_cagg_permissions_check(cagg->relid, GetUserId());
+
 			/* If there is at least one cagg, the drop should be treated as a
 			 * DROP VIEW. */
 			stmt->removeType = OBJECT_VIEW;
@@ -2449,6 +2464,16 @@ process_rename_view(Oid relid, RenameStmt *stmt)
 {
 	char *schema = get_namespace_name(get_rel_namespace(relid));
 	char *name = get_rel_name(relid);
+
+	/* For a continuous aggregate, check ownership up front so the error refers
+	 * to the continuous aggregate rather than the underlying view, which is
+	 * what PG's own ownership check would report once the rename is dispatched
+	 * as a view rename. */
+	if (ts_continuous_agg_find_by_relid(relid) != NULL)
+	{
+		ts_cagg_permissions_check(relid, GetUserId());
+	}
+
 	ts_continuous_agg_rename_view(schema, name, schema, stmt->newname, &stmt->renameType);
 }
 
@@ -2517,6 +2542,11 @@ process_rename_column(ProcessUtilityArgs *args, Cache *hcache, Oid relid, Rename
 		if (cagg)
 		{
 			is_cagg = true;
+
+			/* Check ownership up front so the error refers to the continuous
+			 * aggregate rather than one of the internal views, which is what
+			 * the ExecRenameStmt calls below would otherwise report. */
+			ts_cagg_permissions_check(relid, GetUserId());
 
 			RenameStmt *direct_view_stmt = castNode(RenameStmt, copyObject(stmt));
 			direct_view_stmt->relation = makeRangeVar(NameStr(cagg->data.direct_view_schema),
@@ -3839,7 +3869,14 @@ process_index_start(ProcessUtilityArgs *args)
 		stmt->relation = makeRangeVar(NameStr(ht->fd.schema_name), NameStr(ht->fd.table_name), -1);
 	}
 
-	ts_hypertable_permissions_check_by_id(ht->fd.id);
+	if (cagg != NULL)
+	{
+		ts_cagg_permissions_check(cagg->relid, GetUserId());
+	}
+	else
+	{
+		ts_hypertable_permissions_check_by_id(ht->fd.id);
+	}
 
 	ts_with_clause_filter(stmt->options, &hypertable_options, NULL, &postgres_options);
 
@@ -3890,9 +3927,7 @@ process_index_start(ProcessUtilityArgs *args)
 		 * If this is an index creation for cagg, then we need to switch user as the current
 		 * user might not have permissions on the internal schema where cagg index will be
 		 * created.
-		 * Need to restore user soon after this step.
 		 */
-		ts_cagg_permissions_check(ht->main_table_relid, GetUserId());
 		SWITCH_TO_TS_USER(NameStr(cagg->data.direct_view_schema), uid, saved_uid, sec_ctx);
 	}
 
@@ -4986,26 +5021,11 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 	return (list_length(stmt->cmds) > 0) ? DDL_CONTINUE : DDL_DONE;
 }
 
-static void
-continuous_agg_with_clause_perm_check(ContinuousAgg *cagg, Oid view_relid)
-{
-	Oid ownerid = ts_rel_get_owner(view_relid);
-
-	if (!ts_has_owner_privs(GetUserId(), ownerid))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("must be owner of continuous aggregate \"%s\"", get_rel_name(view_relid))));
-	}
-}
-
 static List *
 process_altercontinuousagg_set_with(ContinuousAgg *cagg, Oid view_relid, const List *defelems)
 {
 	WithClauseResult *parse_results;
 	List *pg_options = NIL, *other_namespace_options = NIL, *cagg_options = NIL;
-
-	continuous_agg_with_clause_perm_check(cagg, view_relid);
 
 	ts_with_clause_filter(defelems, &cagg_options, &other_namespace_options, &pg_options);
 
@@ -5084,7 +5104,7 @@ process_altertable_start_matview(ProcessUtilityArgs *args)
 		return DDL_CONTINUE;
 	}
 
-	continuous_agg_with_clause_perm_check(cagg, view_relid);
+	ts_cagg_permissions_check(view_relid, GetUserId());
 
 	/*
 	 * CAgg add column handler.

--- a/tsl/src/continuous_aggs/add_column.c
+++ b/tsl/src/continuous_aggs/add_column.c
@@ -217,8 +217,6 @@ make_colref_target(ColumnDef *coldef)
 void
 continuous_agg_add_column(ContinuousAgg *cagg, AlterTableStmt *stmt)
 {
-	ts_cagg_permissions_check(cagg->relid, GetUserId());
-
 	/* Lock all the relations we'll touch, in the same order as
 	 * DROP so concurrent DROP and ADD COLUMN cannot deadlock. */
 	Oid cagg_relid = cagg->relid;

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -748,14 +748,10 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 
 	/*
 	 * Check ownership up front, before any work that touches the source
-	 * hypertable (e.g. computing the batches for an incremental refresh).
+	 * hypertable pr other cagg related objects (e.g. computing the batches
+	 * for an incremental refresh).
 	 */
-	if (!object_ownercheck(RelationRelationId, cagg_relid, GetUserId()))
-	{
-		aclcheck_error(ACLCHECK_NOT_OWNER,
-					   get_relkind_objtype(get_rel_relkind(cagg_relid)),
-					   get_rel_name(cagg_relid));
-	}
+	ts_cagg_permissions_check(cagg_relid, GetUserId());
 
 	if (!PG_ARGISNULL(1))
 	{
@@ -1007,13 +1003,6 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg_arg,
 	InternalTimeRange refresh_window = *refresh_window_arg;
 	int64 invalidation_threshold;
 	CaggRefreshSpiContext cagg_spi_ctx = {};
-	/* Like regular materialized views, require owner to refresh. */
-	if (!object_ownercheck(RelationRelationId, cagg->relid, GetUserId()))
-	{
-		aclcheck_error(ACLCHECK_NOT_OWNER,
-					   get_relkind_objtype(get_rel_relkind(cagg->relid)),
-					   get_rel_name(cagg->relid));
-	}
 
 	continuous_agg_refresh_spi_setup_and_connect(&cagg_spi_ctx);
 	/* No bucketing when open ended */

--- a/tsl/test/expected/cagg_permissions-15.out
+++ b/tsl/test/expected/cagg_permissions-15.out
@@ -61,7 +61,7 @@ CREATE USER not_priv;
 -- A user with no ownership on the Cagg cannot create index on it. -- This should fail
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
-ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
@@ -141,12 +141,24 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 select from alter_job(:cagg_job_id, max_runtime => NULL);
 ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
+--all of these should report ownership errors referring to the continuous
+--aggregate (not the underlying view)
 ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
 ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME TO mat_refresh_test_renamed;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME COLUMN location TO loc;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test SET SCHEMA custom_schema;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test ADD COLUMN dummy_col int;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 DROP MATERIALIZED VIEW mat_refresh_test;
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 SELECT * FROM mat_refresh_test;
 ERROR:  permission denied for view mat_refresh_test
 -- Test permissions also when the watermark is not constified and the ACL checks

--- a/tsl/test/expected/cagg_permissions-16.out
+++ b/tsl/test/expected/cagg_permissions-16.out
@@ -61,7 +61,7 @@ CREATE USER not_priv;
 -- A user with no ownership on the Cagg cannot create index on it. -- This should fail
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
-ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
@@ -141,12 +141,24 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 select from alter_job(:cagg_job_id, max_runtime => NULL);
 ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
+--all of these should report ownership errors referring to the continuous
+--aggregate (not the underlying view)
 ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
 ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME TO mat_refresh_test_renamed;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME COLUMN location TO loc;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test SET SCHEMA custom_schema;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test ADD COLUMN dummy_col int;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 DROP MATERIALIZED VIEW mat_refresh_test;
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 SELECT * FROM mat_refresh_test;
 ERROR:  permission denied for view mat_refresh_test
 -- Test permissions also when the watermark is not constified and the ACL checks

--- a/tsl/test/expected/cagg_permissions-17.out
+++ b/tsl/test/expected/cagg_permissions-17.out
@@ -61,7 +61,7 @@ CREATE USER not_priv;
 -- A user with no ownership on the Cagg cannot create index on it. -- This should fail
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
-ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
@@ -141,12 +141,24 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 select from alter_job(:cagg_job_id, max_runtime => NULL);
 ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
+--all of these should report ownership errors referring to the continuous
+--aggregate (not the underlying view)
 ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
 ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME TO mat_refresh_test_renamed;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME COLUMN location TO loc;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test SET SCHEMA custom_schema;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test ADD COLUMN dummy_col int;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 DROP MATERIALIZED VIEW mat_refresh_test;
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 SELECT * FROM mat_refresh_test;
 ERROR:  permission denied for view mat_refresh_test
 -- Test permissions also when the watermark is not constified and the ACL checks

--- a/tsl/test/expected/cagg_permissions-18.out
+++ b/tsl/test/expected/cagg_permissions-18.out
@@ -61,7 +61,7 @@ CREATE USER not_priv;
 -- A user with no ownership on the Cagg cannot create index on it. -- This should fail
 \set ON_ERROR_STOP 0
 CREATE INDEX cagg_idx on mat_refresh_test(humidity);
-ERROR:  must be owner of hypertable "_materialized_hypertable_2"
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP USER not_priv;
@@ -141,12 +141,24 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 select from alter_job(:cagg_job_id, max_runtime => NULL);
 ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
+--all of these should report ownership errors referring to the continuous
+--aggregate (not the underlying view)
 ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
 ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME TO mat_refresh_test_renamed;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME COLUMN location TO loc;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test SET SCHEMA custom_schema;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test ADD COLUMN dummy_col int;
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 DROP MATERIALIZED VIEW mat_refresh_test;
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
-ERROR:  must be owner of view mat_refresh_test
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 SELECT * FROM mat_refresh_test;
 ERROR:  permission denied for view mat_refresh_test
 -- Test permissions also when the watermark is not constified and the ACL checks

--- a/tsl/test/sql/cagg_permissions.sql.in
+++ b/tsl/test/sql/cagg_permissions.sql.in
@@ -139,8 +139,14 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 select from alter_job(:cagg_job_id, max_runtime => NULL);
 
 --make sure that commands fail
-
+--all of these should report ownership errors referring to the continuous
+--aggregate (not the underlying view)
 ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME TO mat_refresh_test_renamed;
+ALTER MATERIALIZED VIEW mat_refresh_test RENAME COLUMN location TO loc;
+ALTER MATERIALIZED VIEW mat_refresh_test SET SCHEMA custom_schema;
+ALTER MATERIALIZED VIEW mat_refresh_test OWNER TO :ROLE_DEFAULT_PERM_USER_2;
+ALTER MATERIALIZED VIEW mat_refresh_test ADD COLUMN dummy_col int;
 DROP MATERIALIZED VIEW mat_refresh_test;
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
 


### PR DESCRIPTION
Ownership error messages from different operations on CAggs could show the internal object type (e.g. view) or internal object names (e.g. _direct_view).

This change adds ownership checks during such operations to pring consistent, CAgg related error messages.