### PR TITLE
Add ddl events for chunk auto publication

### DIFF
--- a/.unreleased/chunk-publication-ddl-events
+++ b/.unreleased/chunk-publication-ddl-events
@@ -1,0 +1,1 @@
+Implements: Emit ALTER PUBLICATION ddl_command_start/end events when enable_chunk_auto_publication adds a chunk to a publication

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1053,25 +1053,82 @@ get_hypertable_publication_filters(Oid puboid, const Chunk *chunk, List **column
 	ReleaseSysCache(pubtuple);
 }
 
+/* Add the given chunk to the given publication.
+ *
+ * NB: it is expected that this method is called for a chunk immediately
+ * following chunk creation when ts_guc_enable_chunk_auto_publication=on.
+ * If this is called at some other point in time where the chunk has
+ * already been added to the publication, it will propagate an error.
+ */
 static void
 chunk_add_to_publication(Oid puboid, const Chunk *chunk)
 {
+	volatile Relation chunk_rel = NULL;
+	volatile bool triggerStartOk = false;
+
 	PublicationRelInfo pri = { 0 };
-	Relation chunk_rel;
 	List *columns = NIL;
 	Node *whereClause = NULL;
 
+	/* Fetch data needed for updating the target publication. */
 	get_hypertable_publication_filters(puboid, chunk, &columns, &whereClause);
-
 	chunk_rel = table_open(chunk->table_id, AccessShareLock);
-
 	pri.relation = chunk_rel;
 	pri.columns = columns;
 	pri.whereClause = whereClause;
 
-	publication_add_relation(puboid, &pri, true);
+	/* Build DDL modes for event triggers. */
+	PublicationTable pubtable = {
+		.type = T_PublicationTable,
+		.relation = makeRangeVar((char *) NameStr(chunk->fd.schema_name),
+								 (char *) NameStr(chunk->fd.table_name),
+								 -1),
+		.whereClause = whereClause,
+		.columns = columns,
+	};
+	PublicationObjSpec pubobj = {
+		.type = T_PublicationObjSpec,
+		.pubobjtype = PUBLICATIONOBJ_TABLE,
+		.pubtable = &pubtable,
+		.location = -1,
+	};
+	AlterPublicationStmt stmt = {
+		.type = T_AlterPublicationStmt,
+		.pubname = GetPublication(puboid)->name,
+		.pubobjects = list_make1(&pubobj),
+		.action = AP_AddObjects,
+	};
 
-	table_close(chunk_rel, AccessShareLock);
+	if (ts_guc_enable_event_triggers)
+	{
+		triggerStartOk = EventTriggerBeginCompleteQuery();
+		EventTriggerDDLCommandStart((Node *) &stmt);
+	}
+
+	PG_TRY();
+	{
+		/* if_not_exists=false (instead of true) because we take it as an invariant that
+		 * this method is ONLY called immediately following chunk creation when chunk auto
+		 * pub is enabled. We rely on the error propagating functionality here
+		 * in order to invalidate the ddl_command_start, which should only happen in
+		 * the case of allocation errors, etc. */
+		ObjectAddress pubAddress = publication_add_relation(puboid, &pri, false);
+
+		if (ts_guc_enable_event_triggers)
+		{
+			EventTriggerCollectSimpleCommand(pubAddress, InvalidObjectAddress, (Node *) &stmt);
+			EventTriggerDDLCommandEnd((Node *) &stmt);
+		}
+	}
+	PG_FINALLY();
+	{
+		if (triggerStartOk)
+		{
+			EventTriggerEndCompleteQuery();
+		}
+		table_close(chunk_rel, AccessShareLock);
+	}
+	PG_END_TRY();
 }
 
 static void
@@ -1084,6 +1141,13 @@ chunk_add_to_publications(const Chunk *chunk)
 	foreach (lc, puboids)
 	{
 		Oid puboid = lfirst_oid(lc);
+
+		/* Previous iteration may have dropped the publication target of this iteration. */
+		if (!SearchSysCacheExists1(PUBLICATIONOID, ObjectIdGetDatum(puboid)))
+		{
+			continue;
+		}
+
 		chunk_add_to_publication(puboid, chunk);
 	}
 }

