### PR TITLE
Get tsdb version from version.config if run from a tag

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -76,10 +76,16 @@ jobs:
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Get version of latest release
+    - name: Get expected version
       id: versions
       run: |
-        version=$(wget -q https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
+        # if run from a tag, check the repo's version, meant to be run after a release
+        # otherwise we rely on github's api for scheduled runs.
+        if [ "${{ github.ref_type }}" = "tag" ]; then
+          version=$(grep '^version = ' version.config | sed -e 's!version = !!')
+        else
+          version=$(wget -q https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
+        fi
         echo "version=${version}"
         echo "version=${version}" >>$GITHUB_OUTPUT
 
@@ -128,4 +134,3 @@ jobs:
       if: always()
       run: |
         cat /var/log/postgresql/postgresql-${{ matrix.pg }}-main.log
-


### PR DESCRIPTION
After running a package test (apt in this case) after a release, we take the latest available version and compare it to the latest installable versions, the version is obtained from Github's API, which can take 2-3 minutes sometimes, so a stale version can false-positive several situations, for example if the packages dont get uploaded to cloud, as in the 2.27.2 release it'd compare the stale github version e.g. 2.27.1 with the latest available installable version, 2.27.1, making the test pass in the 2.27.2 branch.

With this fix we take the version from the repo `version.config` when the run is from a tab, e.g. after a release, so cases like this are caught in the CI. If normally run, e.g. scheduled run, the behaviour is unchanged.