### PR TITLE
Refactoring to prepare for compressed_chunk_id removal

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -36,9 +36,9 @@
 #include "scanner.h"
 #include "ts_catalog/catalog.h"
 
-static Oid ts_chunk_index_create_post_adjustment(int32 hypertable_id, Relation template_indexrel,
-												 Relation chunkrel, IndexInfo *indexinfo,
-												 bool isconstraint, Oid index_tablespace);
+static Oid chunk_index_create_from_indexinfo(int32 hypertable_id, Relation template_indexrel,
+											 Relation chunkrel, IndexInfo *indexinfo,
+											 bool isconstraint, Oid index_tablespace);
 
 static List *
 create_index_colnames(Relation indexrel)
@@ -194,16 +194,22 @@ Oid
 ts_chunk_index_get_tablespace(int32 hypertable_id, Relation template_indexrel, Relation chunkrel)
 {
 	/*
-	 * Determine the index's tablespace. Use the main index's tablespace, or,
-	 * if not set, select one at an offset from the chunk's tablespace.
+	 * Determine the index's tablespace. Use the template index's tablespace,
+	 * or, if not set, select one at an offset from the chunk's tablespace. When
+	 * no hypertable is available (e.g. when duplicating indexes for an internal
+	 * compressed relation) fall back to the chunk relation's own tablespace.
 	 */
 	if (OidIsValid(template_indexrel->rd_rel->reltablespace))
 	{
 		return template_indexrel->rd_rel->reltablespace;
 	}
-	else
+	else if (hypertable_id != INVALID_HYPERTABLE_ID)
 	{
 		return chunk_index_select_tablespace(hypertable_id, chunkrel);
+	}
+	else
+	{
+		return chunkrel->rd_rel->reltablespace;
 	}
 }
 
@@ -243,18 +249,18 @@ chunk_relation_index_create(Relation htrel, Relation template_indexrel, Relation
 	hypertable_id = ts_hypertable_relid_to_id(htrel->rd_id);
 	Assert(hypertable_id != INVALID_HYPERTABLE_ID);
 
-	return ts_chunk_index_create_post_adjustment(hypertable_id,
-												 template_indexrel,
-												 chunkrel,
-												 indexinfo,
-												 isconstraint,
-												 index_tablespace);
+	return chunk_index_create_from_indexinfo(hypertable_id,
+											 template_indexrel,
+											 chunkrel,
+											 indexinfo,
+											 isconstraint,
+											 index_tablespace);
 }
 
 static Oid
