### PR TITLE
Fix ALTER lock order on continuous aggregates

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2484,6 +2484,22 @@ process_rename_column(ProcessUtilityArgs *args, Cache *hcache, Oid relid, Rename
 			 * aggregate rather than one of the internal views, which is what
 			 * the ExecRenameStmt calls below would otherwise report. */
 			ts_cagg_permissions_check(relid, GetUserId());
+			/*
+			 * Renaming a column rewrites all four relations (user view, mat
+			 * hypertable, partial view and direct view) and each ExecRenameStmt
+			 * below takes an AccessExclusiveLock on its target. ExecRenameStmt
+			 * would lock them in the order direct, partial, mat, user view,
+			 * which is the reverse of the canonical order and could deadlock
+			 * with a concurrent ALTER. Lock them all upfront in the canonical
+			 * order; the ExecRenameStmt calls then re-take locks that are already
+			 * held.
+			 */
+			ts_continuous_agg_lock_relations(cagg,
+											 AccessExclusiveLock, /* user_view */
+											 AccessExclusiveLock, /* mat_hypertable */
+											 AccessExclusiveLock, /* partial_view */
+											 AccessExclusiveLock, /* direct_view */
+											 NULL);				  /* waitpoint_prefix */
 
 			RenameStmt *direct_view_stmt = castNode(RenameStmt, copyObject(stmt));
 			direct_view_stmt->relation = makeRangeVar(NameStr(cagg->data.direct_view_schema),
@@ -5061,6 +5077,18 @@ process_altertable_start_matview(ProcessUtilityArgs *args)
 				break;
 
 			case AT_ChangeOwner:
+				/*
+				 * Lock mat. ht and CAgg views upfront in the same order with
+				 * the rest of ALTERs so this cannot deadlock with another concurrent
+				 * ALTER. The per-relation ALTERs below then re-take locks that are
+				 * already held.
+				 */
+				ts_continuous_agg_lock_relations(cagg,
+												 AccessExclusiveLock, /* user_view */
+												 AccessExclusiveLock, /* mat_hypertable */
+												 AccessExclusiveLock, /* partial_view */
+												 AccessExclusiveLock, /* direct_view */
+												 NULL);				  /* waitpoint_prefix */
 				alter_table_by_relation(stmt->relation, cmd);
 				alter_table_by_name(&cagg->data.partial_view_schema,
 									&cagg->data.partial_view_name,

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -32,6 +32,7 @@
 
 #include "bgw/job.h"
 #include "cross_module_fn.h"
+#include "debug_point.h"
 #include "errors.h"
 #include "func_cache.h"
 #include "hypercube.h"
@@ -900,6 +901,50 @@ get_and_lock_rel_by_hypertable_id(int32 hypertable_id, LOCKMODE mode)
 }
 
 /*
+ * Lock the relations that make up a continuous aggregate in the canonical
+ * order: user view, mat hypertable, partial view, direct view.
+ *
+ * Every concurrent ALTER on a continuous aggregate must acquire the locks it
+ * needs in this order so that ALTER operations cannot deadlock with each other
+ * or with a concurrent DROP. An operation that does not touch a particular
+ * relation passes NoLock for it; the relation is skipped and the relative
+ * order of the remaining locks is preserved.
+ */
+void
+ts_continuous_agg_lock_relations(ContinuousAgg *cagg, LOCKMODE user_view, LOCKMODE mat_hypertable,
+								 LOCKMODE partial_view, LOCKMODE direct_view,
+								 const char *waitpoint_prefix)
+{
+	if (user_view != NoLock)
+	{
+		DEBUG_WAITPOINT(psprintf("%s_%s", waitpoint_prefix, "before_uv_lock"));
+		LockRelationOid(cagg->relid, user_view);
+	}
+
+	if (mat_hypertable != NoLock)
+	{
+		DEBUG_WAITPOINT(psprintf("%s_%s", waitpoint_prefix, "before_ht_lock"));
+		get_and_lock_rel_by_hypertable_id(cagg->data.mat_hypertable_id, mat_hypertable);
+	}
+
+	if (partial_view != NoLock)
+	{
+		DEBUG_WAITPOINT(psprintf("%s_%s", waitpoint_prefix, "before_pv_lock"));
+		get_and_lock_rel_by_name(&cagg->data.partial_view_schema,
+								 &cagg->data.partial_view_name,
+								 partial_view);
+	}
+
+	if (direct_view != NoLock)
+	{
+		DEBUG_WAITPOINT(psprintf("%s_%s", waitpoint_prefix, "before_dv_lock"));
+		get_and_lock_rel_by_name(&cagg->data.direct_view_schema,
+								 &cagg->data.direct_view_name,
+								 direct_view);
+	}
+}
+
+/*
  * Drops continuous aggs and all related objects.
  *
  * This function is intended to be run by event trigger during CASCADE,
@@ -915,8 +960,11 @@ get_and_lock_rel_by_hypertable_id(int32 hypertable_id, LOCKMODE mode)
  * - trigger on the raw hypertable (hypertable specified in the user view)
  * - copy of the user view query (AKA the direct view)
  *
- * NOTE: The order in which the objects are dropped should be EXACTLY the
- * same as in materialize.c
+ * NOTE: The order in which the relations are locked here is the canonical
+ * lock order for a continuous aggregate (user view, raw hypertable, mat
+ * hypertable, partial view, direct view). Every concurrent ALTER on a cagg
+ * must lock the relations it touches in this same order to avoid deadlocks;
+ * see ts_continuous_agg_lock_relations().
  *
  * drop_user_view indicates whether to drop the user view.
  *                (should be false if called as part of the drop-user-view callback)
@@ -950,7 +998,8 @@ drop_continuous_agg(FormData_continuous_agg *cadata, bool drop_user_view)
 	 * Following objects might be already dropped in case of CASCADE
 	 * drop including the associated schema object.
 	 *
-	 * NOTE: the lock order matters, see tsl/src/materialization.c.
+	 * NOTE: the lock order matters; this is the canonical order that every
+	 * concurrent ALTER must follow (see ts_continuous_agg_lock_relations()).
 	 * Perform all locking upfront.
 	 *
 	 * AccessExclusiveLock is needed to drop triggers and also prevent

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -149,6 +149,12 @@ extern TSDLLEXPORT bool ts_lock_continuous_agg_tuple(int32 mat_hypertable_id);
 
 extern TSDLLEXPORT Oid ts_cagg_permissions_check(Oid cagg_oid, Oid userid);
 
+extern TSDLLEXPORT void ts_continuous_agg_lock_relations(ContinuousAgg *cagg, LOCKMODE user_view,
+														 LOCKMODE mat_hypertable,
+														 LOCKMODE partial_view,
+														 LOCKMODE direct_view,
+														 const char *waitpoint_prefix);
+
 extern TSDLLEXPORT ContinuousAggInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
 extern TSDLLEXPORT ContinuousAgg *
 ts_continuous_agg_find_by_mat_hypertable_id(int32 mat_hypertable_id, bool missing_ok);

--- a/tsl/src/continuous_aggs/add_column.c
+++ b/tsl/src/continuous_aggs/add_column.c
@@ -217,28 +217,22 @@ make_colref_target(ColumnDef *coldef)
 void
 continuous_agg_add_column(ContinuousAgg *cagg, AlterTableStmt *stmt)
 {
-	/* Lock all the relations we'll touch, in the same order as
-	 * DROP so concurrent DROP and ADD COLUMN cannot deadlock. */
-	Oid cagg_relid = cagg->relid;
-	DEBUG_WAITPOINT("cagg_add_column_before_uv_lock");
-	LockRelationOid(cagg_relid, AccessExclusiveLock);
+	Oid mat_ht_oid;
+	List *expr_targets = NIL;
+	List *colref_targets = NIL;
 
-	/* A concurrent DROP could have committed between the cagg lookup and user-view lock
-	 * here. */
-	cagg = cagg_get_by_relid_or_fail(cagg_relid);
-	Oid mat_ht_oid = ts_hypertable_id_to_relid(cagg->data.mat_hypertable_id, false);
-	Oid partial_view_oid = ts_get_relation_relid(NameStr(cagg->data.partial_view_schema),
-												 NameStr(cagg->data.partial_view_name),
-												 false);
-	Oid direct_view_oid = ts_get_relation_relid(NameStr(cagg->data.direct_view_schema),
-												NameStr(cagg->data.direct_view_name),
-												false);
-	DEBUG_WAITPOINT("cagg_add_column_before_ht_lock");
-	LockRelationOid(mat_ht_oid, AccessExclusiveLock);
-	DEBUG_WAITPOINT("cagg_add_column_before_pv_lock");
-	LockRelationOid(partial_view_oid, AccessExclusiveLock);
-	LockRelationOid(direct_view_oid, AccessExclusiveLock);
+	ts_cagg_permissions_check(cagg->relid, GetUserId());
+
+	ts_continuous_agg_lock_relations(cagg,
+									 AccessExclusiveLock, /* user_view */
+									 AccessExclusiveLock, /* mat_hypertable */
+									 AccessExclusiveLock, /* partial_view */
+									 AccessExclusiveLock, /* direct_view */
+									 "cagg_add_column");  /* waitpoint_prefix */
 	DEBUG_WAITPOINT("cagg_add_column_after_locks");
+
+	cagg = cagg_get_by_relid_or_fail(cagg->relid);
+	mat_ht_oid = ts_hypertable_id_to_relid(cagg->data.mat_hypertable_id, false);
 
 	ListCell *lc;
 	foreach (lc, stmt->cmds)
@@ -251,8 +245,6 @@ continuous_agg_add_column(ContinuousAgg *cagg, AlterTableStmt *stmt)
 	/* Build the per-view ResTarget lists. Partial / direct views get
 	 * the user's aggregate expression; the user view gets a column
 	 * reference to the freshly-added mat-HT column. */
-	List *expr_targets = NIL;
-	List *colref_targets = NIL;
 	foreach (lc, stmt->cmds)
 	{
 		AlterTableCmd *cmd = lfirst_node(AlterTableCmd, lc);

--- a/tsl/src/continuous_aggs/add_column.c
+++ b/tsl/src/continuous_aggs/add_column.c
@@ -235,6 +235,7 @@ continuous_agg_add_column(ContinuousAgg *cagg, AlterTableStmt *stmt)
 												false);
 	DEBUG_WAITPOINT("cagg_add_column_before_ht_lock");
 	LockRelationOid(mat_ht_oid, AccessExclusiveLock);
+	DEBUG_WAITPOINT("cagg_add_column_before_pv_lock");
 	LockRelationOid(partial_view_oid, AccessExclusiveLock);
 	LockRelationOid(direct_view_oid, AccessExclusiveLock);
 	DEBUG_WAITPOINT("cagg_add_column_after_locks");

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -192,6 +192,18 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 
 		Assert(mat_ht != NULL);
 
+		/*
+		 * Flipping the real-time view definition rewrites the user view and
+		 * reads the direct view (both AccessShareLock, taken in
+		 * cagg_flip_realtime_view_definition).
+		 */
+		ts_continuous_agg_lock_relations(agg,
+										 AccessShareLock, /* user_view */
+										 NoLock,		  /* mat_hypertable */
+										 NoLock,		  /* partial_view */
+										 AccessShareLock, /* direct_view */
+										 NULL);			  /* waitpoint_prefix */
+
 		cagg_flip_realtime_view_definition(agg, mat_ht);
 		cagg_update_materialized_only(agg, materialized_only);
 		ts_cache_release(&hcache);
@@ -219,6 +231,20 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		Hypertable *mat_ht =
 			ts_hypertable_cache_get_entry_by_id(hcache, agg->data.mat_hypertable_id);
 		Assert(mat_ht != NULL);
+
+		/*
+		 * Enabling compression locks the mat hypertable (AccessExclusiveLock,
+		 * in tsl_process_compress_table) and reads the partial view to derive the
+		 * default compression settings (AccessShareLock, in cagg_get_compression_params).
+		 * Take locks beforehand to keep the order consistent with DROP and the
+		 * other ALTER operations.
+		 */
+		ts_continuous_agg_lock_relations(agg,
+										 NoLock,			  /* user_view */
+										 AccessExclusiveLock, /* mat_hypertable */
+										 AccessShareLock,	  /* partial_view */
+										 NoLock,			  /* direct_view */
+										 NULL);				  /* waitpoint_prefix */
 
 		cagg_alter_compression(agg, mat_ht, compression_options);
 		ts_cache_release(&hcache);

--- a/tsl/test/isolation/expected/cagg_add_column.out
+++ b/tsl/test/isolation/expected/cagg_add_column.out
@@ -266,15 +266,15 @@ debug_waitpoint_release
 -----------------------
                        
 
+step s1_add_a: <... completed>
+step alt_rename: <... completed>
 step v_cols_a: SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position;
 column_name
 -----------
 bucket     
-avg_val    
+mean_val   
+min_temp   
 
-step s1_add_a: <... completed>
-step alt_rename: <... completed>
-ERROR:  deadlock detected
 
 starting permutation: wp_before_pv_enable s1_add_a alt_compress wp_before_pv_release v_cols_a v_compress_a
 step wp_before_pv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock');
@@ -283,24 +283,24 @@ debug_waitpoint_enable
                       
 
 step s1_add_a: ALTER MATERIALIZED VIEW cagg_a      ADD COLUMN min_temp double precision GENERATED ALWAYS AS (min(temp))      STORED; <waiting ...>
-alt: NOTICE:  defaulting compress_orderby to bucket
 step alt_compress: ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.compress = true); <waiting ...>
 step wp_before_pv_release: SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock');
 debug_waitpoint_release
 -----------------------
                        
 
+step s1_add_a: <... completed>
+alt: NOTICE:  defaulting compress_orderby to bucket
+step alt_compress: <... completed>
 step v_cols_a: SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position;
 column_name
 -----------
 bucket     
 avg_val    
+min_temp   
 
 step v_compress_a: SELECT compression_enabled FROM timescaledb_information.continuous_aggregates WHERE view_name='cagg_a';
 compression_enabled
 -------------------
-f                  
+t                  
 
-step s1_add_a: <... completed>
-step alt_compress: <... completed>
-ERROR:  deadlock detected

--- a/tsl/test/isolation/expected/cagg_add_column.out
+++ b/tsl/test/isolation/expected/cagg_add_column.out
@@ -174,20 +174,21 @@ debug_waitpoint_release
 step s1_add_a: <... completed>
 ERROR:  continuous aggregate does not exist
 
-starting permutation: wp_before_uv_enable alt_matonly s1_add_a wp_before_uv_release v_cols_a v_matonly_a
-step wp_before_uv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_uv_lock');
+starting permutation: wp_before_pv_enable s1_add_a alt_matonly wp_before_pv_release v_cols_a v_matonly_a
+step wp_before_pv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock');
 debug_waitpoint_enable
 ----------------------
                       
 
-step alt_matonly: ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.materialized_only = false);
 step s1_add_a: ALTER MATERIALIZED VIEW cagg_a      ADD COLUMN min_temp double precision GENERATED ALWAYS AS (min(temp))      STORED; <waiting ...>
