### PR TITLE
Make cagg_query refresh tests independent of the timezone database

### DIFF
--- a/tsl/test/expected/cagg_query.out
+++ b/tsl/test/expected/cagg_query.out
@@ -1432,27 +1432,31 @@ SELECT * FROM cagg_4_hours_origin;
  Thu Jan 02 09:00:00 2020 PST | 8888
 
 -- Update materialized data
+-- Use UTC so the lower refresh boundary (minimum timestamp) prints the same
+-- regardless of the timezone database version on the host
+SET timezone TO 'UTC';
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:683: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:683: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 00:00:00 2020 PST, Thu Jan 02 12:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:683: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:686: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:686: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:686: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 08:00:00 2020 UTC, Thu Jan 02 20:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:686: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:686: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:684: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:684: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:684: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:687: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:687: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:687: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 04:30:00 2020 UTC, Thu Jan 02 20:30:00 2020 UTC ]
+psql:include/cagg_query_common.sql:687: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:687: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:685: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:685: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:685: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:688: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:688: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:688: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Thu Jan 02 05:00:00 2020 UTC, Thu Jan 02 21:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:688: LOG:  deleted 1 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:688: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
 RESET client_min_messages;
-psql:include/cagg_query_common.sql:686: LOG:  statement: RESET client_min_messages;
+psql:include/cagg_query_common.sql:689: LOG:  statement: RESET client_min_messages;
+SET timezone TO 'PST8PDT';
 -- Query the CAggs and check that all buckets are materialized
 SELECT * FROM cagg_4_hours;
          time_bucket          | max  
@@ -1644,45 +1648,49 @@ INSERT INTO temperature
 INSERT INTO temperature values('2020-01-02 01:05:00+01', 2222);
 INSERT INTO temperature values('2020-01-02 01:35:00+01', 5555);
 INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
+-- Use UTC so the lower refresh boundary (minimum timestamp) prints the same
+-- regardless of the timezone database version on the host
+SET timezone TO 'UTC';
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:725: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:732: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:732: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:732: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
+psql:include/cagg_query_common.sql:732: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 08:00:00 2000 UTC, Sun Jan 02 08:00:00 2000 UTC ]
+psql:include/cagg_query_common.sql:732: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:732: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:732: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
+psql:include/cagg_query_common.sql:732: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 08:00:00 2020 UTC, Thu Jan 02 08:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:732: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:732: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:732: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:726: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:733: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:733: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:733: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:733: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 08:30:00 2000 UTC, Sun Jan 02 08:30:00 2000 UTC ]
+psql:include/cagg_query_common.sql:733: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:733: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:733: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
+psql:include/cagg_query_common.sql:733: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 04:30:00 2020 UTC, Thu Jan 02 08:30:00 2020 UTC ]
+psql:include/cagg_query_common.sql:733: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:733: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:733: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:727: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
-psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:727: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:734: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:734: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:734: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:734: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 09:00:00 2000 UTC, Sun Jan 02 09:00:00 2000 UTC ]
+psql:include/cagg_query_common.sql:734: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:734: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:734: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
+psql:include/cagg_query_common.sql:734: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 05:00:00 2020 UTC, Thu Jan 02 09:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:734: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:734: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:734: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 1577955600000000
 RESET client_min_messages;
-psql:include/cagg_query_common.sql:728: LOG:  statement: RESET client_min_messages;
+psql:include/cagg_query_common.sql:735: LOG:  statement: RESET client_min_messages;
+SET timezone TO 'PST8PDT';
 ALTER MATERIALIZED VIEW cagg_4_hours SET (timescaledb.materialized_only=true);
 SELECT * FROM cagg_4_hours;
          time_bucket          | max  
@@ -1878,7 +1886,7 @@ CREATE MATERIALIZED VIEW cagg_1_year
   SELECT time_bucket('1 year', time), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:771: NOTICE:  refreshing continuous aggregate "cagg_1_year"
+psql:include/cagg_query_common.sql:779: NOTICE:  refreshing continuous aggregate "cagg_1_year"
 SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
