### PR TITLE
Adjust publication API usage for PostgreSQL 19

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1069,7 +1069,11 @@ chunk_add_to_publication(Oid puboid, const Chunk *chunk)
 	pri.columns = columns;
 	pri.whereClause = whereClause;
 
+#if PG19_GE
+	publication_add_relation(puboid, &pri, true, NULL);
+#else
 	publication_add_relation(puboid, &pri, true);
+#endif
 
 	table_close(chunk_rel, AccessShareLock);
 }
@@ -1080,7 +1084,7 @@ chunk_add_to_publications(const Chunk *chunk)
 	List *puboids;
 	ListCell *lc;
 
-	puboids = GetRelationPublications(chunk->hypertable_relid);
+	puboids = GetRelationIncludedPublications(chunk->hypertable_relid);
 	foreach (lc, puboids)
 	{
 		Oid puboid = lfirst_oid(lc);

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -126,6 +126,14 @@
  * behavior of the new version we simply adopt the new version's name.
  */
 
+/*
+ * GetRelationPublications was renamed to GetRelationIncludedPublications in PG19.
+ * https://github.com/postgres/postgres/commit/fd366065e0
+ */
+#if PG19_LT
+#define GetRelationIncludedPublications(relid) GetRelationPublications(relid)
+#endif
+
 #if PG19_LT
 #define ExecInsertIndexTuplesCompat(rri,                                                           \
 									slot,                                                          \

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1845,7 +1845,7 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 	/*
 	 * Check that the table is not part of any publication
 	 */
-	if (GetRelationPublications(table_relid) != NIL || GetAllTablesPublications() != NIL)
+	if (GetRelationIncludedPublications(table_relid) != NIL || GetAllTablesPublications() != NIL)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),


### PR DESCRIPTION
PostgreSQL 19 renamed GetRelationPublications to
GetRelationIncludedPublications and added an AlterPublicationStmt
argument to publication_add_relation. Adjust our callers for the new
name and signature while keeping the old ones for earlier versions.

Upstream changes:
Allow table exclusions in publications via EXCEPT TABLE.
https://github.com/postgres/postgres/commit/fd366065e0
Add support for EXCEPT TABLE in ALTER PUBLICATION.
https://github.com/postgres/postgres/commit/493f8c6439

Disable-check: force-changelog-file
