### PR TITLE
Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size

### DIFF
--- a/.unreleased/pr_10081
+++ b/.unreleased/pr_10081
@@ -1,0 +1,1 @@
+Implements: #10081 Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -592,7 +592,7 @@ $BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -------------End index size for hypertables -------
 
-CREATE OR REPLACE FUNCTION _timescaledb_functions.estimate_uncompressed_size(IN regclass, OUT tuples bigint, OUT relation_size bigint, OUT index_size bigint, OUT total_size bigint)
+CREATE OR REPLACE FUNCTION _timescaledb_functions.estimate_uncompressed_size(IN regclass, IN samplerate double precision DEFAULT 100, OUT tuples bigint, OUT relation_size bigint, OUT index_size bigint, OUT total_size bigint)
 AS $$
 DECLARE
   v_compressed_chunk regclass;
@@ -609,9 +609,21 @@ DECLARE
   v_varlen_query text:= '';
   v_multiplier decimal:=1.15; -- multiplier to account for page header, fill factor and alignment padding
   v_index_multiplier decimal:=1.25; -- multiplier to account for page header, fill factor and alignment padding
+  v_sample_clause text:= '';
+  v_scale decimal:=1;
 BEGIN
 
   v_compressed_chunk := $1;
+
+  IF samplerate IS NULL OR samplerate >= 100 THEN
+    v_sample_clause := '';
+    v_scale := 1;
+  ELSIF samplerate <= 0 THEN
+    RAISE EXCEPTION 'samplerate must be in the range (0, 100]';
+  ELSE
+    v_sample_clause := format(' TABLESAMPLE BERNOULLI(%s)', samplerate);
+    v_scale := 100.0 / samplerate;
+  END IF;
 
   SELECT relid, segmentby INTO v_uncompressed_chunk, v_segmentby FROM _timescaledb_catalog.compression_settings WHERE compress_relid = v_compressed_chunk;
   IF NOT FOUND THEN
@@ -637,12 +649,15 @@ BEGIN
 	    CASE WHEN attname = ANY(v_segmentby)
 	      THEN format('sum(pg_catalog.pg_column_size(%I) * _ts_meta_count)', attname)
 	      ELSE format('sum(_timescaledb_functions.compressed_data_column_size(%I,NULL::%s))', attname, pg_catalog.format_type(atttypid, atttypmod))
-	    END, ' + ') || ')' FROM pg_attribute INTO v_varlen_query WHERE attrelid = v_uncompressed_chunk AND attnum > 0 AND NOT attisdropped AND attlen = -1;
+	    END, ' + ') || ') * ' || v_scale
+    FROM pg_attribute
+    INTO v_varlen_query
+    WHERE attrelid = v_uncompressed_chunk AND attnum > 0 AND NOT attisdropped AND attlen = -1;
   END IF;
 
   EXECUTE format('SELECT sum(_ts_meta_count) FROM %s', v_compressed_chunk) INTO tuples;
   -- we can optimize the following query if all columns are fixed size
-  EXECUTE format('SELECT (((%s::bigint * (%s::bigint + %s::bigint)) %s) * %s)::bigint FROM %s', tuples, v_tuple_header, v_tuple_data, v_varlen_query, v_multiplier, v_compressed_chunk) INTO relation_size;
+  EXECUTE format('SELECT (((%s::bigint * (%s::bigint + %s::bigint)) %s) * %s)::bigint FROM %s%s', tuples, v_tuple_header, v_tuple_data, v_varlen_query, v_multiplier, v_compressed_chunk, v_sample_clause) INTO relation_size;
 
   index_size := 0;
   FOR v_index, v_varlen_query, v_columns IN
@@ -652,14 +667,18 @@ BEGIN
          CASE WHEN attname = ANY(v_segmentby)
            THEN format('sum(pg_catalog.pg_column_size(%I) * _ts_meta_count)', attname)
            ELSE format('sum(_timescaledb_functions.compressed_data_column_size(%I,NULL::%s))', attname, pg_catalog.format_type(atttypid, atttypmod))
-         END, ' + ' ORDER BY attnum) || ')' FROM pg_attribute att WHERE att.attrelid=i.indrelid AND attnum =ANY(i.indkey)),
+         END, ' + ' ORDER BY attnum
+         )
+         || ') * ' || v_scale
+       FROM pg_attribute att
+       WHERE att.attrelid=i.indrelid AND attnum =ANY(i.indkey)),
       array_length(i.indkey,1) FROM pg_index i
     WHERE i.indrelid = v_uncompressed_chunk
   LOOP
     v_index_header := 8; -- Index tuple header
 
     -- v_compressed_chunk is a regclass, which will be properly escaped when cast to `text`
-    EXECUTE format('SELECT (((%s::bigint * %s::bigint) %s) * %s)::bigint FROM %s', tuples, v_index_header, v_varlen_query, v_index_multiplier, v_compressed_chunk) INTO v_index_size;
+    EXECUTE format('SELECT (((%s::bigint * %s::bigint) %s) * %s)::bigint FROM %s%s', tuples, v_index_header, v_varlen_query, v_index_multiplier, v_compressed_chunk, v_sample_clause) INTO v_index_size;
     index_size := index_size + v_index_size;
   END LOOP;
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -43,3 +43,5 @@ BEGIN
   END IF;
 END
 $$;