@@ -1941,13 +1949,13 @@ CREATE MATERIALIZED VIEW cagg_int
     AS SELECT time_bucket('10', time), SUM(data) as value
         FROM table_int
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:804: NOTICE:  refreshing continuous aggregate "cagg_int"
+psql:include/cagg_query_common.sql:812: NOTICE:  refreshing continuous aggregate "cagg_int"
 CREATE MATERIALIZED VIEW cagg_int_offset
     WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('10', time, "offset"=>5), SUM(data) as value
         FROM table_int
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:810: NOTICE:  refreshing continuous aggregate "cagg_int_offset"
+psql:include/cagg_query_common.sql:818: NOTICE:  refreshing continuous aggregate "cagg_int_offset"
 -- Compare bucketing results
 SELECT time_bucket('10', time), SUM(data) FROM table_int GROUP BY 1 ORDER BY 1;
  time_bucket | sum 
@@ -2150,15 +2158,15 @@ SELECT * FROM cagg_int_offset;
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:845: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:845: DEBUG:  refreshing continuous aggregate "cagg_int_offset" from 100 to 130
-psql:include/cagg_query_common.sql:845: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
-psql:include/cagg_query_common.sql:845: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
-psql:include/cagg_query_common.sql:845: DEBUG:  building index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_68_chunk" serially
-psql:include/cagg_query_common.sql:845: DEBUG:  index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
-psql:include/cagg_query_common.sql:845: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
+psql:include/cagg_query_common.sql:853: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:853: DEBUG:  refreshing continuous aggregate "cagg_int_offset" from 100 to 130
+psql:include/cagg_query_common.sql:853: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
+psql:include/cagg_query_common.sql:853: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_38"
+psql:include/cagg_query_common.sql:853: DEBUG:  building index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_68_chunk" serially
+psql:include/cagg_query_common.sql:853: DEBUG:  index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
+psql:include/cagg_query_common.sql:853: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
 RESET client_min_messages;
-psql:include/cagg_query_common.sql:846: LOG:  statement: RESET client_min_messages;
+psql:include/cagg_query_common.sql:854: LOG:  statement: RESET client_min_messages;
 SELECT * FROM cagg_int_offset;
  time_bucket | value 
 -------------+-------
@@ -2199,42 +2207,42 @@ CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin
   SELECT time_bucket('1 year', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:856: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin"
+psql:include/cagg_query_common.sql:864: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin';
  user_view_schema |              user_view_name              |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+------------------------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
  public           | cagg_1_hour_variable_bucket_fixed_origin | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 1 year     | Fri Dec 31 17:05:00 1999 PST |               | UTC             | f
 
 DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin;
-psql:include/cagg_query_common.sql:858: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:866: NOTICE:  drop cascades to 2 other objects
 -- Variable due to the used timezone
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 hour', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:865: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin2"
+psql:include/cagg_query_common.sql:873: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin2"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin2';
  user_view_schema |              user_view_name               |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+-------------------------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
  public           | cagg_1_hour_variable_bucket_fixed_origin2 | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 1 hour     | Fri Dec 31 17:05:00 1999 PST |               | UTC             | f
 
 DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2;
-psql:include/cagg_query_common.sql:867: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:875: NOTICE:  drop cascades to 2 other objects
 -- Variable with offset
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 year', time, "offset"=>'5 minutes'::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:874: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin3"
+psql:include/cagg_query_common.sql:882: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin3"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin3';
  user_view_schema |              user_view_name               |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+-------------------------------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
  public           | cagg_1_hour_variable_bucket_fixed_origin3 | public.time_bucket(interval,timestamp with time zone,interval) | @ 1 year     |               | @ 5 mins      |                 | f
 
 DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3;
-psql:include/cagg_query_common.sql:876: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:884: NOTICE:  drop cascades to 2 other objects
 ---
 -- Test with blocking a few broken configurations
 ---
@@ -2247,26 +2255,26 @@ CREATE MATERIALIZED VIEW cagg_1_hour_origin
   SELECT time_bucket('1 hour', time, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:891: NOTICE:  refreshing continuous aggregate "cagg_1_hour_origin"
+psql:include/cagg_query_common.sql:899: NOTICE:  refreshing continuous aggregate "cagg_1_hour_origin"
 CREATE MATERIALIZED VIEW cagg_1_week_origin
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, origin=>'2022-01-02 01:00:00 PST'::timestamptz) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_origin
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:897: ERROR:  cannot create continuous aggregate with different bucket origin values
+psql:include/cagg_query_common.sql:905: ERROR:  cannot create continuous aggregate with different bucket origin values
 -- Different time offset
 CREATE MATERIALIZED VIEW cagg_1_hour_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 hour', time, "offset"=>'30m'::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:904: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
+psql:include/cagg_query_common.sql:912: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
 CREATE MATERIALIZED VIEW cagg_1_week_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, "offset"=>'35m'::interval) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:910: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:918: ERROR:  cannot create continuous aggregate with different bucket offset values
 -- Cagg with NULL offset on top of cagg with non-NULL offset
 \set VERBOSITY default
 CREATE MATERIALIZED VIEW cagg_1_week_null_offset
