### PR TITLE
Release 2.28.1

### DIFF
--- a/.unreleased/dml-bitmap-crash
+++ b/.unreleased/dml-bitmap-crash
@@ -1,1 +1,0 @@
-Fixes: #9913: Potential crash on DML on compressed tables when the plan uses Bitmap Heap Scan

--- a/.unreleased/fix_10056
+++ b/.unreleased/fix_10056
@@ -1,1 +1,0 @@
-Fixes: #10056 Enforce CHECK, NOT NULL and view WITH CHECK OPTION constraints for direct compress inserts

--- a/.unreleased/fix_10059
+++ b/.unreleased/fix_10059
@@ -1,1 +1,0 @@
-Fixes: #10059 Fix error when using first/last aggregates in a HAVING clause

--- a/.unreleased/fix_10060
+++ b/.unreleased/fix_10060
@@ -1,1 +1,0 @@
-Fixes: #10060 Fix first/last optimization returning the same value for aggregates that share the value column but order by different columns

--- a/.unreleased/pr_10069
+++ b/.unreleased/pr_10069
@@ -1,2 +1,0 @@
-Fixes: #10069 Fix bgw_job_stat_history definition
-Thanks: @skrenes for reporting a problem with the job_history view when upgrading to 2.28.0

--- a/.unreleased/pr_10073
+++ b/.unreleased/pr_10073
@@ -1,1 +1,0 @@
-Fixes: #10073 Fix uncompressed size estimate for varlen

--- a/.unreleased/pr_10089
+++ b/.unreleased/pr_10089
@@ -1,1 +1,0 @@
-Fixes: #10089 Fix deleting every row on compressed hypertable with subquery returning constant false

--- a/.unreleased/pr_10091
+++ b/.unreleased/pr_10091
@@ -1,1 +1,0 @@
-Fixes: #10091 Fix column rename for compressed chunks

