### PR TITLE
Fix first/last optimization with different orderings

### DIFF
--- a/.unreleased/fix_10060
+++ b/.unreleased/fix_10060
@@ -1,0 +1,1 @@
+Fixes: #10060 Fix first/last optimization returning the same value for aggregates that share the value column but order by different columns

--- a/src/planner/agg_bookend.c
+++ b/src/planner/agg_bookend.c
@@ -71,11 +71,12 @@ typedef struct FirstLastAggInfo
 	MinMaxAggInfo *m_agg_info; /* reusing MinMaxAggInfo to avoid code
 								* duplication */
 	Expr *sort;				   /* Expression to use for ORDER BY */
+	Aggref *aggref;			   /* Aggref node for this aggregate */
 } FirstLastAggInfo;
 
 typedef struct MutatorContext
 {
-	MinMaxAggPath *mm_path;
+	List *first_last_aggs;
 } MutatorContext;
 
 static bool find_first_last_aggs_walker(Node *node, List **context);
@@ -83,7 +84,7 @@ static bool build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, 
 								  Oid sortop, bool reverse_sort, bool nulls_first);
 static void first_last_qp_callback(PlannerInfo *root, void *extra);
 static Node *mutate_aggref_node(Node *node, MutatorContext *context);
-static void replace_aggref_in_tlist(MinMaxAggPath *minmaxagg_path);
+static void replace_aggref_in_tlist(MinMaxAggPath *minmaxagg_path, List *first_last_aggs);
 
 /*
  * mutate_aggref_node
@@ -103,16 +104,17 @@ mutate_aggref_node(Node *node, MutatorContext *context)
 		Aggref *aggref = (Aggref *) node;
 
 		/* See if the Aggref should be replaced by a Param */
