### PR TITLE
Add space-partitioned hypertable to update tests

### DIFF
--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -25,6 +25,24 @@ BEGIN
         LOOP
           RAISE EXCEPTION 'Missing dimension slice for chunk % on dimension %.', gap.chunk_id, gap.dimension_id;
         END LOOP;
+
+        -- Every dimensional CHECK named constraint_<n> on a chunk must point at
+        -- a slice that the chunk actually owns.
+        FOR gap IN
+        SELECT ch.id AS chunk_id,
+               substring(pc.conname FROM 'constraint_([0-9]+)')::int AS slice_id
+        FROM _timescaledb_catalog.chunk ch
+        JOIN pg_constraint pc
+            ON pc.conrelid = pg_catalog.format('%I.%I', ch.schema_name, ch.table_name)::regclass
+           AND pc.contype = 'c'
+           AND pc.conname ~ '^constraint_[0-9]+$'
+        WHERE NOT ch.osm_chunk
+          AND NOT EXISTS (SELECT 1 FROM _timescaledb_catalog.dimension_slice ds
+                          WHERE ds.chunk_id = ch.id
+                            AND ds.id = substring(pc.conname FROM 'constraint_([0-9]+)')::int)
+        LOOP
+          RAISE EXCEPTION 'Chunk % has stale dimensional CHECK constraint_%.', gap.chunk_id, gap.slice_id;
+        END LOOP;
     ELSE
         FOR gap IN
         SELECT ch.id AS chunk_id, d.id AS dimension_id

--- a/test/sql/updates/setup.v7.sql
+++ b/test/sql/updates/setup.v7.sql
@@ -19,3 +19,25 @@ ALTER TABLE PUBLIC.hyper_timestamp
 \ir setup.continuous_aggs.sql
 \ir setup.compression.sql
 \ir setup.policies.sql
+
+-- Space-partitioned hypertable for extra update/downgrade coverage
+CREATE TABLE space_constraints (
+  time timestamptz NOT NULL,
+  device int NOT NULL,
+  value double precision
+);
+
+SELECT create_hypertable('space_constraints', 'time', 'device',
+                         number_partitions => 2,
+                         chunk_time_interval => interval '1 day');
+
+INSERT INTO space_constraints
+SELECT '2020-01-01'::timestamptz + (g % 6) * interval '1 day', g % 4, g
+FROM generate_series(1, 200) g;
+
+-- Drop a couple of chunks.
+SELECT drop_chunks('space_constraints', '2020-01-03'::timestamptz);
+
+INSERT INTO space_constraints
+SELECT '2020-02-01'::timestamptz + (g % 5) * interval '1 day', g % 4, g
+FROM generate_series(1, 200) g;


### PR DESCRIPTION
To get more coverage for space partitioned hypertables add another
one to update test schema so it gets utilized during update/downgrade
test.
