### PR TITLE
Run linters on self-hosted runner

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -9,7 +9,7 @@ name: Code style
 jobs:
   cmake_checks:
     name: Check CMake files
-    runs-on: ubuntu-22.04
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Install prerequisites
         run: pip install cmakelang
@@ -24,7 +24,7 @@ jobs:
 
   perl_checks:
     name: Check Perl code in tree
-    runs-on: ubuntu-22.04
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Install prerequisites
         run: sudo apt install perltidy
@@ -44,7 +44,7 @@ jobs:
 
   yaml_checks:
     name: Check YAML code in tree
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Install prerequisites
         run: |
@@ -57,7 +57,7 @@ jobs:
 
   spelling_checks:
     name: Check spelling
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Install prerequisites
         run: |
@@ -71,7 +71,7 @@ jobs:
 
   cc_checks:
     name: Check code formatting
-    runs-on: ubuntu-22.04
+    runs-on: timescaledb-runner-arm64
     strategy:
       fail-fast: false
     env:
@@ -114,7 +114,7 @@ jobs:
 
   python_checks:
     name: Check Python code in tree
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - name: Install prerequisites
         run: |
@@ -139,10 +139,18 @@ jobs:
 
   misc_checks:
     name: Check license, update scripts, git hooks, missing gitignore entries and unnecessary template tests
-    runs-on: ubuntu-24.04
+    runs-on: timescaledb-runner-arm64
     strategy:
       fail-fast: false
     steps:
+    - name: Install prerequisites
+      if: always()
+      run: |
+        sudo apt-get update
+        # PostgreSQL 18 is not in the Ubuntu 22.04 archives, so add the official PGDG apt repository
+        sudo apt-get install -y postgresql-common
+        sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+        sudo apt-get install -y postgresql-server-dev-18
     - name: Checkout source
       if: always()
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -338,7 +338,7 @@ jobs:
     name: Regression Linux i386 summary
     needs: [check_paths, regress]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -385,7 +385,7 @@ jobs:
     name: Regression summary
     needs: [check_paths, regress]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -129,7 +129,7 @@ jobs:
     name: pg_upgrade summary
     needs: [check_paths, pg_upgrade_test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -8,7 +8,7 @@ name: Shellcheck
       - ?.*.x
 jobs:
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -25,7 +25,7 @@ jobs:
     name: Shellcheck
     needs: [check_paths]
     if: needs.check_paths.outputs.run_ci == 'true'
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
 
     steps:
     - name: Install Linux Dependencies
@@ -46,7 +46,7 @@ jobs:
     name: Shellcheck summary
     needs: [check_paths, shellcheck]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -127,7 +127,7 @@ jobs:
     name: Update and Downgrade summary
     needs: [check_paths, update_test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -415,7 +415,7 @@ jobs:
     name: Regression Windows summary
     needs: [check_paths, build]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: timescaledb-runner-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error


### PR DESCRIPTION
Move the linter and summary jobs from GitHub-hosted runners to the
self-hosted timescaledb-runner-arm64 runner.
