### PR TITLE
Fix column rename for compressed chunks

### DIFF
--- a/.unreleased/pr_10091
+++ b/.unreleased/pr_10091
@@ -1,0 +1,1 @@
+Fixes: #10091 Fix column rename for compressed chunks

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -633,6 +633,12 @@ compression_settings_rename_column(CompressionSettings *settings, const char *ol
 						continue;
 					}
 
+					/* Skip all but `column` key. */
+					if (strcmp(pair->key, ts_sparse_index_common_keys[SparseIndexKeyCol]) != 0)
+					{
+						continue;
+					}
+
 					ListCell *value_cell = NULL;
 					foreach (value_cell, pair->values)
 					{

--- a/tsl/test/expected/compress_sparse_config.out
+++ b/tsl/test/expected/compress_sparse_config.out
@@ -848,3 +848,53 @@ select * from settings;
 
 reset timescaledb.auto_sparse_indexes;
 drop table test_orderby_default_noguc;
+-- Rename a column to a name that matches a sparse index type token
+create table test_rename_token(ts int not null, minmax int not null);
+select create_hypertable('test_rename_token', 'ts', chunk_time_interval => 100);
+        create_hypertable        
+---------------------------------
+ (13,public,test_rename_token,t)
+
+alter table test_rename_token set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into test_rename_token select 1,1;
+select compress_chunk(show_chunks('test_rename_token'));
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_13_17_chunk
+
+select * from settings;
+                  relid                   |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+------------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ test_rename_token                        |                                                  |           | {ts}    | {f}          | {f}                | [{"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]
+ _timescaledb_internal._hyper_13_17_chunk | _timescaledb_internal.compress_hyper_14_18_chunk |           | {ts}    | {f}          | {f}                | [{"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]
+
+-- renaming to a type token must not corrupt the orderby minmax index
+alter table test_rename_token rename column minmax to bloom;
+select * from settings;
+                  relid                   |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+------------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ test_rename_token                        |                                                  |           | {ts}    | {f}          | {f}                | [{"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]
+ _timescaledb_internal._hyper_13_17_chunk | _timescaledb_internal.compress_hyper_14_18_chunk |           | {ts}    | {f}          | {f}                | [{"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]
+
+alter table test_rename_token rename column bloom to firstlast;
+select * from settings;
+                  relid                   |                  compress_relid                  | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                         index                                                         
+------------------------------------------+--------------------------------------------------+-----------+---------+--------------+--------------------+-----------------------------------------------------------------------------------------------------------------------
+ test_rename_token                        |                                                  |           | {ts}    | {f}          | {f}                | [{"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]
+ _timescaledb_internal._hyper_13_17_chunk | _timescaledb_internal.compress_hyper_14_18_chunk |           | {ts}    | {f}          | {f}                | [{"type": "minmax", "column": "ts", "source": "orderby"}, {"type": "firstlast", "column": "ts", "source": "orderby"}]
+
+-- renaming an indexed column to a type token keeps the index intact
+alter table test_rename_token rename column ts to minmax;
+select * from settings;
+                  relid                   |                  compress_relid                  | segmentby | orderby  | orderby_desc | orderby_nullsfirst |                                                             index                                                             
+------------------------------------------+--------------------------------------------------+-----------+----------+--------------+--------------------+-------------------------------------------------------------------------------------------------------------------------------
+ test_rename_token                        |                                                  |           | {minmax} | {f}          | {f}                | [{"type": "minmax", "column": "minmax", "source": "orderby"}, {"type": "firstlast", "column": "minmax", "source": "orderby"}]
+ _timescaledb_internal._hyper_13_17_chunk | _timescaledb_internal.compress_hyper_14_18_chunk |           | {minmax} | {f}          | {f}                | [{"type": "minmax", "column": "minmax", "source": "orderby"}, {"type": "firstlast", "column": "minmax", "source": "orderby"}]
+
+\set ON_ERROR_STOP 0
+alter table test_rename_token rename column minmax to _ts_meta_v2_first_minmax;
+ERROR:  cannot convert tables with reserved column prefix '_ts_meta_' to columnstore
+alter table test_rename_token rename column minmax to _ts_meta_count;
+ERROR:  cannot convert tables with reserved column prefix '_ts_meta_' to columnstore
+\set ON_ERROR_STOP 1
+drop table test_rename_token;

--- a/tsl/test/sql/compress_sparse_config.sql
+++ b/tsl/test/sql/compress_sparse_config.sql
@@ -511,3 +511,27 @@ select * from settings;
 
 reset timescaledb.auto_sparse_indexes;
 drop table test_orderby_default_noguc;
+
+-- Rename a column to a name that matches a sparse index type token
+create table test_rename_token(ts int not null, minmax int not null);
+select create_hypertable('test_rename_token', 'ts', chunk_time_interval => 100);
+alter table test_rename_token set (timescaledb.compress, timescaledb.compress_orderby = 'ts');
+insert into test_rename_token select 1,1;
+select compress_chunk(show_chunks('test_rename_token'));
+select * from settings;
+-- renaming to a type token must not corrupt the orderby minmax index
+alter table test_rename_token rename column minmax to bloom;
+select * from settings;
+alter table test_rename_token rename column bloom to firstlast;
+select * from settings;
+-- renaming an indexed column to a type token keeps the index intact
+alter table test_rename_token rename column ts to minmax;
+select * from settings;
+
+\set ON_ERROR_STOP 0
+alter table test_rename_token rename column minmax to _ts_meta_v2_first_minmax;
+alter table test_rename_token rename column minmax to _ts_meta_count;
+\set ON_ERROR_STOP 1
+
+drop table test_rename_token;
+


### PR DESCRIPTION
Column rename would try to replace all values matching the column
name in the sparse index configuration leading to errors when
column names matched sparse index types.

Fixes: #10062 