-step wp_before_uv_release: SELECT debug_waitpoint_release('cagg_add_column_before_uv_lock');
+step alt_matonly: ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.materialized_only = false); <waiting ...>
+step wp_before_pv_release: SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock');
 debug_waitpoint_release
 -----------------------
                        
 
 step s1_add_a: <... completed>
+step alt_matonly: <... completed>
 step v_cols_a: SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position;
 column_name
 -----------
@@ -201,15 +202,15 @@ materialized_only
 f                
 
 
-starting permutation: wp_after_enable s1_add_a alt_chunk wp_after_release v_cols_a
-step wp_after_enable: SELECT debug_waitpoint_enable('cagg_add_column_after_locks');
+starting permutation: wp_before_pv_enable s1_add_a alt_chunk wp_before_pv_release v_cols_a
+step wp_before_pv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock');
 debug_waitpoint_enable
 ----------------------
                       
 
 step s1_add_a: ALTER MATERIALIZED VIEW cagg_a      ADD COLUMN min_temp double precision GENERATED ALWAYS AS (min(temp))      STORED; <waiting ...>
 step alt_chunk: ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.chunk_interval = '2 days'); <waiting ...>
-step wp_after_release: SELECT debug_waitpoint_release('cagg_add_column_after_locks');
+step wp_before_pv_release: SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock');
 debug_waitpoint_release
 -----------------------
                        
