### PR TITLE
Fix chunk_constraint migration

### DIFF
--- a/.unreleased/pr_10133
+++ b/.unreleased/pr_10133
@@ -1,0 +1,2 @@
+Fixes: #10133 Fix chunk_constraint migration
+Thanks: @rusha1333 for reporting an issue when upgrading to 2.28.1

--- a/sql/updates/2.27.2--2.28.0.sql
+++ b/sql/updates/2.27.2--2.28.0.sql
@@ -121,10 +121,12 @@ DO $$
 DECLARE
     r RECORD;
 BEGIN
+    -- Move every CHECK that needs a new id to a temporary name. The
+    -- "constraint_tmp_" prefix never clashes with the "constraint_<id>" names.
     FOR r IN
         SELECT pg_catalog.format('%I.%I', c.schema_name, c.table_name) AS chunk_table,
                format('constraint_%s', cc.dimension_slice_id)::name AS old_name,
-               format('constraint_%s', ds.id)::name AS new_name
+               format('constraint_tmp_%s', ds.id)::name AS tmp_name
         FROM _timescaledb_catalog.chunk_constraint cc
         JOIN _timescaledb_internal.tmp_dimension_slice tmp
             ON tmp.id = cc.dimension_slice_id
@@ -142,7 +144,32 @@ BEGIN
           )
     LOOP
         EXECUTE pg_catalog.format('ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
-                                  r.chunk_table, r.old_name, r.new_name);
+                                  r.chunk_table, r.old_name, r.tmp_name);
+    END LOOP;
+
+    -- Move the temporary names to their final constraint_<new_id> names.
+    FOR r IN
+        SELECT pg_catalog.format('%I.%I', c.schema_name, c.table_name) AS chunk_table,
+               format('constraint_tmp_%s', ds.id)::name AS tmp_name,
+               format('constraint_%s', ds.id)::name AS new_name
+        FROM _timescaledb_catalog.chunk_constraint cc
+        JOIN _timescaledb_internal.tmp_dimension_slice tmp
+            ON tmp.id = cc.dimension_slice_id
+        JOIN _timescaledb_catalog.chunk c ON c.id = cc.chunk_id
+        JOIN _timescaledb_catalog.dimension_slice ds
+            ON ds.chunk_id = cc.chunk_id
+           AND ds.dimension_id = tmp.dimension_id
+        WHERE cc.dimension_slice_id IS NOT NULL
+          AND cc.dimension_slice_id <> ds.id
+          AND EXISTS (
+              SELECT 1 FROM pg_constraint pc
+              WHERE pc.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
+                AND pc.conname = format('constraint_tmp_%s', ds.id)::name
+                AND pc.contype = 'c'
+          )
+    LOOP
+        EXECUTE pg_catalog.format('ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
+                                  r.chunk_table, r.tmp_name, r.new_name);
     END LOOP;
 END
 $$;

--- a/sql/updates/2.28.0--2.27.2.sql
+++ b/sql/updates/2.28.0--2.27.2.sql
@@ -68,10 +68,12 @@ DO $$
 DECLARE
     r RECORD;
 BEGIN
+    -- Move every CHECK that needs a new id to a temporary name. The
+    -- "constraint_tmp_" prefix never clashes with the "constraint_<id>" names.
     FOR r IN
         SELECT pg_catalog.format('%I.%I', c.schema_name, c.table_name) AS chunk_table,
                format('constraint_%s', tmp.id)::name AS old_name,
-               format('constraint_%s', ds.id)::name AS new_name
+               format('constraint_tmp_%s', ds.id)::name AS tmp_name
         FROM _timescaledb_internal.tmp_dimension_slice tmp
         JOIN _timescaledb_catalog.chunk c ON c.id = tmp.chunk_id
         JOIN _timescaledb_catalog.dimension_slice ds
@@ -87,7 +89,30 @@ BEGIN
           )
     LOOP
         EXECUTE pg_catalog.format('ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
-                                  r.chunk_table, r.old_name, r.new_name);
+                                  r.chunk_table, r.old_name, r.tmp_name);
+    END LOOP;
+
+    -- Move the temporary names to their final constraint_<kept_id> names.
+    FOR r IN
+        SELECT pg_catalog.format('%I.%I', c.schema_name, c.table_name) AS chunk_table,
+               format('constraint_tmp_%s', ds.id)::name AS tmp_name,
+               format('constraint_%s', ds.id)::name AS new_name
+        FROM _timescaledb_internal.tmp_dimension_slice tmp
+        JOIN _timescaledb_catalog.chunk c ON c.id = tmp.chunk_id
+        JOIN _timescaledb_catalog.dimension_slice ds
+            ON ds.dimension_id = tmp.dimension_id
+           AND ds.range_start = tmp.range_start
+           AND ds.range_end = tmp.range_end
+        WHERE tmp.id <> ds.id
+          AND EXISTS (
+              SELECT 1 FROM pg_constraint pc
+              WHERE pc.conrelid = pg_catalog.format('%I.%I', c.schema_name, c.table_name)::regclass
+                AND pc.conname = format('constraint_tmp_%s', ds.id)::name
+                AND pc.contype = 'c'
+          )
+    LOOP
+        EXECUTE pg_catalog.format('ALTER TABLE %s RENAME CONSTRAINT %I TO %I',
+                                  r.chunk_table, r.tmp_name, r.new_name);
     END LOOP;
 END
 $$;


### PR DESCRIPTION
On hypertables with multiple dimensions the migration can fail because
the constraint name we are trying to rename to might be currently used
by a constraint on another dimension. Do the rename in two steps by
first moving all constraints to a temporary name and then renaming to
the final name.

Fixes: #10127 