-ts_chunk_index_create_post_adjustment(int32 hypertable_id, Relation template_indexrel,
-									  Relation chunkrel, IndexInfo *indexinfo, bool isconstraint,
-									  Oid index_tablespace)
+chunk_index_create_from_indexinfo(int32 hypertable_id, Relation template_indexrel,
+								  Relation chunkrel, IndexInfo *indexinfo, bool isconstraint,
+								  Oid index_tablespace)
 {
 	Oid chunk_indexrelid = InvalidOid;
 	const char *indexname;
@@ -335,23 +341,6 @@ ts_chunk_index_create_post_adjustment(int32 hypertable_id, Relation template_ind
 	return chunk_indexrelid;
 }
 
-static Oid
-chunk_index_find_matching(Relation chunk_rel, Oid ht_indexoid)
-{
-	List *indexlist = RelationGetIndexList(chunk_rel);
-	ListCell *lc;
-	foreach (lc, indexlist)
-	{
-		Oid indexoid = lfirst_oid(lc);
-		if (ts_indexing_compare(indexoid, ht_indexoid))
-		{
-			return indexoid;
-		}
-	}
-	list_free(indexlist);
-	return InvalidOid;
-}
-
 /*
  * Create a new chunk index as a child of a parent hypertable index.
  *
@@ -363,8 +352,6 @@ static void
 chunk_index_create(Relation hypertable_rel, int32 hypertable_id, Relation hypertable_idxrel,
 				   int32 chunk_id, Relation chunkrel, Oid constraint_oid, Oid index_tblspc)
 {
-	Oid chunk_indexrelid;
-
 	if (OidIsValid(constraint_oid))
 	{
 		/*
@@ -374,14 +361,15 @@ chunk_index_create(Relation hypertable_rel, int32 hypertable_id, Relation hypert
 		return;
 	}
 
-	chunk_indexrelid = chunk_index_find_matching(chunkrel, RelationGetRelid(hypertable_idxrel));
+	Oid chunk_indexrelid =
+		ts_chunk_index_get_by_hypertable_indexrelid(chunkrel, RelationGetRelid(hypertable_idxrel));
 	if (!OidIsValid(chunk_indexrelid))
 	{
-		chunk_indexrelid = chunk_relation_index_create(hypertable_rel,
-													   hypertable_idxrel,
-													   chunkrel,
-													   false,
-													   index_tblspc);
+		chunk_relation_index_create(hypertable_rel,
+									hypertable_idxrel,
+									chunkrel,
+									false,
+									index_tblspc);
 	}
 }
 
@@ -390,12 +378,12 @@ ts_chunk_index_create_from_adjusted_index_info(int32 hypertable_id, Relation hyp
 											   int32 chunk_id, Relation chunkrel,
 											   IndexInfo *indexinfo)
 {
-	ts_chunk_index_create_post_adjustment(hypertable_id,
-										  hypertable_idxrel,
-										  chunkrel,
-										  indexinfo,
-										  false,
-										  false);
+	chunk_index_create_from_indexinfo(hypertable_id,
+									  hypertable_idxrel,
+									  chunkrel,
+									  indexinfo,
+									  false,
+									  false);
 }
 
 /*
@@ -580,20 +568,19 @@ ts_chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid)
 }
 
 static Oid
-chunk_index_duplicate_index(Relation hypertable_rel, Chunk *src_chunk, Oid chunk_index_oid,
-							Relation dest_chunk_rel, Oid index_tablespace)
+chunk_index_duplicate_index(Oid chunk_index_oid, Relation dest_chunk_rel, Oid index_tablespace)
 {
 	Relation chunk_index_rel = index_open(chunk_index_oid, AccessShareLock);
 	Oid constraint_oid;
 	Oid new_chunk_indexrelid;
 
 	constraint_oid = get_index_constraint(chunk_index_oid);
-
-	new_chunk_indexrelid = chunk_relation_index_create(hypertable_rel,
-													   chunk_index_rel,
-													   dest_chunk_rel,
-													   OidIsValid(constraint_oid),
-													   index_tablespace);
+	new_chunk_indexrelid = chunk_index_create_from_indexinfo(INVALID_HYPERTABLE_ID,
+															 chunk_index_rel,
+															 dest_chunk_rel,
+															 BuildIndexInfo(chunk_index_rel),
+															 OidIsValid(constraint_oid),
+															 index_tablespace);
 
 	index_close(chunk_index_rel, NoLock);
 	return new_chunk_indexrelid;
@@ -608,35 +595,24 @@ TSDLLEXPORT List *
 ts_chunk_index_duplicate(Oid src_chunkrelid, Oid dest_chunkrelid, List **src_index_oids,
 						 Oid index_tablespace)
 {
-	Relation hypertable_rel = NULL;
 	Relation src_chunk_rel;
 	Relation dest_chunk_rel;
 	List *index_oids;
 	ListCell *index_elem;
 	List *new_index_oids = NIL;
-	Chunk *src_chunk;
 
 	src_chunk_rel = table_open(src_chunkrelid, AccessShareLock);
 	dest_chunk_rel = table_open(dest_chunkrelid, ShareLock);
-
-	src_chunk = ts_chunk_get_by_relid(src_chunkrelid, true);
-
-	hypertable_rel = table_open(src_chunk->hypertable_relid, AccessShareLock);
 
 	index_oids = RelationGetIndexList(src_chunk_rel);
 	foreach (index_elem, index_oids)
 	{
 		Oid chunk_index_oid = lfirst_oid(index_elem);
-		Oid new_chunk_indexrelid = chunk_index_duplicate_index(hypertable_rel,
-															   src_chunk,
-															   chunk_index_oid,
-															   dest_chunk_rel,
-															   index_tablespace);
+		Oid new_chunk_indexrelid =
+			chunk_index_duplicate_index(chunk_index_oid, dest_chunk_rel, index_tablespace);
 
 		new_index_oids = lappend_oid(new_index_oids, new_chunk_indexrelid);
 	}
-
-	table_close(hypertable_rel, AccessShareLock);
 
 	table_close(dest_chunk_rel, NoLock);
 	table_close(src_chunk_rel, NoLock);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1663,9 +1663,19 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 		};
 		Chunk *chunk;
 
-		if (NULL == relation)
+		if (!relation)
 		{
 			continue;
+		}
+
+		Oid relid = RangeVarGetRelid(relation, NoLock, true);
+		if (ts_relation_is_compressed_chunk_relation(relid))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("dropping columnstore chunks not supported"),
+					 errhint("Please drop the corresponding chunk on the rowstore hypertable "
+							 "instead.")));
 		}
 
 		chunk = ts_chunk_get_by_name_with_memory_context(relation->schemaname,
@@ -1675,18 +1685,9 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 														 CurrentMemoryContext,
 														 false);
 
-		if (chunk != NULL)
+		if (chunk)
 		{
 			Hypertable *ht;
-
-			if (ts_relation_is_compressed_chunk_relation(chunk->table_id))
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("dropping columnstore chunks not supported"),
-						 errhint("Please drop the corresponding chunk on the rowstore hypertable "
-								 "instead.")));
-			}
 
 			/* if cascade is enabled, delete the compressed chunk with cascade too. Otherwise
 			 *  it would be blocked if there are dependent objects */
@@ -2064,16 +2065,32 @@ process_grant_and_revoke(ProcessUtilityArgs *args)
 												  was_schema_op,
 												  &compressed_hypertable->fd.schema_name,
 												  &compressed_hypertable->fd.table_name);
