### PR TITLE
Upgrading the Ubuntu image to 24 for SQLSmith

### DIFF
--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-22.04"]
+        os: ["ubuntu-24.04"]
         pg: [ "15", "16", "17", "18" ]
         build_type: ["Debug"]
       fail-fast: false


### PR DESCRIPTION
Need to upgrade because autoconf in Ubuntu 22 blows up with SQLSmith 1.5

Disable-check: force-changelog-file
Disable-check: approval-count