### PR TITLE
Fix bgw_job_stat_history migration for 2.28.1

### DIFF
--- a/.unreleased/pr_10126
+++ b/.unreleased/pr_10126
@@ -1,0 +1,2 @@
+Fixes: #10126 Fix bgw_job_stat_history migration for 2.28.1
+Thanks: @juantxorena for reporting an issue with update script for 2.28.1

--- a/sql/updates/2.28.0--2.28.1.sql
+++ b/sql/updates/2.28.0--2.28.1.sql
@@ -32,7 +32,7 @@ BEGIN
     ALTER SEQUENCE _timescaledb_internal.bgw_job_stat_history_id_seq OWNED BY _timescaledb_internal.bgw_job_stat_history.id;
 
     INSERT INTO _timescaledb_internal.bgw_job_stat_history (id, job_id, pid, execution_start, execution_finish, succeeded, data) SELECT id, job_id, pid, execution_start, execution_finish, succeeded, data FROM _timescaledb_internal._tmp_bgw_job_stat_history;
-    SELECT setval('_timescaledb_internal.bgw_job_stat_history_id_seq', last_value, is_called) FROM _timescaledb_internal._tmp_job_stat_history_id_seq;
+    PERFORM setval('_timescaledb_internal.bgw_job_stat_history_id_seq', last_value, is_called) FROM _timescaledb_internal._tmp_job_stat_history_id_seq;
 
     CREATE INDEX bgw_job_stat_history_job_id_idx ON _timescaledb_internal.bgw_job_stat_history (job_id);
     REVOKE ALL ON _timescaledb_internal.bgw_job_stat_history FROM PUBLIC;


### PR DESCRIPTION
Any instance with bgw_job_stat_history catalog table that needed
migration wil trigger an error because the update script used SELECT
without INTO instead of PERFORM.

Fixes: #10120
