### PR TITLE
Remove wrong localhost specification from fdw tests

### DIFF
--- a/tsl/test/expected/cagg_joins.out
+++ b/tsl/test/expected/cagg_joins.out
@@ -1189,7 +1189,7 @@ SELECT current_setting('port') AS "PGPORT", current_database() AS "PGDATABASE" \
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER loopback
    FOREIGN DATA WRAPPER postgres_fdw
-   OPTIONS (host 'localhost', dbname :'PGDATABASE', port :'PGPORT');
+   OPTIONS (dbname :'PGDATABASE', port :'PGPORT');
 CREATE USER MAPPING FOR :ROLE_DEFAULT_PERM_USER
    SERVER loopback
    OPTIONS (user :'ROLE_DEFAULT_PERM_USER', password 'nopassword');

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -446,7 +446,7 @@ INSERT INTO fdw_table VALUES( '2020-01-01 01:00', 100, 1000);
 SELECT current_setting('port') as "PORTNO" \gset
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER s3_server FOREIGN DATA WRAPPER postgres_fdw
-OPTIONS ( host 'localhost', dbname 'postgres_fdw_db', port :'PORTNO');
+OPTIONS ( dbname 'postgres_fdw_db', port :'PORTNO');
 GRANT USAGE ON FOREIGN SERVER s3_server TO :ROLE_4;
 CREATE USER MAPPING FOR :ROLE_4 SERVER s3_server
 OPTIONS (  user :'ROLE_4' , password :'ROLE_4_PASS');

--- a/tsl/test/sql/cagg_joins.sql
+++ b/tsl/test/sql/cagg_joins.sql
@@ -583,7 +583,7 @@ SELECT current_setting('port') AS "PGPORT", current_database() AS "PGDATABASE" \
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER loopback
    FOREIGN DATA WRAPPER postgres_fdw
-   OPTIONS (host 'localhost', dbname :'PGDATABASE', port :'PGPORT');
+   OPTIONS (dbname :'PGDATABASE', port :'PGPORT');
 CREATE USER MAPPING FOR :ROLE_DEFAULT_PERM_USER
    SERVER loopback
    OPTIONS (user :'ROLE_DEFAULT_PERM_USER', password 'nopassword');

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -305,7 +305,7 @@ SELECT current_setting('port') as "PORTNO" \gset
 
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER s3_server FOREIGN DATA WRAPPER postgres_fdw
-OPTIONS ( host 'localhost', dbname 'postgres_fdw_db', port :'PORTNO');
+OPTIONS ( dbname 'postgres_fdw_db', port :'PORTNO');
 GRANT USAGE ON FOREIGN SERVER s3_server TO :ROLE_4;
 
 CREATE USER MAPPING FOR :ROLE_4 SERVER s3_server


### PR DESCRIPTION
The host options can be omitted, so that the libpq defaults are used, which correctly handle both TCP and UNIX sockets. This follows the approach taken by the Postgres FDW tests.