### PR TITLE
Enforce constraints for direct compress inserts

### DIFF
--- a/.unreleased/fix_10056
+++ b/.unreleased/fix_10056
@@ -1,0 +1,1 @@
+Fixes: #10056 Enforce CHECK, NOT NULL and view WITH CHECK OPTION constraints for direct compress inserts

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2482,6 +2482,14 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 					ExecComputeStoredGenerated(ctr->root_rri, estate, hypertable_slot, CMD_INSERT);
 				}
 
+				/* check WITH CHECK OPTIONs against the hypertable tuple
+				 * before it is mapped to chunk format below */
+				if (ctr->root_rri->ri_WithCheckOptions != NIL)
+				{
+					ExecWithCheckOptions(WCO_RLS_INSERT_CHECK, ctr->root_rri, hypertable_slot, estate);
+					ExecWithCheckOptions(WCO_VIEW_CHECK, ctr->root_rri, hypertable_slot, estate);
+				}
+
 				/*
 				 * Convert the slot to the chunk's rowtype if the chunk's
 				 * TupleDesc differs from the hypertable (e.g. due to dropped
@@ -2495,6 +2503,14 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 					chunk_slot = execute_attr_map_slot(ctr->cis->hyper_to_chunk_map->attrMap,
 													   hypertable_slot,
 													   ctr->cis->slot);
+
+				/* enforce NOT NULL and CHECK constraints */
+				ResultRelInfo *chunk_rri = ctr->cis->result_relation_info;
+				if (chunk_rri->ri_RelationDesc->rd_att->constr)
+				{
+					chunk_slot->tts_tableOid = RelationGetRelid(ctr->cis->rel);
+					ExecConstraints(chunk_rri, chunk_slot, estate);
+				}
 
 				ts_cm_functions->compressor_add_slot(ht_state->compressor, ht_state->bulk_writer, chunk_slot);
 				estate->es_processed++;

--- a/tsl/test/expected/direct_compress_copy.out
+++ b/tsl/test/expected/direct_compress_copy.out
@@ -342,3 +342,24 @@ SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, ti
  Thu Jan 02 00:01:00 2025 PST | Sat Jan 04 02:00:00 2025 PST
 
 ROLLBACK;
+-- Direct compress copy must still enforce CHECK and NOT NULL constraints
+CREATE TABLE metrics_check(time timestamptz NOT NULL, value int NOT NULL CHECK (value > 0))
+    WITH (tsdb.hypertable, tsdb.partition_column='time', tsdb.compress, tsdb.compress_orderby='time');
+SET timescaledb.enable_direct_compress_copy = true;
+\set ON_ERROR_STOP 0
+-- CHECK violation should be reported
+COPY metrics_check FROM STDIN WITH (FORMAT CSV);
+ERROR:  new row for relation "_hyper_6_40_chunk" violates check constraint "metrics_check_value_check"
+-- NOT NULL violation should be reported
+COPY metrics_check FROM STDIN WITH (FORMAT CSV);
+ERROR:  null value in column "value" of relation "_hyper_6_42_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+-- valid rows copy without error
+COPY metrics_check FROM STDIN WITH (FORMAT CSV);
+SELECT count(*), min(value), max(value) FROM metrics_check;
+ count | min | max 
+-------+-----+-----
+     3 |   1 |   3
+
+RESET timescaledb.enable_direct_compress_copy;
+DROP TABLE metrics_check;

--- a/tsl/test/expected/direct_compress_insert.out
+++ b/tsl/test/expected/direct_compress_insert.out
@@ -891,3 +891,44 @@ SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text COL
  test_orderby_not_segmentby                |                                                   |           |                  |              |                    | 
 
 ROLLBACK;
+-- Direct compress must still enforce CHECK and NOT NULL constraints
+CREATE TABLE metrics_check(time timestamptz NOT NULL, value int NOT NULL CHECK (value > 0))
+    WITH (tsdb.hypertable, tsdb.partition_column='time');
+SET timescaledb.enable_direct_compress_insert = true;
+\set ON_ERROR_STOP 0
+-- CHECK violation should be reported
+INSERT INTO metrics_check SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, CASE WHEN i = 50 THEN -1 ELSE i END FROM generate_series(1,100) i;
+ERROR:  new row for relation "_hyper_23_110_chunk" violates check constraint "metrics_check_value_check"
+-- NOT NULL violation should be reported
+INSERT INTO metrics_check SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, CASE WHEN i = 50 THEN NULL ELSE i END FROM generate_series(1,100) i;
+ERROR:  null value in column "value" of relation "_hyper_23_112_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+-- valid rows insert and compress without error
+INSERT INTO metrics_check SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,100) i;
+SELECT count(*), min(value), max(value) FROM metrics_check;
+ count | min | max 
+-------+-----+-----
+   100 |   1 | 100
+
+DROP TABLE metrics_check;
+RESET timescaledb.enable_direct_compress_insert;
+-- Direct compress must still enforce a view's WITH CHECK OPTION
+CREATE TABLE metrics_view(time timestamptz NOT NULL, value int)
+    WITH (tsdb.hypertable, tsdb.partition_column='time');
+CREATE VIEW metrics_view_pos AS SELECT * FROM metrics_view WHERE value > 0 WITH CHECK OPTION;
+SET timescaledb.enable_direct_compress_insert = true;
+\set ON_ERROR_STOP 0
+-- row not satisfying the view qual should be reported
+INSERT INTO metrics_view_pos SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, CASE WHEN i = 50 THEN -1 ELSE i END FROM generate_series(1,100) i;
+ERROR:  new row violates check option for view "metrics_view_pos"
+\set ON_ERROR_STOP 1
+-- valid rows insert without error
+INSERT INTO metrics_view_pos SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,100) i;
+SELECT count(*), min(value), max(value) FROM metrics_view;
+ count | min | max 
+-------+-----+-----
+   100 |   1 | 100
+
+RESET timescaledb.enable_direct_compress_insert;
+DROP VIEW metrics_view_pos;
+DROP TABLE metrics_view;

