### PR TITLE
Use ERRCODE_NAME_TOO_LONG for name overflow

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -857,7 +857,7 @@ chunk_create_object(const Hypertable *ht, Hypercube *cube, const char *schema_na
 
 		if (len >= NAMEDATALEN)
 		{
-			elog(ERROR, "chunk table name too long");
+			ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("chunk table name too long")));
 		}
 	}
 	else

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -938,7 +938,11 @@ hypertable_insert(int32 hypertable_id, Name schema_name, Name table_name,
 	}
 	if (strnlen(NameStr(fd.associated_table_prefix), NAMEDATALEN) > MAXIMUM_PREFIX_LENGTH)
 	{
-		elog(ERROR, "associated_table_prefix too long");
+		ereport(ERROR,
+				(errcode(ERRCODE_NAME_TOO_LONG),
+				 errmsg("associated_table_prefix too long"),
+				 errhint("The associated_table_prefix must be less than %zu characters.",
+						 MAXIMUM_PREFIX_LENGTH)));
 	}
 
 	fd.num_dimensions = num_dimensions;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -127,8 +127,7 @@ build_compressed_relation_name(const Chunk *chunk)
 	int ret = snprintf(NameStr(name), NAMEDATALEN, "%s_compressed", NameStr(chunk->fd.table_name));
 	if (ret < 0 || ret >= NAMEDATALEN)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_NAME_TOO_LONG), errmsg("bad compressed chunk internal name")));
+		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("chunk name too long")));
 	}
 	return name;
 }
@@ -149,8 +148,7 @@ rename_compressed_chunk_for_replacement(Oid compressed_relid)
 	int ret = snprintf(tmp_name, NAMEDATALEN, "compress_old_%u", compressed_relid);
 	if (ret < 0 || ret >= NAMEDATALEN)
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_NAME_TOO_LONG), errmsg("bad compressed chunk internal name")));
+		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("chunk name too long")));
 	}
 
 	LockRelationOid(compressed_relid, AccessExclusiveLock);
@@ -918,28 +916,12 @@ Oid
 create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id,
 					  bool skip_segmentby_default, CompressionSettings *settings)
 {
-	char table_name[NAMEDATALEN];
-	int namelen;
 	Oid tablespace_oid;
 	bool settings_provided = (settings != NULL);
 
 	if (OidIsValid(table_id))
 	{
 		LockRelationOid(table_id, AccessShareLock);
-	}
-	else
-	{
-		/* Fail if we overflow the name limit */
-		namelen =
-			snprintf(table_name, NAMEDATALEN, "%s_compressed", NameStr(src_chunk->fd.table_name));
-
-		if (namelen >= NAMEDATALEN)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_NAME_TOO_LONG),
-					 errmsg("invalid name \"%s\" for compressed chunk", table_name),
-					 errdetail("The associated table prefix is too long.")));
-		}
 	}
 
 	/* Create the actual table relation for the chunk


### PR DESCRIPTION
Use ERRCODE_NAME_TOO_LONG as error code for name overflow instead of
ERRCODE_INTERNAL_ERROR.

Disable-check: force-changelog-file