### PR TITLE
Fix chunk skipping near PG_INT64_MAX

### DIFF
--- a/.unreleased/pr_10026
+++ b/.unreleased/pr_10026
@@ -1,0 +1,1 @@
+Fixes: #10026 Fix chunk skipping near PG_INT64_MAX

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -945,8 +945,6 @@ ts_chunk_column_stats_calculate(const Hypertable *ht, const Chunk *chunk)
 			if (max != DIMENSION_SLICE_MAXVALUE)
 			{
 				max++;
-				/* Again, check overflow */
-				max = REMAP_LAST_COORDINATE(max);
 			}
 
 			/*
@@ -1322,7 +1320,7 @@ ts_chunk_column_stats_get_chunk_ids_by_scan(DimensionRestrictInfo *dri)
 		 * check so prepare to short circuit if one evaluates to true.
 		 *
 		 * No real way to know if checking range_start or range_end first will be more
-		 * effective. So let's start with range_end checks first.
+		 * effective. So let's start with range_start checks first.
 		 */
 		switch (open->upper_strategy)
 		{
@@ -1346,19 +1344,20 @@ ts_chunk_column_stats_get_chunk_ids_by_scan(DimensionRestrictInfo *dri)
 			goto done;
 		}
 
-		/* range_end checks didn't match, check for range_start now */
+		/* range_start checks didn't match, check for range_end now */
+		/* range_end is exclusive except when DIMENSION_SLICE_MAXVALUE */
+		int64 range_end =
+			(fd.range_end == DIMENSION_SLICE_MAXVALUE) ? fd.range_end : (fd.range_end - 1);
 		switch (open->lower_strategy)
 		{
 			case BTGreaterEqualStrategyNumber:
 			{
-				/* range_end is exclusive */
-				matched = (fd.range_end - 1) >= open->lower_bound;
+				matched = range_end >= open->lower_bound;
 			}
 			break;
 			case BTGreaterStrategyNumber:
 			{
-				/* range_end is exclusive */
-				matched = (fd.range_end - 1) > open->lower_bound;
+				matched = range_end > open->lower_bound;
 			}
 			break;
 			default:

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -786,4 +786,60 @@ SELECT enable_chunk_skipping('sensor_readings', 'temperature');
  (17,t)
 
 RESET timescaledb.enable_chunk_skipping;
+-- Test chunk skipping with PG_INT64_MAX value
+SET timescaledb.enable_chunk_skipping = on;
+CREATE TABLE chunk_skip_bigint_max(
+    ts     timestamptz NOT NULL,
+    ranged bigint
+);
+SELECT * FROM create_hypertable('chunk_skip_bigint_max', 'ts',
+                         chunk_time_interval => interval '1 day');
+ hypertable_id | schema_name |      table_name       | created 
+---------------+-------------+-----------------------+---------
+            11 | public      | chunk_skip_bigint_max | t
+
+SELECT * FROM enable_chunk_skipping('chunk_skip_bigint_max', 'ranged');
+ column_stats_id | enabled 
+-----------------+---------
+              18 | t
+
+ALTER TABLE chunk_skip_bigint_max SET (timescaledb.compress);
+INSERT INTO chunk_skip_bigint_max VALUES ('2025-01-01', 9223372036854775806); -- PG_INT64_MAX - 1
+INSERT INTO chunk_skip_bigint_max VALUES ('2025-01-02', 9223372036854775807); -- PG_INT64_MAX
+SELECT compress_chunk(c) FROM show_chunks('chunk_skip_bigint_max') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_14_chunk
+ _timescaledb_internal._hyper_11_15_chunk
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged = 9223372036854775807;
+ count 
+-------
+     1
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged >= 9223372036854775807;
+ count 
+-------
+     1
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775806;
+ count 
+-------
+     1
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged = 9223372036854775806;
+ count 
+-------
+     1
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged >= 9223372036854775806;
+ count 
+-------
+     2
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775805;
+ count 
+-------
+     2
+
 RESET timescaledb.enable_chunk_skipping;

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -356,5 +356,29 @@ SELECT create_hypertable('sensor_readings', 'measured_at');
 SELECT enable_chunk_skipping('sensor_readings', 'temperature');
 RESET timescaledb.enable_chunk_skipping;
 
+-- Test chunk skipping with PG_INT64_MAX value
+SET timescaledb.enable_chunk_skipping = on;
+
+CREATE TABLE chunk_skip_bigint_max(
+    ts     timestamptz NOT NULL,
+    ranged bigint
+);
+SELECT * FROM create_hypertable('chunk_skip_bigint_max', 'ts',
+                         chunk_time_interval => interval '1 day');
+SELECT * FROM enable_chunk_skipping('chunk_skip_bigint_max', 'ranged');
+ALTER TABLE chunk_skip_bigint_max SET (timescaledb.compress);
+
+INSERT INTO chunk_skip_bigint_max VALUES ('2025-01-01', 9223372036854775806); -- PG_INT64_MAX - 1
+INSERT INTO chunk_skip_bigint_max VALUES ('2025-01-02', 9223372036854775807); -- PG_INT64_MAX
+
+SELECT compress_chunk(c) FROM show_chunks('chunk_skip_bigint_max') c;
+
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged = 9223372036854775807;
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged >= 9223372036854775807;
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775806;
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged = 9223372036854775806;
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged >= 9223372036854775806;
+SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775805;
+
 
 RESET timescaledb.enable_chunk_skipping;


### PR DESCRIPTION
Remove REMAP_LAST_COORDINATE after incrementing max
to make range_end exclusive. The remap undid the
increment for values near the int64 boundary.

Guard range_end - 1 against DIMENSION_SLICE_MAXVALUE
before converting exclusive to inclusive bound.

Fixes #9995
