### PR TITLE
Fix internal error in first/last for unsortable types

### DIFF
--- a/src/agg_bookend.c
+++ b/src/agg_bookend.c
@@ -11,6 +11,7 @@
 #include <lib/stringinfo.h>
 #include <libpq/pqformat.h>
 #include <nodes/value.h>
+#include <utils/builtins.h>
 #include <utils/datum.h>
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
@@ -299,7 +300,11 @@ cmpproc_init(FunctionCallInfo fcinfo, FmgrInfo *cmp_proc, Oid type_oid, char *op
 	cmp_op = OpernameGetOprid(list_make1(makeString(opname)), type_oid, type_oid);
 	if (!OidIsValid(cmp_op))
 	{
-		elog(ERROR, "could not find a %s operator for type %d", opname, type_oid);
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("could not find a %s operator for type %s",
+						opname,
+						format_type_be(type_oid))));
 	}
 	cmp_regproc = get_opcode(cmp_op);
 	if (!OidIsValid(cmp_regproc))

--- a/src/planner/agg_bookend.c
+++ b/src/planner/agg_bookend.c
@@ -510,10 +510,7 @@ find_first_last_aggs_walker(Node *node, List **context)
 		aggsortop = get_opfamily_member(sort_tce->btree_opf, sort_oid, sort_oid, func_strategy);
 		if (!OidIsValid(aggsortop))
 		{
-			elog(ERROR,
-				 "Cannot resolve sort operator for function \"%s\" and type \"%s\"",
-				 format_procedure(aggref->aggfnoid),
-				 format_type_be(sort_oid));
+			return true; /* can't optimize, let runtime handle the error */
 		}
 
 		/* Used in projection */

--- a/test/expected/agg_bookends-16.out
+++ b/test/expected/agg_bookends-16.out
@@ -2454,3 +2454,24 @@ SELECT time_bucket('3 year', time), last(time, longvalue) FROM partial_aggregati
  Thu Dec 31 16:00:00 2020 PST | Fri Jan 20 09:00:44 2023 PST
 
 SET enable_partitionwise_aggregate = OFF;
+-- test error message for types without btree operator class
+CREATE TABLE weather_observations (ts timestamptz NOT NULL, location point);
+SELECT create_hypertable('weather_observations', 'ts');
+         create_hypertable         
+-----------------------------------
+ (8,public,weather_observations,t)
+
+INSERT INTO weather_observations VALUES ('2024-03-01', '(1,2)'), ('2024-03-02', '(3,4)');
+-- should work: sort key is timestamptz
+SELECT first(location, ts) FROM weather_observations;
+ first 
+-------
+ (1,2)
+
+-- should raise a proper user-facing error, not an internal error
+\set ON_ERROR_STOP 0
+SELECT first(location, location) FROM weather_observations;
+ERROR:  could not find a < operator for type point
+SELECT last(location, location) FROM weather_observations;
+ERROR:  could not find a > operator for type point
+\set ON_ERROR_STOP 1

--- a/test/expected/agg_bookends-17.out
+++ b/test/expected/agg_bookends-17.out
@@ -2402,3 +2402,24 @@ SELECT time_bucket('3 year', time), last(time, longvalue) FROM partial_aggregati
  Thu Dec 31 16:00:00 2020 PST | Fri Jan 20 09:00:44 2023 PST
 
 SET enable_partitionwise_aggregate = OFF;
+-- test error message for types without btree operator class
+CREATE TABLE weather_observations (ts timestamptz NOT NULL, location point);
+SELECT create_hypertable('weather_observations', 'ts');
+         create_hypertable         
+-----------------------------------
+ (8,public,weather_observations,t)
+
+INSERT INTO weather_observations VALUES ('2024-03-01', '(1,2)'), ('2024-03-02', '(3,4)');
+-- should work: sort key is timestamptz
+SELECT first(location, ts) FROM weather_observations;
+ first 
+-------
+ (1,2)
+
+-- should raise a proper user-facing error, not an internal error
+\set ON_ERROR_STOP 0
+SELECT first(location, location) FROM weather_observations;
+ERROR:  could not find a < operator for type point
+SELECT last(location, location) FROM weather_observations;
+ERROR:  could not find a > operator for type point
+\set ON_ERROR_STOP 1

--- a/test/expected/agg_bookends-18.out
+++ b/test/expected/agg_bookends-18.out
@@ -2402,3 +2402,24 @@ SELECT time_bucket('3 year', time), last(time, longvalue) FROM partial_aggregati
  Thu Dec 31 16:00:00 2020 PST | Fri Jan 20 09:00:44 2023 PST
 
 SET enable_partitionwise_aggregate = OFF;
+-- test error message for types without btree operator class
+CREATE TABLE weather_observations (ts timestamptz NOT NULL, location point);
+SELECT create_hypertable('weather_observations', 'ts');
+         create_hypertable         
+-----------------------------------
+ (8,public,weather_observations,t)
+
+INSERT INTO weather_observations VALUES ('2024-03-01', '(1,2)'), ('2024-03-02', '(3,4)');
+-- should work: sort key is timestamptz
+SELECT first(location, ts) FROM weather_observations;
+ first 
+-------
+ (1,2)
+
+-- should raise a proper user-facing error, not an internal error
+\set ON_ERROR_STOP 0
+SELECT first(location, location) FROM weather_observations;
+ERROR:  could not find a < operator for type point
+SELECT last(location, location) FROM weather_observations;
+ERROR:  could not find a > operator for type point
+\set ON_ERROR_STOP 1

--- a/test/sql/agg_bookends.sql.in
+++ b/test/sql/agg_bookends.sql.in
@@ -78,3 +78,17 @@ FROM
 
 SET enable_partitionwise_aggregate = OFF;
 
+-- test error message for types without btree operator class
+CREATE TABLE weather_observations (ts timestamptz NOT NULL, location point);
+SELECT create_hypertable('weather_observations', 'ts');
+INSERT INTO weather_observations VALUES ('2024-03-01', '(1,2)'), ('2024-03-02', '(3,4)');
+
+-- should work: sort key is timestamptz
+SELECT first(location, ts) FROM weather_observations;
+
+-- should raise a proper user-facing error, not an internal error
+\set ON_ERROR_STOP 0
+SELECT first(location, location) FROM weather_observations;
+SELECT last(location, location) FROM weather_observations;
+\set ON_ERROR_STOP 1
+


### PR DESCRIPTION
Replace elog(ERROR) with ereport(ERROR) using
ERRCODE_UNDEFINED_FUNCTION and format_type_be()
for a user-facing error when the sort argument
has no btree operator class.

Fixes #10061

Disable-check: force-changelog-file
