### PR TITLE
Reduce reliance on hardcoded chunk names for compressed relations in tests

### DIFF
--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -82,9 +82,11 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_2_chunk
  _timescaledb_internal._hyper_1_5_chunk
 
+SELECT compress_relid AS "COMPRESSED_CHUNK_1" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_1_chunk'::regclass \gset
+SELECT compress_relid AS "COMPRESSED_CHUNK_2" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_2_chunk'::regclass \gset
 \set ON_ERROR_STOP 0
 -- Cannot merge chunks internal compressed chunks, no dimensions on them.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_10_chunk','_timescaledb_internal.compress_hyper_2_11_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension(:'COMPRESSED_CHUNK_1',:'COMPRESSED_CHUNK_2', 1);
 ERROR:  cannot find slice for merging dimension
 \set ON_ERROR_STOP 1
 -- This creates more data so caggs has multiple chunks.

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1762,7 +1762,7 @@ SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
 --------------
  t
 
-SELECT format('%I.%I', schema_name, table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk ORDER BY id DESC LIMIT 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE relid = :'CHUNK'::regclass \gset
 -- DML on hypertable after freezing should be blocked
 \set ON_ERROR_STOP 0
 INSERT INTO dml_blocks VALUES ('2025-01-01','dev1',1.0);

--- a/tsl/test/expected/compress_bloom_sparse_debug.out
+++ b/tsl/test/expected/compress_bloom_sparse_debug.out
@@ -179,13 +179,11 @@ select count(compress_chunk(x)) from show_chunks('detoaster') x;
 
 with chunks as (
   select
-    row_number() over (order by cc.table_name) index,
-    cc.schema_name || '.' || cc.table_name chunk
+    row_number() over (order by cs.compress_relid::text) index,
+    cs.compress_relid::text chunk
   from _timescaledb_catalog.chunk ch
     join _timescaledb_catalog.compression_settings cs
       on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
-    join _timescaledb_catalog.chunk cc
-      on cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
   where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
         where table_name = 'detoaster')
 )

--- a/tsl/test/expected/compress_firstlast_sparse.out
+++ b/tsl/test/expected/compress_firstlast_sparse.out
@@ -54,9 +54,8 @@ select count(compress_chunk(x)) from show_chunks('fl_basic') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
 \gset
@@ -84,9 +83,8 @@ select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
 \gset
@@ -115,9 +113,8 @@ select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
 \gset
@@ -145,9 +142,8 @@ select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
 \gset
@@ -175,9 +171,8 @@ select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
 \gset
@@ -205,9 +200,8 @@ select count(compress_chunk(x)) from show_chunks('fl_single') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
 \gset
@@ -234,9 +228,8 @@ select count(compress_chunk(x)) from show_chunks('fl_multi') x;
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
 \gset
@@ -270,9 +263,8 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompres
 -------
      1
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
 \gset
@@ -482,12 +474,11 @@ select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_push_reco
 -------
      2
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_push_recompress')
-order by ch.id
+order by uc.id desc
 limit 1
 \gset
 -- both metadata kinds populated per batch
@@ -532,12 +523,11 @@ SELECT compress_chunk(c) FROM show_chunks('sensor_readings') c;
 ------------------------------------------
  _timescaledb_internal._hyper_30_60_chunk
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'sensor_readings')
-order by ch.id
+order by uc.id
 limit 1
 \gset
 -- should see firstlast metadata columns also renamed

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -42,11 +42,13 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_collation_ht') ch;
      1
 
 vacuum analyze compressed_collation_ht;
-SELECT format('%I.%I',ch.schema_name, ch.table_name) AS "CHUNK"
+SELECT cs.compress_relid::text AS "CHUNK"
 FROM _timescaledb_catalog.hypertable ht
     INNER JOIN _timescaledb_catalog.chunk ch
-    ON ch.hypertable_id = ht.compressed_hypertable_id
-        AND ht.table_name = 'compressed_collation_ht' \gset
+    ON ch.hypertable_id = ht.id
+    INNER JOIN _timescaledb_catalog.compression_settings cs
+    ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+WHERE ht.table_name = 'compressed_collation_ht' \gset
 create index on :CHUNK (name);
 set enable_seqscan to off;
 explain (buffers off, costs off)

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -322,15 +322,17 @@ SELECT
    c.schema_name as chunk_schema,
    c.table_name as chunk_name,
    c.status as chunk_status,
-   comp.schema_name as compressed_chunk_schema,
-   comp.table_name as compressed_chunk_name
+   comp_ns.nspname as compressed_chunk_schema,
+   comp_class.relname as compressed_chunk_name
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
    LEFT JOIN _timescaledb_catalog.compression_settings cs
 ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
-   LEFT JOIN _timescaledb_catalog.chunk comp
-ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
+   LEFT JOIN pg_class comp_class
+ON cs.compress_relid = comp_class.oid
+   LEFT JOIN pg_namespace comp_ns
+ON comp_class.relnamespace = comp_ns.oid
 ;
 CREATE TABLE test2 (timec timestamptz NOT NULL, i integer ,
       b bigint, t text);
@@ -453,14 +455,14 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 \set ON_ERROR_STOP 0
 -- call compress_chunk when status is not unordered
 SELECT compress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:109: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
+psql:include/recompress_basic.sql:111: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_14_62_chunk
 
 -- This will succeed and compress the chunk for the test below.
 SELECT compress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:112: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
+psql:include/recompress_basic.sql:114: NOTICE:  chunk "_hyper_14_62_chunk" is already converted to columnstore
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_14_62_chunk
@@ -569,7 +571,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:188: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:190: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_conflicts.out
+++ b/tsl/test/expected/compression_conflicts.out
@@ -195,12 +195,12 @@ INSERT INTO comp_conflicts_3 VALUES ('2020-01-01',NULL, 'label', 0.3);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_3') c
 \gset
 INFO:  using tuplesort to scan rows from "_hyper_5_5_chunk" for converting to columnstore
-SELECT format('%I.%I', i.schemaname, i.indexname) AS "COMPRESSED_CHUNK_INDEX"
-FROM pg_indexes i
-JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name AND i.tablename = cc.table_name
-JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk uc ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name) = :'CHUNK'
+SELECT cs.compress_relid AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings cs WHERE cs.relid = :'CHUNK'::regclass \gset
+SELECT format('%I.%I', n.nspname, i.relname) AS "COMPRESSED_CHUNK_INDEX"
+FROM pg_index idx
+JOIN pg_class i ON i.oid = idx.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+WHERE idx.indrelid = :'COMPRESSED_CHUNK'::regclass
 LIMIT 1 \gset
 -- after compression no data should be in uncompressed chunk
 SELECT count(*) FROM ONLY :CHUNK;
@@ -250,7 +250,7 @@ set timescaledb.debug_compression_path_info to on;
 -- ignore matching partial index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, label, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK (device, label, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)
 	WHERE label LIKE 'missing';
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
@@ -259,7 +259,7 @@ ROLLBACK;
 -- ignore matching covering index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device) INCLUDE (label, _ts_meta_min_1, _ts_meta_max_1);
