### PR TITLE
approximate_row_count: corner case for infinity

### DIFF
--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -378,10 +378,10 @@ BEGIN
   SELECT compress_relid FROM _timescaledb_catalog.compression_settings INTO v_oid WHERE relid = relation;
 
   IF v_oid IS NOT NULL THEN
-    row_count := (SELECT CASE WHEN reltuples IS NULL THEN 0 WHEN reltuples < 0 THEN 0 ELSE reltuples * _timescaledb_functions.estimate_compressed_batch_size(oid) END FROM pg_class WHERE oid = v_oid);
+    row_count := (SELECT CASE WHEN reltuples IS NULL THEN 0 WHEN reltuples < 0 THEN 0 WHEN reltuples = 'Infinity'::float4 THEN 0 ELSE reltuples * _timescaledb_functions.estimate_compressed_batch_size(oid) END FROM pg_class WHERE oid = v_oid);
   END IF;
 
-  row_count := COALESCE((SELECT row_count + CASE WHEN reltuples < 0 OR relkind = 'p' THEN 0 ELSE reltuples END FROM pg_class WHERE oid = relation), 0);
+  row_count := COALESCE((SELECT row_count + CASE WHEN reltuples < 0 OR relkind = 'p' or reltuples = 'Infinity' THEN 0 ELSE reltuples END FROM pg_class WHERE oid = relation), 0);
 
   RETURN row_count;
 END


### PR DESCRIPTION
Since PostgreSQL 18, it is possible that reltuples has the value Infinity. It could be argued this is a bug in PostgreSQL, however, it would also be good to fix this in our own function that reads reltuples.

For example, a user can nowadays specify this value *manually*:
```
=> select
    pg_restore_relation_stats(
        'schemaname',
        'public',
        'relname',
        'test',
        'reltuples',
        'Infinity'::real
    );
```
```
=> select reltuples from pg_class where relname='test';
 reltuples
-----------
  Infinity
(1 row)
```

https://www.postgresql.org/docs/18/functions-admin.html#FUNCTIONS-ADMIN-STATSMOD


Disable-check: force-changelog-file
