### PR TITLE
Release 2.28.2

### DIFF
--- a/.unreleased/bloom-int2
+++ b/.unreleased/bloom-int2
@@ -1,1 +1,0 @@
-Fixes: Automatically drop incompatible smallint bloom filters when upgrading instead of stopping the upgrade

--- a/.unreleased/pr_10126
+++ b/.unreleased/pr_10126
@@ -1,2 +1,0 @@
-Fixes: #10126 Fix bgw_job_stat_history migration for 2.28.1
-Thanks: @juantxorena for reporting an issue with update script for 2.28.1

--- a/.unreleased/pr_10133
+++ b/.unreleased/pr_10133
@@ -1,2 +1,0 @@
-Fixes: #10133 Fix chunk_constraint migration
-Thanks: @rusha1333 for reporting an issue when upgrading to 2.28.1

--- a/.unreleased/pr_10137
+++ b/.unreleased/pr_10137
@@ -1,1 +1,0 @@
-Fixes: #10137 Fix column ordering on firstlast based sparse indexes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.28.2 (2026-06-29)
+## 2.28.2 (2026-06-30)
 
 This release contains bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,11 @@
 
 This release contains performance improvements and bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.28.2**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
-
 **Bugfixes**
-* 
-
-**New Settings**
-
-**GUCs**
+* [#10126](https://github.com/timescale/timescaledb/pull/10126) Fix `bgw_job_stat_history` migration for 2.28.1
 
 **Thanks**
-* 
+* @juantxorena for reporting an issue with update script for 2.28.1
 
 ## 2.28.1 (2026-06-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 This release contains performance improvements and bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
-* [#10164](https://github.com/timescale/timescaledb/pull/10164) Automatically drop incompatible smallint bloom filters when upgrading instead of stopping the upgrade
 * [#10126](https://github.com/timescale/timescaledb/pull/10126) Fix `bgw_job_stat_history` migration for 2.28.1
+* [#10133](https://github.com/timescale/timescaledb/pull/10133) Fix `chunk_constraint` migration
+* [#10137](https://github.com/timescale/timescaledb/pull/10137) Fix column ordering on `first`/`last`-based sparse indexes
+* [#10164](https://github.com/timescale/timescaledb/pull/10164) Automatically drop incompatible smallint bloom filters when upgrading instead of stopping the upgrade
 
 **Thanks**
 * @juantxorena for reporting an issue with update script for 2.28.1
+* @rusha1333 for reporting an issue when upgrading to 2.28.1
 
 ## 2.28.1 (2026-06-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 This release contains performance improvements and bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
+* [#10164](https://github.com/timescale/timescaledb/pull/10164) Automatically drop incompatible smallint bloom filters when upgrading instead of stopping the upgrade
 * [#10126](https://github.com/timescale/timescaledb/pull/10126) Fix `bgw_job_stat_history` migration for 2.28.1
 
 **Thanks**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.28.2 (2026-06-29)
+
+This release contains performance improvements and bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.28.2**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* 
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* 
+
 ## 2.28.1 (2026-06-23)
 
 This release contains performance improvements and bug fixes since the 2.28.0 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.28.2 (2026-06-29)
 
-This release contains performance improvements and bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
+This release contains bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
 * [#10126](https://github.com/timescale/timescaledb/pull/10126) Fix `bgw_job_stat_history` migration for 2.28.1


### PR DESCRIPTION
## 2.28.2 (2026-06-30)

This release contains bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#10126](https://github.com/timescale/timescaledb/pull/10126) Fix `bgw_job_stat_history` migration for 2.28.1
* [#10133](https://github.com/timescale/timescaledb/pull/10133) Fix `chunk_constraint` migration
* [#10137](https://github.com/timescale/timescaledb/pull/10137) Fix column ordering on `first`/`last`-based sparse indexes
* [#10164](https://github.com/timescale/timescaledb/pull/10164) Automatically drop incompatible smallint bloom filters when upgrading instead of stopping the upgrade

**Thanks**
* @juantxorena for reporting an issue with update script for 2.28.1
* @rusha1333 for reporting an issue when upgrading to 2.28.1