### PR TITLE
Fix homebrew package test

### DIFF
--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -34,6 +34,7 @@ jobs:
         brew install postgresql@17
         echo "/opt/homebrew/opt/postgresql@17/bin" >> $GITHUB_PATH
         brew tap timescale/tap
+        brew trust timescale/tap
         brew info timescaledb
 
     - name: Install timescaledb


### PR DESCRIPTION
Homebrew now requires third party taps to be trusted before their
formulas can be loaded. Trust the tap after adding it so the install
test can find the timescaledb formula again.