+  CREATE INDEX covering_index ON :COMPRESSED_CHUNK (device) INCLUDE (label, _ts_meta_min_1, _ts_meta_max_1);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 INFO:  Using index scan with scan keys: index 1, heap 3, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_comp_conflicts_3_time_device_label_key"
@@ -267,7 +267,7 @@ ROLLBACK;
 -- out of order segmentby index, index is still usable
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (label, device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK (label, device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 INFO:  Using index scan with scan keys: index 2, heap 2, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_comp_conflicts_3_time_device_label_key"
@@ -275,7 +275,7 @@ ROLLBACK;
 -- index with sequence number in the middle, index should be usable with single index scan key
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC, label);
+  CREATE INDEX covering_index ON :COMPRESSED_CHUNK (device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC, label);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 INFO:  Using index scan with scan keys: index 1, heap 3, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_comp_conflicts_3_time_device_label_key"
@@ -283,7 +283,7 @@ ROLLBACK;
 -- ignore expression index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, lower(label), _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK (device, lower(label), _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_comp_conflicts_3_time_device_label_key"
@@ -291,7 +291,7 @@ ROLLBACK;
 -- ignore non-btree index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk USING brin (device, label, _ts_meta_min_1, _ts_meta_max_1);
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK USING brin (device, label, _ts_meta_min_1, _ts_meta_max_1);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 INFO:  Using table scan with scan keys: index 0, heap 4, memory 1. 
 ERROR:  duplicate key value violates unique constraint "5_comp_conflicts_3_time_device_label_key"

--- a/tsl/test/expected/compression_create_compressed_table.out
+++ b/tsl/test/expected/compression_create_compressed_table.out
@@ -28,10 +28,12 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
+-- look up the compressed chunk relation for the chunk
+SELECT compress_relid AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_1_chunk'::regclass \gset
 -- create custom compressed chunk table
-CREATE TABLE _timescaledb_internal.custom_compressed_chunk( LIKE _timescaledb_internal.compress_hyper_2_2_chunk);
+CREATE TABLE _timescaledb_internal.custom_compressed_chunk( LIKE :COMPRESSED_CHUNK);
 -- copy compressed row from compressed table into custom compressed chunk table
-INSERT INTO "_timescaledb_internal"."custom_compressed_chunk" SELECT * FROM "_timescaledb_internal"."compress_hyper_2_2_chunk";
+INSERT INTO "_timescaledb_internal"."custom_compressed_chunk" SELECT * FROM :COMPRESSED_CHUNK;
 -- decompress the rows, moving them back to uncompressed space
 SELECT decompress_chunk('"_timescaledb_internal"."_hyper_1_1_chunk"');
             decompress_chunk            

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -115,9 +115,9 @@ INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = 
 WHERE hypertable.table_name like 'test1' \gset
 SELECT count(*) as "COUNT_CHUNKS_COMPRESSED"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1' \gset
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1' \gset
 ALTER TABLE test1 SET TABLESPACE tablespace1;
 --all chunks + both the compressed and uncompressed hypertable moved to new tablespace
 SELECT count(*) = (:COUNT_CHUNKS_UNCOMPRESSED +:COUNT_CHUNKS_COMPRESSED + 2)
@@ -134,14 +134,12 @@ FROM pg_tables WHERE tablespace = 'tablespace2';
  t
 
 SELECT
-    comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME",
+    cs.compress_relid::text as "COMPRESSED_CHUNK_NAME",
     uncomp_chunk.schema_name|| '.' || uncomp_chunk.table_name as "UNCOMPRESSED_CHUNK_NAME"
-FROM _timescaledb_catalog.chunk comp_chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (comp_chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
-INNER JOIN _timescaledb_catalog.chunk uncomp_chunk ON (cs.relid = format('%I.%I', uncomp_chunk.schema_name, uncomp_chunk.table_name)::regclass)
-WHERE uncomp_hyper.table_name like 'test1' ORDER BY comp_chunk.id LIMIT 1\gset
+FROM _timescaledb_catalog.chunk uncomp_chunk
+INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (uncomp_chunk.hypertable_id = uncomp_hyper.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', uncomp_chunk.schema_name, uncomp_chunk.table_name)::regclass)
+WHERE uncomp_hyper.table_name like 'test1' ORDER BY uncomp_chunk.id LIMIT 1\gset
 -- ensure compression chunk cannot be moved directly
 SELECT tablename
 FROM pg_tables WHERE tablespace = 'tablespace1';
@@ -251,9 +249,9 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
  count_chunks_compressed 
 -------------------------
                       27
@@ -283,9 +281,9 @@ WHERE chunk.id IS NULL;
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
  count_chunks_compressed 
 -------------------------
                       26
@@ -312,9 +310,9 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
  count_chunks_compressed 
 -------------------------
                       19
@@ -323,11 +321,11 @@ SELECT chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
-SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
+SELECT cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 \gset
 \set ON_ERROR_STOP 0
 DROP TABLE :COMPRESSED_CHUNK_NAME;
@@ -337,10 +335,9 @@ ERROR:  dropping compressed chunks not supported
 \set ON_ERROR_STOP 1
 SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
-    comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
+    cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 --create a dependent object on the compressed chunk to test cascade behaviour
@@ -363,19 +360,18 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
  count_chunks_compressed 
 -------------------------
                       18
 
 SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
-    comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
+    cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
@@ -421,9 +417,9 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
  count_chunks_compressed 
 -------------------------
                        1
@@ -519,11 +515,11 @@ SELECT count(*) FROM test1_cont_view;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET timezone TO 'America/Los_Angeles';
-SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
+SELECT cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 \gset
 SELECT add_compression_policy('test1', interval '1 day') AS compression_job_id \gset
 ALTER TABLE test1 OWNER TO :ROLE_DEFAULT_PERM_USER_2;

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -26,22 +26,23 @@ SELECT count(*) FROM  test1;
 -------
     25
 
+SELECT compress_relid AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_1_chunk'::regclass \gset
 --we have 1 compressed row --
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
 
 -- single and multi row insert into the compressed chunk --
 INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , 11, 16, 'new' ;
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
 
 INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , i, i +5, 'clay'
 FROM (Select generate_series(10, 20, 1) i ) q;
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
@@ -53,14 +54,14 @@ SELECT count(*) from test1;
 
 -- single row copy
 COPY test1 FROM STDIN DELIMITER ',';
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
 
 -- multi row copy
 COPY test1 FROM STDIN DELIMITER ',';
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
@@ -134,7 +135,7 @@ SELECT * from test1 WHERE i is NULL;
 --TEST 2 now alter the table and add a new column to it
 ALTER TABLE test1 ADD COLUMN newtcol varchar(400);
 --add rows with segments that overlap some of the previous ones
-SELECT count(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT count(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
@@ -157,7 +158,7 @@ SELECT * FROM test1 WHERE b = 16 order by 1, 2, 3, 4, 5;
  Thu Jan 02 08:16:00 2020 PST | 16 | 16 | prev16    | this is the newtcol16
 
 --number of rows in the chunk
-SELECT count(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT count(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
@@ -171,7 +172,7 @@ FROM show_chunks('test1') c;
 COPY test1 FROM STDIN DELIMITER ',';
 COPY test1 FROM STDIN DELIMITER ',';
 --number of rows in the chunk
-SELECT count(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT count(*) from :COMPRESSED_CHUNK;
  count 
 -------
      1
@@ -1496,7 +1497,7 @@ SELECT count(compress_chunk(c)) FROM show_chunks('direct_compressed_insert') c;
 -------
      1
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk ORDER BY id DESC LIMIT 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.table_name = 'direct_compressed_insert' AND cs.compress_relid IS NOT NULL ORDER BY c.id DESC LIMIT 1 \gset
 CREATE TABLE compressed_batches AS SELECT * FROM :CHUNK;
 SELECT _ts_meta_count, count(*) FROM :CHUNK GROUP BY _ts_meta_count ORDER BY 1 DESC;
  _ts_meta_count | count 

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -109,10 +109,11 @@ BEGIN;
 -------
     24
 
-  SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
-    FROM _timescaledb_catalog.chunk ch
-    JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
-    JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test2' LIMIT 1 \gset
+  SELECT cs.compress_relid::text AS "CHUNK"
+    FROM _timescaledb_catalog.compression_settings cs
+    JOIN _timescaledb_catalog.chunk ch ON cs.relid=format('%I.%I',ch.schema_name,ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht2 ON ch.hypertable_id=ht2.id AND ht2.table_name='test2'
+    WHERE cs.compress_relid IS NOT NULL LIMIT 1 \gset
   -- We want to sure we are not fully recompressing them which will make
   -- the chunk contain multiple batches per segment group
   SELECT count(*)
@@ -139,10 +140,11 @@ BEGIN;
 -------
     24
 
-  SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
-    FROM _timescaledb_catalog.chunk ch
-    JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
-    JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test2' LIMIT 1 \gset
+  SELECT cs.compress_relid::text AS "CHUNK"
+    FROM _timescaledb_catalog.compression_settings cs
+    JOIN _timescaledb_catalog.chunk ch ON cs.relid=format('%I.%I',ch.schema_name,ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht2 ON ch.hypertable_id=ht2.id AND ht2.table_name='test2'
+    WHERE cs.compress_relid IS NOT NULL LIMIT 1 \gset
   -- Not using time as first column in orderby makes the merged chunks unordered
   -- We want to sure we are fully recompressing them which will make only
   -- a single batch per segment group
@@ -299,14 +301,14 @@ SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
  _timescaledb_internal._hyper_9_190_chunk
  _timescaledb_internal._hyper_9_190_chunk
 
-SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
-  FROM _timescaledb_catalog.chunk ch
-  JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
-  JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test5' \gset
-SELECT format('%I.%I', schemaname, indexname) AS "INDEXNAME"
+SELECT cs.compress_relid::text AS "CHUNK"
+  FROM _timescaledb_catalog.compression_settings cs
+  JOIN _timescaledb_catalog.chunk ch ON cs.relid=format('%I.%I',ch.schema_name,ch.table_name)::regclass
+  JOIN _timescaledb_catalog.hypertable ht2 ON ch.hypertable_id=ht2.id AND ht2.table_name='test5'
+  WHERE cs.compress_relid IS NOT NULL \gset
+SELECT format('%I.%I', i.schemaname, i.indexname) AS "INDEXNAME"
 FROM pg_indexes i
-INNER JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name and i.tablename = cc.table_name
-INNER JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
+INNER JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', i.schemaname, i.tablename)::regclass
 LIMIT 1 \gset
 DROP INDEX :INDEXNAME;
 -- Merging works without indexes on compressed chunks

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -141,11 +141,12 @@ ORDER BY device_id DESC, time DESC;
 
 -- modify two chunks by adding sequence number to the segments
 -- and rebuild the index based on that column
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -164,11 +165,12 @@ DROP INDEX :CHUNK_INDEX;
 CREATE INDEX ON :CHUNK_FULL_NAME (device_id, _ts_meta_sequence_num);
 SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id OFFSET 2 LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -403,11 +405,12 @@ ORDER BY time;
                      Output: compress_hyper_2_17_chunk._ts_meta_count, compress_hyper_2_17_chunk._ts_meta_min_1, compress_hyper_2_17_chunk._ts_meta_max_1, compress_hyper_2_17_chunk._ts_meta_v2_first_time, compress_hyper_2_17_chunk._ts_meta_v2_last_time, compress_hyper_2_17_chunk."time", compress_hyper_2_17_chunk.device_id, compress_hyper_2_17_chunk.val
 
 -- modify two chunks by adding sequence number to the segments
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id LIMIT 1 \gset
 SET ROLE :ROLE_SUPERUSER;
 SET timescaledb.restoring TO ON;
@@ -420,11 +423,12 @@ ORDER BY _ts_meta_min_1, _ts_meta_max_1;
 DELETE FROM :CHUNK_FULL_NAME WHERE _ts_meta_sequence_num IS NULL;
 SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id OFFSET 3 LIMIT 1 \gset
 SET ROLE :ROLE_SUPERUSER;
 SET timescaledb.restoring TO ON;
@@ -515,11 +519,12 @@ SELECT compress_chunk(show_chunks('hyper'));
  _timescaledb_internal._hyper_1_21_chunk
 
 VACUUM ANALYZE hyper;
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id LIMIT 1 \gset
 SET ROLE :ROLE_SUPERUSER;
 SELECT :'CHUNK_FULL_NAME'::regclass::oid as "CHUNK_OID" \gset

--- a/tsl/test/expected/compression_sorted_merge_unordered.out
+++ b/tsl/test/expected/compression_sorted_merge_unordered.out
@@ -1633,13 +1633,13 @@ set index = '[{"type": "minmax", "column": "val", "source": "orderby"}, {"type":
 where relid = 't'::regclass;
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "val", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
+where compress_relid = (select compress_relid from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't') limit 1));
 -- Use minmax index on (val DESC, time DESC) instead
-select schema_name || '.' || table_name comp_chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+select compress_relid::text comp_chunk from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't') limit 1)
 \gset

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -278,14 +278,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_3_6_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- there should 2 rows matching the conditions coming from 2 chunks
 SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
@@ -427,14 +429,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_5_10_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- there should 2 rows matching the conditions coming from 2 chunks
 SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
@@ -593,14 +597,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_9_20_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get total rowcount from compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -690,14 +696,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_11_24_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 SELECT COUNT(*) FROM sample_table WHERE val = 1234;
  count 
@@ -805,14 +813,16 @@ SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
 
 ROLLBACK;
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get total rowcount from compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -931,14 +941,16 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- ensure segment by column index position in compressed and uncompressed
 -- chunk is different
@@ -1123,9 +1135,10 @@ SELECT * FROM sample_table WHERE c4 IS NULL;
 
 ROLLBACK;
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id \gset
 -- report 2 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -1193,9 +1206,10 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id LIMIT 1 \gset
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- check that you uncompress and delete only for exact SEGMENTBY value
 SET timescaledb.debug_compression_path_info TO true;
@@ -1959,13 +1973,13 @@ WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
-SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT cs.compress_relid::text AS "COMP_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
-ORDER BY ch2.id LIMIT 1 \gset
+AND cs.compress_relid IS NOT NULL
+ORDER BY ch1.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column
 BEGIN;
@@ -2200,9 +2214,16 @@ SELECT compress_chunk(show_chunks('tab1'));
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 \gset
+SELECT cs.compress_relid::text AS "CHUNK" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL \gset
+-- find the default index on the compressed chunk
+SELECT format('%I.%I', n.nspname, i.relname) AS "COMPRESSED_CHUNK_INDEX"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_index idx ON idx.indrelid = cs.compress_relid
+JOIN pg_class i ON i.oid = idx.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+WHERE cs.compress_relid = :'CHUNK'::regclass \gset
 -- create multiple indexes on compressed hypertable
-DROP INDEX _timescaledb_internal.compress_hyper_2_2_chunk_device_id_filler_1_filler_2_filler_idx;
+DROP INDEX :COMPRESSED_CHUNK_INDEX;
 CREATE INDEX ON :CHUNK (_ts_meta_min_1);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_count);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_max_1, filler_1);
@@ -2297,8 +2318,8 @@ SELECT compress_chunk(c) FROM show_chunks('t6367') c;
  _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_2_chunk
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK1" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 \gset
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK2" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 OFFSET 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK1" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK2" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 OFFSET 1 \gset
 SELECT format('%I.%I', i.schemaname, i.indexname) AS "CHUNK1_INDEX"
 FROM pg_indexes i
 WHERE format('%I.%I', i.schemaname, i.tablename) = :'CHUNK1'

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -278,14 +278,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_3_6_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- there should 2 rows matching the conditions coming from 2 chunks
 SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
@@ -427,14 +429,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_5_10_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- there should 2 rows matching the conditions coming from 2 chunks
 SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
@@ -593,14 +597,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_9_20_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get total rowcount from compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -690,14 +696,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_11_24_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 SELECT COUNT(*) FROM sample_table WHERE val = 1234;
  count 
@@ -805,14 +813,16 @@ SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
 
 ROLLBACK;
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get total rowcount from compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -931,14 +941,16 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- ensure segment by column index position in compressed and uncompressed
 -- chunk is different
@@ -1123,9 +1135,10 @@ SELECT * FROM sample_table WHERE c4 IS NULL;
 
 ROLLBACK;
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id \gset
 -- report 2 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -1193,9 +1206,10 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id LIMIT 1 \gset
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- check that you uncompress and delete only for exact SEGMENTBY value
 SET timescaledb.debug_compression_path_info TO true;
@@ -1965,13 +1979,13 @@ WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
-SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT cs.compress_relid::text AS "COMP_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
-ORDER BY ch2.id LIMIT 1 \gset
+AND cs.compress_relid IS NOT NULL
+ORDER BY ch1.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column
 BEGIN;
@@ -2206,9 +2220,16 @@ SELECT compress_chunk(show_chunks('tab1'));
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 \gset
+SELECT cs.compress_relid::text AS "CHUNK" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL \gset
+-- find the default index on the compressed chunk
+SELECT format('%I.%I', n.nspname, i.relname) AS "COMPRESSED_CHUNK_INDEX"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_index idx ON idx.indrelid = cs.compress_relid
+JOIN pg_class i ON i.oid = idx.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+WHERE cs.compress_relid = :'CHUNK'::regclass \gset
 -- create multiple indexes on compressed hypertable
-DROP INDEX _timescaledb_internal.compress_hyper_2_2_chunk_device_id_filler_1_filler_2_filler_idx;
+DROP INDEX :COMPRESSED_CHUNK_INDEX;
 CREATE INDEX ON :CHUNK (_ts_meta_min_1);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_count);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_max_1, filler_1);
@@ -2303,8 +2324,8 @@ SELECT compress_chunk(c) FROM show_chunks('t6367') c;
  _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_2_chunk
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK1" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 \gset
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK2" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 OFFSET 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK1" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK2" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 OFFSET 1 \gset
 SELECT format('%I.%I', i.schemaname, i.indexname) AS "CHUNK1_INDEX"
 FROM pg_indexes i
 WHERE format('%I.%I', i.schemaname, i.tablename) = :'CHUNK1'

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -278,14 +278,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_3_6_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- there should 2 rows matching the conditions coming from 2 chunks
 SELECT * FROM sample_table WHERE  device_id = 3 ORDER BY time, device_id;
@@ -427,14 +429,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_5_10_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- there should 2 rows matching the conditions coming from 2 chunks
 SELECT * FROM sample_table WHERE time = 1 AND val = 2 ORDER BY time, device_id;
@@ -593,14 +597,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_9_20_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get total rowcount from compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -690,14 +696,16 @@ SELECT compress_chunk(show_chunks('sample_table'));
  _timescaledb_internal._hyper_11_24_chunk
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 SELECT COUNT(*) FROM sample_table WHERE val = 1234;
  count 
@@ -805,14 +813,16 @@ SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
 
 ROLLBACK;
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get total rowcount from compressed chunks
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -931,14 +941,16 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 -- ensure segment by column index position in compressed and uncompressed
 -- chunk is different
@@ -1123,9 +1135,10 @@ SELECT * FROM sample_table WHERE c4 IS NULL;
 
 ROLLBACK;
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id \gset
 -- report 2 rows
 SELECT COUNT(*) FROM :COMPRESS_CHUNK_1;
@@ -1193,9 +1206,10 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
 WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id LIMIT 1 \gset
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 -- check that you uncompress and delete only for exact SEGMENTBY value
 SET timescaledb.debug_compression_path_info TO true;
@@ -1965,13 +1979,13 @@ WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
-SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT cs.compress_relid::text AS "COMP_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
-ORDER BY ch2.id LIMIT 1 \gset
+AND cs.compress_relid IS NOT NULL
+ORDER BY ch1.id LIMIT 1 \gset
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 -- test index on single column
 BEGIN;
@@ -2206,9 +2220,16 @@ SELECT compress_chunk(show_chunks('tab1'));
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 \gset
+SELECT cs.compress_relid::text AS "CHUNK" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL \gset
+-- find the default index on the compressed chunk
+SELECT format('%I.%I', n.nspname, i.relname) AS "COMPRESSED_CHUNK_INDEX"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_index idx ON idx.indrelid = cs.compress_relid
+JOIN pg_class i ON i.oid = idx.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+WHERE cs.compress_relid = :'CHUNK'::regclass \gset
 -- create multiple indexes on compressed hypertable
-DROP INDEX _timescaledb_internal.compress_hyper_2_2_chunk_device_id_filler_1_filler_2_filler_idx;
+DROP INDEX :COMPRESSED_CHUNK_INDEX;
 CREATE INDEX ON :CHUNK (_ts_meta_min_1);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_count);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_max_1, filler_1);
@@ -2303,8 +2324,8 @@ SELECT compress_chunk(c) FROM show_chunks('t6367') c;
  _timescaledb_internal._hyper_1_1_chunk
  _timescaledb_internal._hyper_1_2_chunk
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK1" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 \gset
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK2" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 OFFSET 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK1" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK2" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 OFFSET 1 \gset
 SELECT format('%I.%I', i.schemaname, i.indexname) AS "CHUNK1_INDEX"
 FROM pg_indexes i
 WHERE format('%I.%I', i.schemaname, i.tablename) = :'CHUNK1'

--- a/tsl/test/expected/decompress_batch.out
+++ b/tsl/test/expected/decompress_batch.out
@@ -19,9 +19,9 @@ SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
  _timescaledb_internal._hyper_1_1_chunk
 
 -- Capture the compressed chunk relation name
-SELECT format('%I.%I', cc.schema_name, cc.table_name) AS compressed_chunk
+SELECT cs.compress_relid::text AS compressed_chunk
 FROM _timescaledb_catalog.chunk c
-JOIN _timescaledb_catalog.chunk cc ON c.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id
 WHERE h.table_name = 'metrics' \gset
 -- Verify set equality: no source row missing, no extra row introduced

--- a/tsl/test/expected/direct_compress_copy.out
+++ b/tsl/test/expected/direct_compress_copy.out
@@ -151,7 +151,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
  Custom Scan (ColumnarScan) on _hyper_1_23_chunk (actual rows=50.00 loops=1)
    ->  Seq Scan on compress_hyper_2_24_chunk (actual rows=10.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
  count 

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -239,7 +239,7 @@ SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, ti
 ------------------------------+------------------------------
  Wed Jan 01 00:00:00 2025 PST | Sat Jan 04 02:00:00 2025 PST
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 desc limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
  _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
@@ -282,7 +282,7 @@ SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, ti
 ------------------------------+------------------------------
  Wed Jan 01 00:00:00 2025 PST | Tue Jan 07 02:00:00 2025 PST
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 desc limit 1 \gset
 -- should not see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
  _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        
@@ -315,7 +315,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
  Custom Scan (ColumnarScan) on _hyper_1_33_chunk (actual rows=50.00 loops=1)
    ->  Seq Scan on compress_hyper_2_34_chunk (actual rows=10.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
  count 
@@ -345,7 +345,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
    ->  Custom Scan (ColumnarScan) on _hyper_1_37_chunk (actual rows=5042.00 loops=1)
          ->  Seq Scan on compress_hyper_2_38_chunk (actual rows=8.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 desc limit 1 \gset
 -- should see overlapping batches per device
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, device from :COMPRESSED_CHUNK order by 4, 2;
  _ts_meta_count |        _ts_meta_min_1        |        _ts_meta_max_1        | device 
@@ -382,7 +382,7 @@ EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM
    ->  Custom Scan (ColumnarScan) on _hyper_1_41_chunk (actual rows=2522.00 loops=1)
          ->  Seq Scan on compress_hyper_2_42_chunk (actual rows=4.00 loops=1)
 
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_min_2, _ts_meta_max_2 from :COMPRESSED_CHUNK order by 2, 4;
  _ts_meta_count | _ts_meta_min_1 | _ts_meta_max_1 |        _ts_meta_min_2        |        _ts_meta_max_2        

--- a/tsl/test/expected/rebuild_columnstore_tests.out
+++ b/tsl/test/expected/rebuild_columnstore_tests.out
@@ -7,11 +7,10 @@ CREATE VIEW chunk_status_view AS
 SELECT
     h.table_name AS hypertable_name,
     uc.schema_name || '.' || uc.table_name AS chunk,
-    cc.schema_name || '.' || cc.table_name AS compressed_chunk,
+    cs.compress_relid::text AS compressed_chunk,
     _timescaledb_functions.chunk_status_text((uc.schema_name || '.' || uc.table_name)::regclass) AS status
 FROM _timescaledb_catalog.chunk uc
 LEFT JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-LEFT JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h ON uc.hypertable_id = h.id;
 SET timescaledb.enable_direct_compress_insert = true;
 -- Test 1: Rebuild fully compressed (ordered) chunk

--- a/tsl/test/expected/rebuild_sparse_index.out
+++ b/tsl/test/expected/rebuild_sparse_index.out
@@ -8,11 +8,9 @@ RETURNS TABLE(attname name, typname name) AS $$
     FROM pg_attribute a
     JOIN pg_type t ON a.atttypid = t.oid
     WHERE a.attrelid = (
-        SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass
-        FROM _timescaledb_catalog.chunk uc
-        JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-        JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-        WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass
+        SELECT cs.compress_relid
+        FROM _timescaledb_catalog.compression_settings cs
+        WHERE cs.relid = chunk_regclass
     )
     AND a.attname LIKE '_ts_meta_%'
     AND a.attnum > 0
@@ -238,11 +236,9 @@ DECLARE
     compressed_relid oid;
     col_list text;
 BEGIN
-    SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass INTO compressed_relid
-    FROM _timescaledb_catalog.chunk uc
-    JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-    JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-    WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass;
+    SELECT cs.compress_relid INTO compressed_relid
+    FROM _timescaledb_catalog.compression_settings cs
+    WHERE cs.relid = chunk_regclass;
 
     SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY a.attname) INTO col_list
     FROM pg_attribute a
@@ -273,16 +269,16 @@ SELECT compress_chunk(:'ichunk2');
 ----------------------------------------
  _timescaledb_internal._hyper_3_5_chunk
 
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
-SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema2, comp_cl.relname AS ic_table2
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk2'::regclass \gset
 \o :ORIGINAL
 SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
 SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
@@ -357,16 +353,16 @@ SELECT compress_chunk(:'ichunk2');
  _timescaledb_internal._hyper_3_5_chunk
 
 -- re-fetch compressed chunk names after recompress
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
-SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema2, comp_cl.relname AS ic_table2
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk2'::regclass \gset
 \o :ORIGINAL
 SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
 SELECT * FROM dump_sparse_metadata(:'ichunk2'::regclass);
@@ -435,11 +431,11 @@ SELECT compress_chunk(:'ichunk1');
 ----------------------------------------
  _timescaledb_internal._hyper_3_4_chunk
 
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
 ALTER TABLE rsi_integrity SET (
     timescaledb.compress,
     timescaledb.compress_segmentby = 'device',
@@ -540,11 +536,11 @@ SELECT compress_chunk(:'ichunk1');
 ----------------------------------------
  _timescaledb_internal._hyper_3_4_chunk
 
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
 ALTER TABLE rsi_integrity SET (
     timescaledb.compress,
     timescaledb.compress_segmentby = 'device',

--- a/tsl/test/expected/recompress_chunk_segmentwise.out
+++ b/tsl/test/expected/recompress_chunk_segmentwise.out
@@ -9,16 +9,14 @@ SELECT
    c.schema_name as chunk_schema,
    c.table_name as chunk_name,
    c.status as chunk_status,
-   comp.schema_name as compressed_chunk_schema,
-   comp.table_name as compressed_chunk_name,
+   (select nspname from pg_class cl join pg_namespace n on n.oid = cl.relnamespace where cl.oid = cs.compress_relid) as compressed_chunk_schema,
+   (select relname from pg_class cl where cl.oid = cs.compress_relid) as compressed_chunk_name,
    c.id as chunk_id
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
    LEFT JOIN _timescaledb_catalog.compression_settings cs
 ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
-   LEFT JOIN _timescaledb_catalog.chunk comp
-ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 CREATE OR REPLACE VIEW compression_rowcnt_view AS
 select ccs.numrows_pre_compression, ccs.numrows_post_compression,

--- a/tsl/test/expected/recompression_nullable_orderby.out
+++ b/tsl/test/expected/recompression_nullable_orderby.out
@@ -29,13 +29,13 @@ set index = '[{"type": "minmax", "column": "v1", "source": "orderby"}, {"type": 
 where relid = 't1'::regclass;
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "v1", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
+where compress_relid = (select compress_relid from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't1') limit 1));
 -- Use minmax index on (v1, time DESC) instead
-select schema_name || '.' || table_name comp_chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+select compress_relid::text comp_chunk from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't1') limit 1)
 \gset
@@ -123,13 +123,13 @@ set index = '[{"type": "minmax", "column": "v1", "source": "orderby"}, {"type": 
 where relid = 't2'::regclass;
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "v1", "source": "orderby"}, {"type": "firstlast", "column": "v1", "source": "orderby"}, {"type": "minmax", "column": "v2", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}, {"type": "firstlast", "column": "time", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
+where compress_relid = (select compress_relid from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't2') limit 1));
 -- Use minmax index on (v1, v2, time DESC) instead
