### PR TITLE
Pass pointer to the varlena access functions

### DIFF
--- a/tsl/src/compression/algorithms/bool_compress.c
+++ b/tsl/src/compression/algorithms/bool_compress.c
@@ -363,9 +363,10 @@ bool_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
 
 	CheckCompressedData(DatumGetPointer(compressed) != NULL);
 	/* detoasting is caller responsibility */
-	CheckCompressedData(!VARATT_IS_EXTERNAL(compressed));
+	CheckCompressedData(!VARATT_IS_EXTERNAL(DatumGetPointer(compressed)));
 
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed),
+						  .len = VARSIZE(DatumGetPointer(compressed)) };
 	BoolCompressed *header = consumeCompressedData(&si, sizeof(BoolCompressed));
 
 	Assert(header->has_nulls == 0 || header->has_nulls == 1);

--- a/tsl/src/compression/algorithms/deltadelta_impl.c
+++ b/tsl/src/compression/algorithms/deltadelta_impl.c
@@ -15,7 +15,8 @@
 static ArrowArray *
 FUNCTION_NAME(delta_delta_decompress_all, ELEMENT_TYPE)(Datum compressed, MemoryContext dest_mctx)
 {
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed),
+						  .len = VARSIZE(DatumGetPointer(compressed)) };
 	DeltaDeltaCompressed *header = consumeCompressedData(&si, sizeof(DeltaDeltaCompressed));
 	Simple8bRleSerialized *deltas_compressed = bytes_deserialize_simple8b_and_advance(&si);
 

--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -510,7 +510,8 @@ tsl_bool_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryCon
 	Assert(element_type == BOOLOID);
 
 	compressed = PointerGetDatum(PG_DETOAST_DATUM(compressed));
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed),
+						  .len = VARSIZE(DatumGetPointer(compressed)) };
 	const DictionaryCompressed *header = consumeCompressedData(&si, sizeof(DictionaryCompressed));
 
 	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_DICTIONARY);
@@ -588,7 +589,8 @@ tsl_uuid_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryCon
 	Assert(element_type == UUIDOID);
 
 	compressed = PointerGetDatum(PG_DETOAST_DATUM(compressed));
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE_ANY(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed),
+						  .len = VARSIZE_ANY(DatumGetPointer(compressed)) };
 	const DictionaryCompressed *header = consumeCompressedData(&si, sizeof(DictionaryCompressed));
 
 	Assert(header->compression_algorithm == COMPRESSION_ALGORITHM_DICTIONARY);
@@ -684,7 +686,8 @@ tsl_text_dictionary_decompress_all(Datum compressed, Oid element_type, MemoryCon
 
 	compressed = PointerGetDatum(PG_DETOAST_DATUM(compressed));
 
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed),
+						  .len = VARSIZE(DatumGetPointer(compressed)) };
 
 	const DictionaryCompressed *header = consumeCompressedData(&si, sizeof(DictionaryCompressed));
 

--- a/tsl/src/compression/algorithms/uuid_compress.c
+++ b/tsl/src/compression/algorithms/uuid_compress.c
@@ -495,7 +495,7 @@ uuid_compressed_recv(StringInfo buffer)
 	compressed->compression_algorithm = COMPRESSION_ALGORITHM_UUID;
 
 	Datum delta_delta_compressed = deltadelta_compressed_recv(buffer);