--- a/tsl/test/sql/direct_compress_copy.sql
+++ b/tsl/test/sql/direct_compress_copy.sql
@@ -236,3 +236,31 @@ COPY metrics FROM PROGRAM 'seq 3000 | xargs -II date -d "2025-01-02 + I minute" 
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics;
 SELECT first(time,rn), last(time,rn) FROM (SELECT ROW_NUMBER() OVER () as rn, time FROM metrics) sub;
 ROLLBACK;
+
+-- Direct compress copy must still enforce CHECK and NOT NULL constraints
+CREATE TABLE metrics_check(time timestamptz NOT NULL, value int NOT NULL CHECK (value > 0))
+    WITH (tsdb.hypertable, tsdb.partition_column='time', tsdb.compress, tsdb.compress_orderby='time');
+SET timescaledb.enable_direct_compress_copy = true;
+\set ON_ERROR_STOP 0
+-- CHECK violation should be reported
+COPY metrics_check FROM STDIN WITH (FORMAT CSV);
+2025-01-01 00:00:00,1
+2025-01-01 00:01:00,-1
+2025-01-01 00:02:00,3
+\.
+-- NOT NULL violation should be reported
+COPY metrics_check FROM STDIN WITH (FORMAT CSV);
+2025-01-01 00:00:00,1
+2025-01-01 00:01:00,
+2025-01-01 00:02:00,3
+\.
+\set ON_ERROR_STOP 1
+-- valid rows copy without error
+COPY metrics_check FROM STDIN WITH (FORMAT CSV);
+2025-01-01 00:00:00,1
+2025-01-01 00:01:00,2
+2025-01-01 00:02:00,3
+\.
+SELECT count(*), min(value), max(value) FROM metrics_check;
+RESET timescaledb.enable_direct_compress_copy;
+DROP TABLE metrics_check;

--- a/tsl/test/sql/direct_compress_insert.sql
+++ b/tsl/test/sql/direct_compress_insert.sql
@@ -519,3 +519,35 @@ INSERT INTO test_orderby_not_segmentby SELECT '2024-06-01'::timestamptz + (i||' 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::text COLLATE "C";
 ROLLBACK;
 
+-- Direct compress must still enforce CHECK and NOT NULL constraints
+CREATE TABLE metrics_check(time timestamptz NOT NULL, value int NOT NULL CHECK (value > 0))
+    WITH (tsdb.hypertable, tsdb.partition_column='time');
+SET timescaledb.enable_direct_compress_insert = true;
+\set ON_ERROR_STOP 0
+-- CHECK violation should be reported
+INSERT INTO metrics_check SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, CASE WHEN i = 50 THEN -1 ELSE i END FROM generate_series(1,100) i;
+-- NOT NULL violation should be reported
+INSERT INTO metrics_check SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, CASE WHEN i = 50 THEN NULL ELSE i END FROM generate_series(1,100) i;
+\set ON_ERROR_STOP 1
+-- valid rows insert and compress without error
+INSERT INTO metrics_check SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,100) i;
+SELECT count(*), min(value), max(value) FROM metrics_check;
+DROP TABLE metrics_check;
+RESET timescaledb.enable_direct_compress_insert;
+
+-- Direct compress must still enforce a view's WITH CHECK OPTION
+CREATE TABLE metrics_view(time timestamptz NOT NULL, value int)
+    WITH (tsdb.hypertable, tsdb.partition_column='time');
+CREATE VIEW metrics_view_pos AS SELECT * FROM metrics_view WHERE value > 0 WITH CHECK OPTION;
+SET timescaledb.enable_direct_compress_insert = true;
+\set ON_ERROR_STOP 0
+-- row not satisfying the view qual should be reported
+INSERT INTO metrics_view_pos SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, CASE WHEN i = 50 THEN -1 ELSE i END FROM generate_series(1,100) i;
+\set ON_ERROR_STOP 1
+-- valid rows insert without error
+INSERT INTO metrics_view_pos SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,100) i;
+SELECT count(*), min(value), max(value) FROM metrics_view;
+RESET timescaledb.enable_direct_compress_insert;
+DROP VIEW metrics_view_pos;
+DROP TABLE metrics_view;
+


### PR DESCRIPTION
Direct compress inserts added rows straight to the compressor and
skipped the normal insert path. As a result CHECK and NOT NULL
constraints were not checked, so invalid rows were silently accepted.

Run the same checks the normal insert path runs before the rows are
compressed so invalid rows are rejected as expected.

Fixes #10056
