### PR TITLE
Adapt path creation functions for PostgreSQL 19

### DIFF
--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -84,7 +84,11 @@ set_tablesample_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *
 	if ((root->query_level > 1 || bms_membership(root->all_baserels) != BMS_SINGLETON) &&
 		!(GetTsmRoutine(rte->tablesample->tsmhandler)->repeatable_across_scans))
 	{
+#if PG19_GE
+		path = (Path *) create_material_path(rel, path, enable_material);
+#else
 		path = (Path *) create_material_path(rel, path);
+#endif
 	}
 
 	add_path(rel, path);
@@ -325,8 +329,19 @@ set_dummy_rel_pathlist(RelOptInfo *rel)
 
 	/* Set up the dummy path */
 	add_path(rel,
-			 (Path *)
-				 create_append_path(NULL, rel, NIL, NIL, NIL, rel->lateral_relids, 0, false, -1));
+			 (Path *) create_append_path(/* root = */ NULL,
+										 rel,
+#if PG19_GE
+										 (AppendPathInput) { 0 },
+#else
+										 /* subpaths = */ NIL,
+										 /* partial_subpaths = */ NIL,
+#endif
+										 /* pathkeys = */ NIL,
+										 rel->lateral_relids,
+										 /* parallel_workers = */ 0,
+										 /* parallel_aware = */ false,
+										 /* rows = */ -1));
 
 	/*
 	 * We set the cheapest-path fields immediately, just in case they were

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -52,8 +52,14 @@ create_group_subpath(PlannerInfo *root, RelOptInfo *rel, List *group, List *path
 {
 	if (list_length(group) > 1)
 	{
-		MergeAppendPath *append =
-			create_merge_append_path(root, rel, group, pathkeys, required_outer);
+		MergeAppendPath *append = create_merge_append_path(root,
+														   rel,
+														   group,
+#if PG19_GE
+														   /* child_append_relid_sets = */ NIL,
+#endif
+														   pathkeys,
+														   required_outer);
 		*nested_children = lappend(*nested_children, append);
 	}
 	else
@@ -434,6 +440,9 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 				append = create_merge_append_path(root,
 												  rel,
 												  merge_childs,
+#if PG19_GE
+												  /* child_append_relid_sets = */ NIL,
+#endif
 												  path->cpath.path.pathkeys,
 												  PATH_REQ_OUTER(subpath));
 				nested_children = lappend(nested_children, append);

