### PR TITLE
Adjust pg_nodiscard placement for PostgreSQL 19

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -213,7 +213,7 @@ ts_flags_are_set_32(uint32 bitmap, uint32 flags)
 	return (bitmap & flags) == flags;
 }
 
-static inline pg_nodiscard uint32
+pg_nodiscard static inline uint32
 ts_set_flags_32(uint32 bitmap, uint32 flags)
 {
 	return bitmap | flags;

--- a/tsl/src/chunkwise_agg.c
+++ b/tsl/src/chunkwise_agg.c
@@ -534,7 +534,7 @@ generate_agg_pushdown_path(PlannerInfo *root, Path *cheapest_total_path, RelOptI
 /*
  Is the provided path a agg path that uses a sorted or plain agg strategy?
 */
-static bool pg_nodiscard
+pg_nodiscard static bool
 is_path_sorted_or_plain_agg_path(Path *path)
 {
 	AggPath *agg_path = castNode(AggPath, path);

--- a/tsl/src/compression/arrow_c_data_interface.h
+++ b/tsl/src/compression/arrow_c_data_interface.h
@@ -187,7 +187,7 @@ arrow_set_row_validity(uint64 *bitmap, size_t row_number, bool value)
  * Combine the validity bitmaps into the given storage. Can return one of the
  * input filters if the others are NULL.
  */
-static inline pg_nodiscard const uint64 *
+pg_nodiscard static inline const uint64 *
 arrow_combine_validity(size_t num_words, uint64 *restrict storage, const uint64 *filter1,
 					   const uint64 *filter2, const uint64 *filter3)
 {

--- a/tsl/src/continuous_aggs/planner.c
+++ b/tsl/src/continuous_aggs/planner.c
@@ -187,7 +187,7 @@ typedef struct WatermarkConstEntry
  * We maintain a hash map (hypertable id -> constant) to ensure we use the same constant
  * for the same watermark across the while query.
  */
-static HTAB *pg_nodiscard
+pg_nodiscard static HTAB *
 init_watermark_map()
 {
 	struct HASHCTL hctl = {

--- a/tsl/src/nodes/columnar_scan/batch_queue_heap.c
+++ b/tsl/src/nodes/columnar_scan/batch_queue_heap.c
@@ -150,7 +150,7 @@ compare_heap_pos_signed(Datum a, Datum b, void *arg)
  * the binaryheap_add_unordered() function, the capacity of the heap is automatically
  * increased if needed.
  */
-static pg_nodiscard binaryheap *
+pg_nodiscard static binaryheap *
 binaryheap_add_unordered_autoresize(binaryheap *heap, Datum d)
 {
 	/* Resize heap if needed */


### PR DESCRIPTION
PostgreSQL 19 defines pg_nodiscard as the C23 [[nodiscard]] attribute
when available, which has to come before the storage class specifier.
Move it in front of static so the declarations keep compiling. This also
works on earlier versions.

Upstream change: Use standard C23 and C++ attributes if available
https://github.com/postgres/postgres/commit/76f4b92bac

Disable-check: force-changelog-file