-		if (context->mm_path != NULL && list_length(aggref->args) == 2)
+		if (list_length(aggref->args) == 2)
 		{
-			TargetEntry *curTarget = (TargetEntry *) linitial(aggref->args);
 			ListCell *cell;
 
-			foreach (cell, context->mm_path->mmaggregates)
+			/* match on aggregate, value and sort expression */
+			foreach (cell, context->first_last_aggs)
 			{
-				MinMaxAggInfo *mminfo = (MinMaxAggInfo *) lfirst(cell);
+				FirstLastAggInfo *fl_info = (FirstLastAggInfo *) lfirst(cell);
+				MinMaxAggInfo *mminfo = fl_info->m_agg_info;
 
-				if (mminfo->aggfnoid == aggref->aggfnoid && equal(mminfo->target, curTarget->expr))
+				if (equal(fl_info->aggref, aggref))
 				{
 					return (Node *) copyObject(mminfo->param);
 				}
@@ -132,11 +134,11 @@ mutate_aggref_node(Node *node, MutatorContext *context)
  *
  */
 void
-replace_aggref_in_tlist(MinMaxAggPath *minmaxagg_path)
+replace_aggref_in_tlist(MinMaxAggPath *minmaxagg_path, List *first_last_aggs)
 {
 	MutatorContext context;
 
-	context.mm_path = minmaxagg_path;
+	context.first_last_aggs = first_last_aggs;
 
 	((Path *) minmaxagg_path)->pathtarget->exprs =
 		(List *) mutate_aggref_node((Node *) ((Path *) minmaxagg_path)->pathtarget->exprs,
@@ -251,16 +253,18 @@ ts_preprocess_first_last_aggregates(PlannerInfo *root, List *tlist)
 	/*
 	 * Reject unoptimizable cases.
 	 *
-	 * We don't handle the case when agg function is in ORDER BY. The reason
-	 * being is that we replace Aggref node before sort keys are being
-	 * generated.
+	 * We don't handle the case when a first/last function is in ORDER BY or
+	 * DISTINCT because we replace the Aggref node before sort keys are being
+	 * generated, so the sort keys could not be matched to the modified path
+	 * target.
 	 *
 	 * We don't handle GROUP BY or windowing, because our current
 	 * implementations of grouping require looking at all the rows anyway, and
 	 * so there's not much point in optimizing FIRST/LAST.
 	 */
 	if (parse->groupClause || list_length(parse->groupingSets) > 1 || parse->hasWindowFuncs ||
-		contains_first_last_node(parse->sortClause, tlist))
+		contains_first_last_node(parse->sortClause, tlist) ||
+		contains_first_last_node(parse->distinctClause, tlist))
 	{
 		return;
 	}
@@ -413,7 +417,7 @@ ts_preprocess_first_last_aggregates(PlannerInfo *root, List *tlist)
 										   mm_agg_list,
 										   (List *) parse->havingQual);
 	/* Let's replace Aggref node since we will use subquery we've generated  */
-	replace_aggref_in_tlist(minmaxagg_path);
+	replace_aggref_in_tlist(minmaxagg_path, first_last_aggs);
 	add_path(grouped_rel, (Path *) minmaxagg_path);
 }
 
@@ -532,8 +536,11 @@ find_first_last_aggs_walker(Node *node, List **context)
 		 */
 		foreach (l, *context)
 		{
-			mminfo = (MinMaxAggInfo *) lfirst(l);
-			if (mminfo->aggfnoid == aggref->aggfnoid && equal(mminfo->target, value->expr))
+			FirstLastAggInfo *existing = (FirstLastAggInfo *) lfirst(l);
+
+			mminfo = existing->m_agg_info;
+			if (mminfo->aggfnoid == aggref->aggfnoid && equal(mminfo->target, value->expr) &&
+				equal(existing->sort, sort->expr))
 			{
 				return false;
 			}
@@ -551,6 +558,7 @@ find_first_last_aggs_walker(Node *node, List **context)
 		fl_info = palloc(sizeof(FirstLastAggInfo));
 
 		fl_info->m_agg_info = mminfo;
+		fl_info->aggref = aggref;
 		fl_info->sort = sort->expr;
 		*context = lappend(*context, fl_info);
 

--- a/test/expected/agg_bookends-16.out
+++ b/test/expected/agg_bookends-16.out
@@ -582,6 +582,56 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+ schema_name |      table_name       | created 
+-------------+-----------------------+---------
+ public      | bookend_two_orderings | t
+
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Result (actual rows=1.00 loops=1)
+   InitPlan 1 (returns $1)
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_3_8_chunk_bookend_two_orderings_time_alt_idx on _hyper_3_8_chunk (actual rows=1.00 loops=1)
+   InitPlan 2 (returns $0)
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_3_8_chunk_bookend_two_orderings_time_idx1 on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=1.00 loops=1)
+
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Result (actual rows=1.00 loops=1)
+   InitPlan 1 (returns $1)
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_3_8_chunk_bookend_two_orderings_time_alt_idx on _hyper_3_8_chunk (actual rows=1.00 loops=1)
+                 Index Cond: (time_alt IS NOT NULL)
+   InitPlan 2 (returns $0)
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_3_8_chunk_bookend_two_orderings_time_idx1 on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=1.00 loops=1)
+                 Index Cond: ("time" IS NOT NULL)
+
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Unique (actual rows=1.00 loops=1)
+   ->  Sort (actual rows=1.00 loops=1)
+         Sort Key: (first(_hyper_3_8_chunk.val, _hyper_3_8_chunk."time")), (first(_hyper_3_8_chunk.val, _hyper_3_8_chunk.time_alt))
+         Sort Method: quicksort 
+         ->  Aggregate (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_3_8_chunk (actual rows=200.00 loops=1)
+
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -606,25 +656,25 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
  Result (actual rows=1.00 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1.00 loops=1)
-           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
  Result (actual rows=1.00 loops=1)
    InitPlan 1 (returns $0)
      ->  Limit (actual rows=1.00 loops=1)
-           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
                  Index Cond: ("time" IS NOT NULL)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
 
 -- NULL values followed by non-NULL values
 INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
@@ -636,8 +686,8 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time"
-                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
@@ -646,24 +696,24 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1.00 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
 
 TRUNCATE btest_numeric;
 -- non-NULL values followed by NULL values
@@ -678,8 +728,8 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time"
-                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                 ->  Index Scan Backward using _hyper_2_12_chunk_btest_numeric_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
@@ -688,24 +738,24 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1.00 loops=1)
                        Index Cond: ("time" IS NOT NULL)
-                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                 ->  Index Scan using _hyper_2_12_chunk_btest_numeric_time_idx on _hyper_2_12_chunk (never executed)
                        Index Cond: ("time" IS NOT NULL)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_11_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_11_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2.00 loops=1)
 
 ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
@@ -990,6 +1040,40 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
  35.3
 
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+ schema_name |      table_name       | created 
+-------------+-----------------------+---------
+ public      | bookend_two_orderings | t
+
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+ first | first 
+-------+-------
+     1 |   200
+
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+ last | last 
+------+------
+  200 |    1
+
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+ first | first 
+-------+-------
+     1 |   200
+
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -1169,6 +1253,24 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -1291,6 +1393,24 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
 ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;

