### PR TITLE
Remove no longer needed compat macros

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -92,46 +92,6 @@ pushJsonbValueCompat(JsonbInState *state, JsonbIteratorToken seq, JsonbValue *jb
 #endif
 }
 
-#if ((PG_VERSION_NUM >= 150009 && PG_VERSION_NUM < 160000) ||                                      \
-	 (PG_VERSION_NUM >= 160005 && PG_VERSION_NUM < 170000) || (PG_VERSION_NUM >= 170001))
-/*
- * The above versions introduced a fix for potentially losing updates to
- * pg_class and pg_database due to inplace updates done to those catalog
- * tables by PostgreSQL. The fix requires taking a lock on the tuple via
- * SearchSysCacheLocked1(). For older PG versions, we just map the new
- * function to the unlocked version and the unlocking of the tuple is a noop.
- *
- * https://github.com/postgres/postgres/commit/3b7a689e1a805c4dac2f35ff14fd5c9fdbddf150
- *
- * Here's an excerpt from README.tuplock that explains the need for additional
- * tuple locks:
- *
- * If IsInplaceUpdateRelation() returns true for a table, the table is a
- * system catalog that receives systable_inplace_update_begin() calls.
- * Preparing a heap_update() of these tables follows additional locking rules,
- * to ensure we don't lose the effects of an inplace update. In particular,
- * consider a moment when a backend has fetched the old tuple to modify, not
- * yet having called heap_update(). Another backend's inplace update starting
- * then can't conclude until the heap_update() places its new tuple in a
- * buffer. We enforce that using locktags as follows. While DDL code is the
- * main audience, the executor follows these rules to make e.g. "MERGE INTO
- * pg_class" safer. Locking rules are per-catalog:
- *
- * pg_class heap_update() callers: before copying the tuple to modify, take a
- * lock on the tuple, a ShareUpdateExclusiveLock on the relation, or a
- * ShareRowExclusiveLock or stricter on the relation.
- */
-#define SYSCACHE_TUPLE_LOCK_NEEDED 1
-#define AssertSufficientPgClassUpdateLockHeld(relid)                                               \
-	Assert(CheckRelationOidLockedByMe(relid, ShareUpdateExclusiveLock, false) ||                   \
-		   CheckRelationOidLockedByMe(relid, ShareRowExclusiveLock, true));
-#define UnlockSysCacheTuple(rel, tid) UnlockTuple(rel, tid, InplaceUpdateTupleLock);
-#else
-#define SearchSysCacheLockedCopy1(rel, datum) SearchSysCacheCopy1(rel, datum)
-#define UnlockSysCacheTuple(rel, tid)
-#define AssertSufficientPgClassUpdateLockHeld(relid)
-#endif
-
 /*
  * The following are compatibility functions for different versions of
  * PostgreSQL. Each compatibility function (or group) has its own logic for

--- a/src/utils.c
+++ b/src/utils.c
@@ -1742,7 +1742,8 @@ ts_copy_relation_acl(const Oid source_relid, const Oid target_relid, const Oid o
 		 * which takes an AccessExclusiveLock and should be enough to handle any
 		 * inplace update issues.
 		 */
-		AssertSufficientPgClassUpdateLockHeld(target_relid);
+		Assert(CheckRelationOidLockedByMe(target_relid, ShareUpdateExclusiveLock, false) ||
+			   CheckRelationOidLockedByMe(target_relid, ShareRowExclusiveLock, true));
 
 		/* Find the tuple for the target in `pg_class` */
 		target_tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(target_relid));
@@ -1940,9 +1941,7 @@ relation_set_reloption_impl(Relation rel, List *options, LOCKMODE lockmode)
 	{
 		elog(ERROR, "cache lookup failed for relation %u", relid);
 	}
-#ifdef SYSCACHE_TUPLE_LOCK_NEEDED
 	ItemPointerData otid = tuple->t_self;
-#endif
 
 	/* Get the old reloptions */
 	Datum datum = SysCacheGetAttr(RELOID, tuple, Anum_pg_class_reloptions, &isnull);
@@ -1971,7 +1970,7 @@ relation_set_reloption_impl(Relation rel, List *options, LOCKMODE lockmode)
 	/* Not sure if we need this one, but keeping it as a precaution */
 	InvokeObjectPostAlterHook(RelationRelationId, RelationGetRelid(rel), 0);
 
-	UnlockSysCacheTuple(pgclass, &otid);
+	UnlockTuple(pgclass, &otid, InplaceUpdateTupleLock);
 	heap_freetuple(newtuple);
 	heap_freetuple(tuple);
 	table_close(pgclass, RowExclusiveLock);


### PR DESCRIPTION
This was overlooked when removing PG15 support. All supported
postgres versions have the fix.

Disable-check: force-changelog-file