--- a/.unreleased/pr_10094
+++ b/.unreleased/pr_10094
@@ -1,1 +1,0 @@
-Fixes: #10094 Fix use-after-free in ALTER TABLE ADD CONSTRAINT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This release contains performance improvements and bug fixes since the 2.28.0 re
 
 **Bugfixes**
 * [#10091](https://github.com/timescale/timescaledb/pull/10091) Fix column rename for compressed chunks
+* [#10056](https://github.com/timescale/timescaledb/pull/10056) Enforce CHECK, NOT NULL and view WITH CHECK OPTION constraints for direct compress inserts
 
 ## 2.28.0 (2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@
 This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
+* [#9913](https://github.com/timescale/timescaledb/pull/9913) Fix potential crash on DML on compressed tables when the plan uses Bitmap Heap Scan
 * [#10091](https://github.com/timescale/timescaledb/pull/10091) Fix column rename for compressed chunks
 * [#10056](https://github.com/timescale/timescaledb/pull/10056) Enforce CHECK, NOT NULL and view WITH CHECK OPTION constraints for direct compress inserts
+* [#10059](https://github.com/timescale/timescaledb/pull/10059) Fix error when using first/last aggregates in a HAVING clause
+* [#10060](https://github.com/timescale/timescaledb/pull/10060) Fix first/last optimization returning the same value for aggregates that share the value column but order by different columns
+* [#10069](https://github.com/timescale/timescaledb/pull/10069) Fix bgw_job_stat_history definition
+* [#10073](https://github.com/timescale/timescaledb/pull/10073) Fix uncompressed size estimate for varlen
+* [#10089](https://github.com/timescale/timescaledb/pull/10089) Fix deleting every row on compressed hypertable with subquery returning constant false
+
+**Thanks**
+* @skrenes for reporting a problem with the job_history view when upgrading to 2.28.0
 
 ## 2.28.0 (2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.28.1 (2026-06-22)
+
+This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.28.1**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* 
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+
 ## 2.28.0 (2026-06-16)
 
 This release contains performance improvements and bug fixes since the 2.27.2 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,8 @@
 
 This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.28.1**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
-
 **Bugfixes**
-* 
-
-**New Settings**
-
-**GUCs**
-
-**Thanks**
+* [#10091](https://github.com/timescale/timescaledb/pull/10091) Fix column rename for compressed chunks
 
 ## 2.28.0 (2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.28.1 (2026-06-22)
+## 2.28.1 (2026-06-23)
 
 This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,19 @@
 This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
-* [#9913](https://github.com/timescale/timescaledb/pull/9913) Fix potential crash on DML on compressed tables when the plan uses Bitmap Heap Scan
+* [#9913](https://github.com/timescale/timescaledb/pull/9913) Fix potential crash on `DML` on compressed tables when the plan uses `Bitmap Heap Scan`
 * [#10091](https://github.com/timescale/timescaledb/pull/10091) Fix column rename for compressed chunks
-* [#10056](https://github.com/timescale/timescaledb/pull/10056) Enforce CHECK, NOT NULL and view WITH CHECK OPTION constraints for direct compress inserts
-* [#10059](https://github.com/timescale/timescaledb/pull/10059) Fix error when using first/last aggregates in a HAVING clause
-* [#10060](https://github.com/timescale/timescaledb/pull/10060) Fix first/last optimization returning the same value for aggregates that share the value column but order by different columns
-* [#10061](https://github.com/timescale/timescaledb/pull/10061) Fix internal error in first/last for unsortable types
-* [#10069](https://github.com/timescale/timescaledb/pull/10069) Fix bgw_job_stat_history definition
-* [#10073](https://github.com/timescale/timescaledb/pull/10073) Fix uncompressed size estimate for varlen
+* [#10056](https://github.com/timescale/timescaledb/pull/10056) Enforce `CHECK`, `NOT NULL` and view `WITH CHECK OPTION` constraints for direct compress inserts
+* [#10059](https://github.com/timescale/timescaledb/pull/10059) Fix error when using `first`/`last` aggregates in a `HAVING` clause
+* [#10060](https://github.com/timescale/timescaledb/pull/10060) Fix `first`/`last` optimization returning the same value for aggregates that share the value column but order by different columns
+* [#10061](https://github.com/timescale/timescaledb/pull/10061) Fix internal error in `first`/`last` for unsortable types
+* [#10069](https://github.com/timescale/timescaledb/pull/10069) Fix `bgw_job_stat_history` definition
+* [#10073](https://github.com/timescale/timescaledb/pull/10073) Fix uncompressed size estimate for `varlen`
 * [#10089](https://github.com/timescale/timescaledb/pull/10089) Fix deleting every row on compressed hypertable with subquery returning constant false
-* [#10094](https://github.com/timescale/timescaledb/pull/10094) Fix use-after-free in ALTER TABLE ADD CONSTRAINT
+* [#10094](https://github.com/timescale/timescaledb/pull/10094) Fix use-after-free in `ALTER TABLE ADD CONSTRAINT`
 
 **Thanks**
-* @skrenes for reporting a problem with the job_history view when upgrading to 2.28.0
+* @skrenes for reporting a problem with the `job_history` view when upgrading to 2.28.0
 
 ## 2.28.0 (2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ This release contains performance improvements and bug fixes since the 2.28.0 re
 * [#10056](https://github.com/timescale/timescaledb/pull/10056) Enforce CHECK, NOT NULL and view WITH CHECK OPTION constraints for direct compress inserts
 * [#10059](https://github.com/timescale/timescaledb/pull/10059) Fix error when using first/last aggregates in a HAVING clause
 * [#10060](https://github.com/timescale/timescaledb/pull/10060) Fix first/last optimization returning the same value for aggregates that share the value column but order by different columns
+* [#10061](https://github.com/timescale/timescaledb/pull/10061) Fix internal error in first/last for unsortable types
 * [#10069](https://github.com/timescale/timescaledb/pull/10069) Fix bgw_job_stat_history definition
 * [#10073](https://github.com/timescale/timescaledb/pull/10073) Fix uncompressed size estimate for varlen
 * [#10089](https://github.com/timescale/timescaledb/pull/10089) Fix deleting every row on compressed hypertable with subquery returning constant false
+* [#10094](https://github.com/timescale/timescaledb/pull/10094) Fix use-after-free in ALTER TABLE ADD CONSTRAINT
 
 **Thanks**
 * @skrenes for reporting a problem with the job_history view when upgrading to 2.28.0


### PR DESCRIPTION
## 2.28.1 (2026-06-23)

This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#9913](https://github.com/timescale/timescaledb/pull/9913) Fix potential crash on `DML` on compressed tables when the plan uses `Bitmap Heap Scan`
* [#10091](https://github.com/timescale/timescaledb/pull/10091) Fix column rename for compressed chunks
* [#10056](https://github.com/timescale/timescaledb/pull/10056) Enforce `CHECK`, `NOT NULL` and view `WITH CHECK OPTION` constraints for direct compress inserts
* [#10059](https://github.com/timescale/timescaledb/pull/10059) Fix error when using `first`/`last` aggregates in a `HAVING` clause
* [#10060](https://github.com/timescale/timescaledb/pull/10060) Fix `first`/`last` optimization returning the same value for aggregates that share the value column but order by different columns
* [#10061](https://github.com/timescale/timescaledb/pull/10061) Fix internal error in `first`/`last` for unsortable types
* [#10069](https://github.com/timescale/timescaledb/pull/10069) Fix `bgw_job_stat_history` definition
* [#10073](https://github.com/timescale/timescaledb/pull/10073) Fix uncompressed size estimate for `varlen`
* [#10089](https://github.com/timescale/timescaledb/pull/10089) Fix deleting every row on compressed hypertable with subquery returning constant false
* [#10094](https://github.com/timescale/timescaledb/pull/10094) Fix use-after-free in `ALTER TABLE ADD CONSTRAINT`

**Thanks**
* @skrenes for reporting a problem with the `job_history` view when upgrading to 2.28.0