### PR TITLE
Adjust target lists in cagg tests to use column names

### DIFF
--- a/tsl/test/expected/cagg.out
+++ b/tsl/test/expected/cagg.out
@@ -1465,7 +1465,7 @@ ORDER BY 1;
  _hyper_41_79_chunk | Fri Dec 24 16:00:00 1999 PST | Mon May 22 17:00:00 2000 PDT | t
  _hyper_41_83_chunk | Sun Mar 18 16:00:00 2001 PST | Wed Aug 15 17:00:00 2001 PDT | f
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------

--- a/tsl/test/expected/cagg_multi.out
+++ b/tsl/test/expected/cagg_multi.out
@@ -249,7 +249,7 @@ insert into continuous_agg_test values( 14, -2, 100);
 --add entry [14 15] to mat inv log for cagg_2. (invalidations are expanded to bucket
 --boundaries and we have bucket size of 2.
 SET ROLE :ROLE_SUPERUSER;
-select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+select materialization_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   5 |  -9223372036854775808 |             -2147483649
@@ -257,7 +257,7 @@ select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   6 |  -9223372036854775808 |             -2147483649
                   6 |                    14 |     9223372036854775807
 
-select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
+select hypertable_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              4 |                    14 |                      14
@@ -286,7 +286,7 @@ select * from _timescaledb_catalog.continuous_aggs_invalidation_threshold order 
 ---------------+-----------
              4 |        18
 
-select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+select materialization_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   5 |  -9223372036854775808 |             -2147483649
@@ -321,7 +321,7 @@ select * from cagg_2 order by 1;
 --TEST5 2 inserts with the same value can be copied over to materialization invalidation log
 insert into continuous_agg_test values( 18, -2, 100);
 insert into continuous_agg_test values( 18, -2, 100);
-select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
+select hypertable_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              4 |                    18 |                      18
@@ -334,7 +334,7 @@ select * from cagg_1 where timed = 18 ;
     18 |   3
 
 --copied over for cagg_2 to process later?
-select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+select materialization_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   5 |  -9223372036854775808 |             -2147483649

--- a/tsl/test/expected/cagg_query.out
+++ b/tsl/test/expected/cagg_query.out
@@ -1861,7 +1861,7 @@ INSERT INTO temperature
 --(which add -infinity, infinity) to the invalidation log, and the fact the the invalidation
 -- cutting during refresh won't merge entries which are not overlapping with its refresh window.
 -- The duplicates will be merged when there is a refresh that overlaps with them.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   2 |  -9223372036854775808 |     -210866803200000001
@@ -1887,7 +1887,7 @@ CREATE MATERIALIZED VIEW cagg_1_year
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:779: NOTICE:  refreshing continuous aggregate "cagg_1_year"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   2 |  -9223372036854775808 |     -210866803200000001
@@ -1913,7 +1913,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
 
 --try a refresh that overlaps with the invalidation log entries to check that they are merged properly
 --in this case, the duplicates at the +infinity end should be merged.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id IN (SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
                              WHERE user_view_name = 'cagg_4_hours')
 ORDER BY 1, 2, 3;
@@ -1926,7 +1926,7 @@ ORDER BY 1, 2, 3;
                  33 |      1577995200000000 |     9223372036854775807
 
 CALL refresh_continuous_aggregate('cagg_4_hours', '2000-01-01 00:00:00'::timestamptz, '2020-12-31 23:59:59'::timestamptz, options => '{"buckets_per_batch": 0}'::jsonb);
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id IN (SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
                              WHERE user_view_name = 'cagg_4_hours')
 ORDER BY 1, 2, 3;

--- a/tsl/test/expected/cagg_query_using_merge.out
+++ b/tsl/test/expected/cagg_query_using_merge.out
@@ -1856,7 +1856,7 @@ INSERT INTO temperature
 --(which add -infinity, infinity) to the invalidation log, and the fact the the invalidation
 -- cutting during refresh won't merge entries which are not overlapping with its refresh window.
 -- The duplicates will be merged when there is a refresh that overlaps with them.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   2 |  -9223372036854775808 |     -210866803200000001
@@ -1882,7 +1882,7 @@ CREATE MATERIALIZED VIEW cagg_1_year
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 psql:include/cagg_query_common.sql:779: NOTICE:  refreshing continuous aggregate "cagg_1_year"
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
                   2 |  -9223372036854775808 |     -210866803200000001
@@ -1908,7 +1908,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_
 
 --try a refresh that overlaps with the invalidation log entries to check that they are merged properly
 --in this case, the duplicates at the +infinity end should be merged.
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id IN (SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
                              WHERE user_view_name = 'cagg_4_hours')
 ORDER BY 1, 2, 3;
@@ -1921,7 +1921,7 @@ ORDER BY 1, 2, 3;
                  33 |      1577995200000000 |     9223372036854775807
 
 CALL refresh_continuous_aggregate('cagg_4_hours', '2000-01-01 00:00:00'::timestamptz, '2020-12-31 23:59:59'::timestamptz, options => '{"buckets_per_batch": 0}'::jsonb);
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id IN (SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
                              WHERE user_view_name = 'cagg_4_hours')
 ORDER BY 1, 2, 3;

--- a/tsl/test/expected/cagg_watermark.out
+++ b/tsl/test/expected/cagg_watermark.out
@@ -19,7 +19,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
  hypertable_id | watermark 
 ---------------+-----------
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
 
@@ -29,7 +29,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
  hypertable_id | watermark 
 ---------------+-----------
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
 
@@ -45,7 +45,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-------------
              1 | -2147483648
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
 
@@ -59,7 +59,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    10 |                      11
@@ -71,7 +71,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    10 |                      11
@@ -83,7 +83,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    10 |                      11
@@ -96,7 +96,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                     1 |                       1
@@ -112,7 +112,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    -4 |                      -1
@@ -127,7 +127,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    -4 |                      -1
@@ -144,7 +144,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    -7 |                      -3
@@ -160,7 +160,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              1 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              1 |                    -7 |                      -3
@@ -204,7 +204,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-------------
              3 | -2147483648
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
 
@@ -219,7 +219,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              3 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              3 |                     5 |                       9
@@ -231,7 +231,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              3 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              3 |                     5 |                       9
@@ -253,7 +253,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              3 |        15
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              3 |                     5 |                       6
@@ -293,7 +293,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-------------
              5 | -2147483648
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
 
@@ -308,7 +308,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              5 |         2
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              5 |                     1 |                       1
@@ -322,7 +322,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER 
 ---------------+-----------
              5 |         2
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
              5 |                     1 |                       1

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -3360,7 +3360,7 @@ EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cag
                ->  Seq Scan on _hyper_47_89_chunk cagg_inval_2 (actual rows=0.00 loops=1)
 
 -- should have invalidation entry from the direct batch delete
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
             47 |      1577865600000000 |        1577865600000000

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -3360,7 +3360,7 @@ EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cag
                ->  Seq Scan on _hyper_47_89_chunk cagg_inval_2 (actual rows=0.00 loops=1)
 
 -- should have invalidation entry from the direct batch delete
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
             47 |      1577865600000000 |        1577865600000000

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -3360,7 +3360,7 @@ EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cag
                ->  Seq Scan on _hyper_47_89_chunk cagg_inval_2 (actual rows=0.00 loops=1)
 
 -- should have invalidation entry from the direct batch delete
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
  hypertable_id | lowest_modified_value | greatest_modified_value 
 ---------------+-----------------------+-------------------------
             47 |      1577865600000000 |        1577865600000000

--- a/tsl/test/sql/cagg.sql
+++ b/tsl/test/sql/cagg.sql
@@ -1139,7 +1139,7 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = :'MAT_TABLE_NAME'
 ORDER BY 1;
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id = :'MAT_HTID' ORDER BY 1, 2,3;
 
 SELECT * from search_query_count_3

--- a/tsl/test/sql/cagg_multi.sql
+++ b/tsl/test/sql/cagg_multi.sql
@@ -127,8 +127,8 @@ insert into continuous_agg_test values( 14, -2, 100);
 --add entry [14 15] to mat inv log for cagg_2. (invalidations are expanded to bucket
 --boundaries and we have bucket size of 2.
 SET ROLE :ROLE_SUPERUSER;
-select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
-select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
+select materialization_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+select hypertable_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CALL refresh_continuous_aggregate('cagg_1', NULL, NULL);
 select * from cagg_1 order by 1;
@@ -136,7 +136,7 @@ CALL refresh_continuous_aggregate('cagg_2', NULL, 14);
 select * from cagg_2 order by 1;
 SET ROLE :ROLE_SUPERUSER;
 select * from _timescaledb_catalog.continuous_aggs_invalidation_threshold order by 1;
-select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+select materialization_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --this insert will be processed only by cagg_1 and cagg_2 will process the previous
 --one
@@ -150,11 +150,11 @@ select * from cagg_2 order by 1;
 --TEST5 2 inserts with the same value can be copied over to materialization invalidation log
 insert into continuous_agg_test values( 18, -2, 100);
 insert into continuous_agg_test values( 18, -2, 100);
-select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
+select hypertable_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
 CALL refresh_continuous_aggregate('cagg_1', NULL, NULL);
 select * from cagg_1 where timed = 18 ;
 --copied over for cagg_2 to process later?
-select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+select materialization_id, lowest_modified_value, greatest_modified_value from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
 DROP MATERIALIZED VIEW cagg_1;
 DROP MATERIALIZED VIEW cagg_2;
 

--- a/tsl/test/sql/cagg_watermark.sql
+++ b/tsl/test/sql/cagg_watermark.sql
@@ -11,13 +11,13 @@ SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
 
 -- watermark tabels start out empty
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- inserting into a table that does not have continuous_agg_insert_trigger doesn't change the watermark
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 CREATE MATERIALIZED VIEW cagg1 WITH (tsdb.continuous, tsdb.materialized_only=false)
   AS SELECT time_bucket('5', time) FROM continuous_agg_test GROUP BY 1 WITH NO DATA;
@@ -29,7 +29,7 @@ CREATE MATERIALIZED VIEW cagg1 WITH (tsdb.continuous, tsdb.materialized_only=fal
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- set the continuous_aggs_invalidation_threshold to 15, any insertions below that value need an invalidation
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -39,25 +39,25 @@ UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold SET watermark
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- INSERTs only above the continuous_aggs_invalidation_threshold won't change the continuous_aggs_hypertable_invalidation_log
 INSERT INTO continuous_agg_test VALUES (21, 3), (22, 4);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- INSERTs only below the continuous_aggs_invalidation_threshold will change the continuous_aggs_hypertable_invalidation_log
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- test INSERTing other values
 INSERT INTO continuous_agg_test VALUES (1, 7), (12, 6), (24, 5), (51, 4);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- INSERT after dropping a COLUMN
 ALTER TABLE continuous_agg_test DROP COLUMN data;
@@ -65,12 +65,12 @@ ALTER TABLE continuous_agg_test DROP COLUMN data;
 INSERT INTO continuous_agg_test VALUES (-1), (-2), (-3), (-4);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 INSERT INTO continuous_agg_test VALUES (100);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- INSERT after adding a COLUMN
 ALTER TABLE continuous_agg_test ADD COLUMN d BOOLEAN;
@@ -78,12 +78,12 @@ ALTER TABLE continuous_agg_test ADD COLUMN d BOOLEAN;
 INSERT INTO continuous_agg_test VALUES (-6, true), (-7, false), (-3, true), (-4, false);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 INSERT INTO continuous_agg_test VALUES (120, false), (200, true);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DELETE FROM _timescaledb_catalog.continuous_agg where mat_hypertable_id =  2;
@@ -111,7 +111,7 @@ CREATE MATERIALIZED VIEW cit_view
 INSERT INTO ca_inval_test SELECT generate_series(0, 5);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
@@ -122,12 +122,12 @@ WHERE hypertable_id = 3;
 INSERT INTO ca_inval_test SELECT generate_series(5, 15);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 INSERT INTO ca_inval_test SELECT generate_series(16, 20);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
@@ -144,7 +144,7 @@ UPDATE ca_inval_test SET time = 19 WHERE time = 18;
 UPDATE ca_inval_test SET time = 17 WHERE time = 19;
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 DROP TABLE ca_inval_test CASCADE;
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -167,7 +167,7 @@ CREATE MATERIALIZED VIEW continuous_view
         GROUP BY 1 WITH NO DATA;
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 UPDATE _timescaledb_catalog.continuous_aggs_invalidation_threshold
@@ -178,7 +178,7 @@ WHERE hypertable_id = 5;
 INSERT INTO ts_continuous_test VALUES (1, 1);
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 -- aborts don't get written
 BEGIN;
@@ -186,7 +186,7 @@ BEGIN;
 ABORT;
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold ORDER BY 1,2;
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2,3;
 
 DROP TABLE ts_continuous_test CASCADE;
 

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1764,7 +1764,7 @@ CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_buck
 EXPLAIN (analyze,costs off, timing off,summary off, buffers off) DELETE FROM cagg_inval;
 
 -- should have invalidation entry from the direct batch delete
-SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log ORDER BY 1,2;
 
 -- direct batch delete with time column as segmentby. Segmentby columns don't
 -- have _ts_meta_min/max, so the invalidation context must read the segmentby

--- a/tsl/test/sql/include/cagg_query_common.sql
+++ b/tsl/test/sql/include/cagg_query_common.sql
@@ -770,7 +770,7 @@ INSERT INTO temperature
 -- cutting during refresh won't merge entries which are not overlapping with its refresh window.
 -- The duplicates will be merged when there is a refresh that overlaps with them.
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
 
 CREATE MATERIALIZED VIEW cagg_1_year
   WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -778,19 +778,19 @@ CREATE MATERIALIZED VIEW cagg_1_year
     FROM temperature
     GROUP BY 1 ORDER BY 1;
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ORDER BY 1, 2, 3;
 
 --try a refresh that overlaps with the invalidation log entries to check that they are merged properly
 --in this case, the duplicates at the +infinity end should be merged.
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id IN (SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
                              WHERE user_view_name = 'cagg_4_hours')
 ORDER BY 1, 2, 3;
 
 CALL refresh_continuous_aggregate('cagg_4_hours', '2000-01-01 00:00:00'::timestamptz, '2020-12-31 23:59:59'::timestamptz, options => '{"buckets_per_batch": 0}'::jsonb);
 
-SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT materialization_id, lowest_modified_value, greatest_modified_value FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
 WHERE materialization_id IN (SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg
                              WHERE user_view_name = 'cagg_4_hours')
 ORDER BY 1, 2, 3;


### PR DESCRIPTION
Use explicit column names for reading from invalidation_log tables to prevent them from failing due to future cagg related changes.