-select schema_name || '.' || table_name comp_chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+select compress_relid::text comp_chunk from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't2') limit 1)
 \gset

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -57,10 +57,13 @@ SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_intern
 
 SELECT compress_chunk(i) FROM show_chunks('test1') i;
 
+SELECT compress_relid AS "COMPRESSED_CHUNK_1" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_1_chunk'::regclass \gset
+SELECT compress_relid AS "COMPRESSED_CHUNK_2" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_2_chunk'::regclass \gset
+
 \set ON_ERROR_STOP 0
 
 -- Cannot merge chunks internal compressed chunks, no dimensions on them.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_10_chunk','_timescaledb_internal.compress_hyper_2_11_chunk', 1);
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension(:'COMPRESSED_CHUNK_1',:'COMPRESSED_CHUNK_2', 1);
 
 \set ON_ERROR_STOP 1
 

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -927,7 +927,7 @@ COPY :CHUNK FROM STDIN;
 SELECT _timescaledb_functions.unfreeze_chunk(:'CHUNK');
 SELECT compress_chunk(:'CHUNK');
 SELECT _timescaledb_functions.freeze_chunk(:'CHUNK');
-SELECT format('%I.%I', schema_name, table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk ORDER BY id DESC LIMIT 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE relid = :'CHUNK'::regclass \gset
 
 -- DML on hypertable after freezing should be blocked
 \set ON_ERROR_STOP 0

--- a/tsl/test/sql/compress_bloom_sparse_debug.sql
+++ b/tsl/test/sql/compress_bloom_sparse_debug.sql
@@ -135,13 +135,11 @@ select count(compress_chunk(x)) from show_chunks('detoaster') x;
 
 with chunks as (
   select
-    row_number() over (order by cc.table_name) index,
-    cc.schema_name || '.' || cc.table_name chunk
+    row_number() over (order by cs.compress_relid::text) index,
+    cs.compress_relid::text chunk
   from _timescaledb_catalog.chunk ch
     join _timescaledb_catalog.compression_settings cs
       on cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
-    join _timescaledb_catalog.chunk cc
-      on cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
   where ch.hypertable_id = (select id from _timescaledb_catalog.hypertable
         where table_name = 'detoaster')
 )

--- a/tsl/test/sql/compress_firstlast_sparse.sql
+++ b/tsl/test/sql/compress_firstlast_sparse.sql
@@ -38,9 +38,8 @@ alter table fl_basic set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_basic') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_basic')
 \gset