@@ -2274,7 +2282,7 @@ CREATE MATERIALIZED VIEW cagg_1_week_null_offset
   SELECT time_bucket('1 week', hour_bucket, "offset"=>NULL::interval) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:918: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:926: ERROR:  cannot create continuous aggregate with different bucket offset values
 DETAIL:  Time origin of "public.cagg_1_week_null_offset" [NULL] and "public.cagg_1_hour_offset" [@ 30 mins] should be the same.
 -- Cagg with non-NULL offset on top of cagg with NULL offset
 CREATE MATERIALIZED VIEW cagg_1_hour_null_offset
@@ -2282,14 +2290,14 @@ CREATE MATERIALIZED VIEW cagg_1_hour_null_offset
   SELECT time_bucket('1 hour', time, "offset"=>NULL::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:925: NOTICE:  refreshing continuous aggregate "cagg_1_hour_null_offset"
+psql:include/cagg_query_common.sql:933: NOTICE:  refreshing continuous aggregate "cagg_1_hour_null_offset"
 HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
 CREATE MATERIALIZED VIEW cagg_1_week_non_null_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, "offset"=>'35m'::interval) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_null_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:931: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:939: ERROR:  cannot create continuous aggregate with different bucket offset values
 DETAIL:  Time origin of "public.cagg_1_week_non_null_offset" [@ 35 mins] and "public.cagg_1_hour_null_offset" [NULL] should be the same.
 \set VERBOSITY terse
 -- Different integer offset
@@ -2298,20 +2306,20 @@ CREATE MATERIALIZED VIEW cagg_int_offset_5
     AS SELECT time_bucket('10', time, "offset"=>5) AS time, SUM(data) AS value
         FROM table_int
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:939: NOTICE:  refreshing continuous aggregate "cagg_int_offset_5"
+psql:include/cagg_query_common.sql:947: NOTICE:  refreshing continuous aggregate "cagg_int_offset_5"
 CREATE MATERIALIZED VIEW cagg_int_offset_10
     WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('10', time, "offset"=>10) AS time, SUM(value) AS value
         FROM cagg_int_offset_5
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:945: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:953: ERROR:  cannot create continuous aggregate with different bucket offset values
 \set ON_ERROR_STOP 1
 DROP MATERIALIZED VIEW cagg_1_hour_origin;
-psql:include/cagg_query_common.sql:949: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:957: NOTICE:  drop cascades to 2 other objects
 DROP MATERIALIZED VIEW cagg_1_hour_offset;
-psql:include/cagg_query_common.sql:950: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:958: NOTICE:  drop cascades to 2 other objects
 DROP MATERIALIZED VIEW cagg_int_offset_5;
-psql:include/cagg_query_common.sql:951: NOTICE:  drop cascades to 3 other objects
+psql:include/cagg_query_common.sql:959: NOTICE:  drop cascades to 3 other objects
 ---
 -- CAGGs on CAGGs tests
 ---