--- a/test/expected/chunk_publication_ddl_events.out
+++ b/test/expected/chunk_publication_ddl_events.out
@@ -1,0 +1,63 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Verify that automatically adding a chunk to a publication emits the
+-- ddl_command_start/end events for the implicit ALTER PUBLICATION ... ADD TABLE,
+-- and that no event is emitted when the publication is not actually updated.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION log_pub_ddl() RETURNS event_trigger AS $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN SELECT * FROM pg_event_trigger_ddl_commands() LOOP
+        RAISE NOTICE 'ddl_command_end: tag=% identity=%', r.command_tag, r.object_identity;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION drop_pub2() RETURNS event_trigger AS $$
+BEGIN
+    DROP PUBLICATION IF EXISTS pub2;
+END;
+$$ LANGUAGE plpgsql;
+CREATE EVENT TRIGGER pub_ddl_trigger ON ddl_command_end
+    WHEN TAG IN ('ALTER PUBLICATION') EXECUTE FUNCTION log_pub_ddl();
+SET client_min_messages = WARNING;
+SET timescaledb.enable_chunk_auto_publication = true;
+SET timescaledb.enable_event_triggers = true;
+CREATE TABLE pub_test (time timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('pub_test', 'time', chunk_time_interval => interval '1 day');
+   create_hypertable   
+-----------------------
+ (1,public,pub_test,t)
+
+CREATE PUBLICATION test_pub FOR TABLE pub_test;
+SET client_min_messages = NOTICE;
+-- Each new chunk fires an ALTER PUBLICATION ddl_command_end event.
+INSERT INTO pub_test VALUES ('2024-01-01 00:00:00+00', 1, 1.0);
+NOTICE:  ddl_command_end: tag=ALTER PUBLICATION identity=_timescaledb_internal._hyper_1_1_chunk in publication test_pub
+INSERT INTO pub_test VALUES ('2024-01-02 00:00:00+00', 2, 2.0);
+NOTICE:  ddl_command_end: tag=ALTER PUBLICATION identity=_timescaledb_internal._hyper_1_2_chunk in publication test_pub
+-- Inserting into an existing chunk does NOT update the publication, so no event.
+INSERT INTO pub_test VALUES ('2024-01-01 12:00:00+00', 2, 2.1);
+-- Error Handling --
+-- Two publications that both include the hypertable.
+CREATE PUBLICATION pub1 FOR TABLE pub_test;
+CREATE PUBLICATION pub2 FOR TABLE pub_test;
+-- Event trigger handler which will drop pub2, invalidating internal iteration of publications to update.
+CREATE EVENT TRIGGER sub_drop_pub2 ON ddl_command_end
+    WHEN TAG IN ('ALTER PUBLICATION') EXECUTE FUNCTION drop_pub2();
+-- Pub1 will be updated, emitting a notice. Pub2 will be deleted, so no DDL for pub2 being updated.
+INSERT INTO pub_test VALUES ('2024-01-03 00:00:00+00', 3, 3.0);
+NOTICE:  ddl_command_end: tag=ALTER PUBLICATION identity=_timescaledb_internal._hyper_1_3_chunk in publication test_pub
+NOTICE:  ddl_command_end: tag=ALTER PUBLICATION identity=_timescaledb_internal._hyper_1_3_chunk in publication pub1
+NOTICE:  publication "pub2" does not exist, skipping
+-- With event triggers disabled, creating a chunk emits no event.
+SET timescaledb.enable_event_triggers = false;
+INSERT INTO pub_test VALUES ('2024-01-04 00:00:00+00', 4, 4.0);
+DROP EVENT TRIGGER pub_ddl_trigger;
+DROP EVENT TRIGGER sub_drop_pub2;
+DROP PUBLICATION test_pub;
+DROP PUBLICATION pub1; -- pub2 already dropped.
+DROP TABLE pub_test;
+DROP FUNCTION log_pub_ddl();
+DROP FUNCTION drop_pub2();

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_FILES
     alternate_users.sql
     baserel_cache.sql
     chunk_publication.sql
+    chunk_publication_ddl_events.sql
     chunk_utils.sql
     chunks.sql
     cluster.sql

--- a/test/sql/chunk_publication_ddl_events.sql
+++ b/test/sql/chunk_publication_ddl_events.sql
@@ -1,0 +1,68 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Verify that automatically adding a chunk to a publication emits the
+-- ddl_command_start/end events for the implicit ALTER PUBLICATION ... ADD TABLE,
+-- and that no event is emitted when the publication is not actually updated.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE OR REPLACE FUNCTION log_pub_ddl() RETURNS event_trigger AS $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN SELECT * FROM pg_event_trigger_ddl_commands() LOOP
+        RAISE NOTICE 'ddl_command_end: tag=% identity=%', r.command_tag, r.object_identity;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION drop_pub2() RETURNS event_trigger AS $$
+BEGIN
+    DROP PUBLICATION IF EXISTS pub2;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EVENT TRIGGER pub_ddl_trigger ON ddl_command_end
+    WHEN TAG IN ('ALTER PUBLICATION') EXECUTE FUNCTION log_pub_ddl();
+
+SET client_min_messages = WARNING;
+SET timescaledb.enable_chunk_auto_publication = true;
+SET timescaledb.enable_event_triggers = true;
+
+CREATE TABLE pub_test (time timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('pub_test', 'time', chunk_time_interval => interval '1 day');
+CREATE PUBLICATION test_pub FOR TABLE pub_test;
+SET client_min_messages = NOTICE;
+
+-- Each new chunk fires an ALTER PUBLICATION ddl_command_end event.
+INSERT INTO pub_test VALUES ('2024-01-01 00:00:00+00', 1, 1.0);
+INSERT INTO pub_test VALUES ('2024-01-02 00:00:00+00', 2, 2.0);
+
+-- Inserting into an existing chunk does NOT update the publication, so no event.
+INSERT INTO pub_test VALUES ('2024-01-01 12:00:00+00', 2, 2.1);
+
+-- Error Handling --
+-- Two publications that both include the hypertable.
+CREATE PUBLICATION pub1 FOR TABLE pub_test;
+CREATE PUBLICATION pub2 FOR TABLE pub_test;
+
+-- Event trigger handler which will drop pub2, invalidating internal iteration of publications to update.
+CREATE EVENT TRIGGER sub_drop_pub2 ON ddl_command_end
+    WHEN TAG IN ('ALTER PUBLICATION') EXECUTE FUNCTION drop_pub2();
+
+-- Pub1 will be updated, emitting a notice. Pub2 will be deleted, so no DDL for pub2 being updated.
+INSERT INTO pub_test VALUES ('2024-01-03 00:00:00+00', 3, 3.0);
+
+-- With event triggers disabled, creating a chunk emits no event.
+SET timescaledb.enable_event_triggers = false;
+INSERT INTO pub_test VALUES ('2024-01-04 00:00:00+00', 4, 4.0);
+
+DROP EVENT TRIGGER pub_ddl_trigger;
+DROP EVENT TRIGGER sub_drop_pub2;
+DROP PUBLICATION test_pub;
+DROP PUBLICATION pub1; -- pub2 already dropped.
+DROP TABLE pub_test;
+DROP FUNCTION log_pub_ddl();
+DROP FUNCTION drop_pub2();


### PR DESCRIPTION
When chunk auto publication is enabled, we now emit ddl events
when publications are altered for adding new chunks.

# NOTE - reviewers
The DDL events emitted by our code for chunk creation (not this PR) is not aligned with PG's recommendations on using PG_TRY, observing the return from `EventTriggerBeginCompleteQuery()`, etc. A later PR will address those bits.