### PR TITLE
Fail update test clearly when no update path is found

### DIFF
--- a/scripts/test_update_from_version.sh
+++ b/scripts/test_update_from_version.sh
@@ -80,6 +80,10 @@ singlestep_update() {
             > string_to_array(regexp_replace('${current}', '[^0-9.].*\$', ''), '.')::int[]
       ORDER BY string_to_array(regexp_replace(target, '[^0-9.].*\$', ''), '.')::int[]
       LIMIT 1")
+    if [ -z "${next}" ]; then
+      echo "No update path forward from ${current} to ${TO_VERSION} (dead end at ${current})" >&2
+      exit 1
+    fi
     run_sql "ALTER EXTENSION timescaledb UPDATE TO \"${next}\";"
     current="${next}"
   done


### PR DESCRIPTION
The step-by-step update test walks from one version to the next by
asking the database for the next version to update to. When no next
version was found it would still try to run the update with an empty
version name, which failed with a confusing parser error.
This could happen after a release but the forward-port not yet merged.

Previously this would show:
ERROR:  zero-length delimited identifier at or near """" at character 39

Disable-check: approval-count