+
+DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_uncompressed_size(regclass);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,1 +1,2 @@
 DROP FUNCTION IF EXISTS _timescaledb_functions.decompress_batch(record);
+DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_uncompressed_size(regclass, double precision);

--- a/tsl/test/expected/uncompressed_size.out
+++ b/tsl/test/expected/uncompressed_size.out
@@ -25,6 +25,37 @@ SELECT cs.compress_relid, l.relation_size, l.index_size, l.total_size FROM _time
  _timescaledb_internal.compress_hyper_2_3_chunk |       5980000 |    2000000 |    7980000
  _timescaledb_internal.compress_hyper_4_4_chunk |       5520000 |    2000000 |    7520000
 
+-- samplerate of 100 reads the whole chunk and matches the default
+SELECT
+  d.tuples = s.tuples AS tuples_match,
+  d.relation_size = s.relation_size AS relation_size_match,
+  d.index_size = s.index_size AS index_size_match,
+  d.total_size = s.total_size AS total_size_match
+FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk') d,
+     _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', 100) s;
+ tuples_match | relation_size_match | index_size_match | total_size_match 
+--------------+---------------------+------------------+------------------
+ t            | t                   | t                | t
+
+-- samplerate scales the sampled variable length size back up to the full chunk
+SELECT
+  s.tuples = d.tuples AS tuples_match,
+  s.relation_size BETWEEN d.relation_size * 0.8 AND d.relation_size * 1.2 AS relation_size_in_range,
+  s.index_size BETWEEN d.index_size * 0.8 AND d.index_size * 1.2 AS index_size_in_range,
+  s.total_size BETWEEN d.total_size * 0.8 AND d.total_size * 1.2 AS total_size_in_range
+FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk') d,
+     _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', 50) s;
+ tuples_match | relation_size_in_range | index_size_in_range | total_size_in_range 
+--------------+------------------------+---------------------+---------------------
+ t            | t                      | t                   | t
+
+-- samplerate outside the (0, 100] range is rejected
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', 0);
+ERROR:  samplerate must be in the range (0, 100]
+SELECT * FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', -5);
+ERROR:  samplerate must be in the range (0, 100]
+\set ON_ERROR_STOP 1
 -- test NULL compression does not error and returns NULL
 INSERT INTO t1 SELECT '2026-01-01'::timestamptz + format('%s ms', i)::interval, NULL, NULL FROM generate_series(1, 3000) i;
 SELECT compress_chunk(chunk) FROM show_chunks('t1') AS chunk;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -63,7 +63,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.drop_chunk(regclass)
  _timescaledb_functions.drop_osm_chunk(regclass)
  _timescaledb_functions.estimate_compressed_batch_size(regclass)
- _timescaledb_functions.estimate_uncompressed_size(regclass)
+ _timescaledb_functions.estimate_uncompressed_size(regclass,double precision)
  _timescaledb_functions.extension_state()
  _timescaledb_functions.first_combinefunc(internal,internal)
  _timescaledb_functions.first_sfunc(internal,anyelement,"any")

--- a/tsl/test/sql/uncompressed_size.sql
+++ b/tsl/test/sql/uncompressed_size.sql
@@ -17,6 +17,30 @@ SELECT compress_chunk(chunk) FROM show_chunks('t2') AS chunk;
 
 SELECT cs.compress_relid, l.relation_size, l.index_size, l.total_size FROM _timescaledb_catalog.compression_chunk_size ccs JOIN _timescaledb_catalog.chunk uc ON uc.id=ccs.chunk_id JOIN _timescaledb_catalog.compression_settings cs ON cs.relid=format('%I.%I',uc.schema_name,uc.table_name)::regclass JOIN LATERAL (SELECT * FROM _timescaledb_functions.estimate_uncompressed_size(cs.compress_relid)) l ON true;
 
+-- samplerate of 100 reads the whole chunk and matches the default
+SELECT
+  d.tuples = s.tuples AS tuples_match,
+  d.relation_size = s.relation_size AS relation_size_match,
+  d.index_size = s.index_size AS index_size_match,
+  d.total_size = s.total_size AS total_size_match
+FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk') d,
+     _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', 100) s;
+
+-- samplerate scales the sampled variable length size back up to the full chunk
+SELECT
+  s.tuples = d.tuples AS tuples_match,
+  s.relation_size BETWEEN d.relation_size * 0.8 AND d.relation_size * 1.2 AS relation_size_in_range,
+  s.index_size BETWEEN d.index_size * 0.8 AND d.index_size * 1.2 AS index_size_in_range,
+  s.total_size BETWEEN d.total_size * 0.8 AND d.total_size * 1.2 AS total_size_in_range
+FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk') d,
+     _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', 50) s;
+
+-- samplerate outside the (0, 100] range is rejected
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', 0);
+SELECT * FROM _timescaledb_functions.estimate_uncompressed_size('_timescaledb_internal.compress_hyper_2_3_chunk', -5);
+\set ON_ERROR_STOP 1
+
 -- test NULL compression does not error and returns NULL
 INSERT INTO t1 SELECT '2026-01-01'::timestamptz + format('%s ms', i)::interval, NULL, NULL FROM generate_series(1, 3000) i;
 SELECT compress_chunk(chunk) FROM show_chunks('t1') AS chunk;


### PR DESCRIPTION
Allow decompressing only a sample of the compressed data. The function
uses bernoulli tablesample method to do the sampling