@@ -61,9 +60,8 @@ alter table fl_nulls set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_nulls') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_nulls')
 \gset
@@ -85,9 +83,8 @@ alter table fl_mixed set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_mixed') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_mixed')
 \gset
@@ -108,9 +105,8 @@ alter table fl_firstnull set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_firstnull') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_firstnull')
 \gset
@@ -131,9 +127,8 @@ alter table fl_lastnull set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_lastnull') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_lastnull')
 \gset
@@ -154,9 +149,8 @@ alter table fl_single set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_single') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_single')
 \gset
@@ -176,9 +170,8 @@ alter table fl_multi set (timescaledb.compress,
     timescaledb.compress_index = 'firstlast("value")');
 select count(compress_chunk(x)) from show_chunks('fl_multi') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_multi')
 \gset
@@ -202,9 +195,8 @@ select count(compress_chunk(x)) from show_chunks('fl_recompress') x;
 insert into fl_recompress values (6, 600);
 select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_recompress') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_recompress')
 \gset
@@ -333,12 +325,11 @@ select count(compress_chunk(x)) from show_chunks('fl_push_recompress') x;
 insert into fl_push_recompress values (1600, 16000);
 select count(compress_chunk(x, recompress:=true)) from show_chunks('fl_push_recompress') x;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'fl_push_recompress')