--- a/tsl/src/chunkwise_agg.c
+++ b/tsl/src/chunkwise_agg.c
@@ -134,14 +134,18 @@ get_subpaths_from_append_path(Path *path, List **subpaths, Path **append, Path *
  * Copy an AppendPath and set new subpaths.
  */
 static AppendPath *
-copy_append_path(AppendPath *path, List *subpaths, PathTarget *pathtarget)
+copy_append_path(PlannerInfo *root, AppendPath *path, List *subpaths, PathTarget *pathtarget)
 {
 	AppendPath *newPath = makeNode(AppendPath);
 	memcpy(newPath, path, sizeof(AppendPath));
 	newPath->subpaths = subpaths;
 	newPath->path.pathtarget = copy_pathtarget(pathtarget);
 
+#if PG19_GE
+	cost_append(newPath, root);
+#else
 	cost_append(newPath);
+#endif
 
 	return newPath;
 }
@@ -153,8 +157,14 @@ static MergeAppendPath *
 copy_merge_append_path(PlannerInfo *root, MergeAppendPath *path, List *subpaths,
 					   PathTarget *pathtarget)
 {
-	MergeAppendPath *newPath =
-		create_merge_append_path(root, path->path.parent, subpaths, path->path.pathkeys, NULL);
+	MergeAppendPath *newPath = create_merge_append_path(root,
+														path->path.parent,
+														subpaths,
+#if PG19_GE
+														path->child_append_relid_sets,
+#endif
+														path->path.pathkeys,
+														NULL);
 
 	newPath->path.param_info = path->path.param_info;
 	newPath->path.pathtarget = copy_pathtarget(pathtarget);
@@ -171,7 +181,7 @@ copy_append_like_path(PlannerInfo *root, Path *path, List *new_subpaths, PathTar
 	if (IsA(path, AppendPath))
 	{
 		AppendPath *append_path = castNode(AppendPath, path);
-		AppendPath *new_append_path = copy_append_path(append_path, new_subpaths, pathtarget);
+		AppendPath *new_append_path = copy_append_path(root, append_path, new_subpaths, pathtarget);
 		return &new_append_path->path;
 	}
 	else if (IsA(path, MergeAppendPath))

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -1719,16 +1719,23 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 			sequential_paths = lappend(sequential_paths, unordered_uncompressed_path);
 		}
 
-		Path *plain_append = (Path *) create_append_path(root,
-														 chunk_rel,
-														 sequential_paths,
-														 parallel_paths,
-														 /* pathkeys = */ NIL,
-														 req_outer,
-														 workers,
-														 workers > 0,
-														 chunk_path_no_sort->rows +
-															 unordered_uncompressed_path->rows);
+		Path *plain_append =
+			(Path *) create_append_path(/* root = */ root,
+										/* rel = */ chunk_rel,
+#if PG19_GE
+										/* input = */
+										(AppendPathInput){ .subpaths = sequential_paths,
+														   .partial_subpaths = parallel_paths },
+#else
+										/* subpaths = */ sequential_paths,
+										/* partial_subpaths = */ parallel_paths,
+#endif
+										/* pathkeys = */ NIL,
+										/* required_outer = */ req_outer,
+										/* parallel_workers = */ workers,
+										/* parallel_aware = */ workers > 0,
+										/* rows = */ chunk_path_no_sort->rows +
+											unordered_uncompressed_path->rows);
 
 		combined_paths = lappend(combined_paths, plain_append);
 	}
@@ -1807,6 +1814,9 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 											  chunk_rel,
 											  list_make2(decompression_path,
 														 uncompressed_path_for_merge),
+#if PG19_GE
+											  /* child_append_relid_sets = */ NIL,
+#endif
 											  sort_info->decompressed_sort_pathkeys,
 											  req_outer);
 		combined_paths = lappend(combined_paths, merge_append);

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -666,6 +666,9 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 			subpath = (Path *) create_merge_append_path(root,
 														merge_path->path.parent,
 														new_paths,
+#if PG19_GE
+														merge_path->child_append_relid_sets,
+#endif
 														merge_path->path.pathkeys,
 														NULL);
 			subpath->pathtarget = copy_pathtarget(merge_path->path.pathtarget);
@@ -690,15 +693,23 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 				continue;
 			}
 
-			subpath = (Path *) create_append_path(root,
-												  append_path->path.parent,
-												  new_paths,
-												  NULL,
-												  append_path->path.pathkeys,
-												  NULL,
-												  append_path->path.parallel_workers,
-												  append_path->path.parallel_aware,
-												  -1);
+			subpath = (Path *)
+				create_append_path(/* root = */ root,
+								   /* rel = */ append_path->path.parent,
+#if PG19_GE
+								   /* input = */
+								   (AppendPathInput){ .subpaths = new_paths,
+													  .child_append_relid_sets =
+														  append_path->child_append_relid_sets },
+#else
+								   /* subpaths = */ new_paths,
+								   /* partial_subpaths = */ NULL,
+#endif
+								   /* pathkeys = */ append_path->path.pathkeys,
+								   /* required_outer = */ NULL,
+								   /* parallel_workers = */ append_path->path.parallel_workers,
+								   /* parallel_aware = */ append_path->path.parallel_aware,
+								   /* rows = */ -1);
 			subpath->pathtarget = copy_pathtarget(append_path->path.pathtarget);
 		}
 		else if (ts_is_chunk_append_path(subpath))


### PR DESCRIPTION
PostgreSQL 19 changed the signatures of several path creation functions.
create_append_path now takes the subpaths in an AppendPathInput struct,
create_merge_append_path takes an additional argument for the child
append relid sets, create_material_path takes an enable_material flag
and cost_append takes the planner info. Adjust our callers for the new
signatures while keeping the old ones for earlier versions.

Upstream changes:
Store information about Append node consolidation in the final plan.
https://github.com/postgres/postgres/commit/7358abcc60
Allow for plugin control over path generation strategies.
https://github.com/postgres/postgres/commit/4020b370f2
Consider explicit incremental sort for Append and MergeAppend
https://github.com/postgres/postgres/commit/55a780e947

Disable-check: force-changelog-file
