### PR TITLE
Adjust post_analyze_hook definition for PG19

### DIFF
--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -472,7 +472,11 @@ database_allowconn(const Oid db_oid)
 }
 
 static void
+#if PG19_GE
+post_analyze_hook(ParseState *pstate, Query *query, const JumbleState *jstate)
+#else
 post_analyze_hook(ParseState *pstate, Query *query, JumbleState *jstate)
+#endif
 {
 	if (query->commandType == CMD_UTILITY)
 	{


### PR DESCRIPTION
PG19 makes JumbleState argument const so we need to adjust our
definition when building against PG19.

Upstream change: postgres commit 49cc0d41488b92a1d547e278b459c3b224393c8f (Mark JumbleState as a const in the post_parse_analyze hook)

Disable-check: loader-change
Disable-check: force-changelog-file