### PR TITLE
Fix division by zero when planning time_bucket with zero width

### DIFF
--- a/.unreleased/pr_10143
+++ b/.unreleased/pr_10143
@@ -1,0 +1,1 @@
+Fixes: #10143 Fix division by zero when planning time_bucket with zero width

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -569,6 +569,12 @@ time_bucket_width_to_integral(const Const *width, Oid bucket_type, int64 integra
 		default:
 			return false;
 	}
+
+	if (*integral_width == 0)
+	{
+		return false;
+	}
+
 	return true;
 }
 

--- a/test/expected/qual_filtering.out
+++ b/test/expected/qual_filtering.out
@@ -124,6 +124,11 @@ SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10
 -------
      9
 
+-- A zero width period is rejected
+\set ON_ERROR_STOP 0
+SELECT count(*) FROM qual_filter_tb WHERE time_bucket(INTERVAL '0', ts) < '2024-03-10'::timestamptz;
+ERROR:  period must be greater than 0
+\set ON_ERROR_STOP 1
 DROP TABLE qual_filter_tb;
 -- A timestamptz constant against a date time_bucket is not transformed.
 CREATE TABLE qual_filter_tb_date(d date NOT NULL);

--- a/test/sql/qual_filtering.sql
+++ b/test/sql/qual_filtering.sql
@@ -83,6 +83,10 @@ SELECT generate_series('2024-03-01'::timestamptz, '2024-03-20'::timestamptz, '1 
 -- Both count the 9 buckets before March 10.
 SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10'::date;
 SELECT count(*) FROM qual_filter_tb WHERE time_bucket('1 day', ts) < '2024-03-10'::timestamptz;
+-- A zero width period is rejected
+\set ON_ERROR_STOP 0
+SELECT count(*) FROM qual_filter_tb WHERE time_bucket(INTERVAL '0', ts) < '2024-03-10'::timestamptz;
+\set ON_ERROR_STOP 1
 DROP TABLE qual_filter_tb;
 
 -- A timestamptz constant against a date time_bucket is not transformed.


### PR DESCRIPTION
- **Fix division by zero when planning time_bucket with zero width**
