### PR TITLE
Drop automatic smallint bloom filters on upgrade

### DIFF
--- a/.unreleased/bloom-int2
+++ b/.unreleased/bloom-int2
@@ -1,0 +1,1 @@
+Fixes: Automatically drop incompatible smallint bloom filters when upgrading instead of stopping the upgrade

--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -28,12 +28,12 @@ export PGHOST PGPORT PGDATABASE PGDATA
 
 run_sql() {
   local db=${2:-$PGDATABASE}
-  psql -X -q --echo-queries -d "${db}" -v ON_ERROR_STOP=1 -v VERBOSITY=verbose -v WITH_ROLES=true -v WITH_SUPERUSER=true -v WITH_CHUNK=true -c "${1}"
+  psql -X -q --echo-queries -d "${db}" -v ON_ERROR_STOP=1 -v VERBOSITY=verbose -v WITH_ROLES=true -v WITH_SUPERUSER=true -v WITH_CHUNK=true -v UPDATE_MODE="${UPDATE_MODE}" -c "${1}"
 }
 
 run_sql_file() {
   local db=${2:-$PGDATABASE}
-  psql -X -q --echo-queries -d "${db}" -v ON_ERROR_STOP=1 -v VERBOSITY=verbose -v WITH_ROLES=true -v WITH_SUPERUSER=true -v WITH_CHUNK=true -f "${1}"
+  psql -X -q --echo-queries -d "${db}" -v ON_ERROR_STOP=1 -v VERBOSITY=verbose -v WITH_ROLES=true -v WITH_SUPERUSER=true -v WITH_CHUNK=true -v UPDATE_MODE="${UPDATE_MODE}" -f "${1}"
 }
 
 check_version() {

--- a/scripts/test_update_smoke.sh
+++ b/scripts/test_update_smoke.sh
@@ -56,7 +56,7 @@ echo "**** pg_dump at   " "$(which pg_dump)"
 echo "**** pg_restore at" "$(which pg_restore)"
 
 # Extra options to pass to psql
-PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false"
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=${WITH_ROLES} -v WITH_CHUNK=false -v UPDATE_MODE=direct"
 PSQL="psql -a -qX $PGOPTS"
 
 # If we are providing a URI for the connection, we parse it here and

--- a/sql/updates/2.26.4--2.27.0.sql
+++ b/sql/updates/2.26.4--2.27.0.sql
@@ -81,67 +81,60 @@ ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT IF EXISTS hypertable
 ALTER TABLE _timescaledb_catalog.chunk DROP CONSTRAINT IF EXISTS chunk_compressed_chunk_id_fkey;
 
 
--- Block upgrade if bloom filter sparse indexes exist on smallint (int2)
--- columns. These bloom filters used PostgreSQL's hashint2extended while
--- the new code uses bloom1_hash_2. Existing bloom data must be dropped
--- before upgrading; recompress afterwards to rebuild with the new hash.
+-- Bloom filters on smallint columns are incompatible with this version because
+-- the int2 hash changed, so the bloom data must be dropped. Drop it only when
+-- every such bloom was created automatically (source is not 'config'); if any
+-- was configured explicitly, block the upgrade with manual instructions instead.
 DO $$
 DECLARE
   drop_commands text;
+  has_explicit boolean;
 BEGIN
-  WITH bloom_entries AS (
-    SELECT relid AS chunk_oid,
-           compress_relid,
-           columns,
-           (SELECT string_agg(col, '_' ORDER BY ordinality)
-            FROM jsonb_array_elements_text(columns)
-                 WITH ORDINALITY AS t(col, ordinality)) AS col_suffix
-    FROM _timescaledb_catalog.compression_settings,
-         jsonb_array_elements(index) AS elem,
-         LATERAL (SELECT
-           CASE jsonb_typeof(elem->'column')
-             WHEN 'array' THEN elem->'column'
-             ELSE jsonb_build_array(elem->'column')
-           END AS columns
-         ) AS normalized
+  -- Find the bloom metadata columns of int2 blooms on compressed chunks. The
+  -- column is named after the bloom's columns joined by '_'; the prefix depends
+  -- on the build that wrote it (bloom1 for old builds, bloomh/bloomg for current
+  -- ones), and names longer than 39 chars are truncated with a 4 char md5 hash.
+  WITH int2_blooms AS (
+    SELECT cs.compress_relid,
+           COALESCE(elem->>'source', 'default') AS source,
+           (SELECT string_agg(col, '_' ORDER BY ord)
+            FROM jsonb_array_elements_text(cols) WITH ORDINALITY AS t(col, ord)) AS suffix
+    FROM _timescaledb_catalog.compression_settings cs,
+         jsonb_array_elements(cs.index) AS elem,
+         LATERAL (SELECT CASE jsonb_typeof(elem->'column')
+                           WHEN 'array' THEN elem->'column'
+                           ELSE jsonb_build_array(elem->'column')
+                         END) AS n(cols)
     WHERE elem->>'type' = 'bloom'
-      AND compress_relid IS NOT NULL
+      AND cs.compress_relid IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements_text(cols) AS colname
+        JOIN pg_attribute a ON a.attrelid = cs.relid AND a.attname = colname
+         AND a.atttypid = 'int2'::regtype AND a.attnum > 0
+      )
   ),
-  bloom_column_names AS (
-    SELECT chunk_oid, compress_relid, col_suffix, colname
-    FROM bloom_entries,
-         jsonb_array_elements_text(columns) AS bloom_column(colname)
-  ),
-  int2_bloom_suffixes AS (
-    SELECT DISTINCT compress_relid, col_suffix
-    FROM bloom_column_names
-    JOIN pg_attribute ON attrelid = chunk_oid
-     AND attname = colname
-     AND atttypid = 'int2'::regtype
-     AND attnum > 0
-  ),
-  bloom_cols_to_drop AS (
-    SELECT compress_relid,
-           attname AS bloom_attname
-    FROM int2_bloom_suffixes
-    JOIN pg_attribute ON attrelid = compress_relid
-     AND attname IN (
-       '_ts_meta_v2_bloom1_' || col_suffix,
-       '_ts_meta_v2_bloomh_' || col_suffix,
-       '_ts_meta_v2_bloomg_' || col_suffix
-     )
-     AND attnum > 0
+  drop_cmds AS (
+    SELECT format('ALTER TABLE %s DROP COLUMN %I;', b.compress_relid::regclass, a.attname) AS cmd,
+           b.source
+    FROM int2_blooms b
+    CROSS JOIN LATERAL (
+      SELECT CASE WHEN length(b.suffix) > 39
+                  THEN substr(md5(b.suffix), 1, 4) || '_' || substr(b.suffix, 1, 39)
+                  ELSE b.suffix END AS body
+    ) m
+    JOIN pg_attribute a ON a.attrelid = b.compress_relid AND a.attnum > 0
+     AND a.attname IN ('_ts_meta_v2_bloom1_' || m.body,
+                       '_ts_meta_v2_bloomh_' || m.body,
+                       '_ts_meta_v2_bloomg_' || m.body)
   )
-  SELECT string_agg(DISTINCT
-           format('ALTER TABLE %s DROP COLUMN %I;',
-                  compress_relid::regclass, bloom_attname),
-           E'\n' ORDER BY
-           format('ALTER TABLE %s DROP COLUMN %I;',
-                  compress_relid::regclass, bloom_attname))
-  INTO drop_commands
-  FROM bloom_cols_to_drop;
+  SELECT string_agg(DISTINCT cmd, E'\n' ORDER BY cmd), bool_or(source = 'config')
+  INTO drop_commands, has_explicit
+  FROM drop_cmds;
 
-  IF drop_commands IS NOT NULL THEN
+  IF drop_commands IS NULL THEN
+    -- Nothing to migrate.
+  ELSIF has_explicit THEN
+    -- Not all can be dropped automatically, so drop none and block the upgrade.
     RAISE EXCEPTION
       'existing bloom filter sparse indexes on smallint columns are incompatible '
       'with this version of TimescaleDB'
@@ -151,9 +144,39 @@ BEGIN
                  || drop_commands || E'\n'
                  || 'SET timescaledb.restoring = off;',
         HINT = 'To rebuild the bloom filter indexes after upgrading, decompress and compress the affected chunks.';
+  ELSE
+    EXECUTE drop_commands;
   END IF;
 END
 $$;
+
+-- Drop the same blooms from the compression settings so they no longer
+-- reference the removed columns, keeping explicitly configured entries.
+WITH rebuilt AS (
+  SELECT cs.relid,
+         jsonb_agg(elem ORDER BY ord) FILTER (WHERE keep) AS new_index,
+         bool_or(NOT keep) AS changed
+  FROM _timescaledb_catalog.compression_settings cs,
+       jsonb_array_elements(cs.index) WITH ORDINALITY AS arr(elem, ord),
+       LATERAL (SELECT NOT (
+         elem->>'type' = 'bloom'
+         AND COALESCE(elem->>'source', 'default') <> 'config'
+         AND EXISTS (
+           SELECT 1
+           FROM jsonb_array_elements_text(CASE jsonb_typeof(elem->'column')
+                                            WHEN 'array' THEN elem->'column'
+                                            ELSE jsonb_build_array(elem->'column')
+                                          END) AS colname
+           JOIN pg_attribute a ON a.attrelid = cs.relid AND a.attname = colname
+            AND a.atttypid = 'int2'::regtype AND a.attnum > 0
+         ))) AS k(keep)
+  GROUP BY cs.relid
+)
+UPDATE _timescaledb_catalog.compression_settings cs
+SET index = rebuilt.new_index
+FROM rebuilt
+WHERE cs.relid = rebuilt.relid
+  AND rebuilt.changed;
 
 
 DROP FUNCTION IF EXISTS _timescaledb_functions.job_history_bsearch;

--- a/test/sql/updates/cleanup.int2_bloom_migration.sql
+++ b/test/sql/updates/cleanup.int2_bloom_migration.sql
@@ -2,5 +2,5 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir cleanup.v11.sql
-\ir cleanup.int2_bloom_migration.sql
+DROP TABLE IF EXISTS int2_bloom;
+DROP TABLE IF EXISTS int2_bloom_long;

--- a/test/sql/updates/post.int2_bloom_migration.sql
+++ b/test/sql/updates/post.int2_bloom_migration.sql
@@ -1,0 +1,38 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- The 2.26.4--2.27.0 migration must drop the incompatible smallint bloom filter
+-- columns together with their compression settings. Each bloom sparse index in
+-- the settings owns exactly one bloom1 metadata column on the compressed chunk,
+-- so the two counts must match on every compressed chunk. This holds both for a
+-- fresh install (bloom kept) and for a migrated database (bloom dropped); a
+-- leftover settings entry or an orphaned column would make the counts differ and
+-- show up here as a diff.
+\a
+WITH bloom_entry_counts AS (
+  SELECT cs.compress_relid, count(*) AS n
+  FROM _timescaledb_catalog.compression_settings cs,
+       jsonb_array_elements(cs.index) AS elem
+  WHERE cs.compress_relid IS NOT NULL
+    AND cs.index IS NOT NULL
+    AND elem->>'type' = 'bloom'
+  GROUP BY cs.compress_relid
+),
+bloom_column_counts AS (
+  SELECT cs.compress_relid, count(*) AS n
+  FROM _timescaledb_catalog.compression_settings cs
+  JOIN pg_attribute a ON a.attrelid = cs.compress_relid
+   AND a.attnum > 0
+   AND NOT a.attisdropped
+  JOIN pg_type t ON t.oid = a.atttypid AND t.typname = 'bloom1'
+  WHERE cs.compress_relid IS NOT NULL
+  GROUP BY cs.compress_relid
+)
+SELECT coalesce(e.n, 0) AS bloom_settings_entries,
+       coalesce(c.n, 0) AS bloom_columns
+FROM bloom_entry_counts e
+FULL JOIN bloom_column_counts c ON e.compress_relid = c.compress_relid
+WHERE coalesce(e.n, 0) <> coalesce(c.n, 0)
+ORDER BY 1, 2;
+\a

--- a/test/sql/updates/post.v12.sql
+++ b/test/sql/updates/post.v12.sql
@@ -3,3 +3,9 @@
 -- LICENSE-APACHE for a copy of the license.
 
 \ir post.v11.sql
+
+-- int2 bloom fixture is skipped for singlestep mode
+SELECT :'UPDATE_MODE' <> 'singlestep' AS run_int2_bloom \gset
+\if :run_int2_bloom
+\ir post.int2_bloom_migration.sql
+\endif

--- a/test/sql/updates/setup.int2_bloom_migration.sql
+++ b/test/sql/updates/setup.int2_bloom_migration.sql
@@ -1,0 +1,60 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Auto-created composite bloom filters that span smallint (int2) columns are
+-- dropped by the 2.26.4--2.27.0 migration because the int2 hash changed.
+-- Composite bloom filters exist since 2.26.0, so this only runs for baselines
+-- that can create them.
+CREATE TABLE int2_bloom (
+    ts timestamptz NOT NULL,
+    a  smallint,
+    b  smallint
+);
+
+SELECT create_hypertable('int2_bloom', 'ts');
+
+INSERT INTO int2_bloom
+SELECT '2021-01-01'::timestamptz + (INTERVAL '1 hour') * i,
+       (i % 97)::smallint,
+       (i % 53)::smallint
+FROM generate_series(1, 5000) i;
+
+-- A multi-column btree index makes the default sparse index a composite bloom
+-- filter over the two smallint columns.
+CREATE INDEX int2_bloom_a_b_idx ON int2_bloom (a, b);
+
+ALTER TABLE int2_bloom SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'ts'
+);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('int2_bloom') c;
+
+-- Same, but with column names long enough that the bloom column name is
+-- truncated and suffixed with a hash, exercising that branch of the migration.
+CREATE TABLE int2_bloom_long (
+    ts timestamptz NOT NULL,
+    sensor_measurement_identifier_one smallint,
+    sensor_measurement_identifier_two smallint
+);
+
+SELECT create_hypertable('int2_bloom_long', 'ts');
+
+INSERT INTO int2_bloom_long
+SELECT '2021-01-01'::timestamptz + (INTERVAL '1 hour') * i,
+       (i % 97)::smallint,
+       (i % 53)::smallint
+FROM generate_series(1, 5000) i;
+
+CREATE INDEX int2_bloom_long_idx ON int2_bloom_long
+    (sensor_measurement_identifier_one, sensor_measurement_identifier_two);
+
+ALTER TABLE int2_bloom_long SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = '',
+    timescaledb.compress_orderby = 'ts'
+);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('int2_bloom_long') c;

--- a/test/sql/updates/setup.v12.sql
+++ b/test/sql/updates/setup.v12.sql
@@ -4,6 +4,13 @@
 
 \ir setup.v11.sql
 
+-- Skip int2 boom test in singlestep mode cause otherwise we
+-- would have to skip too many intermediate steps
+SELECT :'UPDATE_MODE' <> 'singlestep' AS run_int2_bloom \gset
+\if :run_int2_bloom
+\ir setup.int2_bloom_migration.sql
+\endif
+
 CREATE schema user_views;
 
 CREATE OR REPLACE VIEW user_views.hypertables AS SELECT * FROM timescaledb_information.hypertables;


### PR DESCRIPTION
Smallint bloom filters built before 2.27 used hashint2extended, but
2.27+ uses bloom1_hash_2, so the old filters no longer match and must
be dropped. The update now drops automatically created ones and removes
their compression settings; explicitly configured ones still block the
upgrade with instructions.
