### PR TITLE
Add new update test mode that does not skip intermediate versions

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -49,13 +49,24 @@ jobs:
         wget --quiet --tries=6 --waitretry=15 -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
         sudo apt-get update
         sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
-        sudo apt-get install -y --no-install-recommends timescaledb-2-postgresql-${{ matrix.pg }}
+        # The unversioned timescaledb-2-postgresql package only ships update
+        # scripts that jump straight to the latest version. Install every
+        # versioned package instead so the extension directory also has the
+        # consecutive update scripts the singlestep update test needs.
+        ts_packages=$(apt-cache search --names-only '^timescaledb-2-[0-9].*-postgresql-${{ matrix.pg }}$' | awk '{ print $1 }')
+        sudo apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-overwrite" ${ts_packages}
         git fetch --tags
 
     - name: Update tests PG${{ matrix.pg }}
       run: |
         PATH="/usr/lib/postgresql/${{ matrix.pg }}/bin:$PATH"
         ./scripts/test_updates.sh
+
+    - name: Singlestep update tests PG${{ matrix.pg }}
+      if: always()
+      run: |
+        PATH="/usr/lib/postgresql/${{ matrix.pg }}/bin:$PATH"
+        UPDATE_MODE=singlestep ./scripts/test_updates.sh
 
     - name: Downgrade tests PG${{ matrix.pg }}
       if: always()

--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -4,6 +4,10 @@
 # - baseline: fresh installation of $TO_VERSION
 # - updated: install $FROM_VERSION, update to $TO_VERSION
 # - restored: restore from updated dump
+#
+# UPDATE_MODE controls how the "updated" database is updated:
+# - direct (default): jump straight from $FROM_VERSION to $TO_VERSION
+# - singlestep: update through every intermediate version one at a time
 
 set -xeu
 
