### PR TITLE
Skip classifying compressed relations to speed up planning

### DIFF
--- a/.unreleased/pr_10010
+++ b/.unreleased/pr_10010
@@ -1,0 +1,1 @@
+Implements: #10010 Skip classifying compressed relations to speed up planning

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -123,6 +123,7 @@ static void cagg_reorder_groupby_clause(RangeTblEntry *subq_rte, Index rtno, Lis
  */
 static const char *TS_CTE_EXPAND = "ts_expand";
 static const char *TS_FK_EXPAND = "ts_fk_expand";
+static const char *TS_CTE_COMPRESSED_RELATION = "ts_compressed_relation";
 
 /*
  * A simplehash hash table that records the chunks and their corresponding
@@ -186,6 +187,20 @@ rte_mark_for_fk_expansion(RangeTblEntry *rte)
 	 * initially for hypertables.
 	 */
 	Assert(!rte->inh);
+}
+
+void
+ts_rte_mark_compressed_relation(RangeTblEntry *rte)
+{
+	Assert(rte->rtekind == RTE_RELATION);
+	Assert(rte->ctename == NULL);
+	rte->ctename = (char *) TS_CTE_COMPRESSED_RELATION;
+}
+
+static bool
+ts_rte_is_compressed_relation(const RangeTblEntry *rte)
+{
+	return rte->ctename == TS_CTE_COMPRESSED_RELATION;
 }
 
 bool
@@ -1531,6 +1546,17 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 	}
 
 	RangeTblEntry *rte = planner_rt_fetch(rel->relid, root);
+
+	/*
+	 * Fast path for compressed relation built by ColumnarScan.
+	 * Don't need to classify relation as we already know what it is.
+	 */
+	if (ts_rte_is_compressed_relation(rte))
+	{
+		ts_create_private_reloptinfo(rel);
+		return;
+	}
+
 	Query *query = root->parse;
 	Hypertable *ht;
 	const TsRelType type = ts_classify_relation(root, rel, &ht);

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -44,6 +44,7 @@ typedef struct TimescaleDBPrivate
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte);
 extern TSDLLEXPORT bool ts_rte_is_marked_for_expansion(const RangeTblEntry *rte);
+extern TSDLLEXPORT void ts_rte_mark_compressed_relation(RangeTblEntry *rte);
 extern TSDLLEXPORT bool ts_contains_external_param(Node *node);
 extern TSDLLEXPORT bool ts_contains_join_param(Node *node);
 

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -5,8 +5,6 @@
  */
 
 #include <postgres.h>
-#include "chunk.h"
-#include "hypertable_cache.h"
 #include <catalog/pg_operator.h>
 #include <math.h>
 #include <miscadmin.h>
@@ -21,8 +19,6 @@
 #include <optimizer/paths.h>
 #include <parser/parse_relation.h>
 #include <parser/parsetree.h>
-#include <planner.h>
-#include <planner/planner.h>
 #include <storage/lockdefs.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
@@ -30,16 +26,20 @@
 #include <utils/typcache.h>
 
 #include "compat/compat.h"
+#include "chunk.h"
 #include "compression/compression.h"
 #include "compression/create.h"
 #include "cross_module_fn.h"
 #include "custom_type_cache.h"
 #include "debug_assert.h"
+#include "hypertable_cache.h"
 #include "import/allpaths.h"
 #include "import/planner.h"
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/columnar_scan/planner.h"
 #include "nodes/columnar_scan/qual_pushdown.h"
+#include "planner.h"
+#include "planner/planner.h"
 #include "ts_catalog/array_utils.h"
 #include "utils.h"
 
@@ -2366,6 +2366,9 @@ columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Ch
 	info->compressed_rte = columnar_scan_make_rte(info->settings->fd.compress_relid,
 												  info->chunk_rte->rellockmode,
 												  root->parse);
+
+	/* mark RTE to skip ts_classify_relation */
+	ts_rte_mark_compressed_relation(info->compressed_rte);
 	root->simple_rte_array[compressed_index] = info->compressed_rte;
 
 	root->parse->rtable = lappend(root->parse->rtable, info->compressed_rte);


### PR DESCRIPTION
When building RelOptInfo for compressed relation label the RTE as
compressed relation so our planner hook can skip trying to classify
them.

This gives 10% planning speedup for queries on hypertables with
compression.

Disable-check: force-changelog-file