--- a/test/expected/agg_bookends-17.out
+++ b/test/expected/agg_bookends-17.out
@@ -537,6 +537,54 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+ schema_name |      table_name       | created 
+-------------+-----------------------+---------
+ public      | bookend_two_orderings | t
+
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Result (actual rows=1.00 loops=1)
+   InitPlan 1
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_3_8_chunk_bookend_two_orderings_time_alt_idx on _hyper_3_8_chunk (actual rows=1.00 loops=1)
+   InitPlan 2
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_3_8_chunk_bookend_two_orderings_time_idx1 on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=1.00 loops=1)
+
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Result (actual rows=1.00 loops=1)
+   InitPlan 1
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_3_8_chunk_bookend_two_orderings_time_alt_idx on _hyper_3_8_chunk (actual rows=1.00 loops=1)
+   InitPlan 2
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_3_8_chunk_bookend_two_orderings_time_idx1 on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=1.00 loops=1)
+
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Unique (actual rows=1.00 loops=1)
+   ->  Sort (actual rows=1.00 loops=1)
+         Sort Key: (first(_hyper_3_8_chunk.val, _hyper_3_8_chunk."time")), (first(_hyper_3_8_chunk.val, _hyper_3_8_chunk.time_alt))
+         Sort Method: quicksort 
+         ->  Aggregate (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_3_8_chunk (actual rows=200.00 loops=1)
+
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -561,24 +609,24 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
  Result (actual rows=1.00 loops=1)
    InitPlan 1
      ->  Limit (actual rows=1.00 loops=1)
-           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
  Result (actual rows=1.00 loops=1)
    InitPlan 1
      ->  Limit (actual rows=1.00 loops=1)
-           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
 
 -- NULL values followed by non-NULL values
 INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
@@ -590,8 +638,8 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time"
-                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
@@ -600,22 +648,22 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
 
 TRUNCATE btest_numeric;
 -- non-NULL values followed by NULL values
@@ -630,8 +678,8 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time"
-                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                 ->  Index Scan Backward using _hyper_2_12_chunk_btest_numeric_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
@@ -640,22 +688,22 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan using _hyper_2_12_chunk_btest_numeric_time_idx on _hyper_2_12_chunk (never executed)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_11_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_11_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2.00 loops=1)
 
 ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
@@ -940,6 +988,40 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
  35.3
 
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+ schema_name |      table_name       | created 
+-------------+-----------------------+---------
+ public      | bookend_two_orderings | t
+
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+ first | first 
+-------+-------
+     1 |   200
+
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+ last | last 
+------+------
+  200 |    1
+
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+ first | first 
+-------+-------
+     1 |   200
+
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -1119,6 +1201,24 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -1241,6 +1341,24 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
 ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;

--- a/test/expected/agg_bookends-18.out
+++ b/test/expected/agg_bookends-18.out
@@ -537,6 +537,54 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
                ->  Seq Scan on _hyper_1_5_chunk (actual rows=1.00 loops=1)
 
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+ schema_name |      table_name       | created 
+-------------+-----------------------+---------
+ public      | bookend_two_orderings | t
+
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Result (actual rows=1.00 loops=1)
+   InitPlan 1
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_3_8_chunk_bookend_two_orderings_time_alt_idx on _hyper_3_8_chunk (actual rows=1.00 loops=1)
+   InitPlan 2
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_3_8_chunk_bookend_two_orderings_time_idx1 on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=1.00 loops=1)
+
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Result (actual rows=1.00 loops=1)
+   InitPlan 1
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_3_8_chunk_bookend_two_orderings_time_alt_idx on _hyper_3_8_chunk (actual rows=1.00 loops=1)
+   InitPlan 2
+     ->  Limit (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_3_8_chunk_bookend_two_orderings_time_idx1 on _hyper_3_8_chunk _hyper_3_8_chunk_1 (actual rows=1.00 loops=1)
+
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+--- QUERY PLAN ---
+ Unique (actual rows=1.00 loops=1)
+   ->  Sort (actual rows=1.00 loops=1)
+         Sort Key: (first(_hyper_3_8_chunk.val, _hyper_3_8_chunk."time")), (first(_hyper_3_8_chunk.val, _hyper_3_8_chunk.time_alt))
+         Sort Method: quicksort 
+         ->  Aggregate (actual rows=1.00 loops=1)
+               ->  Seq Scan on _hyper_3_8_chunk (actual rows=200.00 loops=1)
+
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -561,24 +609,24 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
  Result (actual rows=1.00 loops=1)
    InitPlan 1
      ->  Limit (actual rows=1.00 loops=1)
-           ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
+           ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
  Result (actual rows=1.00 loops=1)
    InitPlan 1
      ->  Limit (actual rows=1.00 loops=1)
-           ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
+           ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
 
 -- NULL values followed by non-NULL values
 INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 1);
