### PR TITLE
Fix more memory leaks in direct compress

### DIFF
--- a/.unreleased/leak-direct
+++ b/.unreleased/leak-direct
@@ -1,0 +1,1 @@
+Implements: #10119 Improve memory usage of INSERT queries using Direct Compress and spanning multiple chunks

--- a/.unreleased/leak-direct
+++ b/.unreleased/leak-direct
@@ -1,1 +1,1 @@
-Implements: #10119 Improve memory usage of INSERT queries using Direct Compress and spanning multiple chunks
+Implements: #10119 Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -416,6 +416,36 @@ ts_compression_settings_get(Oid relid)
 	return settings;
 }
 
+TSDLLEXPORT void
+ts_compression_settings_free(CompressionSettings *settings)
+{
+	if (settings == NULL)
+	{
+		return;
+	}
+	if (settings->fd.segmentby)
+	{
+		pfree(settings->fd.segmentby);
+	}
+	if (settings->fd.orderby)
+	{
+		pfree(settings->fd.orderby);
+	}
+	if (settings->fd.orderby_desc)
+	{
+		pfree(settings->fd.orderby_desc);
+	}
+	if (settings->fd.orderby_nullsfirst)
+	{
+		pfree(settings->fd.orderby_nullsfirst);
+	}
+	if (settings->fd.index)
+	{
+		pfree(settings->fd.index);
+	}
+	pfree(settings);
+}
+
 /*
  * Get the compression settings for a relation given its associated compressed
  * relation.

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -142,6 +142,7 @@ ts_compression_settings_create(Oid relid, Oid compress_relid, ArrayType *segment
 							   ArrayType *orderby_nullsfirst, Jsonb *sparse_index);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get(Oid relid);
 TSDLLEXPORT CompressionSettings *ts_compression_settings_get_by_compress_relid(Oid relid);
+TSDLLEXPORT void ts_compression_settings_free(CompressionSettings *settings);
 TSDLLEXPORT bool ts_relation_is_compressed_chunk_relation(Oid relid);
 TSDLLEXPORT Oid ts_relation_get_uncompressed_relid(Oid compress_relid);
 TSDLLEXPORT Oid ts_relation_get_compressed_relid(Oid relid);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1284,6 +1284,8 @@ tsl_compressor_init(Relation in_rel, BulkWriter **bulk_writer, bool sort, int so
 
 	MemoryContextSwitchTo(old_context);
 
+	ts_compression_settings_free(settings);
+
 	return compressor;
 }
 
@@ -1294,10 +1296,8 @@ void
 row_compressor_init(RowCompressor *row_compressor, const CompressionSettings *settings,
 					const TupleDesc noncompressed_tupdesc, const TupleDesc compressed_tupdesc)
 {
-	Name count_metadata_name = DatumGetName(
-		DirectFunctionCall1(namein, CStringGetDatum(COMPRESSION_COLUMN_METADATA_COUNT_NAME)));
 	AttrNumber count_metadata_column_num =
-		get_attnum(settings->fd.compress_relid, NameStr(*count_metadata_name));
+		get_attnum(settings->fd.compress_relid, COMPRESSION_COLUMN_METADATA_COUNT_NAME);
 
 	if (count_metadata_column_num == InvalidAttrNumber)
 	{
@@ -1982,12 +1982,15 @@ bulk_writer_build(Relation out_rel, int insert_options)
 {
 	BulkWriter writer = {
 		.out_rel = out_rel,
-		.indexstate = CatalogOpenIndexes(out_rel),
 		.mycid = GetCurrentCommandId(true),
-		.bistate = GetBulkInsertState(),
 		.estate = CreateExecutorState(),
 		.insert_options = insert_options,
 	};
+
+	MemoryContext oldcxt = MemoryContextSwitchTo(writer.estate->es_query_cxt);
+	writer.indexstate = CatalogOpenIndexes(out_rel);
+	writer.bistate = GetBulkInsertState();
+	MemoryContextSwitchTo(oldcxt);
 
 	return writer;
 }

--- a/tsl/test/expected/direct_compress_memory.out
+++ b/tsl/test/expected/direct_compress_memory.out
@@ -19,13 +19,22 @@ select create_hypertable('dc_mem', 'time', chunk_time_interval => interval '1 da
 alter table dc_mem set (timescaledb.compress,
     timescaledb.compress_segmentby = 'device',
     timescaledb.compress_orderby = 'time');
+-- A direct `generate_series` call can materialize its results in a tuplestore,
+-- leading to memory usage growth, so use plain tables as source instead.
+create table dc_mem_src_alt(time timestamptz not null, device text, value float8);
+insert into dc_mem_src_alt
+select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
+from generate_series(1, 800) i;
+create table dc_mem_src_grow(time timestamptz not null, device text, value float8);
+insert into dc_mem_src_grow
+select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
+from generate_series(1, 800) i;
 create table dc_mem_log(nchunks int, bytes bigint);
 -- Insert into alternating chunks to test chunk changes with direct compress.
 select format('
 with ins as (
     insert into dc_mem
-    select ''2025-01-01''::timestamptz + (i %% 2) * (interval ''1 day''), ''dev1'', random()
-    from generate_series(1, %1$s) i returning 1),
+    select * from dc_mem_src_alt limit %1$s returning 1),
 mem as (select %1$s as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 ', unnest(array[50, 100, 200, 400, 800]))
@@ -33,47 +42,42 @@ insert into dc_mem_log select n, b from mem;
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 50) i returning 1),
+    select * from dc_mem_src_alt limit 50 returning 1),
 mem as (select 50 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 100) i returning 1),
+    select * from dc_mem_src_alt limit 100 returning 1),
 mem as (select 100 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 200) i returning 1),
+    select * from dc_mem_src_alt limit 200 returning 1),
 mem as (select 200 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 400) i returning 1),
+    select * from dc_mem_src_alt limit 400 returning 1),
 mem as (select 400 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 800) i returning 1),
+    select * from dc_mem_src_alt limit 800 returning 1),
 mem as (select 800 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 ;
 -- Check if we have memory usage growth with the number of chunks processed.
 select * from dc_mem_log where (
-    select regr_slope(bytes, nchunks) / regr_intercept(bytes, nchunks)::float > 0.01
+    select regr_slope(bytes, nchunks) / regr_intercept(bytes, nchunks)::float > 0.001
     from dc_mem_log)
 ;
  nchunks | bytes 
@@ -84,8 +88,7 @@ truncate dc_mem_log;
 select format('
 with ins as (
     insert into dc_mem
-    select ''2025-01-01''::timestamptz + i * (interval ''1 day''), ''dev1'', random()
-    from generate_series(1, %1$s) i returning 1),
+    select * from dc_mem_src_grow limit %1$s returning 1),
 mem as (select %1$s as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 ', unnest(array[50, 100, 200, 400, 800]))
@@ -93,40 +96,35 @@ insert into dc_mem_log select n, b from mem;
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 50) i returning 1),
+    select * from dc_mem_src_grow limit 50 returning 1),
 mem as (select 50 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 100) i returning 1),
+    select * from dc_mem_src_grow limit 100 returning 1),
 mem as (select 100 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 200) i returning 1),
+    select * from dc_mem_src_grow limit 200 returning 1),
 mem as (select 200 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 400) i returning 1),
+    select * from dc_mem_src_grow limit 400 returning 1),
 mem as (select 400 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 
 
 with ins as (
     insert into dc_mem
-    select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
-    from generate_series(1, 800) i returning 1),
+    select * from dc_mem_src_grow limit 800 returning 1),
 mem as (select 800 as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 

--- a/tsl/test/sql/direct_compress_memory.sql
+++ b/tsl/test/sql/direct_compress_memory.sql
@@ -21,14 +21,25 @@ alter table dc_mem set (timescaledb.compress,
     timescaledb.compress_segmentby = 'device',
     timescaledb.compress_orderby = 'time');
 
+-- A direct `generate_series` call can materialize its results in a tuplestore,
+-- leading to memory usage growth, so use plain tables as source instead.
+create table dc_mem_src_alt(time timestamptz not null, device text, value float8);
+insert into dc_mem_src_alt
+select '2025-01-01'::timestamptz + (i % 2) * (interval '1 day'), 'dev1', random()
+from generate_series(1, 800) i;
+
+create table dc_mem_src_grow(time timestamptz not null, device text, value float8);
+insert into dc_mem_src_grow
+select '2025-01-01'::timestamptz + i * (interval '1 day'), 'dev1', random()
+from generate_series(1, 800) i;
+
 create table dc_mem_log(nchunks int, bytes bigint);
 
 -- Insert into alternating chunks to test chunk changes with direct compress.
 select format('
 with ins as (
     insert into dc_mem
-    select ''2025-01-01''::timestamptz + (i %% 2) * (interval ''1 day''), ''dev1'', random()
-    from generate_series(1, %1$s) i returning 1),
+    select * from dc_mem_src_alt limit %1$s returning 1),
 mem as (select %1$s as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 ', unnest(array[50, 100, 200, 400, 800]))
@@ -37,7 +48,7 @@ insert into dc_mem_log select n, b from mem;
 
 -- Check if we have memory usage growth with the number of chunks processed.
 select * from dc_mem_log where (
-    select regr_slope(bytes, nchunks) / regr_intercept(bytes, nchunks)::float > 0.01
+    select regr_slope(bytes, nchunks) / regr_intercept(bytes, nchunks)::float > 0.001
     from dc_mem_log)
 ;
 
@@ -47,8 +58,7 @@ truncate dc_mem_log;
 select format('
 with ins as (
     insert into dc_mem
-    select ''2025-01-01''::timestamptz + i * (interval ''1 day''), ''dev1'', random()
-    from generate_series(1, %1$s) i returning 1),
+    select * from dc_mem_src_grow limit %1$s returning 1),
 mem as (select %1$s as n, count(*), ts_debug_allocated_bytes() as b from ins)
 insert into dc_mem_log select n, b from mem;
 ', unnest(array[50, 100, 200, 400, 800]))


### PR DESCRIPTION
Move some things into temporary contexts, remove some allocations, free some others.

This work was started in https://github.com/timescale/timescaledb/pull/9606