-	size_t delta_delta_compressed_size = VARSIZE(delta_delta_compressed);
+	size_t delta_delta_compressed_size = VARSIZE(DatumGetPointer(delta_delta_compressed));
 	CheckCompressedData(delta_delta_compressed_size == timestamp_size);
 
 	memcpy(result + sizeof(UuidCompressed),
@@ -598,9 +598,10 @@ uuid_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
 
 	CheckCompressedData(DatumGetPointer(compressed) != NULL);
 	/* detoasting is caller responsibility */
-	CheckCompressedData(!VARATT_IS_EXTERNAL(compressed));
+	CheckCompressedData(!VARATT_IS_EXTERNAL(DatumGetPointer(compressed)));
 
-	StringInfoData si = { .data = DatumGetPointer(compressed), .len = VARSIZE_ANY(compressed) };
+	StringInfoData si = { .data = DatumGetPointer(compressed),
+						  .len = VARSIZE_ANY(DatumGetPointer(compressed)) };
 	UuidCompressed *header = consumeCompressedData(&si, sizeof(UuidCompressed));
 	char *timestamp_compressed_data = NULL;
 	char *rand_b_and_variant_compressed_data;

--- a/tsl/src/compression/batch_metadata_builder_bloom1.c
+++ b/tsl/src/compression/batch_metadata_builder_bloom1.c
@@ -1104,8 +1104,9 @@ ts_bloom1_debug_info(PG_FUNCTION_ARGS)
 	bool nulls[_out_columns] = { 0 };
 
 	Datum toasted = PG_GETARG_DATUM(0);
-	values[out_toast_header] = Int32GetDatum(((varattrib_1b *) toasted)->va_header);
-	values[out_toasted_bytes] = Int32GetDatum(VARSIZE_ANY_EXHDR(toasted));
+	struct varlena *toasted_va = (struct varlena *) DatumGetPointer(toasted);
+	values[out_toast_header] = Int32GetDatum(((varattrib_1b *) toasted_va)->va_header);
+	values[out_toasted_bytes] = Int32GetDatum(VARSIZE_ANY_EXHDR(toasted_va));
 
 	struct varlena *detoasted = PG_DETOAST_DATUM(toasted);
 	values[out_detoasted_bytes] = Int32GetDatum(VARSIZE_ANY_EXHDR(detoasted));
@@ -1119,10 +1120,10 @@ ts_bloom1_debug_info(PG_FUNCTION_ARGS)
 
 	values[out_estimated_elements] = Int32GetDatum(bloom1_estimate_ndistinct(detoasted));
 
-	if (VARATT_IS_EXTERNAL_ONDISK(toasted))
+	if (VARATT_IS_EXTERNAL_ONDISK(toasted_va))
 	{
 		struct varatt_external toast_pointer;
-		VARATT_EXTERNAL_GET_POINTER(toast_pointer, toasted);
+		VARATT_EXTERNAL_GET_POINTER(toast_pointer, toasted_va);
 
 		if (TS_VARATT_EXTERNAL_IS_COMPRESSED(toast_pointer))
 		{
@@ -1133,9 +1134,9 @@ ts_bloom1_debug_info(PG_FUNCTION_ARGS)
 			nulls[out_compressed_bytes] = true;
 		}
 	}
-	else if (VARATT_IS_COMPRESSED(toasted))
+	else if (VARATT_IS_COMPRESSED(toasted_va))
 	{
-		values[out_compressed_bytes] = VARDATA_COMPRESSED_GET_EXTSIZE(toasted);
+		values[out_compressed_bytes] = VARDATA_COMPRESSED_GET_EXTSIZE(toasted_va);
 	}
 	else
 	{

--- a/tsl/src/nodes/columnar_scan/compressed_batch.h
+++ b/tsl/src/nodes/columnar_scan/compressed_batch.h
@@ -209,8 +209,8 @@ store_text_datum(CompressedColumnValues *column_values, int arrow_row)
 
 	const int total_bytes = value_bytes + VARHDRSZ;
 	Assert(DatumGetPointer(*column_values->output_value) != NULL);
-	SET_VARSIZE(*column_values->output_value, total_bytes);
-	memcpy(VARDATA(*column_values->output_value),
+	SET_VARSIZE(DatumGetPointer(*column_values->output_value), total_bytes);
+	memcpy(VARDATA(DatumGetPointer(*column_values->output_value)),
 		   &((uint8 *) column_values->buffers[2])[start],
 		   value_bytes);
 }

--- a/tsl/src/nodes/vector_agg/exec.c
+++ b/tsl/src/nodes/vector_agg/exec.c
@@ -171,7 +171,7 @@ columnar_result_set_row(ColumnarResult *columnar_result, DecompressBatchState co
 		}
 		case DT_ArrowText:
 		{
-			const Size result_bytes = VARSIZE_ANY_EXHDR(datum);
+			const Size result_bytes = VARSIZE_ANY_EXHDR(DatumGetPointer(datum));
 			const Size required_body_bytes =
 				pad_to_multiple(64, columnar_result->current_offset + result_bytes);
 			if (required_body_bytes > MaxAllocSize)
@@ -203,7 +203,7 @@ columnar_result_set_row(ColumnarResult *columnar_result, DecompressBatchState co
 			}
 
 			memcpy(&columnar_result->body_buffer[columnar_result->current_offset],
-				   VARDATA_ANY(datum),
+				   VARDATA_ANY(DatumGetPointer(datum)),
 				   result_bytes);
 			/* offset_buffer should be allocated for ArrowText type */
 			Assert(columnar_result->offset_buffer != NULL);

--- a/tsl/src/nodes/vector_agg/function/minmax_text.c
+++ b/tsl/src/nodes/vector_agg/function/minmax_text.c
@@ -136,8 +136,8 @@ FUNCTION_NAME(scalar)(void *agg_state, Datum constvalue, bool constisnull, int n
 		return;
 	}
 
-	BytesView value = { .data = (const uint8 *) VARDATA_ANY(constvalue),
-						.len = VARSIZE_ANY_EXHDR(constvalue) };
+	BytesView value = { .data = (const uint8 *) VARDATA_ANY(DatumGetPointer(constvalue)),
+						.len = VARSIZE_ANY_EXHDR(DatumGetPointer(constvalue)) };
 	MemoryContext old = MemoryContextSwitchTo(agg_extra_mctx);
 	FUNCTION_NAME(one)(agg_state, value);
 	MemoryContextSwitchTo(old);

--- a/tsl/src/nodes/vector_agg/hashing/hash_strategy_serialized.c
+++ b/tsl/src/nodes/vector_agg/hashing/hash_strategy_serialized.c
@@ -238,7 +238,7 @@ serialized_key_hashing_get_key(BatchHashingParams params, int row, void *restric
 					 * The default value always has a long varlena header, but
 					 * we are going to use short if it fits.
 					 */
-					const int32 value_bytes = VARSIZE_ANY_EXHDR(value);
+					const int32 value_bytes = VARSIZE_ANY_EXHDR(DatumGetPointer(value));
 					if (value_bytes + VARHDRSZ_SHORT <= VARATT_SHORT_MAX)
 					{
 						/* Short varlena, no alignment. */
@@ -256,7 +256,9 @@ serialized_key_hashing_get_key(BatchHashingParams params, int row, void *restric
 						offset += VARHDRSZ;
 					}
 
-					memcpy(&serialized_key_storage[offset], VARDATA_ANY(value), value_bytes);
+					memcpy(&serialized_key_storage[offset],
+						   VARDATA_ANY(DatumGetPointer(value)),
+						   value_bytes);
 
 					offset += value_bytes;
 				}
@@ -404,8 +406,10 @@ serialized_emit_key(GroupingPolicyHash *policy, uint32 current_key, TupleTableSl
 	const HashingStrategy *hashing = &policy->hashing;
 	const int num_key_columns = policy->num_grouping_columns;
 	const Datum serialized_key_datum = hashing->output_keys[current_key];
-	const uint8 *serialized_key = (const uint8 *) VARDATA_ANY(serialized_key_datum);
-	PG_USED_FOR_ASSERTS_ONLY const int key_data_bytes = VARSIZE_ANY_EXHDR(serialized_key_datum);
+	const uint8 *serialized_key =
+		(const uint8 *) VARDATA_ANY(DatumGetPointer(serialized_key_datum));
+	PG_USED_FOR_ASSERTS_ONLY const int key_data_bytes =
+		VARSIZE_ANY_EXHDR(DatumGetPointer(serialized_key_datum));
 	const uint8 *restrict ptr = serialized_key;
 
 	/*
@@ -418,9 +422,9 @@ serialized_emit_key(GroupingPolicyHash *policy, uint32 current_key, TupleTableSl
 
 	DEBUG_PRINT("emit key #%d, with header %ld without %d bytes: ",
 				current_key,
-				VARSIZE_ANY(serialized_key_datum),
+				VARSIZE_ANY(DatumGetPointer(serialized_key_datum)),
 				key_data_bytes);
-	for (size_t i = 0; i < VARSIZE_ANY(serialized_key_datum); i++)
+	for (size_t i = 0; i < VARSIZE_ANY(DatumGetPointer(serialized_key_datum)); i++)
 	{
 		DEBUG_PRINT("%.2x.", ((const uint8 *) serialized_key_datum)[i]);
 	}

--- a/tsl/test/src/compression_unit_test.c
+++ b/tsl/test/src/compression_unit_test.c
@@ -1177,8 +1177,8 @@ compare_datum_ptr(Datum datum1, Datum datum2, const char *msg)
 	char *ptr2 = DatumGetPointer(datum2);
 	TestAssertTrue(ptr1 != NULL);
 	TestAssertTrue(ptr2 != NULL);
-	size_t size1 = VARSIZE_ANY(datum1);
-	size_t size2 = VARSIZE_ANY(datum2);
+	size_t size1 = VARSIZE_ANY(ptr1);
+	size_t size2 = VARSIZE_ANY(ptr2);
 	TestAssertInt64Eq(size1, size2);
 	int memcmp_result = memcmp(ptr1, ptr2, size1);
 	if (memcmp_result != 0)

--- a/tsl/test/src/decompress_text_test_impl.c
+++ b/tsl/test/src/decompress_text_test_impl.c
@@ -65,8 +65,8 @@ decompress_generic_text_check_arrow(ArrowArray *arrow, int errorlevel, Decompres
 			size_t arrow_len = arrow_get_str(arrow, i, &arrow_cstring);
 
 			const Datum rowbyrow_varlena = results[i].val;
-			const size_t rowbyrow_len = VARSIZE_ANY_EXHDR(rowbyrow_varlena);
-			const char *rowbyrow_cstring = VARDATA_ANY(rowbyrow_varlena);
+			const size_t rowbyrow_len = VARSIZE_ANY_EXHDR(DatumGetPointer(rowbyrow_varlena));
+			const char *rowbyrow_cstring = VARDATA_ANY(DatumGetPointer(rowbyrow_varlena));
 
 			if (rowbyrow_len != arrow_len)
 			{
@@ -201,14 +201,15 @@ decompress_generic_text(const uint8 *Data, size_t Size, bool bulk, int requested
 			 * Floats can also be NaN/infinite and the comparison doesn't
 			 * work in that case.
 			 */
-			if (VARSIZE_ANY_EXHDR(old_value) != VARSIZE_ANY_EXHDR(new_value))
+			if (VARSIZE_ANY_EXHDR(DatumGetPointer(old_value)) !=
+				VARSIZE_ANY_EXHDR(DatumGetPointer(new_value)))
 			{
 				elog(ERROR, "the repeated decompression result doesn't match");
 			}
 
-			if (strncmp(VARDATA_ANY(old_value),
-						VARDATA_ANY(new_value),
-						VARSIZE_ANY_EXHDR(new_value)) != 0)
+			if (strncmp(VARDATA_ANY(DatumGetPointer(old_value)),
+						VARDATA_ANY(DatumGetPointer(new_value)),
+						VARSIZE_ANY_EXHDR(DatumGetPointer(new_value))) != 0)
 			{
 				elog(ERROR, "the repeated decompression result doesn't match");
 			}


### PR DESCRIPTION
PostgreSQL 19 turns the varlena access macros such as VARSIZE and VARDATA
into inline functions that take a pointer. Passing a Datum to them no longer
compiles, so convert the Datum to a pointer first.
This also works on earlier versions.

Upstream change: Convert varatt.h access macros to static inline functions
https://github.com/postgres/postgres/commit/e035863c9a

Disable-check: force-changelog-file