@@ -11,8 +15,9 @@ FROM_VERSION=${FROM_VERSION:-$(grep '^previous_version ' version.config | awk '{
 TO_VERSION=${TO_VERSION:-$(grep '^version ' version.config | awk '{ print $3 }')}
 
 TEST_VERSION=${TEST_VERSION:-v10}
+UPDATE_MODE=${UPDATE_MODE:-direct}
 
-OUTPUT_DIR=${OUTPUT_DIR:-update_test/${FROM_VERSION}_to_${TO_VERSION}}
+OUTPUT_DIR=${OUTPUT_DIR:-update_test/${FROM_VERSION}_to_${TO_VERSION}_${UPDATE_MODE}}
 PGDATA="${OUTPUT_DIR}/data"
 # Get an unused port to allow	for parallel execution
 PGHOST=localhost
@@ -33,6 +38,51 @@ run_sql_file() {
 
 check_version() {
   psql -X -c "DO \$\$BEGIN PERFORM from pg_available_extension_versions WHERE name='timescaledb' AND version='$1'; IF NOT FOUND THEN RAISE 'Version $1 not available'; END IF; END\$\$;" > /dev/null
+}
+
+# Single-step transitions that are known to be broken when applied on their own
+# (e.g. an old release script that predates a later fix).
+SINGLESTEP_SKIP=(
+  # The 2.14.0 update script fails on tables with dropped columns; this was
+  # fixed in 2.15.0, so skip the broken edges and step straight to 2.15.0.
+  "2.13.1--2.14.0"
+  "2.13.1--2.14.1"
+  "2.13.1--2.14.2"
+)
+
+# Updates starting before 2.15 carry a fixture that the 2.28.0 and 2.28.1 update
+# scripts can't migrate (int->bigint view change); the 2.28.2 update script handles
+# it, so step from 2.27.2 straight to 2.28.2 when updating from <2.15.
+if [ "$(echo "${FROM_VERSION}" | awk -F. '{print $2}')" -lt 15 ]; then
+  SINGLESTEP_SKIP+=("2.27.2--2.28.0" "2.27.2--2.28.1")
+fi
+
+# Update the current database one version at a time from FROM_VERSION to
+# TO_VERSION, exercising every intermediate update script. We can't step through
+# the versions in numeric order because back-patch releases (e.g. 2.21.4 was
+# released after 2.22.0) have no update script to the next numeric version.
+# Instead we repeatedly move to the lowest version reachable from the current
+# one through a single update script, ignoring transitions listed in
+# SINGLESTEP_SKIP.
+singlestep_update() {
+  local current="${FROM_VERSION}" next skip_clause=""
+  if [ ${#SINGLESTEP_SKIP[@]} -gt 0 ]; then
+    local quoted
+    quoted=$(printf "'%s'," "${SINGLESTEP_SKIP[@]}")
+    skip_clause="AND source || '--' || target NOT IN (${quoted%,})"
+  fi
+  while [ "${current}" != "${TO_VERSION}" ]; do
+    next=$(psql -X -At -d "${PGDATABASE}" -c "
+      SELECT target FROM pg_extension_update_paths('timescaledb')
+      WHERE source = '${current}' AND path = source || '--' || target
+        ${skip_clause}
+        AND string_to_array(regexp_replace(target, '[^0-9.].*\$', ''), '.')::int[]
+            > string_to_array(regexp_replace('${current}', '[^0-9.].*\$', ''), '.')::int[]
+      ORDER BY string_to_array(regexp_replace(target, '[^0-9.].*\$', ''), '.')::int[]
+      LIMIT 1")
+    run_sql "ALTER EXTENSION timescaledb UPDATE TO \"${next}\";"
+    current="${next}"
+  done
 }
 
 trap cleanup EXIT
@@ -61,7 +111,7 @@ pg_ctl -l "${OUTPUT_DIR}/postgres.log" start -o "-c unix_socket_directories=${UN
 
 pg_isready -t 30 > /dev/null
 
-echo -e "\nUpdate test version ${TEST_VERSION} for ${FROM_VERSION} -> ${TO_VERSION}\n"
+echo -e "\nUpdate test version ${TEST_VERSION} (${UPDATE_MODE}) for ${FROM_VERSION} -> ${TO_VERSION}\n"
 
 # caller should ensure that the versions are available
 check_version "${FROM_VERSION}"
@@ -88,7 +138,11 @@ echo "Creating updated database"
   run_sql_file test/sql/updates/pre.testing.sql
   run_sql_file test/sql/updates/setup.${TEST_VERSION}.sql
   run_sql "CHECKPOINT;" >> "${OUTPUT_DIR}/updated.log"
-  run_sql "ALTER EXTENSION timescaledb UPDATE TO \"${TO_VERSION}\";"
+  if [ "${UPDATE_MODE}" = singlestep ]; then
+    singlestep_update
+  else
+    run_sql "ALTER EXTENSION timescaledb UPDATE TO \"${TO_VERSION}\";"
+  fi
   run_sql_file test/sql/updates/setup.check.sql
 } > "${OUTPUT_DIR}/updated.log" 2>&1
 

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -86,7 +86,7 @@ if [ -n "${VERSIONS}" ]; then
   for version in ${VERSIONS}; do
     ts_minor_version=$(echo "${version}" | awk -F. '{print $2}')
 
-    if [ "${ts_minor_version}" -ge 25 ]; then
+    if [ "${ts_minor_version}" -ge 26 ]; then
         TEST_VERSION=v12
     elif [ "${ts_minor_version}" -ge 22 ]; then
         TEST_VERSION=v11

--- a/sql/updates/2.28.0--2.28.1.sql
+++ b/sql/updates/2.28.0--2.28.1.sql
@@ -36,6 +36,9 @@ BEGIN
 
     CREATE INDEX bgw_job_stat_history_job_id_idx ON _timescaledb_internal.bgw_job_stat_history (job_id);
     REVOKE ALL ON _timescaledb_internal.bgw_job_stat_history FROM PUBLIC;
+
+    DROP TABLE _timescaledb_internal._tmp_bgw_job_stat_history;
+    DROP TABLE _timescaledb_internal._tmp_job_stat_history_id_seq;
     --
     -- END bgw_job_stat_history
     --


### PR DESCRIPTION
When testing updates update from source to target directly is different
from chaining single version updates as all objects get fully rebuilt
in the latter variant. Test both variants in CI.

Disable-check: force-changelog-file
Disable-check: commit-count
