### PR TITLE
Include math.h explicitly for PostgreSQL 19

### DIFF
--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -25,6 +25,7 @@
 #include <catalog/pg_inherits.h>
 #include <catalog/pg_namespace.h>
 #include <catalog/pg_type.h>
+#include <math.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
 #include <nodes/plannodes.h>

--- a/tsl/src/nodes/columnar_scan/vector_predicates.c
+++ b/tsl/src/nodes/columnar_scan/vector_predicates.c
@@ -10,6 +10,7 @@
 
 #include <postgres.h>
 
+#include <math.h>
 #include <mb/pg_wchar.h>
 #include <utils/date.h>
 #include <utils/fmgroids.h>

--- a/tsl/src/nodes/vector_agg/function/functions.c
+++ b/tsl/src/nodes/vector_agg/function/functions.c
@@ -5,6 +5,7 @@
  */
 
 #include <limits.h>
+#include <math.h>
 
 #include <postgres.h>
 

--- a/tsl/src/nodes/vector_agg/function/minmax_templates.c
+++ b/tsl/src/nodes/vector_agg/function/minmax_templates.c
@@ -4,6 +4,8 @@
  * LICENSE-TIMESCALE for a copy of the license.
  */
 
+#include <math.h>
+
 #include <postgres.h>
 
 #include <port/pg_bitutils.h>


### PR DESCRIPTION
PostgreSQL 19 no longer includes math.h from utils/date.h, so files that
relied on getting it indirectly no longer build. Add the include where
it is needed.

Upstream change: Remove #include <math.h> where not needed
https://github.com/postgres/postgres/commit/35e3fae738

Disable-check: force-changelog-file