@@ -224,20 +225,21 @@ avg_val
 min_temp   
 
 
-starting permutation: wp_before_uv_enable alt_owner s1_add_a wp_before_uv_release v_cols_a v_owner_a
-step wp_before_uv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_uv_lock');
+starting permutation: wp_before_pv_enable s1_add_a alt_owner wp_before_pv_release v_cols_a v_owner_a
+step wp_before_pv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock');
 debug_waitpoint_enable
 ----------------------
                       
 
-step alt_owner: ALTER MATERIALIZED VIEW cagg_a OWNER TO cagg_role;
 step s1_add_a: ALTER MATERIALIZED VIEW cagg_a      ADD COLUMN min_temp double precision GENERATED ALWAYS AS (min(temp))      STORED; <waiting ...>
-step wp_before_uv_release: SELECT debug_waitpoint_release('cagg_add_column_before_uv_lock');
+step alt_owner: ALTER MATERIALIZED VIEW cagg_a OWNER TO cagg_role; <waiting ...>
+step wp_before_pv_release: SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock');
 debug_waitpoint_release
 -----------------------
                        
 
 step s1_add_a: <... completed>
+step alt_owner: <... completed>
 step v_cols_a: SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position;
 column_name
 -----------
@@ -250,3 +252,55 @@ owner
 ---------
 cagg_role
 