-						List *chunks =
-							ts_chunk_get_by_hypertable_id(hypertable->fd.compressed_hypertable_id);
+						List *chunks = ts_chunk_get_by_hypertable_id(hypertable->fd.id);
 						ListCell *cell;
 						foreach (cell, chunks)
 						{
 							Chunk *chunk = lfirst(cell);
+							Oid compressed_relid =
+								ts_relation_get_compressed_relid(chunk->table_id);
+							if (!OidIsValid(compressed_relid))
+							{
+								continue;
+							}
+							/*
+							 * makeRangeVar() keeps the name pointers without
+							 * copying, so the NameData must outlive this loop
+							 * iteration. Allocate it instead of using stack
+							 * storage which is reused on every iteration.
+							 */
+							NameData *compressed_schema_name = palloc(sizeof(NameData));
+							NameData *compressed_table_name = palloc(sizeof(NameData));
+							namestrcpy(compressed_schema_name,
+									   get_namespace_name(get_rel_namespace(compressed_relid)));
+							namestrcpy(compressed_table_name, get_rel_name(compressed_relid));
 							process_grant_add_by_name(stmt,
 													  was_schema_op,
-													  &chunk->fd.schema_name,
-													  &chunk->fd.table_name);
+													  compressed_schema_name,
+													  compressed_table_name);
 						}
 					}
 				}

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1044,9 +1044,9 @@ drop_continuous_agg(FormData_continuous_agg *cadata, bool drop_user_view)
 
 	if (OidIsValid(mat_hypertable.objectId))
 	{
-		performDeletion(&mat_hypertable, DROP_CASCADE, 0);
 		ts_compression_settings_delete(mat_hypertable.objectId);
 		ts_hypertable_delete_by_id(cadata->mat_hypertable_id);
+		performDeletion(&mat_hypertable, DROP_CASCADE, 0);
 	}
 
 	if (OidIsValid(partial_view.objectId))

