### PR TITLE
Bumping CI network related timeouts

### DIFF
--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Build PostgreSQL
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-       wget -q -O postgresql.tar.bz2 \
+       wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
          https://ftp.postgresql.org/pub/source/v${{ steps.config.outputs.PG18_LATEST }}/postgresql-${{ steps.config.outputs.PG18_LATEST }}.tar.bz2
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -140,7 +140,7 @@ jobs:
     - name: Build PostgreSQL ${{ matrix.pg }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        wget -q -O postgresql.tar.bz2 \
+        wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -133,10 +133,10 @@ jobs:
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
         if [ "${{ matrix.snapshot }}" = "snapshot" ]; then
-          wget -q -O postgresql.tar.bz2 \
+          wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
             https://ftp.postgresql.org/pub/snapshot/${{ matrix.pg }}/postgresql-${{ matrix.pg }}-snapshot.tar.bz2
         else
-          wget -q -O postgresql.tar.bz2 \
+          wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
             https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
         fi
         mkdir -p ~/$PG_SRC_DIR

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -121,7 +121,7 @@ jobs:
     - name: Build PostgreSQL ${{ needs.config.outputs.pg_latest }} if not in cache
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        wget -q -O postgresql.tar.bz2 \
+        wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/source/v${{ needs.config.outputs.pg_latest }}/postgresql-${{ needs.config.outputs.pg_latest }}.tar.bz2
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
           echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
-          wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+          wget --quiet --tries=6 --waitretry=15 -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install -y \
             postgresql-${{ matrix.pg_version_old }} postgresql-server-dev-${{ matrix.pg_version_old }} \

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -118,7 +118,7 @@ jobs:
     - name: Build PostgreSQL ${{ matrix.pg }} if not in cache
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        wget -q -O postgresql.tar.bz2 \
+        wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Download Postgres ${{ matrix.pg }}
       run: |
-        wget -q -O postgresql.tar.bz2 \
+        wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/source/v${{ matrix.abi_min }}/postgresql-${{ matrix.abi_min }}.tar.bz2
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
@@ -105,7 +105,7 @@ jobs:
 
     - name: Download Postgres ${{ matrix.pg }}-snapshot
       run: |
-        wget -q -O postgresql.tar.bz2 \
+        wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/snapshot/${{ matrix.pg }}/postgresql-${{ matrix.pg }}-snapshot.tar.bz2
         mkdir -p ~/$PG_SRC_DIR-snapshot
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR-snapshot --strip-components 1

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -107,7 +107,7 @@ jobs:
     - name: Build PostgreSQL ${{ steps.pg.outputs.version }}
       if: steps.check.outputs.should_run == 'true' && steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        wget -q -O postgresql.tar.bz2 \
+        wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/source/v${{ steps.pg.outputs.version }}/postgresql-${{ steps.pg.outputs.version }}.tar.bz2
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
         echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
-        wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
+        wget --quiet --tries=6 --waitretry=15 -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
         sudo apt-get update
         sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
         sudo apt-get install -y --no-install-recommends timescaledb-2-postgresql-${{ matrix.pg }}

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -46,12 +46,14 @@ jobs:
       run: |
         choco feature disable --name=usePackageExitCodes
         choco feature disable --name=showDownloadProgress
+        choco config set webRequestTimeoutSeconds 120
+        choco config set commandExecutionTimeoutSeconds 600
         choco uninstall postgresql --yes
         winget install --id PostgreSQL.PostgreSQL.${{ matrix.pg }} --accept-source-agreements --accept-package-agreements --disable-interactivity
         choco install wget
 
     - name: Download TimescaleDB
-      run: "wget --quiet -O timescaledb.zip 'https://github.com/timescale/timescaledb/releases/download/\
+      run: "wget --quiet --tries=6 --waitretry=15 -O timescaledb.zip 'https://github.com/timescale/timescaledb/releases/download/\
         ${{ steps.version.outputs.version }}/timescaledb-postgresql-${{ matrix.pg}}-windows-amd64.zip'"
 
     - name: Install TimescaleDB


### PR DESCRIPTION
The CI tests on github are notoriously unreliable both at accessing external resources and internal github URLs. Now I bump a few timeouts for wget and the choco package manager installs.

Disable-check: force-changelog-file
Disable-check: approval-count