@@ -2320,7 +2328,7 @@ CREATE MATERIALIZED VIEW cagg_1_hour_offset
   SELECT time_bucket('1 hour', time, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:960: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
+psql:include/cagg_query_common.sql:968: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_offset';
  user_view_schema |   user_view_name   |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
@@ -2331,7 +2339,7 @@ CREATE MATERIALIZED VIEW cagg_1_week_offset
   SELECT time_bucket('1 week', hour_bucket, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:967: NOTICE:  refreshing continuous aggregate "cagg_1_week_offset"
+psql:include/cagg_query_common.sql:975: NOTICE:  refreshing continuous aggregate "cagg_1_week_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_week_offset';
  user_view_schema |   user_view_name   |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------

--- a/tsl/test/expected/cagg_query_using_merge.out
+++ b/tsl/test/expected/cagg_query_using_merge.out
@@ -1434,26 +1434,30 @@ SELECT * FROM cagg_4_hours_origin;
  Thu Jan 02 09:00:00 2020 PST | 8888
 
 -- Update materialized data
+-- Use UTC so the lower refresh boundary (minimum timestamp) prints the same
+-- regardless of the timezone database version on the host
+SET timezone TO 'UTC';
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:683: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:683: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:683: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 00:00:00 2020 PST, Thu Jan 02 12:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:683: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:686: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:686: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:686: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Thu Jan 02 08:00:00 2020 UTC, Thu Jan 02 20:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:686: LOG:  inserted 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:684: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:684: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:684: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 20:30:00 2020 PST, Thu Jan 02 12:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:684: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:684: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:687: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:687: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:687: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Thu Jan 02 04:30:00 2020 UTC, Thu Jan 02 20:30:00 2020 UTC ]
+psql:include/cagg_query_common.sql:687: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:687: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_34"
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:685: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:685: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:685: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 21:00:00 2020 PST, Thu Jan 02 13:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:685: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:685: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:688: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:688: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:688: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Thu Jan 02 05:00:00 2020 UTC, Thu Jan 02 21:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:688: LOG:  merged 3 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:688: LOG:  deleted 0 row(s) from materialization table "_timescaledb_internal._materialized_hypertable_35"
 RESET client_min_messages;
-psql:include/cagg_query_common.sql:686: LOG:  statement: RESET client_min_messages;
+psql:include/cagg_query_common.sql:689: LOG:  statement: RESET client_min_messages;
+SET timezone TO 'PST8PDT';
 -- Query the CAggs and check that all buckets are materialized
 SELECT * FROM cagg_4_hours;
          time_bucket          | max  
@@ -1645,39 +1649,43 @@ INSERT INTO temperature
 INSERT INTO temperature values('2020-01-02 01:05:00+01', 2222);
 INSERT INTO temperature values('2020-01-02 01:35:00+01', 5555);
 INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
+-- Use UTC so the lower refresh boundary (minimum timestamp) prints the same
+-- regardless of the timezone database version on the host
+SET timezone TO 'UTC';
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:725: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:725: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
-psql:include/cagg_query_common.sql:725: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 00:00:00 2020 PST, Thu Jan 02 00:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:725: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
-psql:include/cagg_query_common.sql:725: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
+psql:include/cagg_query_common.sql:732: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:732: DEBUG:  refreshing continuous aggregate "cagg_4_hours" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:732: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577952000000000
+psql:include/cagg_query_common.sql:732: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Sat Jan 01 08:00:00 2000 UTC, Sun Jan 02 08:00:00 2000 UTC ]
+psql:include/cagg_query_common.sql:732: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:732: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 946800000000000
+psql:include/cagg_query_common.sql:732: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours" in window [ Wed Jan 01 08:00:00 2020 UTC, Thu Jan 02 08:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:732: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_33"
+psql:include/cagg_query_common.sql:732: DEBUG:  hypertable 33 existing watermark >= new watermark 1577995200000000 1577952000000000
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:726: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:726: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 00:30:00 2000 PST, Sun Jan 02 00:30:00 2000 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
-psql:include/cagg_query_common.sql:726: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Tue Dec 31 20:30:00 2019 PST, Thu Jan 02 00:30:00 2020 PST ]
-psql:include/cagg_query_common.sql:726: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
-psql:include/cagg_query_common.sql:726: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
+psql:include/cagg_query_common.sql:733: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:733: DEBUG:  refreshing continuous aggregate "cagg_4_hours_offset" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:733: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577953800000000
+psql:include/cagg_query_common.sql:733: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Sat Jan 01 08:30:00 2000 UTC, Sun Jan 02 08:30:00 2000 UTC ]
+psql:include/cagg_query_common.sql:733: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:733: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 946801800000000
+psql:include/cagg_query_common.sql:733: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_offset" in window [ Wed Jan 01 04:30:00 2020 UTC, Thu Jan 02 08:30:00 2020 UTC ]
+psql:include/cagg_query_common.sql:733: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_34"
+psql:include/cagg_query_common.sql:733: DEBUG:  hypertable 34 existing watermark >= new watermark 1577997000000000 1577953800000000
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:727: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:727: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Sun Nov 23 16:07:02 4714 LMT BC to infinity
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 01:00:00 2000 PST, Sun Jan 02 01:00:00 2000 PST ]
-psql:include/cagg_query_common.sql:727: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
-psql:include/cagg_query_common.sql:727: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Tue Dec 31 21:00:00 2019 PST, Thu Jan 02 01:00:00 2020 PST ]
-psql:include/cagg_query_common.sql:727: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
-psql:include/cagg_query_common.sql:727: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:734: LOG:  statement: CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:734: DEBUG:  refreshing continuous aggregate "cagg_4_hours_origin" from Mon Nov 24 00:00:00 4714 UTC BC to infinity
+psql:include/cagg_query_common.sql:734: DEBUG:  hypertable 4 existing watermark >= new invalidation threshold 1577998800000000 1577955600000000
+psql:include/cagg_query_common.sql:734: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Sat Jan 01 09:00:00 2000 UTC, Sun Jan 02 09:00:00 2000 UTC ]
+psql:include/cagg_query_common.sql:734: LOG:  inserted 6 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:734: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 946803600000000
+psql:include/cagg_query_common.sql:734: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_4_hours_origin" in window [ Wed Jan 01 05:00:00 2020 UTC, Thu Jan 02 09:00:00 2020 UTC ]
+psql:include/cagg_query_common.sql:734: LOG:  inserted 7 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_35"
+psql:include/cagg_query_common.sql:734: DEBUG:  hypertable 35 existing watermark >= new watermark 1577998800000000 1577955600000000
 RESET client_min_messages;
