### PR TITLE
Refactor grant propagation for compressed relations

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2064,16 +2064,32 @@ process_grant_and_revoke(ProcessUtilityArgs *args)
 												  was_schema_op,
 												  &compressed_hypertable->fd.schema_name,
 												  &compressed_hypertable->fd.table_name);
-						List *chunks =
-							ts_chunk_get_by_hypertable_id(hypertable->fd.compressed_hypertable_id);
+						List *chunks = ts_chunk_get_by_hypertable_id(hypertable->fd.id);
 						ListCell *cell;
 						foreach (cell, chunks)
 						{
 							Chunk *chunk = lfirst(cell);
+							Oid compressed_relid =
+								ts_relation_get_compressed_relid(chunk->table_id);
+							if (!OidIsValid(compressed_relid))
+							{
+								continue;
+							}
+							/*
+							 * makeRangeVar() keeps the name pointers without
+							 * copying, so the NameData must outlive this loop
+							 * iteration. Allocate it instead of using stack
+							 * storage which is reused on every iteration.
+							 */
+							NameData *compressed_schema_name = palloc(sizeof(NameData));
+							NameData *compressed_table_name = palloc(sizeof(NameData));
+							namestrcpy(compressed_schema_name,
+									   get_namespace_name(get_rel_namespace(compressed_relid)));
+							namestrcpy(compressed_table_name, get_rel_name(compressed_relid));
 							process_grant_add_by_name(stmt,
 													  was_schema_op,
-													  &chunk->fd.schema_name,
-													  &chunk->fd.table_name);
+													  compressed_schema_name,
+													  compressed_table_name);
 						}
 					}
 				}


### PR DESCRIPTION
Don't rely on compressed_hypertable_id when propagating grants
to compressed relations and use compression_settings instead.