--- a/src/utils.c
+++ b/src/utils.c
@@ -50,6 +50,7 @@
 #include "hypertable_cache.h"
 #include "jsonb_utils.h"
 #include "time_utils.h"
+#include "ts_catalog/compression_settings.h"
 #include "utils.h"
 #include "uuid.h"
 
@@ -1442,17 +1443,9 @@ ts_hypertable_approximate_size(PG_FUNCTION_ARGS)
 		bool isnull, is_osm_chunk;
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		Datum id = slot_getattr(ti->slot, Anum_chunk_id, &isnull);
-		Datum comp_id = DatumGetInt32(slot_getattr(ti->slot, Anum_chunk_id, &isnull));
-		int32 chunk_id, compressed_chunk_id;
+		Datum status = slot_getattr(ti->slot, Anum_chunk_status, &isnull);
 		Oid chunk_relid, compressed_chunk_relid;
 		RelationSize chunk_relsize, compressed_chunk_relsize;
-
-		if (isnull)
-		{
-			continue;
-		}
-
-		chunk_id = DatumGetInt32(id);
 
 		/* avoid if it's an OSM chunk */
 		is_osm_chunk = slot_getattr(ti->slot, Anum_chunk_osm_chunk, &isnull);
@@ -1462,20 +1455,18 @@ ts_hypertable_approximate_size(PG_FUNCTION_ARGS)
 			continue;
 		}
 
-		chunk_relid = ts_chunk_get_relid(chunk_id, false);
+		chunk_relid = ts_chunk_get_relid(DatumGetInt32(id), false);
 		chunk_relsize = ts_relation_approximate_size_impl(chunk_relid);
 		/* add this chunk's size to the total size */
 		ADD_RELATIONSIZE(total_relsize, chunk_relsize);
 
 		/* check if the chunk has a compressed counterpart and add if yes */
-		comp_id = slot_getattr(ti->slot, Anum_chunk_compressed_chunk_id, &isnull);
-		if (isnull)
+		if (!ts_flags_are_set_32(DatumGetInt32(status), CHUNK_STATUS_COMPRESSED))
 		{
 			continue;
 		}
 
-		compressed_chunk_id = DatumGetInt32(comp_id);
-		compressed_chunk_relid = ts_chunk_get_relid(compressed_chunk_id, false);
+		compressed_chunk_relid = ts_relation_get_compressed_relid(chunk_relid);
 		compressed_chunk_relsize = ts_relation_approximate_size_impl(compressed_chunk_relid);
 		/* add this compressed chunk's size to the total size */
 		ADD_RELATIONSIZE(total_relsize, compressed_chunk_relsize);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -917,7 +917,7 @@ create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id,
 		if (namelen >= NAMEDATALEN)
 		{
 			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
+					(errcode(ERRCODE_NAME_TOO_LONG),
 					 errmsg("invalid name \"%s\" for compressed chunk",
 							NameStr(compress_chunk->fd.table_name)),
 					 errdetail("The associated table prefix is too long.")));

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1325,8 +1325,8 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 						NameStr(uncompressed_chunk->fd.table_name))));
 	}
 