-psql:include/cagg_query_common.sql:728: LOG:  statement: RESET client_min_messages;
+psql:include/cagg_query_common.sql:735: LOG:  statement: RESET client_min_messages;
+SET timezone TO 'PST8PDT';
 ALTER MATERIALIZED VIEW cagg_4_hours SET (timescaledb.materialized_only=true);
 SELECT * FROM cagg_4_hours;
          time_bucket          | max  
@@ -1873,7 +1881,7 @@ CREATE MATERIALIZED VIEW cagg_1_year
   SELECT time_bucket('1 year', time), max(value)
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:771: NOTICE:  refreshing continuous aggregate "cagg_1_year"
+psql:include/cagg_query_common.sql:779: NOTICE:  refreshing continuous aggregate "cagg_1_year"
 SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
@@ -1936,13 +1944,13 @@ CREATE MATERIALIZED VIEW cagg_int
     AS SELECT time_bucket('10', time), SUM(data) as value
         FROM table_int
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:804: NOTICE:  refreshing continuous aggregate "cagg_int"
+psql:include/cagg_query_common.sql:812: NOTICE:  refreshing continuous aggregate "cagg_int"
 CREATE MATERIALIZED VIEW cagg_int_offset
     WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('10', time, "offset"=>5), SUM(data) as value
         FROM table_int
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:810: NOTICE:  refreshing continuous aggregate "cagg_int_offset"
+psql:include/cagg_query_common.sql:818: NOTICE:  refreshing continuous aggregate "cagg_int_offset"
 -- Compare bucketing results
 SELECT time_bucket('10', time), SUM(data) FROM table_int GROUP BY 1 ORDER BY 1;
  time_bucket | sum 