+
+starting permutation: wp_before_pv_enable s1_add_a alt_rename wp_before_pv_release v_cols_a
+step wp_before_pv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock');
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_add_a: ALTER MATERIALIZED VIEW cagg_a      ADD COLUMN min_temp double precision GENERATED ALWAYS AS (min(temp))      STORED; <waiting ...>
+step alt_rename: ALTER MATERIALIZED VIEW cagg_a RENAME COLUMN avg_val TO mean_val; <waiting ...>
+step wp_before_pv_release: SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock');
+debug_waitpoint_release
+-----------------------
+                       
+
+step v_cols_a: SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position;
+column_name
+-----------
+bucket     
+avg_val    
+
+step s1_add_a: <... completed>
+step alt_rename: <... completed>
+ERROR:  deadlock detected
+
+starting permutation: wp_before_pv_enable s1_add_a alt_compress wp_before_pv_release v_cols_a v_compress_a
+step wp_before_pv_enable: SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock');
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_add_a: ALTER MATERIALIZED VIEW cagg_a      ADD COLUMN min_temp double precision GENERATED ALWAYS AS (min(temp))      STORED; <waiting ...>
+alt: NOTICE:  defaulting compress_orderby to bucket
+step alt_compress: ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.compress = true); <waiting ...>
+step wp_before_pv_release: SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock');
+debug_waitpoint_release
+-----------------------
+                       
+
+step v_cols_a: SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position;
+column_name
+-----------
+bucket     
+avg_val    
+
+step v_compress_a: SELECT compression_enabled FROM timescaledb_information.continuous_aggregates WHERE view_name='cagg_a';
+compression_enabled
+-------------------
+f                  
+
+step s1_add_a: <... completed>
+step alt_compress: <... completed>
+ERROR:  deadlock detected

