### PR TITLE
Fix deleting all rows on compressed hypertable with subquery predicate returning const False

### DIFF
--- a/.unreleased/pr_10089
+++ b/.unreleased/pr_10089
@@ -1,0 +1,1 @@
+Fixes: #10089 Fix deleting every row on compressed hypertable with subquery returning constant false

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -80,9 +80,11 @@ static Relation find_matching_index(Relation comp_chunk_rel, List **index_filter
 									List **heap_filters);
 static tuple_filtering_constraints *get_batch_keys_for_unique_constraints(Relation relation);
 static bool decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chunk,
-												 List *predicates, EState *estate, bool has_joins);
+												 List *predicates, EState *estate,
+												 bool plan_requires_decompression);
 static bool decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk *chunk,
-													  EState *estate, bool has_joins);
+													  EState *estate,
+													  bool plan_requires_decompression);
 static BatchFilter *make_batchfilter(char *column_name, StrategyNumber strategy, Oid collation,
 									 RegProcedure opcode, Const *value, bool is_null_check,
 									 bool is_null, bool is_array_op);
@@ -683,7 +685,7 @@ build_changed_key_filter(CompressionSettings *settings, Relation rel, Oid chunk_
  */
 static bool
 decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk *chunk,
-										  EState *estate, bool has_joins)
+										  EState *estate, bool plan_requires_decompression)
 {
 	ModifyTable *mt = ht_state->mt;
 
@@ -795,8 +797,11 @@ decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk
 		}
 
 		/* Decompress the batches that could hold a row with the new key value. */
-		batches_decompressed |=
-			decompress_batches_for_update_delete(ht_state, chunk, predicates, estate, has_joins);
+		batches_decompressed |= decompress_batches_for_update_delete(ht_state,
+																	 chunk,
+																	 predicates,
+																	 estate,
+																	 plan_requires_decompression);
 	}
 
 	return batches_decompressed;
@@ -814,7 +819,8 @@ decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk
  */
 static bool
 decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chunk,
-									 List *predicates, EState *estate, bool has_joins)
+									 List *predicates, EState *estate,
+									 bool plan_requires_decompression)
 {
 	/* process each chunk with its corresponding predicates */
 
@@ -838,7 +844,7 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	List *bloom_filters = NIL;
 
 	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
-	bool delete_only = ht_state->mt->operation == CMD_DELETE && !has_joins &&
+	bool delete_only = ht_state->mt->operation == CMD_DELETE && !plan_requires_decompression &&
 					   can_delete_without_decompression(ht_state, settings, chunk, predicates);
 	InvalidationContext invalidation_ctx = { 0 };
 
@@ -1659,6 +1665,7 @@ struct decompress_chunk_context
 	/* indicates decompression actually occurred */
 	bool batches_decompressed;
 	bool has_joins;
+	bool has_onetime_filter;
 };
 
 static void decompress_chunk_plan_walker(Plan *plan, EState *estate,
@@ -1747,6 +1754,14 @@ decompress_chunk_plan_walker(Plan *plan, EState *estate, struct decompress_chunk
 				decompress_chunk_plan_walker(lfirst(lc), estate, ctx);
 			}
 			break;
+		case T_Result:
+		{
+			if (((Result *) plan)->resconstantqual)
+			{
+				ctx->has_onetime_filter = true;
+			}
+			break;
+		}
 		default:
 			break;
 	}
@@ -1783,11 +1798,13 @@ decompress_chunk_plan_walker(Plan *plan, EState *estate, struct decompress_chunk
 									get_rel_name(rte->relid))));
 				}
 