@@ -2145,14 +2153,14 @@ SELECT * FROM cagg_int_offset;
 INSERT INTO table_int VALUES(114, 0);
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:845: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130, options => '{"buckets_per_batch": 0}'::jsonb);
-psql:include/cagg_query_common.sql:845: DEBUG:  refreshing continuous aggregate "cagg_int_offset" from 100 to 130
-psql:include/cagg_query_common.sql:845: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
-psql:include/cagg_query_common.sql:845: DEBUG:  building index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_68_chunk" serially
-psql:include/cagg_query_common.sql:845: DEBUG:  index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
-psql:include/cagg_query_common.sql:845: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
+psql:include/cagg_query_common.sql:853: LOG:  statement: CALL refresh_continuous_aggregate('cagg_int_offset', 100, 130, options => '{"buckets_per_batch": 0}'::jsonb);
+psql:include/cagg_query_common.sql:853: DEBUG:  refreshing continuous aggregate "cagg_int_offset" from 100 to 130
+psql:include/cagg_query_common.sql:853: DEBUG:  continuous aggregate refresh (individual invalidation) on "cagg_int_offset" in window [ 105, 125 ]
+psql:include/cagg_query_common.sql:853: DEBUG:  building index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" on table "_hyper_38_68_chunk" serially
+psql:include/cagg_query_common.sql:853: DEBUG:  index "_hyper_38_68_chunk__materialized_hypertable_38_time_bucket_idx" can safely use deduplication
+psql:include/cagg_query_common.sql:853: LOG:  inserted 1 row(s) into materialization table "_timescaledb_internal._materialized_hypertable_38"
 RESET client_min_messages;
-psql:include/cagg_query_common.sql:846: LOG:  statement: RESET client_min_messages;
+psql:include/cagg_query_common.sql:854: LOG:  statement: RESET client_min_messages;
 SELECT * FROM cagg_int_offset;
  time_bucket | value 
 -------------+-------
@@ -2193,42 +2201,42 @@ CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin
   SELECT time_bucket('1 year', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:856: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin"
+psql:include/cagg_query_common.sql:864: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin';
  user_view_schema |              user_view_name              |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+------------------------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
  public           | cagg_1_hour_variable_bucket_fixed_origin | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 1 year     | Fri Dec 31 17:05:00 1999 PST |               | UTC             | f
 
 DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin;
-psql:include/cagg_query_common.sql:858: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:866: NOTICE:  drop cascades to 2 other objects
 -- Variable due to the used timezone
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 hour', time, origin=>'2000-01-01 01:05:00 UTC'::timestamptz, timezone=>'UTC') AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:865: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin2"
+psql:include/cagg_query_common.sql:873: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin2"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin2';
  user_view_schema |              user_view_name               |                                               bucket_func                                               | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+-------------------------------------------+---------------------------------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
  public           | cagg_1_hour_variable_bucket_fixed_origin2 | public.time_bucket(interval,timestamp with time zone,pg_catalog.text,timestamp with time zone,interval) | @ 1 hour     | Fri Dec 31 17:05:00 1999 PST |               | UTC             | f
 
 DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin2;
-psql:include/cagg_query_common.sql:867: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:875: NOTICE:  drop cascades to 2 other objects
 -- Variable with offset
 CREATE MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 year', time, "offset"=>'5 minutes'::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:874: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin3"
+psql:include/cagg_query_common.sql:882: NOTICE:  refreshing continuous aggregate "cagg_1_hour_variable_bucket_fixed_origin3"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_variable_bucket_fixed_origin3';
  user_view_schema |              user_view_name               |                          bucket_func                           | bucket_width | bucket_origin | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+-------------------------------------------+----------------------------------------------------------------+--------------+---------------+---------------+-----------------+--------------------
  public           | cagg_1_hour_variable_bucket_fixed_origin3 | public.time_bucket(interval,timestamp with time zone,interval) | @ 1 year     |               | @ 5 mins      |                 | f
 
 DROP MATERIALIZED VIEW cagg_1_hour_variable_bucket_fixed_origin3;
-psql:include/cagg_query_common.sql:876: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:884: NOTICE:  drop cascades to 2 other objects
 ---
 -- Test with blocking a few broken configurations
 ---
@@ -2241,26 +2249,26 @@ CREATE MATERIALIZED VIEW cagg_1_hour_origin
   SELECT time_bucket('1 hour', time, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:891: NOTICE:  refreshing continuous aggregate "cagg_1_hour_origin"
+psql:include/cagg_query_common.sql:899: NOTICE:  refreshing continuous aggregate "cagg_1_hour_origin"
 CREATE MATERIALIZED VIEW cagg_1_week_origin
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, origin=>'2022-01-02 01:00:00 PST'::timestamptz) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_origin
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:897: ERROR:  cannot create continuous aggregate with different bucket origin values
+psql:include/cagg_query_common.sql:905: ERROR:  cannot create continuous aggregate with different bucket origin values
 -- Different time offset
 CREATE MATERIALIZED VIEW cagg_1_hour_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 hour', time, "offset"=>'30m'::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:904: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
+psql:include/cagg_query_common.sql:912: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
 CREATE MATERIALIZED VIEW cagg_1_week_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, "offset"=>'35m'::interval) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:910: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:918: ERROR:  cannot create continuous aggregate with different bucket offset values
 -- Cagg with NULL offset on top of cagg with non-NULL offset
 \set VERBOSITY default
 CREATE MATERIALIZED VIEW cagg_1_week_null_offset