--- a/tsl/test/isolation/specs/cagg_add_column.spec
+++ b/tsl/test/isolation/specs/cagg_add_column.spec
@@ -44,6 +44,8 @@ step "wp_before_uv_enable"  { SELECT debug_waitpoint_enable('cagg_add_column_bef
 step "wp_before_uv_release" { SELECT debug_waitpoint_release('cagg_add_column_before_uv_lock'); }
 step "wp_before_ht_enable"  { SELECT debug_waitpoint_enable('cagg_add_column_before_ht_lock'); }
 step "wp_before_ht_release" { SELECT debug_waitpoint_release('cagg_add_column_before_ht_lock'); }
+step "wp_before_pv_enable"    { SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock'); }
+step "wp_before_pv_release"   { SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock'); }
 step "wp_after_enable"      { SELECT debug_waitpoint_enable('cagg_add_column_after_locks'); }
 step "wp_after_release"     { SELECT debug_waitpoint_release('cagg_add_column_after_locks'); }
 step "wp_refresh_enable"    { SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock'); }
@@ -72,6 +74,8 @@ session "alt"
 step "alt_matonly"  { ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.materialized_only = false); }
 step "alt_chunk"    { ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.chunk_interval = '2 days'); }
 step "alt_owner"    { ALTER MATERIALIZED VIEW cagg_a OWNER TO cagg_role; }
+step "alt_compress" { ALTER MATERIALIZED VIEW cagg_a SET (timescaledb.compress = true); }
+step "alt_rename"   { ALTER MATERIALIZED VIEW cagg_a RENAME COLUMN avg_val TO mean_val; }
 
 session "v"
 step "v_cols_a"      { SELECT column_name FROM information_schema.columns WHERE table_name='cagg_a'      ORDER BY ordinal_position; }
@@ -80,6 +84,7 @@ step "v_cols_child"  { SELECT column_name FROM information_schema.columns WHERE 
 step "v_exists_a"    { SELECT count(*) AS cagg_a_exists FROM pg_class WHERE relname='cagg_a' AND relkind='v'; }
 step "v_matonly_a"   { SELECT materialized_only FROM timescaledb_information.continuous_aggregates WHERE view_name='cagg_a'; }
 step "v_owner_a"     { SELECT pg_get_userbyid(relowner) AS owner FROM pg_class WHERE relname='cagg_a'; }
+step "v_compress_a"  { SELECT compression_enabled FROM timescaledb_information.continuous_aggregates WHERE view_name='cagg_a'; }
 
 # Two concurrent ADD COLUMNs serialize on the user-view lock alone.
 # s1 pauses BEFORE mat HT lock (so it holds only the user view), then s2 blocks
@@ -106,11 +111,21 @@ permutation "wp_after_enable" "s1_add_a" "drop_a"("s1_add_a") "wp_after_release"
 # DROP takes locks first; subsequent ADD COLUMN errors because the cagg is gone.
 permutation "wp_before_uv_enable" "s1_add_a" "drop_a" "wp_before_uv_release"
 
-# SET materialized_only flips to real-time (takes the user-view lock).
-permutation "wp_before_uv_enable" "alt_matonly" "s1_add_a"("alt_matonly") "wp_before_uv_release" "v_cols_a" "v_matonly_a"
+# No deadlock cases due to non-conflicting locks
+permutation "wp_before_pv_enable" "s1_add_a" "alt_matonly"("s1_add_a") "wp_before_pv_release" "v_cols_a" "v_matonly_a"
+permutation "wp_before_pv_enable" "s1_add_a" "alt_chunk"("s1_add_a")   "wp_before_pv_release" "v_cols_a"
+permutation "wp_before_pv_enable" "s1_add_a" "alt_owner"("s1_add_a")   "wp_before_pv_release" "v_cols_a" "v_owner_a"
 
-# SET chunk_interval updates the mat-HT dimension.
-permutation "wp_after_enable" "s1_add_a" "alt_chunk"("s1_add_a") "wp_after_release" "v_cols_a"
-
-# OWNER TO re-owns the user view, partial/direct views and the mat HT.
-permutation "wp_before_uv_enable" "alt_owner" "s1_add_a"("alt_owner") "wp_before_uv_release" "v_cols_a" "v_owner_a"
+# DEADLOCK REPRODUCER due to different ordering in locks taken
+#
+# e.g. ADD COLUMN locks the cagg relations as user view -> mat HT -> partial view
+# -> direct view, whereas RENAME COLUMN locks them in the reverse order
+# (direct view -> partial view -> mat HT -> user view).
+#
+# Here ADD COLUMN pauses BEFORE the mat-HT lock, holding only the user-view
+# lock. RENAME COLUMN then takes the direct view, partial view and mat HT and
+# finally blocks waiting for the user view (held by ADD COLUMN). When ADD COLUMN
+# resumes it tries to take the mat HT (now held by RENAME COLUMN) and the two
+# deadlock.
+permutation "wp_before_pv_enable" "s1_add_a" "alt_rename"("s1_add_a")   "wp_before_pv_release" "v_cols_a"
+permutation "wp_before_pv_enable" "s1_add_a" "alt_compress"("s1_add_a") "wp_before_pv_release" "v_cols_a" "v_compress_a"

--- a/tsl/test/isolation/specs/cagg_add_column.spec
+++ b/tsl/test/isolation/specs/cagg_add_column.spec
@@ -44,8 +44,8 @@ step "wp_before_uv_enable"  { SELECT debug_waitpoint_enable('cagg_add_column_bef
 step "wp_before_uv_release" { SELECT debug_waitpoint_release('cagg_add_column_before_uv_lock'); }
 step "wp_before_ht_enable"  { SELECT debug_waitpoint_enable('cagg_add_column_before_ht_lock'); }
 step "wp_before_ht_release" { SELECT debug_waitpoint_release('cagg_add_column_before_ht_lock'); }
-step "wp_before_pv_enable"    { SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock'); }
-step "wp_before_pv_release"   { SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock'); }
+step "wp_before_pv_enable"  { SELECT debug_waitpoint_enable('cagg_add_column_before_pv_lock'); }
+step "wp_before_pv_release" { SELECT debug_waitpoint_release('cagg_add_column_before_pv_lock'); }
 step "wp_after_enable"      { SELECT debug_waitpoint_enable('cagg_add_column_after_locks'); }
 step "wp_after_release"     { SELECT debug_waitpoint_release('cagg_add_column_after_locks'); }
 step "wp_refresh_enable"    { SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock'); }
@@ -116,16 +116,10 @@ permutation "wp_before_pv_enable" "s1_add_a" "alt_matonly"("s1_add_a") "wp_befor
 permutation "wp_before_pv_enable" "s1_add_a" "alt_chunk"("s1_add_a")   "wp_before_pv_release" "v_cols_a"
 permutation "wp_before_pv_enable" "s1_add_a" "alt_owner"("s1_add_a")   "wp_before_pv_release" "v_cols_a" "v_owner_a"
 
-# DEADLOCK REPRODUCER due to different ordering in locks taken
-#
-# e.g. ADD COLUMN locks the cagg relations as user view -> mat HT -> partial view
-# -> direct view, whereas RENAME COLUMN locks them in the reverse order
-# (direct view -> partial view -> mat HT -> user view).
-#
-# Here ADD COLUMN pauses BEFORE the mat-HT lock, holding only the user-view
-# lock. RENAME COLUMN then takes the direct view, partial view and mat HT and
-# finally blocks waiting for the user view (held by ADD COLUMN). When ADD COLUMN
-# resumes it tries to take the mat HT (now held by RENAME COLUMN) and the two
-# deadlock.
+# Before the canonical lock ordering was enforced these two permutations
+# deadlocked: SET compress locked the partial view (to derive default settings)
+# before the mat HT, and RENAME COLUMN locked the views in the reverse (direct,
+# partial, mat, user) order. Now both take the mat HT / user view first, so they
+# simply wait for ADD COLUMN and then complete.
 permutation "wp_before_pv_enable" "s1_add_a" "alt_rename"("s1_add_a")   "wp_before_pv_release" "v_cols_a"
 permutation "wp_before_pv_enable" "s1_add_a" "alt_compress"("s1_add_a") "wp_before_pv_release" "v_cols_a" "v_compress_a"


### PR DESCRIPTION
Concurrent ALTER operations on a continuous aggregate could deadlock
with each other and with DROP because they acquired locks on the cagg's
relations (user view, mat hypertable, partial view, direct view) in
inconsistent orders

Establish a canonical lock order and route every ALTER through a shared
ts_continuous_agg_lock_relations() helper that takes the locks it needs
upfront in that order, which removes the deadlock.