### PR TITLE
Fix rename on compressed continuous aggs

### DIFF
--- a/.unreleased/pr_10025
+++ b/.unreleased/pr_10025
@@ -1,0 +1,1 @@
+Fixes: #10025 Fix rename on compressed continuous aggs

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -2381,7 +2381,8 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 void
 tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt)
 {
-	Assert(stmt->relationType == OBJECT_TABLE && stmt->renameType == OBJECT_COLUMN);
+	Assert((stmt->relationType == OBJECT_TABLE || stmt->relationType == OBJECT_MATVIEW) &&
+		   stmt->renameType == OBJECT_COLUMN);
 	Assert(TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
 
 	struct RenameFromTo

--- a/tsl/test/shared/expected/cagg_compression.out
+++ b/tsl/test/shared/expected/cagg_compression.out
@@ -353,3 +353,26 @@ ALTER MATERIALIZED VIEW comp_rename_cagg SET ( timescaledb.compress='true');
 RESET client_min_messages;
 DROP TABLE comp_rename CASCADE;
 NOTICE:  drop cascades to 3 other objects
+-- test renaming a column on cagg after compression is enabled
+CREATE TABLE comp_rename2(ts timestamptz NOT NULL, val double precision);
+SELECT table_name FROM create_hypertable('comp_rename2', 'ts');
+  table_name  
+--------------
+ comp_rename2
+
+CREATE MATERIALIZED VIEW comp_rename2_cagg WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', ts) AS bucket, avg(val) AS avg_val
+FROM comp_rename2 GROUP BY 1 WITH NO DATA;
+ALTER MATERIALIZED VIEW comp_rename2_cagg SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'bucket'
+);
+ALTER MATERIALIZED VIEW comp_rename2_cagg RENAME COLUMN avg_val TO average_value;
+-- verify the column was renamed
+SELECT attname FROM pg_attribute WHERE attrelid = 'comp_rename2_cagg'::regclass AND attname = 'average_value';
+    attname    
+---------------
+ average_value
+
+DROP TABLE comp_rename2 CASCADE;
+NOTICE:  drop cascades to 2 other objects

--- a/tsl/test/shared/sql/cagg_compression.sql
+++ b/tsl/test/shared/sql/cagg_compression.sql
@@ -113,3 +113,24 @@ RESET client_min_messages;
 
 DROP TABLE comp_rename CASCADE;
 
+-- test renaming a column on cagg after compression is enabled
+CREATE TABLE comp_rename2(ts timestamptz NOT NULL, val double precision);
+SELECT table_name FROM create_hypertable('comp_rename2', 'ts');
+
+CREATE MATERIALIZED VIEW comp_rename2_cagg WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', ts) AS bucket, avg(val) AS avg_val
+FROM comp_rename2 GROUP BY 1 WITH NO DATA;
+
+ALTER MATERIALIZED VIEW comp_rename2_cagg SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'bucket'
+);
+
+ALTER MATERIALIZED VIEW comp_rename2_cagg RENAME COLUMN avg_val TO average_value;
+
+-- verify the column was renamed
+SELECT attname FROM pg_attribute WHERE attrelid = 'comp_rename2_cagg'::regclass AND attname = 'average_value';
+
+DROP TABLE comp_rename2 CASCADE;
+
+


### PR DESCRIPTION
The process_utility hook for column renames asserted
that the relation type is OBJECT_TABLE. Continuous
aggregates use OBJECT_MATVIEW, so renaming a column on
a compressed continuous aggregate hit a SIGABRT from
the failed assertion.

Relax the assertion to also accept OBJECT_MATVIEW so
the rename propagates to the compressed hypertable.

Fixes #10005