@@ -590,8 +638,8 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time"
-                 ->  Index Scan Backward using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
@@ -600,22 +648,22 @@ INSERT INTO btest_numeric VALUES('2019-01-20T09:00:43', 2);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan using _hyper_2_8_chunk_btest_numeric_time_idx on _hyper_2_8_chunk (never executed)
+                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan using _hyper_2_9_chunk_btest_numeric_time_idx on _hyper_2_9_chunk (never executed)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_9_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
 
 TRUNCATE btest_numeric;
 -- non-NULL values followed by NULL values
@@ -630,8 +678,8 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time"
-                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan Backward using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (never executed)
+                 ->  Index Scan Backward using _hyper_2_12_chunk_btest_numeric_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan Backward using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
 
 :PREFIX SELECT last(quantity, time) FROM btest_numeric;
 --- QUERY PLAN ---
@@ -640,22 +688,22 @@ INSERT INTO btest_numeric VALUES('2018-01-20T09:00:43', NULL);
      ->  Limit (actual rows=1.00 loops=1)
            ->  Custom Scan (ChunkAppend) on btest_numeric (actual rows=1.00 loops=1)
                  Order: btest_numeric."time" DESC
-                 ->  Index Scan using _hyper_2_10_chunk_btest_numeric_time_idx on _hyper_2_10_chunk (actual rows=1.00 loops=1)
-                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (never executed)
+                 ->  Index Scan using _hyper_2_11_chunk_btest_numeric_time_idx on _hyper_2_11_chunk (actual rows=1.00 loops=1)
+                 ->  Index Scan using _hyper_2_12_chunk_btest_numeric_time_idx on _hyper_2_12_chunk (never executed)
 
 :PREFIX SELECT first(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_11_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2.00 loops=1)
 
 :PREFIX SELECT last(time, quantity) FROM btest_numeric;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
    ->  Append (actual rows=4.00 loops=1)
-         ->  Seq Scan on _hyper_2_10_chunk (actual rows=2.00 loops=1)
          ->  Seq Scan on _hyper_2_11_chunk (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2.00 loops=1)
 
 ROLLBACK;
 -- we want test results as part of the output too to make sure we produce correct output
@@ -940,6 +988,40 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
  35.3
 
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+ schema_name |      table_name       | created 
+-------------+-----------------------+---------
+ public      | bookend_two_orderings | t
+
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+ first | first 
+-------+-------
+     1 |   200
+
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+ last | last 
+------+------
+  200 |    1
+
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+ first | first 
+-------+-------
+     1 |   200
+
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -1119,6 +1201,24 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
 ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
+ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;
@@ -1241,6 +1341,24 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 :PREFIX SELECT abs(last(temp, time)) FROM btest;
 -- test nested FIRST/LAST in ORDER BY - no optimization possible
 :PREFIX SELECT abs(last(temp, time)) FROM btest ORDER BY abs(last(temp,time));
+ROLLBACK;
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
 ROLLBACK;
 -- Test with NULL numeric values
 BEGIN;

--- a/test/sql/include/agg_bookends_query.sql
+++ b/test/sql/include/agg_bookends_query.sql
@@ -122,6 +122,25 @@ CREATE INDEX btest_time_alt_idx ON btest(time_alt);
 
 ROLLBACK;
 
+-- two FIRST/LAST sharing the value column but ordering on different columns
+BEGIN;
+CREATE TABLE bookend_two_orderings(time timestamptz NOT NULL, time_alt timestamptz NOT NULL, val int NOT NULL);
+SELECT schema_name, table_name, created FROM create_hypertable('bookend_two_orderings', 'time');
+INSERT INTO bookend_two_orderings
+SELECT '2025-01-01'::timestamptz + g * interval '1 minute',
+       '2025-01-01'::timestamptz + (201 - g) * interval '1 minute',
+       g
+FROM generate_series(1, 200) g;
+CREATE INDEX ON bookend_two_orderings(time);
+CREATE INDEX ON bookend_two_orderings(time_alt);
+:PREFIX SELECT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+:PREFIX SELECT last(val, time), last(val, time_alt) FROM bookend_two_orderings;
+-- DISTINCT sorts on the first/last results, so the optimization must be skipped
+SET enable_hashagg = off;
+:PREFIX SELECT DISTINCT first(val, time), first(val, time_alt) FROM bookend_two_orderings;
+RESET enable_hashagg;
+ROLLBACK;
+
 -- Test with NULL numeric values
 BEGIN;
 TRUNCATE btest_numeric;


### PR DESCRIPTION
When a query used two first() or two last() calls on the same value
column but ordered by different columns, both calls returned the same
value. The optimization that turns first/last into an index scan
matched the calls only by the value column and ignored the ordering
column, so both ended up reusing the same subquery result.

The ordering column is now part of the match, so each call keeps its
own result.

Fixes: #10060