-				ctx->batches_decompressed |= decompress_batches_for_update_delete(ctx->ht_state,
-																				  current_chunk,
-																				  predicates,
-																				  estate,
-																				  ctx->has_joins);
+				ctx->batches_decompressed |=
+					decompress_batches_for_update_delete(ctx->ht_state,
+														 current_chunk,
+														 predicates,
+														 estate,
+														 (ctx->has_joins ||
+														  ctx->has_onetime_filter));
 
 				/*
 				 * For UPDATEs that change a unique key column, also decompress
@@ -1799,7 +1816,8 @@ decompress_chunk_plan_walker(Plan *plan, EState *estate, struct decompress_chunk
 					decompress_unique_update_conflict_batches(ctx->ht_state,
 															  current_chunk,
 															  estate,
-															  ctx->has_joins);
+															  (ctx->has_joins ||
+															   ctx->has_onetime_filter));
 			}
 		}
 

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -1063,3 +1063,45 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 
 -- clean up dml artefacts to prevent plan switches on subsequent tests
 VACUUM FULL ANALYZE metrics_compressed;
+-- Test issue #10072: DELETE on compressed hypertable with subquery returning constant false should not delete any rows
+CREATE TABLE t10072 (ts timestamptz NOT NULL, payload text);
+SELECT count(*) FROM create_hypertable('t10072', 'ts');
+ count 
+-------
+     1
+
+INSERT INTO t10072
+SELECT '2025-01-01'::timestamptz + (g || ' min')::interval,
+       'parcel-' || g
+FROM generate_series(1, 5) g;
+ALTER TABLE t10072 SET (timescaledb.compress, timescaledb.compress_orderby='ts DESC');
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('t10072') chunk_name;
+ count 
+-------
+     1
+
+-- Should be fully compressed
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('t10072') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+SELECT count(*) FROM t10072;
+ count 
+-------
+     5
+
+-- Should delete 0 rows
+DELETE FROM t10072 WHERE EXISTS (SELECT 1 WHERE false);
+SELECT count(*) FROM t10072;
+ count 
+-------
+     5
+
+-- Should be partial as rows were decompressed for subquery predicate
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('t10072') chunk;
+  chunk_status_text   
+----------------------
+ {COMPRESSED,PARTIAL}
+
+drop table t10072 cascade;

--- a/tsl/test/shared/sql/compression_dml.sql
+++ b/tsl/test/shared/sql/compression_dml.sql
@@ -409,3 +409,27 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 -- clean up dml artefacts to prevent plan switches on subsequent tests
 VACUUM FULL ANALYZE metrics_compressed;
 
+-- Test issue #10072: DELETE on compressed hypertable with subquery returning constant false should not delete any rows
+CREATE TABLE t10072 (ts timestamptz NOT NULL, payload text);
+SELECT count(*) FROM create_hypertable('t10072', 'ts');
+INSERT INTO t10072
+SELECT '2025-01-01'::timestamptz + (g || ' min')::interval,
+       'parcel-' || g
+FROM generate_series(1, 5) g;
+
+ALTER TABLE t10072 SET (timescaledb.compress, timescaledb.compress_orderby='ts DESC');
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('t10072') chunk_name;
+-- Should be fully compressed
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('t10072') chunk;
+
+SELECT count(*) FROM t10072;
+
+-- Should delete 0 rows
+DELETE FROM t10072 WHERE EXISTS (SELECT 1 WHERE false);
+
+SELECT count(*) FROM t10072;
+
+-- Should be partial as rows were decompressed for subquery predicate
+SELECT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('t10072') chunk;
+
+drop table t10072 cascade;


### PR DESCRIPTION
Fixes #10072.

We checked predicates on compressed chunk to see whether decompression is needed for DELETE, and we were missing WHERE EXISTS because this predicate does not sit on the compressed chunk but on Result node above compressed chunk, as a One-Time Filter. 

Therefore we treated DELETE ... WHERE EXISTS as DELETE with no predicates, meaning it was OK to delete all rows. It is now fixed. To check that WHERE EXISTS triggers decompressing of rows for DELETE filtering, see that the chunk becomes Partial after DELETE as some rows were decompressed.