-	Chunk *compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
-	Ensure(compressed_chunk != NULL,
+	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
+	Ensure(OidIsValid(compressed_relid),
 		   "compressed chunk not found for chunk \"%s\"",
 		   get_rel_name(uncompressed_chunk->table_id));
 
@@ -1341,8 +1341,7 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 	 * For uncompressed chunk, we just need to read so AccessShareLock is fine.
 	 */
 	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
-	Relation compressed_chunk_rel =
-		table_open(compressed_chunk->table_id, ShareUpdateExclusiveLock);
+	Relation compressed_chunk_rel = table_open(compressed_relid, ShareUpdateExclusiveLock);
 
 	int count;
 	LOCKTAG locktag;

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -407,16 +407,16 @@ SELECT ts_setup_osm_hook();
 
 BEGIN;
 DROP MATERIALIZED VIEW hyper1_cagg CASCADE;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_9_chunk
 NOTICE:  hypertable_drop_hook
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_9_chunk
 DROP TABLE test1.hyper1;
 NOTICE:  hypertable_drop_hook
 ROLLBACK;
 BEGIN;
 DROP TABLE test1.hyper1 CASCADE;
 NOTICE:  drop cascades to 3 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_9_chunk
 NOTICE:  hypertable_drop_hook
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_9_chunk
 NOTICE:  hypertable_drop_hook
 ROLLBACK;
 SELECT ts_undo_osm_hook();

--- a/tsl/test/expected/compact_chunk.out
+++ b/tsl/test/expected/compact_chunk.out
@@ -22,15 +22,13 @@ SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks
  {COMPRESSED,UNORDERED}
 
 -- Get the first compressed chunk for inspection
-SELECT comp_ch.table_name AS "CHUNK_NAME",
-       comp_ch.schema_name || '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics'
+ORDER BY ch.id LIMIT 1 \gset
 -- Show batch metadata: 3 non-overlapping batches (ordered by min time)
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time
 FROM :CHUNK_FULL_NAME
@@ -202,14 +200,13 @@ SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks
  {COMPRESSED,UNORDERED}
 
 -- Get the compressed chunk for metrics_seg
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "SEG_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_seg'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "SEG_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_seg'
+ORDER BY ch.id LIMIT 1 \gset
 -- 4 batches: 2 per segment, no overlaps
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time
 FROM :SEG_CHUNK_FULL_NAME
@@ -320,14 +317,13 @@ SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_nul
  _timescaledb_internal._hyper_5_8_chunk
 
 -- Get the compressed chunk for metrics_nullable
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NULLABLE_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_nullable'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NULLABLE_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_nullable'
+ORDER BY ch.id LIMIT 1 \gset
 -- 1 batch, no nulls
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :NULLABLE_CHUNK_FULL_NAME
@@ -411,14 +407,13 @@ SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks
  {COMPRESSED,UNORDERED}
 
 -- Get the compressed chunk for metrics_desc
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "DESC_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_desc'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "DESC_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_desc'
+ORDER BY ch.id LIMIT 1 \gset
 -- 4 batches: 2 per segment, ordered by max time descending
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time
 FROM :DESC_CHUNK_FULL_NAME
@@ -545,14 +540,13 @@ SELECT '2025-01-03'::timestamptz + ((500 + i) || ' minute')::interval,
        (500 + i)::float
 FROM generate_series(1,500) i;
 -- Get the compressed chunk for metrics_multi
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "MULTI_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_multi'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "MULTI_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_multi'
+ORDER BY ch.id LIMIT 1 \gset
 -- 2 batches: boundary tie on col1 (device=d2), non-overlapping time ranges
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_device, _ts_meta_v2_last_device, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_time, _ts_meta_v2_last_time
 FROM :MULTI_CHUNK_FULL_NAME
@@ -641,14 +635,13 @@ SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval,
        i::float
 FROM generate_series(1,500) i;
 -- Get the compressed chunk
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "MULTI_DESC_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_multi_desc'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "MULTI_DESC_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_multi_desc'
+ORDER BY ch.id LIMIT 1 \gset
 -- 2 batches: boundary tie on col1 (device=d2), non-overlapping DESC time ranges
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_device, _ts_meta_v2_last_device, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_time, _ts_meta_v2_last_time
 FROM :MULTI_DESC_CHUNK
@@ -726,14 +719,13 @@ INSERT INTO metrics_combined
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd2', (i + 1000)::float
 FROM generate_series(1,1000) i;
 -- Get the compressed chunk
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "COMBINED_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_combined'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "COMBINED_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_combined'
+ORDER BY ch.id LIMIT 1 \gset
 -- 2 batches: 1 per segment, no overlaps, no nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :COMBINED_CHUNK
@@ -880,14 +872,13 @@ FROM generate_series(1,1000) i;
 INSERT INTO metrics_nulls_last
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd2', (i + 1000)::float
 FROM generate_series(1,1000) i;
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NULLS_LAST_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_nulls_last'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NULLS_LAST_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_nulls_last'
+ORDER BY ch.id LIMIT 1 \gset
 -- 2 non-overlapping batches, no nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :NULLS_LAST_CHUNK
@@ -1024,14 +1015,13 @@ FROM generate_series(1,1000) i;
 INSERT INTO metrics_nulls_first
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd2', (i + 1000)::float
 FROM generate_series(1,1000) i;
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NULLS_FIRST_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_nulls_first'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NULLS_FIRST_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_nulls_first'
+ORDER BY ch.id LIMIT 1 \gset
 -- 2 non-overlapping batches, no nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :NULLS_FIRST_CHUNK
@@ -1178,14 +1168,13 @@ SELECT '2025-01-03'::timestamptz + ((2000 + i) || ' minute')::interval,
        'd1',
        (1800 + i)::float
 FROM generate_series(1,1000) i;
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "MIXED_NULLS_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_mixed_nulls'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "MIXED_NULLS_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_mixed_nulls'
+ORDER BY ch.id LIMIT 1 \gset
 -- Show batch metadata before compaction: 3 batches, batch 2 has mixed nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :MIXED_NULLS_CHUNK
@@ -1274,14 +1263,13 @@ SELECT '2025-01-03'::timestamptz + ((499 + i) || ' minute')::interval,
        'd1',
        (1000 + i)::float
 FROM generate_series(1,500) i;
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "SEC_NULL_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_secondary_null'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "SEC_NULL_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_secondary_null'
+ORDER BY ch.id LIMIT 1 \gset
 -- Show batch metadata: col1 (time) ranges overlap at the boundary
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :SEC_NULL_CHUNK
@@ -1359,14 +1347,13 @@ SELECT '2025-01-03'::timestamptz + ((499 + i) || ' minute')::interval,
        'd1',
        CASE WHEN i = 1 THEN NULL ELSE (1000 + i)::float END
 FROM generate_series(1,500) i;
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "SEC_NF_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_secondary_null_first'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "SEC_NF_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_secondary_null_first'
+ORDER BY ch.id LIMIT 1 \gset
 -- Show batch metadata: boundary tie on col1 (time) at 08:20
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
 FROM :SEC_NF_CHUNK
@@ -1437,14 +1424,13 @@ FROM generate_series(1,1000) i;
 INSERT INTO metrics_no_firstlast
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd1', (1000 + i)::float
 FROM generate_series(1,1000) i;
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NO_FL_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_no_firstlast'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NO_FL_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_no_firstlast'
+ORDER BY ch.id LIMIT 1 \gset
 -- The orderby column only carries minmax metadata (no _ts_meta_v2_first/last).
 SELECT count(*) FILTER (WHERE attname LIKE '\_ts\_meta\_v2\_first%') AS first_cols,
        count(*) FILTER (WHERE attname LIKE '\_ts\_meta\_v2\_last%') AS last_cols

--- a/tsl/test/isolation/expected/deadlock_recompress_chunk.out
+++ b/tsl/test/isolation/expected/deadlock_recompress_chunk.out
@@ -15,11 +15,9 @@ step lock_after_decompress:
     DECLARE
       chunk regclass;
     BEGIN
-      SELECT format('%I.%I', c.schema_name, c.table_name)::regclass INTO chunk
-      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c, _timescaledb_catalog.compression_settings cs
-      WHERE cs.relid = format('%I.%I', p.schema_name, p.table_name)::regclass
-      AND cs.compress_relid = format('%I.%I', c.schema_name, c.table_name)::regclass
-      AND format('%I.%I', p.schema_name, p.table_name)::regclass = show_chunks;
+      SELECT cs.compress_relid INTO chunk
+      FROM show_chunks('hyper'), _timescaledb_catalog.compression_settings cs
+      WHERE cs.relid = show_chunks;
       EXECUTE format('LOCK TABLE %s IN EXCLUSIVE MODE', chunk);
     END;
     $$;

--- a/tsl/test/isolation/specs/deadlock_recompress_chunk.spec
+++ b/tsl/test/isolation/specs/deadlock_recompress_chunk.spec
@@ -50,11 +50,9 @@ step "lock_after_decompress" {
     DECLARE
       chunk regclass;
     BEGIN
-      SELECT format('%I.%I', c.schema_name, c.table_name)::regclass INTO chunk
-      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c, _timescaledb_catalog.compression_settings cs
-      WHERE cs.relid = format('%I.%I', p.schema_name, p.table_name)::regclass
-      AND cs.compress_relid = format('%I.%I', c.schema_name, c.table_name)::regclass
-      AND format('%I.%I', p.schema_name, p.table_name)::regclass = show_chunks;
+      SELECT cs.compress_relid INTO chunk
+      FROM show_chunks('hyper'), _timescaledb_catalog.compression_settings cs
+      WHERE cs.relid = show_chunks;
       EXECUTE format('LOCK TABLE %s IN EXCLUSIVE MODE', chunk);
     END;
     $$;

--- a/tsl/test/sql/compact_chunk.sql
+++ b/tsl/test/sql/compact_chunk.sql
@@ -23,15 +23,13 @@ FROM generate_series(1,3000) i;
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
 
 -- Get the first compressed chunk for inspection
-SELECT comp_ch.table_name AS "CHUNK_NAME",
-       comp_ch.schema_name || '.' || comp_ch.table_name AS "CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- Show batch metadata: 3 non-overlapping batches (ordered by min time)
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time
@@ -160,14 +158,13 @@ FROM generate_series(0,1999) i;
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_seg') chunk;
 
 -- Get the compressed chunk for metrics_seg
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "SEG_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_seg'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "SEG_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_seg'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 4 batches: 2 per segment, no overlaps
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time
@@ -233,14 +230,13 @@ FROM generate_series(1,1000) i;
 SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_nullable') chunk;
 
 -- Get the compressed chunk for metrics_nullable
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NULLABLE_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_nullable'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NULLABLE_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_nullable'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 1 batch, no nulls
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -303,14 +299,13 @@ FROM generate_series(0,1999) i;
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_desc') chunk;
 
 -- Get the compressed chunk for metrics_desc
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "DESC_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_desc'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "DESC_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_desc'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 4 batches: 2 per segment, ordered by max time descending
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time
@@ -390,14 +385,13 @@ SELECT '2025-01-03'::timestamptz + ((500 + i) || ' minute')::interval,
 FROM generate_series(1,500) i;
 
 -- Get the compressed chunk for metrics_multi
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "MULTI_CHUNK_FULL_NAME"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_multi'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "MULTI_CHUNK_FULL_NAME"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_multi'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 2 batches: boundary tie on col1 (device=d2), non-overlapping time ranges
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_device, _ts_meta_v2_last_device, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_time, _ts_meta_v2_last_time
@@ -466,14 +460,13 @@ SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval,
 FROM generate_series(1,500) i;
 
 -- Get the compressed chunk
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "MULTI_DESC_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_multi_desc'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "MULTI_DESC_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_multi_desc'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 2 batches: boundary tie on col1 (device=d2), non-overlapping DESC time ranges
 SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_device, _ts_meta_v2_last_device, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_time, _ts_meta_v2_last_time
@@ -533,14 +526,13 @@ SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd2', (i + 1000):
 FROM generate_series(1,1000) i;
 
 -- Get the compressed chunk
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "COMBINED_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_combined'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "COMBINED_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_combined'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 2 batches: 1 per segment, no overlaps, no nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -634,14 +626,13 @@ INSERT INTO metrics_nulls_last
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd2', (i + 1000)::float
 FROM generate_series(1,1000) i;
 
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NULLS_LAST_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_nulls_last'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NULLS_LAST_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_nulls_last'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 2 non-overlapping batches, no nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -731,14 +722,13 @@ INSERT INTO metrics_nulls_first
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd2', (i + 1000)::float
 FROM generate_series(1,1000) i;
 
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NULLS_FIRST_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_nulls_first'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NULLS_FIRST_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_nulls_first'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- 2 non-overlapping batches, no nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -838,14 +828,13 @@ SELECT '2025-01-03'::timestamptz + ((2000 + i) || ' minute')::interval,
        (1800 + i)::float
 FROM generate_series(1,1000) i;
 
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "MIXED_NULLS_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_mixed_nulls'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "MIXED_NULLS_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_mixed_nulls'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- Show batch metadata before compaction: 3 batches, batch 2 has mixed nulls
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -909,14 +898,13 @@ SELECT '2025-01-03'::timestamptz + ((499 + i) || ' minute')::interval,
        (1000 + i)::float
 FROM generate_series(1,500) i;
 
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "SEC_NULL_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_secondary_null'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "SEC_NULL_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_secondary_null'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- Show batch metadata: col1 (time) ranges overlap at the boundary
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -975,14 +963,13 @@ SELECT '2025-01-03'::timestamptz + ((499 + i) || ' minute')::interval,
        CASE WHEN i = 1 THEN NULL ELSE (1000 + i)::float END
 FROM generate_series(1,500) i;
 
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "SEC_NF_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_secondary_null_first'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "SEC_NF_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_secondary_null_first'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- Show batch metadata: boundary tie on col1 (time) at 08:20
 SELECT ctid, device, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_time, _ts_meta_v2_last_time, _ts_meta_min_2, _ts_meta_max_2, _ts_meta_v2_first_value, _ts_meta_v2_last_value
@@ -1034,14 +1021,13 @@ INSERT INTO metrics_no_firstlast
 SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd1', (1000 + i)::float
 FROM generate_series(1,1000) i;
 
-SELECT comp_ch.schema_name || '.' || comp_ch.table_name AS "NO_FL_CHUNK"
-FROM _timescaledb_catalog.chunk ch1,
-     _timescaledb_catalog.chunk comp_ch,
-     _timescaledb_catalog.hypertable ht
-WHERE ch1.hypertable_id = ht.id
-  AND ht.table_name = 'metrics_no_firstlast'
-  AND ch1.compressed_chunk_id = comp_ch.id
-ORDER BY ch1.id LIMIT 1 \gset
+SELECT cs.compress_relid::regclass::text AS "NO_FL_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = format('%I.%I', ch.schema_name, ch.table_name)::regclass
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_no_firstlast'
+ORDER BY ch.id LIMIT 1 \gset
 
 -- The orderby column only carries minmax metadata (no _ts_meta_v2_first/last).
 SELECT count(*) FILTER (WHERE attname LIKE '\_ts\_meta\_v2\_first%') AS first_cols,


### PR DESCRIPTION
- **Fix deadlock_recompress_chunk to not rely on compressed_chunk_id**
- **recompress fix**
- **Delete compression_settings before cascading DELETE for materialized hypertables**
- **Use compression_settings to get compressed relation ts_hypertable_approximate_size**

Disable-check: force-changelog-file

