### PR TITLE
Fix bgw_job_stat_history definition

### DIFF
--- a/.unreleased/pr_10069
+++ b/.unreleased/pr_10069
@@ -1,0 +1,2 @@
+Fixes: #10069 Fix bgw_job_stat_history definition
+Thanks: @skrenes for reporting a problem with the job_history view when upgrading to 2.28.0

--- a/sql/updates/2.14.2--2.15.0.sql
+++ b/sql/updates/2.14.2--2.15.0.sql
@@ -347,12 +347,12 @@ DROP VIEW IF EXISTS timescaledb_information.job_errors;
 CREATE SEQUENCE _timescaledb_internal.bgw_job_stat_history_id_seq MINVALUE 1;
 
 CREATE TABLE _timescaledb_internal.bgw_job_stat_history (
-  id INTEGER NOT NULL DEFAULT nextval('_timescaledb_internal.bgw_job_stat_history_id_seq'),
+  id BIGINT NOT NULL DEFAULT nextval('_timescaledb_internal.bgw_job_stat_history_id_seq'),
   job_id INTEGER NOT NULL,
   pid INTEGER,
   execution_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   execution_finish TIMESTAMPTZ,
-  succeeded boolean NOT NULL DEFAULT FALSE,
+  succeeded boolean,
   data jsonb,
   -- table constraints
   CONSTRAINT bgw_job_stat_history_pkey PRIMARY KEY (id)

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,45 @@
+
+-- the update script from 2.14.2 to 2.15.0 migrated _timescaledb_internal.bgw_job_stat_history with incorrect definition
+-- fix _timescaledb_internal.bgw_job_stat_history if definition is incorrect
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_attribute WHERE attrelid='_timescaledb_internal.bgw_job_stat_history'::regclass AND attname = 'id' AND atttypid <> 'bigint'::regtype) THEN
+
+    --
+    -- START bgw_job_stat_history
+    --
+    DROP VIEW IF EXISTS timescaledb_information.job_history;
+
+    CREATE TABLE _timescaledb_internal._tmp_bgw_job_stat_history AS SELECT * FROM _timescaledb_internal.bgw_job_stat_history;
+    CREATE TABLE _timescaledb_internal._tmp_job_stat_history_id_seq AS SELECT last_value, is_called FROM _timescaledb_internal.bgw_job_stat_history_id_seq;
+
+    DROP TABLE _timescaledb_internal.bgw_job_stat_history;
+
+    CREATE SEQUENCE _timescaledb_internal.bgw_job_stat_history_id_seq MINVALUE 1;
+
+    CREATE TABLE _timescaledb_internal.bgw_job_stat_history (
+      id BIGINT NOT NULL DEFAULT nextval('_timescaledb_internal.bgw_job_stat_history_id_seq'),
+      job_id INTEGER NOT NULL,
+      pid INTEGER,
+      execution_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      execution_finish TIMESTAMPTZ,
+      succeeded boolean,
+      data jsonb,
+      -- table constraints
+      CONSTRAINT bgw_job_stat_history_pkey PRIMARY KEY (id)
+    );
+
+    ALTER SEQUENCE _timescaledb_internal.bgw_job_stat_history_id_seq OWNED BY _timescaledb_internal.bgw_job_stat_history.id;
+
+    INSERT INTO _timescaledb_internal.bgw_job_stat_history (id, job_id, pid, execution_start, execution_finish, succeeded, data) SELECT id, job_id, pid, execution_start, execution_finish, succeeded, data FROM _timescaledb_internal._tmp_bgw_job_stat_history;
+    SELECT setval('_timescaledb_internal.bgw_job_stat_history_id_seq', last_value, is_called) FROM _timescaledb_internal._tmp_job_stat_history_id_seq;
+
+    CREATE INDEX bgw_job_stat_history_job_id_idx ON _timescaledb_internal.bgw_job_stat_history (job_id);
+    REVOKE ALL ON _timescaledb_internal.bgw_job_stat_history FROM PUBLIC;
+    --
+    -- END bgw_job_stat_history
+    --
+
+  END IF;
+END
+$$;

--- a/sql/views_detached.sql
+++ b/sql/views_detached.sql
@@ -121,20 +121,28 @@ SELECT
   NULL::text AS sqlerrcode,
   NULL::text AS err_message;
 
-CREATE OR REPLACE VIEW timescaledb_information.job_history
-WITH (security_barrier = true) AS
-SELECT
-  NULL::bigint AS id,
-  NULL::integer AS job_id,
-  NULL::boolean AS succeeded,
-  NULL::text COLLATE "C" AS proc_schema,
-  NULL::text COLLATE "C" AS proc_name,
-  NULL::integer AS pid,
-  NULL::timestamptz AS start_time,
-  NULL::timestamptz AS finish_time,
-  NULL::jsonb AS config,
-  NULL::text AS sqlerrcode,
-  NULL::text AS err_message;
+-- only detach if the definition is correct, otherwise update script needs to drop the view to fix
+-- the conditional detach can be removed once we drop support for PG16
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_attribute WHERE attrelid='_timescaledb_internal.bgw_job_stat_history'::regclass AND attname = 'id' AND atttypid = 'bigint'::regtype) THEN
+    CREATE OR REPLACE VIEW timescaledb_information.job_history
+    WITH (security_barrier = true) AS
+    SELECT
+      NULL::bigint AS id,
+      NULL::integer AS job_id,
+      NULL::boolean AS succeeded,
+      NULL::text COLLATE "C" AS proc_schema,
+      NULL::text COLLATE "C" AS proc_name,
+      NULL::integer AS pid,
+      NULL::timestamptz AS start_time,
+      NULL::timestamptz AS finish_time,
+      NULL::jsonb AS config,
+      NULL::text AS sqlerrcode,
+      NULL::text AS err_message;
+    END IF;
+END
+$$;
 
 CREATE OR REPLACE VIEW timescaledb_information.hypertable_compression_settings AS
 SELECT


### PR DESCRIPTION
When upgrading from a timescaledb instance that was created with
a version before 2.15.0 the table definition of bgw_job_stat_history
is out of sync with the definition used for fresh installations.
This patch syncs the table definition if it deviated.

Fixes: #10070 