-order by ch.id
+order by uc.id desc
 limit 1
 \gset
 
@@ -375,12 +366,11 @@ SELECT i, i FROM generate_series(101, 200) i;
 -- Should work correctly after renaming
 SELECT compress_chunk(c) FROM show_chunks('sensor_readings') c;
 
-select ch.schema_name || '.' || ch.table_name as compressed_chunk
-from _timescaledb_catalog.chunk ch
-inner join _timescaledb_catalog.compression_settings cs on cs.compress_relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+select cs.compress_relid::text as compressed_chunk
+from _timescaledb_catalog.compression_settings cs
 inner join _timescaledb_catalog.chunk uc on cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
 where uc.hypertable_id = (select id from _timescaledb_catalog.hypertable where table_name = 'sensor_readings')
-order by ch.id
+order by uc.id
 limit 1
 \gset
 -- should see firstlast metadata columns also renamed

--- a/tsl/test/sql/compressed_collation.sql
+++ b/tsl/test/sql/compressed_collation.sql
@@ -42,11 +42,13 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('compressed_collation_ht') ch;
 
 vacuum analyze compressed_collation_ht;
 
-SELECT format('%I.%I',ch.schema_name, ch.table_name) AS "CHUNK"
+SELECT cs.compress_relid::text AS "CHUNK"
 FROM _timescaledb_catalog.hypertable ht
     INNER JOIN _timescaledb_catalog.chunk ch
-    ON ch.hypertable_id = ht.compressed_hypertable_id
-        AND ht.table_name = 'compressed_collation_ht' \gset
+    ON ch.hypertable_id = ht.id
+    INNER JOIN _timescaledb_catalog.compression_settings cs
+    ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+WHERE ht.table_name = 'compressed_collation_ht' \gset
 
 create index on :CHUNK (name);
 

--- a/tsl/test/sql/compression_conflicts.sql
+++ b/tsl/test/sql/compression_conflicts.sql
@@ -148,12 +148,13 @@ INSERT INTO comp_conflicts_3 VALUES ('2020-01-01',NULL, 'label', 0.3);
 SELECT compress_chunk(c) AS "CHUNK" FROM show_chunks('comp_conflicts_3') c
 \gset
 
-SELECT format('%I.%I', i.schemaname, i.indexname) AS "COMPRESSED_CHUNK_INDEX"
-FROM pg_indexes i
-JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name AND i.tablename = cc.table_name
-JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk uc ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name) = :'CHUNK'
+SELECT cs.compress_relid AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings cs WHERE cs.relid = :'CHUNK'::regclass \gset
+
+SELECT format('%I.%I', n.nspname, i.relname) AS "COMPRESSED_CHUNK_INDEX"
+FROM pg_index idx
+JOIN pg_class i ON i.oid = idx.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+WHERE idx.indrelid = :'COMPRESSED_CHUNK'::regclass
 LIMIT 1 \gset
 
 -- after compression no data should be in uncompressed chunk
@@ -190,7 +191,7 @@ set timescaledb.debug_compression_path_info to on;
 -- ignore matching partial index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, label, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK (device, label, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC)
 	WHERE label LIKE 'missing';
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
@@ -198,35 +199,35 @@ ROLLBACK;
 -- ignore matching covering index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device) INCLUDE (label, _ts_meta_min_1, _ts_meta_max_1);