@@ -2268,7 +2276,7 @@ CREATE MATERIALIZED VIEW cagg_1_week_null_offset
   SELECT time_bucket('1 week', hour_bucket, "offset"=>NULL::interval) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:918: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:926: ERROR:  cannot create continuous aggregate with different bucket offset values
 DETAIL:  Time origin of "public.cagg_1_week_null_offset" [NULL] and "public.cagg_1_hour_offset" [@ 30 mins] should be the same.
 -- Cagg with non-NULL offset on top of cagg with NULL offset
 CREATE MATERIALIZED VIEW cagg_1_hour_null_offset
@@ -2276,14 +2284,14 @@ CREATE MATERIALIZED VIEW cagg_1_hour_null_offset
   SELECT time_bucket('1 hour', time, "offset"=>NULL::interval) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:925: NOTICE:  refreshing continuous aggregate "cagg_1_hour_null_offset"
+psql:include/cagg_query_common.sql:933: NOTICE:  refreshing continuous aggregate "cagg_1_hour_null_offset"
 HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
 CREATE MATERIALIZED VIEW cagg_1_week_non_null_offset
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 week', hour_bucket, "offset"=>'35m'::interval) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_null_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:931: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:939: ERROR:  cannot create continuous aggregate with different bucket offset values
 DETAIL:  Time origin of "public.cagg_1_week_non_null_offset" [@ 35 mins] and "public.cagg_1_hour_null_offset" [NULL] should be the same.
 \set VERBOSITY terse
 -- Different integer offset
@@ -2292,20 +2300,20 @@ CREATE MATERIALIZED VIEW cagg_int_offset_5
     AS SELECT time_bucket('10', time, "offset"=>5) AS time, SUM(data) AS value
         FROM table_int
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:939: NOTICE:  refreshing continuous aggregate "cagg_int_offset_5"
+psql:include/cagg_query_common.sql:947: NOTICE:  refreshing continuous aggregate "cagg_int_offset_5"
 CREATE MATERIALIZED VIEW cagg_int_offset_10
     WITH (timescaledb.continuous, timescaledb.materialized_only=false)
     AS SELECT time_bucket('10', time, "offset"=>10) AS time, SUM(value) AS value
         FROM cagg_int_offset_5
         GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:945: ERROR:  cannot create continuous aggregate with different bucket offset values
+psql:include/cagg_query_common.sql:953: ERROR:  cannot create continuous aggregate with different bucket offset values
 \set ON_ERROR_STOP 1
 DROP MATERIALIZED VIEW cagg_1_hour_origin;
