### PR TITLE
Add missing includes for PostgreSQL 19

### DIFF
--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -13,6 +13,7 @@
 #include <executor/executor.h>
 #include <utils/array.h>
 #include <utils/builtins.h>
+#include <utils/tuplestore.h>
 
 #include "compat/compat.h"
 #include "event_trigger.h"

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -4,6 +4,7 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
+#include <access/attmap.h>
 #include <access/xact.h>
 #include <catalog/index.h>
 #include <catalog/indexing.h>

--- a/src/loader/bgw_message_queue.c
+++ b/src/loader/bgw_message_queue.c
@@ -14,6 +14,7 @@
 #include <storage/shm_mq.h>
 #include <storage/shmem.h>
 #include <storage/spin.h>
+#include <utils/wait_event.h>
 
 #include "../compat/compat.h"
 

--- a/src/loader/function_telemetry.h
+++ b/src/loader/function_telemetry.h
@@ -6,6 +6,9 @@
  */
 #pragma once
 
+#include <storage/lwlock.h>
+#include <utils/hsearch.h>
+
 #define RENDEZVOUS_FUNCTION_TELEMENTRY "ts_function_telemetry"
 #define FN_TELEMETRY_LWLOCK_TRANCHE_NAME "ts_fn_telemetry_lwlock_tranche"
 

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -19,6 +19,7 @@
 #include <optimizer/restrictinfo.h>
 #include <parser/parsetree.h>
 #include <rewrite/rewriteManip.h>
+#include <storage/lwlock.h>
 #include <utils/builtins.h>
 #include <utils/memutils.h>
 #include <utils/ruleutils.h>

--- a/src/ts_stats/ts_stats_srf.c
+++ b/src/ts_stats/ts_stats_srf.c
@@ -13,6 +13,7 @@
 #include <miscadmin.h>
 #include <utils/builtins.h>
 #include <utils/timestamp.h>
+#include <utils/tuplestore.h>
 
 /*
  * SRF Pushdown args:

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -16,6 +16,7 @@
 #include <common/base64.h>
 #include <funcapi.h>
 #include <libpq/pqformat.h>
+#include <storage/latch.h>
 #include <storage/predicate.h>
 #include <utils/datum.h>
 #include <utils/elog.h>
@@ -24,7 +25,9 @@
 #include <utils/rel.h>
 #include <utils/snapmgr.h>
 #include <utils/syscache.h>
+#include <utils/tuplesort.h>
 #include <utils/typcache.h>
+#include <utils/wait_event.h>
 
 #include "compat/compat.h"
 

--- a/tsl/src/continuous_aggs/rewrite_with_caggs.c
+++ b/tsl/src/continuous_aggs/rewrite_with_caggs.c
@@ -5,6 +5,7 @@
  */
 #include "rewrite_with_caggs.h"
 
+#include <access/attmap.h>
 #include <optimizer/tlist.h>
 #include <parser/parse_relation.h>
 #include <rewrite/rewriteDefine.h>

--- a/tsl/src/nodes/vector_agg/function/functions.c
+++ b/tsl/src/nodes/vector_agg/function/functions.c
@@ -14,6 +14,7 @@
 #include <utils/float.h>
 #include <utils/fmgroids.h>
 #include <utils/fmgrprotos.h>
+#include <utils/timestamp.h>
 
 #include "functions.h"
 

--- a/tsl/test/src/compression_sql_test.c
+++ b/tsl/test/src/compression_sql_test.c
@@ -6,6 +6,7 @@
 #include <math.h>
 
 #include <postgres.h>
+#include <dirent.h>
 
 #include "guc.h"
 


### PR DESCRIPTION
PostgreSQL 19 removed a number of transitive includes from its headers,
so files that relied on getting other headers indirectly no longer build.
Add the includes where they are needed. This also works on earlier
versions.

Upstream changes:
Don't include proc.h in shm_mq.h
https://github.com/postgres/postgres/commit/a2c89835f5
Reduce header inclusions via execnodes.h
https://github.com/postgres/postgres/commit/fba4233c83
Don't include wait_event.h in pgstat.h
https://github.com/postgres/postgres/commit/868825aaeb
Don't include latch.h in libpq/libpq.h
https://github.com/postgres/postgres/commit/7b9b620d8f

Disable-check: force-changelog-file
Disable-check: loader-change
