### PR TITLE
Remove recursive cmake calls

### DIFF
--- a/coverage/CMakeLists.txt
+++ b/coverage/CMakeLists.txt
@@ -121,7 +121,6 @@ else()
 
   # Make sure coverage_test runs after tests (installcheck) finish
   add_custom_target(coverage_test DEPENDS ${OUTPUT_FILE}.test)
-  add_dependencies(installcheck-post-hook coverage_test)
 
   # Generate the final coverage file by combining the pre and post test
   # tracefiles

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,16 +106,6 @@ endif()
 # might add dependencies to it even when regress checks are disabled.
 add_custom_target(installcheck DEPENDS ${_install_checks})
 
-# Define a post test hook that is invoked after the installcheck target
-# finishes. One can use add_dependencies on post hook target to run other
-# targets after tests complete. This is used, e.g., by code coverage.
-add_custom_target(installcheck-post-hook COMMENT "Post test hook")
-add_custom_command(
-  TARGET installcheck
-  POST_BUILD
-  COMMAND cmake --build ${CMAKE_CURRENT_BINARY_DIR} --target
-          installcheck-post-hook)
-
 add_custom_target(
   installcheck-rerun
   COMMAND ${PRIMARY_TEST_DIR}/ci_rerun.sh installcheck


### PR DESCRIPTION
This breaks with Ninja. At the moment it's only used to run some code coverage building steps after installcheck, which adds no value over just building the "coverage" target manually.


Disable-check: force-changelog-file