-psql:include/cagg_query_common.sql:949: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:957: NOTICE:  drop cascades to 2 other objects
 DROP MATERIALIZED VIEW cagg_1_hour_offset;
-psql:include/cagg_query_common.sql:950: NOTICE:  drop cascades to 2 other objects
+psql:include/cagg_query_common.sql:958: NOTICE:  drop cascades to 2 other objects
 DROP MATERIALIZED VIEW cagg_int_offset_5;
-psql:include/cagg_query_common.sql:951: NOTICE:  drop cascades to 3 other objects
+psql:include/cagg_query_common.sql:959: NOTICE:  drop cascades to 3 other objects
 ---
 -- CAGGs on CAGGs tests
 ---
@@ -2314,7 +2322,7 @@ CREATE MATERIALIZED VIEW cagg_1_hour_offset
   SELECT time_bucket('1 hour', time, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS hour_bucket, max(value) AS max_value
     FROM temperature
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:960: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
+psql:include/cagg_query_common.sql:968: NOTICE:  refreshing continuous aggregate "cagg_1_hour_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_hour_offset';
  user_view_schema |   user_view_name   |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------
@@ -2325,7 +2333,7 @@ CREATE MATERIALIZED VIEW cagg_1_week_offset
   SELECT time_bucket('1 week', hour_bucket, origin=>'2000-01-02 01:00:00 PST'::timestamptz) AS week_bucket, max(max_value) AS max_value
     FROM cagg_1_hour_offset
     GROUP BY 1 ORDER BY 1;
-psql:include/cagg_query_common.sql:967: NOTICE:  refreshing continuous aggregate "cagg_1_week_offset"
+psql:include/cagg_query_common.sql:975: NOTICE:  refreshing continuous aggregate "cagg_1_week_offset"
 SELECT * FROM caggs_info WHERE user_view_name = 'cagg_1_week_offset';
  user_view_schema |   user_view_name   |                                  bucket_func                                   | bucket_width |        bucket_origin         | bucket_offset | bucket_timezone | bucket_fixed_width 
 ------------------+--------------------+--------------------------------------------------------------------------------+--------------+------------------------------+---------------+-----------------+--------------------

--- a/tsl/test/sql/include/cagg_query_common.sql
+++ b/tsl/test/sql/include/cagg_query_common.sql
@@ -679,11 +679,15 @@ SELECT * FROM cagg_4_hours_offset;
 SELECT * FROM cagg_4_hours_origin;
 
 -- Update materialized data
+-- Use UTC so the lower refresh boundary (minimum timestamp) prints the same
+-- regardless of the timezone database version on the host
+SET timezone TO 'UTC';
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
 RESET client_min_messages;
+SET timezone TO 'PST8PDT';
 
 -- Query the CAggs and check that all buckets are materialized
 SELECT * FROM cagg_4_hours;
@@ -721,11 +725,15 @@ INSERT INTO temperature values('2020-01-02 01:05:00+01', 2222);
 INSERT INTO temperature values('2020-01-02 01:35:00+01', 5555);
 INSERT INTO temperature values('2020-01-02 05:05:00+01', 8888);
 
+-- Use UTC so the lower refresh boundary (minimum timestamp) prints the same
+-- regardless of the timezone database version on the host
+SET timezone TO 'UTC';
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cagg_4_hours', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
 CALL refresh_continuous_aggregate('cagg_4_hours_offset', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
 CALL refresh_continuous_aggregate('cagg_4_hours_origin', NULL, NULL, options => '{"buckets_per_batch": 0}'::jsonb);
 RESET client_min_messages;
+SET timezone TO 'PST8PDT';
 
 ALTER MATERIALIZED VIEW cagg_4_hours SET (timescaledb.materialized_only=true);
 SELECT * FROM cagg_4_hours;


### PR DESCRIPTION
The cagg_query and cagg_query_using_merge tests run under PST8PDT and
print the lower bound of a full refresh, which is the minimum timestamp.
How that very old timestamp is shown depends on the timezone database
version on the host, so a newer database made the tests fail. Switch to
UTC around those refresh calls so the boundary always prints the same.