+  CREATE INDEX covering_index ON :COMPRESSED_CHUNK (device) INCLUDE (label, _ts_meta_min_1, _ts_meta_max_1);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 
 -- out of order segmentby index, index is still usable
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (label, device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK (label, device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 
 -- index with sequence number in the middle, index should be usable with single index scan key
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX covering_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC, label);
+  CREATE INDEX covering_index ON :COMPRESSED_CHUNK (device, _ts_meta_min_1 DESC, _ts_meta_max_1 DESC, label);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 
 -- ignore expression index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk (device, lower(label), _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK (device, lower(label), _ts_meta_min_1 DESC, _ts_meta_max_1 DESC);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 
 -- ignore non-btree index
 BEGIN;
   DROP INDEX :COMPRESSED_CHUNK_INDEX;
-  CREATE INDEX partial_index ON _timescaledb_internal.compress_hyper_6_6_chunk USING brin (device, label, _ts_meta_min_1, _ts_meta_max_1);
+  CREATE INDEX partial_index ON :COMPRESSED_CHUNK USING brin (device, label, _ts_meta_min_1, _ts_meta_max_1);
   INSERT INTO comp_conflicts_3 VALUES ('2020-01-01','d1', 'label', 0.1);
 ROLLBACK;
 \set ON_ERROR_STOP 1

--- a/tsl/test/sql/compression_create_compressed_table.sql
+++ b/tsl/test/sql/compression_create_compressed_table.sql
@@ -22,11 +22,14 @@ SELECT count(*) FROM _timescaledb_internal._hyper_1_1_chunk;
 -- compress these rows, we do this to get compressed row data for the test
 SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 
+-- look up the compressed chunk relation for the chunk
+SELECT compress_relid AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_1_chunk'::regclass \gset
+
 -- create custom compressed chunk table
-CREATE TABLE _timescaledb_internal.custom_compressed_chunk( LIKE _timescaledb_internal.compress_hyper_2_2_chunk);
+CREATE TABLE _timescaledb_internal.custom_compressed_chunk( LIKE :COMPRESSED_CHUNK);
 
 -- copy compressed row from compressed table into custom compressed chunk table
-INSERT INTO "_timescaledb_internal"."custom_compressed_chunk" SELECT * FROM "_timescaledb_internal"."compress_hyper_2_2_chunk";
+INSERT INTO "_timescaledb_internal"."custom_compressed_chunk" SELECT * FROM :COMPRESSED_CHUNK;
 
 -- decompress the rows, moving them back to uncompressed space
 SELECT decompress_chunk('"_timescaledb_internal"."_hyper_1_1_chunk"');

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -81,9 +81,9 @@ WHERE hypertable.table_name like 'test1' \gset
 
 SELECT count(*) as "COUNT_CHUNKS_COMPRESSED"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1' \gset
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1' \gset
 
 ALTER TABLE test1 SET TABLESPACE tablespace1;
 
@@ -96,14 +96,12 @@ SELECT count(*) = (:COUNT_CHUNKS_UNCOMPRESSED +:COUNT_CHUNKS_COMPRESSED + 2)
 FROM pg_tables WHERE tablespace = 'tablespace2';
 
 SELECT
-    comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME",
+    cs.compress_relid::text as "COMPRESSED_CHUNK_NAME",
     uncomp_chunk.schema_name|| '.' || uncomp_chunk.table_name as "UNCOMPRESSED_CHUNK_NAME"
-FROM _timescaledb_catalog.chunk comp_chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (comp_chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
-INNER JOIN _timescaledb_catalog.chunk uncomp_chunk ON (cs.relid = format('%I.%I', uncomp_chunk.schema_name, uncomp_chunk.table_name)::regclass)
-WHERE uncomp_hyper.table_name like 'test1' ORDER BY comp_chunk.id LIMIT 1\gset
+FROM _timescaledb_catalog.chunk uncomp_chunk
+INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (uncomp_chunk.hypertable_id = uncomp_hyper.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', uncomp_chunk.schema_name, uncomp_chunk.table_name)::regclass)
+WHERE uncomp_hyper.table_name like 'test1' ORDER BY uncomp_chunk.id LIMIT 1\gset
 
 -- ensure compression chunk cannot be moved directly
 SELECT tablename
@@ -171,9 +169,9 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
 
 
 SELECT chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME"
@@ -197,9 +195,9 @@ WHERE chunk.id IS NULL;
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
 
 SELECT drop_chunks('test1', older_than => '2018-03-10'::TIMESTAMPTZ);
 
@@ -211,20 +209,20 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
 
 SELECT chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 
-SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
+SELECT cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 \gset
 
 \set ON_ERROR_STOP 0
@@ -234,10 +232,9 @@ SELECT _timescaledb_functions.drop_chunk(:'COMPRESSED_CHUNK_NAME');
 
 SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
-    comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
+    cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 
@@ -259,16 +256,15 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
 
 SELECT
     chunk.schema_name|| '.' || chunk.table_name as "UNCOMPRESSED_CHUNK_NAME",
-    comp_chunk.schema_name|| '.' || comp_chunk.table_name as "COMPRESSED_CHUNK_NAME"
+    cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
-INNER JOIN _timescaledb_catalog.chunk comp_chunk ON (cs.compress_relid = format('%I.%I', comp_chunk.schema_name, comp_chunk.table_name)::regclass)
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 
@@ -292,9 +288,9 @@ WHERE hypertable.table_name like 'test1';
 
 SELECT count(*) as count_chunks_compressed
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1';
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1';
 
 --make sure there are no orphaned  _timescaledb_catalog.compression_chunk_size entries (should be 0)
 SELECT count(*) as orphaned_compression_chunk_size
@@ -366,11 +362,11 @@ SELECT count(*) FROM test1_cont_view;
 
 SET timezone TO 'America/Los_Angeles';
 
-SELECT chunk.schema_name|| '.' || chunk.table_name as "COMPRESSED_CHUNK_NAME"
+SELECT cs.compress_relid::text as "COMPRESSED_CHUNK_NAME"
 FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = comp_hyper.id)
-INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
-WHERE uncomp_hyper.table_name like 'test1' ORDER BY chunk.id LIMIT 1
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass)
+WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1
 \gset
 
 SELECT add_compression_policy('test1', interval '1 day') AS compression_job_id \gset

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -20,16 +20,18 @@ FROM show_chunks('test1') c;
 
 SELECT count(*) FROM  test1;
 
+SELECT compress_relid AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE relid = '_timescaledb_internal._hyper_1_1_chunk'::regclass \gset
+
 --we have 1 compressed row --
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
 
 -- single and multi row insert into the compressed chunk --
 INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , 11, 16, 'new' ;
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
 
 INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , i, i +5, 'clay'
 FROM (Select generate_series(10, 20, 1) i ) q;
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
 
 SELECT count(*) from test1;
 
@@ -37,7 +39,7 @@ SELECT count(*) from test1;
 COPY test1 FROM STDIN DELIMITER ',';
 2020-01-02 11:16:00-05,11,16,copy
 \.
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
 
 -- multi row copy
 COPY test1 FROM STDIN DELIMITER ',';
@@ -45,7 +47,7 @@ COPY test1 FROM STDIN DELIMITER ',';
 2020-01-02 11:16:00-05,12,17,multicopy
 2020-01-02 11:16:00-05,13,18,multicopy
 \.
-SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT COUNT(*) from :COMPRESSED_CHUNK;
 
 --Verify that all the data went into the initial chunk
 SELECT count(*)
@@ -74,14 +76,14 @@ SELECT * from test1 WHERE i is NULL;
 --TEST 2 now alter the table and add a new column to it
 ALTER TABLE test1 ADD COLUMN newtcol varchar(400);
 --add rows with segments that overlap some of the previous ones
-SELECT count(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT count(*) from :COMPRESSED_CHUNK;
 INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , 100, 101, 'prev101', 'this is the newtcol101';
 INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , i, 16, 'prev16', 'this is the newtcol16'
 FROM (Select generate_series(11, 16, 1) i ) q;
 SELECT * FROM test1 WHERE b = 16 order by 1, 2, 3, 4, 5;
 
 --number of rows in the chunk
-SELECT count(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT count(*) from :COMPRESSED_CHUNK;
 SELECT count(*)
 FROM show_chunks('test1') c;
 
@@ -96,7 +98,7 @@ COPY test1 FROM STDIN DELIMITER ',';
 \.
 
 --number of rows in the chunk
-SELECT count(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+SELECT count(*) from :COMPRESSED_CHUNK;
 SELECT count(*)
 FROM show_chunks('test1') c;
 
@@ -1121,7 +1123,7 @@ CREATE TABLE direct_compressed_insert (time timestamptz) WITH (tsdb.hypertable);
 
 INSERT INTO direct_compressed_insert SELECT generate_series('2024-01-01'::timestamptz, '2024-01-01 1:00:00'::timestamptz, '1 second');
 SELECT count(compress_chunk(c)) FROM show_chunks('direct_compressed_insert') c;
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk ORDER BY id DESC LIMIT 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.table_name = 'direct_compressed_insert' AND cs.compress_relid IS NOT NULL ORDER BY c.id DESC LIMIT 1 \gset
 
 CREATE TABLE compressed_batches AS SELECT * FROM :CHUNK;
 SELECT _ts_meta_count, count(*) FROM :CHUNK GROUP BY _ts_meta_count ORDER BY 1 DESC;

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -52,10 +52,11 @@ ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i',
 -- Verify we are not generating unordered chunks
 BEGIN;
   SELECT count(compress_chunk(chunk,  true)) FROM show_chunks('test2') chunk;
-  SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
-    FROM _timescaledb_catalog.chunk ch
-    JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
-    JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test2' LIMIT 1 \gset
+  SELECT cs.compress_relid::text AS "CHUNK"
+    FROM _timescaledb_catalog.compression_settings cs
+    JOIN _timescaledb_catalog.chunk ch ON cs.relid=format('%I.%I',ch.schema_name,ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht2 ON ch.hypertable_id=ht2.id AND ht2.table_name='test2'
+    WHERE cs.compress_relid IS NOT NULL LIMIT 1 \gset
 
   -- We want to sure we are not fully recompressing them which will make
   -- the chunk contain multiple batches per segment group
@@ -72,10 +73,11 @@ ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i',
 -- Verify we are fully recompressing unordered chunks
 BEGIN;
   SELECT count(compress_chunk(chunk,  true)) FROM show_chunks('test2') chunk;
-  SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
-    FROM _timescaledb_catalog.chunk ch
-    JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
-    JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test2' LIMIT 1 \gset
+  SELECT cs.compress_relid::text AS "CHUNK"
+    FROM _timescaledb_catalog.compression_settings cs
+    JOIN _timescaledb_catalog.chunk ch ON cs.relid=format('%I.%I',ch.schema_name,ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht2 ON ch.hypertable_id=ht2.id AND ht2.table_name='test2'
+    WHERE cs.compress_relid IS NOT NULL LIMIT 1 \gset
 
   -- Not using time as first column in orderby makes the merged chunks unordered
   -- We want to sure we are fully recompressing them which will make only
@@ -155,15 +157,15 @@ SELECT
 
 SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 4;
 
-SELECT format('%I.%I',ch.schema_name,ch.table_name) AS "CHUNK"
-  FROM _timescaledb_catalog.chunk ch
-  JOIN _timescaledb_catalog.hypertable ht ON ht.id=ch.hypertable_id
-  JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name='test5' \gset
+SELECT cs.compress_relid::text AS "CHUNK"
+  FROM _timescaledb_catalog.compression_settings cs
+  JOIN _timescaledb_catalog.chunk ch ON cs.relid=format('%I.%I',ch.schema_name,ch.table_name)::regclass
+  JOIN _timescaledb_catalog.hypertable ht2 ON ch.hypertable_id=ht2.id AND ht2.table_name='test5'
+  WHERE cs.compress_relid IS NOT NULL \gset
 
-SELECT format('%I.%I', schemaname, indexname) AS "INDEXNAME"
+SELECT format('%I.%I', i.schemaname, i.indexname) AS "INDEXNAME"
 FROM pg_indexes i
-INNER JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name and i.tablename = cc.table_name
-INNER JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
+INNER JOIN _timescaledb_catalog.compression_settings cs ON cs.compress_relid = format('%I.%I', i.schemaname, i.tablename)::regclass
 LIMIT 1 \gset
 
 

--- a/tsl/test/sql/compression_sequence_num_removal.sql
+++ b/tsl/test/sql/compression_sequence_num_removal.sql
@@ -40,11 +40,12 @@ ORDER BY device_id DESC, time DESC;
 
 -- modify two chunks by adding sequence number to the segments
 -- and rebuild the index based on that column
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -65,11 +66,12 @@ CREATE INDEX ON :CHUNK_FULL_NAME (device_id, _ts_meta_sequence_num);
 SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id OFFSET 2 LIMIT 1 \gset
 SELECT schemaname || '.' || indexname AS "CHUNK_INDEX" FROM pg_indexes where tablename = :'CHUNK_NAME'
 LIMIT 1 \gset
@@ -129,11 +131,12 @@ VACUUM ANALYZE hyper;
 ORDER BY time;
 
 -- modify two chunks by adding sequence number to the segments
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id LIMIT 1 \gset
 
 SET ROLE :ROLE_SUPERUSER;
@@ -148,11 +151,12 @@ DELETE FROM :CHUNK_FULL_NAME WHERE _ts_meta_sequence_num IS NULL;
 SET timescaledb.restoring TO OFF;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id OFFSET 3 LIMIT 1 \gset
 
 SET ROLE :ROLE_SUPERUSER;
@@ -197,11 +201,12 @@ INSERT INTO hyper VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2)
 SELECT compress_chunk(show_chunks('hyper'));
 VACUUM ANALYZE hyper;
 
-SELECT comp_ch.table_name AS "CHUNK_NAME", comp_ch.schema_name|| '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk comp_ch, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT comp_cl.relname AS "CHUNK_NAME", comp_ns.nspname || '.' || comp_cl.relname AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs,
+     pg_class comp_cl, pg_namespace comp_ns
 WHERE ch1.hypertable_id = ht.id AND ht.table_name LIKE 'hyper'
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', comp_ch.schema_name, comp_ch.table_name)::regclass
+AND cs.compress_relid = comp_cl.oid AND comp_cl.relnamespace = comp_ns.oid
 ORDER BY ch1.id LIMIT 1 \gset
 
 SET ROLE :ROLE_SUPERUSER;

--- a/tsl/test/sql/compression_sorted_merge_unordered.sql
+++ b/tsl/test/sql/compression_sorted_merge_unordered.sql
@@ -517,14 +517,14 @@ where relid = 't'::regclass;
 
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "val", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
+where compress_relid = (select compress_relid from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't') limit 1));
 
 -- Use minmax index on (val DESC, time DESC) instead
-select schema_name || '.' || table_name comp_chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+select compress_relid::text comp_chunk from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't') limit 1)
 \gset

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -197,15 +197,17 @@ INSERT INTO sample_table VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11
 SELECT compress_chunk(show_chunks('sample_table'));
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 -- there should 2 rows matching the conditions coming from 2 chunks
@@ -277,15 +279,17 @@ INSERT INTO sample_table VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (1, 3, 2), (11,
 SELECT compress_chunk(show_chunks('sample_table'));
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 -- there should 2 rows matching the conditions coming from 2 chunks
@@ -379,15 +383,17 @@ INSERT INTO sample_table VALUES (1, 1, 1), (2, NULL, 1), (3, NULL, 1), (10, NULL
 SELECT compress_chunk(show_chunks('sample_table'));
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 -- get total rowcount from compressed chunks
@@ -441,15 +447,17 @@ INSERT INTO sample_table VALUES (1, NULL, 1), (2, NULL, 1), (3, NULL, 1), (10, 3
 SELECT compress_chunk(show_chunks('sample_table'));
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 SELECT COUNT(*) FROM sample_table WHERE val = 1234;
@@ -518,15 +526,17 @@ SELECT * FROM sample_table WHERE device_id = 3 AND val IS NULL;
 ROLLBACK;
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 -- get total rowcount from compressed chunks
@@ -608,15 +618,17 @@ WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get SECOND compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_2"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_2"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id DESC LIMIT 1 \gset
 
 -- ensure segment by column index position in compressed and uncompressed
@@ -714,9 +726,10 @@ SELECT * FROM sample_table WHERE c4 IS NULL;
 ROLLBACK;
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id \gset
 
 -- report 2 rows
@@ -760,9 +773,10 @@ WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE '_hyper_%'
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- get FIRST compressed chunk
-SELECT ch1.schema_name|| '.' || ch1.table_name AS "COMPRESS_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id AND ch1.table_name LIKE 'compress_%'
+SELECT cs.compress_relid::text AS "COMPRESS_CHUNK_1"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch1 ON cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
+WHERE cs.compress_relid IS NOT NULL
 ORDER BY ch1.id LIMIT 1 \gset
 
 -- check that you uncompress and delete only for exact SEGMENTBY value
@@ -1159,13 +1173,13 @@ AND ch1.hypertable_id = ht.id
 AND ch1.table_name LIKE '_hyper%'
 ORDER BY ch1.id LIMIT 1 \gset
 
-SELECT ch2.schema_name|| '.' || ch2.table_name AS "COMP_CHUNK_1"
-FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.chunk ch2, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
+SELECT cs.compress_relid::text AS "COMP_CHUNK_1"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht, _timescaledb_catalog.compression_settings cs
 WHERE ht.table_name = 'index_scan_test'
 AND ch1.hypertable_id = ht.id
 AND cs.relid = format('%I.%I', ch1.schema_name, ch1.table_name)::regclass
-AND cs.compress_relid = format('%I.%I', ch2.schema_name, ch2.table_name)::regclass
-ORDER BY ch2.id LIMIT 1 \gset
+AND cs.compress_relid IS NOT NULL
+ORDER BY ch1.id LIMIT 1 \gset
 
 INSERT INTO index_scan_test(time,device_id,value) SELECT time, device_id, device_id + 0.5 FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','1m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 
@@ -1299,10 +1313,18 @@ ALTER TABLE tab1 SET (timescaledb.compress, timescaledb.compress_orderby='time D
 
 SELECT compress_chunk(show_chunks('tab1'));
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 \gset
+SELECT cs.compress_relid::text AS "CHUNK" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL \gset
+
+-- find the default index on the compressed chunk
+SELECT format('%I.%I', n.nspname, i.relname) AS "COMPRESSED_CHUNK_INDEX"
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_index idx ON idx.indrelid = cs.compress_relid
+JOIN pg_class i ON i.oid = idx.indexrelid
+JOIN pg_namespace n ON n.oid = i.relnamespace
+WHERE cs.compress_relid = :'CHUNK'::regclass \gset
 
 -- create multiple indexes on compressed hypertable
-DROP INDEX _timescaledb_internal.compress_hyper_2_2_chunk_device_id_filler_1_filler_2_filler_idx;
+DROP INDEX :COMPRESSED_CHUNK_INDEX;
 CREATE INDEX ON :CHUNK (_ts_meta_min_1);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_count);
 CREATE INDEX ON :CHUNK (_ts_meta_min_1, _ts_meta_max_1, filler_1);
@@ -1375,8 +1397,8 @@ generate_series(1, 3, 1 ) AS g3(label);
 
 SELECT compress_chunk(c) FROM show_chunks('t6367') c;
 
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK1" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 \gset
-SELECT format('%I.%I', schema_name, table_name) AS "CHUNK2" FROM _timescaledb_catalog.chunk WHERE hypertable_id = 2 ORDER BY id LIMIT 1 OFFSET 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK1" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 \gset
+SELECT cs.compress_relid::text AS "CHUNK2" FROM _timescaledb_catalog.compression_settings cs JOIN _timescaledb_catalog.chunk c ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id WHERE h.compressed_hypertable_id = 2 AND cs.compress_relid IS NOT NULL ORDER BY c.id LIMIT 1 OFFSET 1 \gset
 
 SELECT format('%I.%I', i.schemaname, i.indexname) AS "CHUNK1_INDEX"
 FROM pg_indexes i

--- a/tsl/test/sql/decompress_batch.sql
+++ b/tsl/test/sql/decompress_batch.sql
@@ -20,9 +20,9 @@ INSERT INTO metrics VALUES ('2025-01-01 02:00', NULL, NULL);
 SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
 
 -- Capture the compressed chunk relation name
-SELECT format('%I.%I', cc.schema_name, cc.table_name) AS compressed_chunk
+SELECT cs.compress_relid::text AS compressed_chunk
 FROM _timescaledb_catalog.chunk c
-JOIN _timescaledb_catalog.chunk cc ON c.compressed_chunk_id = cc.id
+JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h ON c.hypertable_id = h.id
 WHERE h.table_name = 'metrics' \gset
 

--- a/tsl/test/sql/direct_compress_copy.sql
+++ b/tsl/test/sql/direct_compress_copy.sql
@@ -87,7 +87,7 @@ SET timescaledb.enable_direct_compress_copy = true;
 SET timescaledb.enable_direct_compress_copy_client_sorted = true;
 COPY metrics FROM PROGRAM 'seq 0 0.2 9.8 | sed -e ''s!.[0-9]$!!'' | xargs -II date -d "2025-01-01 - I minute" +"%Y-%m-%d %H:%M:%S,dI,0.I"' WITH (FORMAT CSV);
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
 ROLLBACK;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -118,7 +118,7 @@ INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interva
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 desc limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
 -- since the chunks are new status should be COMPRESSED, UNORDERED, PARTIAL and COMPRESSED, UNORDERED
@@ -134,7 +134,7 @@ INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interva
 INSERT INTO metrics SELECT '2025-01-05'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 desc limit 1 \gset
 -- should not see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1 from :COMPRESSED_CHUNK order by 2;
 -- since the chunks are new status should be COMPRESSED, UNORDERED, PARTIAL and COMPRESSED, UNORDERED
@@ -148,7 +148,7 @@ SET timescaledb.enable_direct_compress_insert = true;
 SET timescaledb.enable_direct_compress_insert_client_sorted = true;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz - (i || ' minute')::interval, floor(i), i::float FROM generate_series(0.0,9.8,0.2) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL \gset
 -- should have 10 batches
 SELECT count(*) FROM :COMPRESSED_CHUNK;
 -- since the chunks are new status should be COMPRESSED
@@ -163,7 +163,7 @@ SET timescaledb.enable_direct_compress_insert_client_sorted = false;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd'||i%2, i::float FROM generate_series(0,3000) i;
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd'||i%2, i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 desc limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 desc limit 1 \gset
 -- should see overlapping batches per device
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, device from :COMPRESSED_CHUNK order by 4, 2;
 -- since the chunks are new status should be COMPRESSED, UNORDERED
@@ -178,7 +178,7 @@ SET timescaledb.enable_direct_compress_insert_client_sorted = false;
 INSERT INTO metrics SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd'||i%3, i::float FROM generate_series(0,3000) i;
 INSERT INTO metrics SELECT '2025-01-02'::timestamptz - (i || ' minute')::interval, 'd'||i%3, i::float FROM generate_series(0,3000) i;
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
-SELECT format('%I.%I',schema_name,table_name) AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.chunk where format('%I.%I', schema_name, table_name)::regclass IN (SELECT compress_relid FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL) order by 1 limit 1 \gset
+SELECT compress_relid::text AS "COMPRESSED_CHUNK" FROM _timescaledb_catalog.compression_settings WHERE compress_relid IS NOT NULL order by 1 limit 1 \gset
 -- should see overlapping batches
 select _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_min_2, _ts_meta_max_2 from :COMPRESSED_CHUNK order by 2, 4;
 -- since the chunks are new status should be COMPRESSED, UNORDERED

--- a/tsl/test/sql/include/compression_test_hypertable_segment_meta.sql
+++ b/tsl/test/sql/include/compression_test_hypertable_segment_meta.sql
@@ -10,10 +10,13 @@ SELECT 'NULL::'||:'TYPE' as "NULLTYPE" \gset
 SELECT count(compress_chunk(ch, true)) FROM show_chunks(:'HYPERTABLE_NAME') ch;
 
 SELECT
-    ch.schema_name AS "COMP_SCHEMA_NAME",
-    ch.table_name AS "COMP_TABLE_NAME"
+    ns.nspname AS "COMP_SCHEMA_NAME",
+    cl.relname AS "COMP_TABLE_NAME"
 FROM _timescaledb_catalog.hypertable ht
-INNER JOIN _timescaledb_catalog.chunk ch ON (ch.hypertable_id = ht.compressed_hypertable_id)
+INNER JOIN _timescaledb_catalog.chunk ch ON (ch.hypertable_id = ht.id)
+INNER JOIN _timescaledb_catalog.compression_settings cs ON (cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass)
+INNER JOIN pg_class cl ON (cl.oid = cs.compress_relid)
+INNER JOIN pg_namespace ns ON (ns.oid = cl.relnamespace)
 WHERE ht.table_name like :'HYPERTABLE_NAME' ORDER BY ch.id LIMIT 1\gset
 
 SELECT

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -9,15 +9,17 @@ SELECT
    c.schema_name as chunk_schema,
    c.table_name as chunk_name,
    c.status as chunk_status,
-   comp.schema_name as compressed_chunk_schema,
-   comp.table_name as compressed_chunk_name
+   comp_ns.nspname as compressed_chunk_schema,
+   comp_class.relname as compressed_chunk_name
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
    LEFT JOIN _timescaledb_catalog.compression_settings cs
 ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
-   LEFT JOIN _timescaledb_catalog.chunk comp
-ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
+   LEFT JOIN pg_class comp_class
+ON cs.compress_relid = comp_class.oid
+   LEFT JOIN pg_namespace comp_ns
+ON comp_class.relnamespace = comp_ns.oid
 ;
 
 CREATE TABLE test2 (timec timestamptz NOT NULL, i integer ,

--- a/tsl/test/sql/rebuild_columnstore_tests.sql
+++ b/tsl/test/sql/rebuild_columnstore_tests.sql
@@ -9,11 +9,10 @@ CREATE VIEW chunk_status_view AS
 SELECT
     h.table_name AS hypertable_name,
     uc.schema_name || '.' || uc.table_name AS chunk,
-    cc.schema_name || '.' || cc.table_name AS compressed_chunk,
+    cs.compress_relid::text AS compressed_chunk,
     _timescaledb_functions.chunk_status_text((uc.schema_name || '.' || uc.table_name)::regclass) AS status
 FROM _timescaledb_catalog.chunk uc
 LEFT JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-LEFT JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
 JOIN _timescaledb_catalog.hypertable h ON uc.hypertable_id = h.id;
 
 SET timescaledb.enable_direct_compress_insert = true;

--- a/tsl/test/sql/rebuild_sparse_index.sql
+++ b/tsl/test/sql/rebuild_sparse_index.sql
@@ -10,11 +10,9 @@ RETURNS TABLE(attname name, typname name) AS $$
     FROM pg_attribute a
     JOIN pg_type t ON a.atttypid = t.oid
     WHERE a.attrelid = (
-        SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass
-        FROM _timescaledb_catalog.chunk uc
-        JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-        JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-        WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass
+        SELECT cs.compress_relid
+        FROM _timescaledb_catalog.compression_settings cs
+        WHERE cs.relid = chunk_regclass
     )
     AND a.attname LIKE '_ts_meta_%'
     AND a.attnum > 0
@@ -154,11 +152,9 @@ DECLARE
     compressed_relid oid;
     col_list text;
 BEGIN
-    SELECT format('%I.%I', cc.schema_name, cc.table_name)::regclass INTO compressed_relid
-    FROM _timescaledb_catalog.chunk uc
-    JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-    JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-    WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = chunk_regclass;
+    SELECT cs.compress_relid INTO compressed_relid
+    FROM _timescaledb_catalog.compression_settings cs
+    WHERE cs.relid = chunk_regclass;
 
     SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY a.attname) INTO col_list
     FROM pg_attribute a
@@ -183,17 +179,17 @@ ALTER TABLE rsi_integrity SET (
 SELECT compress_chunk(:'ichunk1');
 SELECT compress_chunk(:'ichunk2');
 
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
 
-SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema2, comp_cl.relname AS ic_table2
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk2'::regclass \gset
 
 \o :ORIGINAL
 SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
@@ -241,17 +237,17 @@ SELECT compress_chunk(:'ichunk1');
 SELECT compress_chunk(:'ichunk2');
 
 -- re-fetch compressed chunk names after recompress
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
 
-SELECT cc.schema_name AS ic_schema2, cc.table_name AS ic_table2
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk2'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema2, comp_cl.relname AS ic_table2
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk2'::regclass \gset
 
 \o :ORIGINAL
 SELECT * FROM dump_sparse_metadata(:'ichunk1'::regclass);
@@ -297,11 +293,11 @@ ALTER TABLE rsi_integrity SET (
 );
 SELECT compress_chunk(:'ichunk1');
 
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
 
 ALTER TABLE rsi_integrity SET (
     timescaledb.compress,
@@ -370,11 +366,11 @@ ALTER TABLE rsi_integrity SET (
 );
 SELECT compress_chunk(:'ichunk1');
 
-SELECT cc.schema_name AS ic_schema1, cc.table_name AS ic_table1
-FROM _timescaledb_catalog.chunk uc
-JOIN _timescaledb_catalog.compression_settings cs ON cs.relid = format('%I.%I', uc.schema_name, uc.table_name)::regclass
-JOIN _timescaledb_catalog.chunk cc ON cs.compress_relid = format('%I.%I', cc.schema_name, cc.table_name)::regclass
-WHERE format('%I.%I', uc.schema_name, uc.table_name)::regclass = :'ichunk1'::regclass \gset
+SELECT comp_ns.nspname AS ic_schema1, comp_cl.relname AS ic_table1
+FROM _timescaledb_catalog.compression_settings cs
+JOIN pg_class comp_cl ON cs.compress_relid = comp_cl.oid
+JOIN pg_namespace comp_ns ON comp_cl.relnamespace = comp_ns.oid
+WHERE cs.relid = :'ichunk1'::regclass \gset
 
 ALTER TABLE rsi_integrity SET (
     timescaledb.compress,

--- a/tsl/test/sql/recompress_chunk_segmentwise.sql
+++ b/tsl/test/sql/recompress_chunk_segmentwise.sql
@@ -11,16 +11,14 @@ SELECT
    c.schema_name as chunk_schema,
    c.table_name as chunk_name,
    c.status as chunk_status,
-   comp.schema_name as compressed_chunk_schema,
-   comp.table_name as compressed_chunk_name,
+   (select nspname from pg_class cl join pg_namespace n on n.oid = cl.relnamespace where cl.oid = cs.compress_relid) as compressed_chunk_schema,
+   (select relname from pg_class cl where cl.oid = cs.compress_relid) as compressed_chunk_name,
    c.id as chunk_id
 FROM
    _timescaledb_catalog.hypertable h JOIN
   _timescaledb_catalog.chunk c ON h.id = c.hypertable_id
    LEFT JOIN _timescaledb_catalog.compression_settings cs
 ON cs.relid = format('%I.%I', c.schema_name, c.table_name)::regclass
-   LEFT JOIN _timescaledb_catalog.chunk comp
-ON cs.compress_relid = format('%I.%I', comp.schema_name, comp.table_name)::regclass
 ;
 
 CREATE OR REPLACE VIEW compression_rowcnt_view AS

--- a/tsl/test/sql/recompression_nullable_orderby.sql
+++ b/tsl/test/sql/recompression_nullable_orderby.sql
@@ -28,14 +28,14 @@ where relid = 't1'::regclass;
 
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "v1", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
+where compress_relid = (select compress_relid from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't1') limit 1));
 
 -- Use minmax index on (v1, time DESC) instead
-select schema_name || '.' || table_name comp_chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+select compress_relid::text comp_chunk from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't1') limit 1)
 \gset
@@ -91,14 +91,14 @@ where relid = 't2'::regclass;
 
 update _timescaledb_catalog.compression_settings
 set index = '[{"type": "minmax", "column": "v1", "source": "orderby"}, {"type": "firstlast", "column": "v1", "source": "orderby"}, {"type": "minmax", "column": "v2", "source": "orderby"}, {"type": "minmax", "column": "time", "source": "orderby"}, {"type": "firstlast", "column": "time", "source": "orderby"}]'
-where compress_relid = (select format('%I.%I', schema_name, table_name)::regclass AS chunk_regclass from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id  from _timescaledb_catalog.chunk
+where compress_relid = (select compress_relid from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't2') limit 1));
 
 -- Use minmax index on (v1, v2, time DESC) instead
-select schema_name || '.' || table_name comp_chunk  from _timescaledb_catalog.chunk
-    where id = (select compressed_chunk_id from _timescaledb_catalog.chunk
+select compress_relid::text comp_chunk from _timescaledb_catalog.compression_settings
+    where relid = (select format('%I.%I', schema_name, table_name)::regclass from _timescaledb_catalog.chunk
         where hypertable_id = (select id from _timescaledb_catalog.hypertable
             where table_name = 't2') limit 1)
 \gset


### PR DESCRIPTION
Adjust tests to not rely on hardcoded compressed chunk names by
using psql variables and joins with compression_settings.

This is small refactoring to prepare for compressed_chunk_id removal