### PR TITLE
Adapt jsonb construction for PostgreSQL 19

### DIFF
--- a/src/bgw/job_stat_history.c
+++ b/src/bgw/job_stat_history.c
@@ -27,28 +27,28 @@ typedef struct BgwJobStatHistoryContext
 static Jsonb *
 build_job_info(BgwJob *job)
 {
-	JsonbParseState *parse_state = NULL;
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	JsonbInState parse_state = { 0 };
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
 	/* all fields that is possible to change with `alter_job` API */
-	ts_jsonb_add_interval(parse_state, "schedule_interval", &job->fd.schedule_interval);
-	ts_jsonb_add_interval(parse_state, "max_runtime", &job->fd.max_runtime);
-	ts_jsonb_add_int32(parse_state, "max_retries", job->fd.max_retries);
-	ts_jsonb_add_interval(parse_state, "retry_period", &job->fd.retry_period);
-	ts_jsonb_add_str(parse_state, "proc_schema", NameStr(job->fd.proc_schema));
-	ts_jsonb_add_str(parse_state, "proc_name", NameStr(job->fd.proc_name));
-	ts_jsonb_add_str(parse_state, "owner", GetUserNameFromId(job->fd.owner, false));
-	ts_jsonb_add_bool(parse_state, "scheduled", job->fd.scheduled);
-	ts_jsonb_add_bool(parse_state, "fixed_schedule", job->fd.fixed_schedule);
+	ts_jsonb_add_interval(&parse_state, "schedule_interval", &job->fd.schedule_interval);
+	ts_jsonb_add_interval(&parse_state, "max_runtime", &job->fd.max_runtime);
+	ts_jsonb_add_int32(&parse_state, "max_retries", job->fd.max_retries);
+	ts_jsonb_add_interval(&parse_state, "retry_period", &job->fd.retry_period);
+	ts_jsonb_add_str(&parse_state, "proc_schema", NameStr(job->fd.proc_schema));
+	ts_jsonb_add_str(&parse_state, "proc_name", NameStr(job->fd.proc_name));
+	ts_jsonb_add_str(&parse_state, "owner", GetUserNameFromId(job->fd.owner, false));
+	ts_jsonb_add_bool(&parse_state, "scheduled", job->fd.scheduled);
+	ts_jsonb_add_bool(&parse_state, "fixed_schedule", job->fd.fixed_schedule);
 
 	if (job->fd.initial_start)
 	{
-		ts_jsonb_add_interval(parse_state, "initial_start", &job->fd.retry_period);
+		ts_jsonb_add_interval(&parse_state, "initial_start", &job->fd.retry_period);
 	}
 
 	if (job->fd.hypertable_id != INVALID_HYPERTABLE_ID)
 	{
-		ts_jsonb_add_int32(parse_state, "hypertable_id", job->fd.hypertable_id);
+		ts_jsonb_add_int32(&parse_state, "hypertable_id", job->fd.hypertable_id);
 	}
 
 	if (job->fd.config != NULL)
@@ -56,48 +56,50 @@ build_job_info(BgwJob *job)
 		/* config information jsonb*/
 		JsonbValue value = { 0 };
 		JsonbToJsonbValue(job->fd.config, &value);
-		ts_jsonb_add_value(parse_state, "config", &value);
+		ts_jsonb_add_value(&parse_state, "config", &value);
 	}
 
 	if (strlen(NameStr(job->fd.check_schema)) > 0)
 	{
-		ts_jsonb_add_str(parse_state, "check_schema", NameStr(job->fd.check_schema));
+		ts_jsonb_add_str(&parse_state, "check_schema", NameStr(job->fd.check_schema));
 	}
 
 	if (strlen(NameStr(job->fd.check_name)) > 0)
 	{
-		ts_jsonb_add_str(parse_state, "check_name", NameStr(job->fd.check_name));
+		ts_jsonb_add_str(&parse_state, "check_name", NameStr(job->fd.check_name));
 	}
 
 	if (job->fd.timezone != NULL)
 	{
-		ts_jsonb_add_str(parse_state, "timezone", text_to_cstring(job->fd.timezone));
+		ts_jsonb_add_str(&parse_state, "timezone", text_to_cstring(job->fd.timezone));
 	}
 
-	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL));
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	return JsonbValueToJsonb(parse_state.result);
 }
 
 static Jsonb *
 ts_bgw_job_stat_history_build_data_info(BgwJobStatHistoryContext *context)
 {
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 	JsonbValue value = { 0 };
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
 	Assert(context != NULL && context->job != NULL);
 
 	/* job information jsonb */
 	JsonbToJsonbValue(build_job_info(context->job), &value);
-	ts_jsonb_add_value(parse_state, "job", &value);
+	ts_jsonb_add_value(&parse_state, "job", &value);
 
 	if (context->edata != NULL)
 	{
 		/* error information jsonb */
 		JsonbToJsonbValue(context->edata, &value);
-		ts_jsonb_add_value(parse_state, "error_data", &value);
+		ts_jsonb_add_value(&parse_state, "error_data", &value);
 	}
 
-	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL));
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	return JsonbValueToJsonb(parse_state.result);
 }
 
 static void

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -66,6 +66,32 @@
 #error "Unsupported PostgreSQL version"
 #endif
 
+/*
+ * PG19 reworked jsonb construction: pushJsonbValue() now takes a JsonbInState *
+ * and returns void, leaving the completed value in state->result (populated only
+ * when the outermost container is closed). Older versions took a JsonbParseState **
+ * and returned the completed value directly.
+ *
+ * https://github.com/postgres/postgres/commit/0986e95161
+ */
+#if PG19_LT
+typedef struct JsonbInState
+{
+	JsonbParseState *parseState;
+	JsonbValue *result;
+} JsonbInState;
+#endif
+
+static inline void
+pushJsonbValueCompat(JsonbInState *state, JsonbIteratorToken seq, JsonbValue *jbval)
+{
+#if PG19_GE
+	pushJsonbValue(state, seq, jbval);
+#else
+	state->result = pushJsonbValue(&state->parseState, seq, jbval);
+#endif
+}
+
 #if ((PG_VERSION_NUM >= 150009 && PG_VERSION_NUM < 160000) ||                                      \
 	 (PG_VERSION_NUM >= 160005 && PG_VERSION_NUM < 170000) || (PG_VERSION_NUM >= 170001))
 /*

--- a/src/jsonb_utils.c
+++ b/src/jsonb_utils.c
@@ -17,10 +17,10 @@
 #include "jsonb_utils.h"
 #include "utils.h"
 
-static void ts_jsonb_add_pair(JsonbParseState *state, JsonbValue *key, JsonbValue *value);
+static void ts_jsonb_add_pair(JsonbInState *state, JsonbValue *key, JsonbValue *value);
 
 void
-ts_jsonb_add_null(JsonbParseState *state, const char *key)
+ts_jsonb_add_null(JsonbInState *state, const char *key)
 {
 	JsonbValue json_value;
 
@@ -29,7 +29,7 @@ ts_jsonb_add_null(JsonbParseState *state, const char *key)
 }
 
 void
-ts_jsonb_add_bool(JsonbParseState *state, const char *key, bool boolean)
+ts_jsonb_add_bool(JsonbInState *state, const char *key, bool boolean)
 {
 	JsonbValue json_value;
 
@@ -40,7 +40,7 @@ ts_jsonb_add_bool(JsonbParseState *state, const char *key, bool boolean)
 }
 
 void
-ts_jsonb_add_str(JsonbParseState *state, const char *key, const char *value)
+ts_jsonb_add_str(JsonbInState *state, const char *key, const char *value)
 {
 	JsonbValue json_value;
 
@@ -59,7 +59,7 @@ ts_jsonb_add_str(JsonbParseState *state, const char *key, const char *value)
 }
 
 static void
-ts_jsonb_add_str_element(JsonbParseState *state, const char *elem)
+ts_jsonb_add_str_element(JsonbInState *state, const char *elem)
 {
 	JsonbValue json_value;
 
@@ -74,11 +74,11 @@ ts_jsonb_add_str_element(JsonbParseState *state, const char *elem)
 	json_value.val.string.val = (char *) elem;
 	json_value.val.string.len = strlen(elem);
 
-	pushJsonbValue(&state, WJB_ELEM, &json_value);
+	pushJsonbValueCompat(state, WJB_ELEM, &json_value);
 }
 
 void
-ts_jsonb_add_str_array(JsonbParseState *state, const char *key, const char **values, int num_values)
+ts_jsonb_add_str_array(JsonbInState *state, const char *key, const char **values, int num_values)
 {
 	JsonbValue json_key;
 	Assert(key != NULL);
@@ -93,9 +93,9 @@ ts_jsonb_add_str_array(JsonbParseState *state, const char *key, const char **val
 	json_key.type = jbvString;
 	json_key.val.string.val = (char *) key;
 	json_key.val.string.len = strlen(key);
-	pushJsonbValue(&state, WJB_KEY, &json_key);
+	pushJsonbValueCompat(state, WJB_KEY, &json_key);
 
-	pushJsonbValue(&state, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValueCompat(state, WJB_BEGIN_ARRAY, NULL);
 	for (int i = 0; i < num_values; i++)
 	{
 		if (values[i] == NULL || values[i][0] == '\0')
@@ -104,7 +104,7 @@ ts_jsonb_add_str_array(JsonbParseState *state, const char *key, const char **val
 		}
 		ts_jsonb_add_str_element(state, values[i]);
 	}
-	pushJsonbValue(&state, WJB_END_ARRAY, NULL);
+	pushJsonbValueCompat(state, WJB_END_ARRAY, NULL);
 }
 
 static PGFunction
@@ -150,7 +150,7 @@ ts_jsonb_set_value_by_type(JsonbValue *value, Oid typeid, Datum datum)
 }
 
 void
-ts_jsonb_add_int32(JsonbParseState *state, const char *key, const int32 int_value)
+ts_jsonb_add_int32(JsonbInState *state, const char *key, const int32 int_value)
 {
 	JsonbValue json_value;
 
@@ -159,7 +159,7 @@ ts_jsonb_add_int32(JsonbParseState *state, const char *key, const int32 int_valu
 }
 
 void
-ts_jsonb_add_int64(JsonbParseState *state, const char *key, const int64 int_value)
+ts_jsonb_add_int64(JsonbInState *state, const char *key, const int64 int_value)
 {
 	JsonbValue json_value;
 
@@ -168,7 +168,7 @@ ts_jsonb_add_int64(JsonbParseState *state, const char *key, const int64 int_valu
 }
 
 void
-ts_jsonb_add_interval(JsonbParseState *state, const char *key, Interval *interval)
+ts_jsonb_add_interval(JsonbInState *state, const char *key, Interval *interval)
 {
 	JsonbValue json_value;
 
@@ -177,7 +177,7 @@ ts_jsonb_add_interval(JsonbParseState *state, const char *key, Interval *interva
 }
 
 void
-ts_jsonb_add_value(JsonbParseState *state, const char *key, JsonbValue *value)
+ts_jsonb_add_value(JsonbInState *state, const char *key, JsonbValue *value)
 {
 	JsonbValue json_key;
 
@@ -195,7 +195,7 @@ ts_jsonb_add_value(JsonbParseState *state, const char *key, JsonbValue *value)
 }
 
 static void
-ts_jsonb_add_pair(JsonbParseState *state, JsonbValue *key, JsonbValue *value)
+ts_jsonb_add_pair(JsonbInState *state, JsonbValue *key, JsonbValue *value)
 {
 	Assert(state != NULL);
 	Assert(key != NULL);
@@ -204,8 +204,8 @@ ts_jsonb_add_pair(JsonbParseState *state, JsonbValue *key, JsonbValue *value)
 		return;
 	}
 
-	pushJsonbValue(&state, WJB_KEY, key);
-	pushJsonbValue(&state, WJB_VALUE, value);
+	pushJsonbValueCompat(state, WJB_KEY, key);
+	pushJsonbValueCompat(state, WJB_VALUE, value);
 }
 
 char *

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -9,23 +9,21 @@
 #include <utils/json.h>
 #include <utils/jsonb.h>
 
+#include "compat/compat.h"
 #include "export.h"
 
-extern TSDLLEXPORT void ts_jsonb_add_null(JsonbParseState *state, const char *key);
-extern TSDLLEXPORT void ts_jsonb_add_bool(JsonbParseState *state, const char *key, bool boolean);
-extern TSDLLEXPORT void ts_jsonb_add_str(JsonbParseState *state, const char *key,
-										 const char *value);
-extern TSDLLEXPORT void ts_jsonb_add_str_array(JsonbParseState *state, const char *key,
+extern TSDLLEXPORT void ts_jsonb_add_null(JsonbInState *state, const char *key);
+extern TSDLLEXPORT void ts_jsonb_add_bool(JsonbInState *state, const char *key, bool boolean);
+extern TSDLLEXPORT void ts_jsonb_add_str(JsonbInState *state, const char *key, const char *value);
+extern TSDLLEXPORT void ts_jsonb_add_str_array(JsonbInState *state, const char *key,
 											   const char **values, int num_values);
-extern TSDLLEXPORT void ts_jsonb_add_interval(JsonbParseState *state, const char *key,
+extern TSDLLEXPORT void ts_jsonb_add_interval(JsonbInState *state, const char *key,
 											  Interval *interval);
-extern TSDLLEXPORT void ts_jsonb_add_int32(JsonbParseState *state, const char *key,
-										   const int32 value);
-extern TSDLLEXPORT void ts_jsonb_add_int64(JsonbParseState *state, const char *key,
-										   const int64 value);
+extern TSDLLEXPORT void ts_jsonb_add_int32(JsonbInState *state, const char *key, const int32 value);
+extern TSDLLEXPORT void ts_jsonb_add_int64(JsonbInState *state, const char *key, const int64 value);
 extern TSDLLEXPORT void ts_jsonb_set_value_by_type(JsonbValue *value, Oid typeid, Datum datum);
 
-extern void ts_jsonb_add_value(JsonbParseState *state, const char *key, JsonbValue *value);
+extern void ts_jsonb_add_value(JsonbInState *state, const char *key, JsonbValue *value);
 
 extern TSDLLEXPORT char *ts_jsonb_get_str_field(const Jsonb *jsonb, const char *key);
 extern TSDLLEXPORT Interval *ts_jsonb_get_interval_field(const Jsonb *jsonb, const char *key);

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -282,7 +282,7 @@ get_architecture_bit_size()
 }
 
 static void
-add_job_counts(JsonbParseState *state)
+add_job_counts(JsonbInState *state)
 {
 	BgwJobTypeCount counts = bgw_job_type_counts();
 
@@ -299,7 +299,7 @@ add_job_counts(JsonbParseState *state)
 }
 
 static JsonbValue *
-add_errors_by_sqlerrcode_internal(JsonbParseState *parse_state, const char *job_type,
+add_errors_by_sqlerrcode_internal(JsonbInState *parse_state, const char *job_type,
 								  Jsonb *sqlerrs_jsonb)
 {
 	JsonbIterator *it;
@@ -312,8 +312,8 @@ add_errors_by_sqlerrcode_internal(JsonbParseState *parse_state, const char *job_
 		.val.string.len = strlen(job_type),
 	};
 
-	ret = pushJsonbValue(&parse_state, WJB_KEY, &key);
-	ret = pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(parse_state, WJB_BEGIN_OBJECT, NULL);
 
 	/* we don't expect nested values here */
 	it = JsonbIteratorInit(&sqlerrs_jsonb->root);
@@ -350,7 +350,8 @@ add_errors_by_sqlerrcode_internal(JsonbParseState *parse_state, const char *job_
 		}
 	}
 
-	ret = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_END_OBJECT, NULL);
+	ret = parse_state->result;
 	return ret;
 }
 /* this function queries the database through SPI and gets back a set of records
@@ -361,7 +362,7 @@ add_errors_by_sqlerrcode_internal(JsonbParseState *parse_state, const char *job_
  Then for each returned row adds a new kv pair to the jsonb,
  which looks like "job_type": {"errtype1": errcnt1, ...} */
 static void
-add_errors_by_sqlerrcode(JsonbParseState *parse_state)
+add_errors_by_sqlerrcode(JsonbInState *parse_state)
 {
 	int res;
 	StringInfoData command;
@@ -449,15 +450,15 @@ add_errors_by_sqlerrcode(JsonbParseState *parse_state)
 }
 
 static JsonbValue *
-add_job_stats_internal(JsonbParseState *state, const char *job_type, TelemetryJobStats *stats)
+add_job_stats_internal(JsonbInState *state, const char *job_type, TelemetryJobStats *stats)
 {
 	JsonbValue key = {
 		.type = jbvString,
 		.val.string.val = pstrdup(job_type),
 		.val.string.len = strlen(job_type),
 	};
-	pushJsonbValue(&state, WJB_KEY, &key);
-	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_KEY, &key);
+	pushJsonbValueCompat(state, WJB_BEGIN_OBJECT, NULL);
 
 	ts_jsonb_add_int64(state, "total_runs", stats->total_runs);
 	ts_jsonb_add_int64(state, "total_successes", stats->total_successes);
@@ -468,11 +469,12 @@ add_job_stats_internal(JsonbParseState *state, const char *job_type, TelemetryJo
 	ts_jsonb_add_interval(state, "total_duration", stats->total_duration);
 	ts_jsonb_add_interval(state, "total_duration_failures", stats->total_duration_failures);
 
-	return pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_END_OBJECT, NULL);
+	return state->result;
 }
 
 static void
-add_job_stats_by_job_type(JsonbParseState *parse_state)
+add_job_stats_by_job_type(JsonbInState *parse_state)
 {
 	StringInfoData command;
 	int res;
@@ -589,9 +591,9 @@ get_database_size()
 }
 
 static void
-add_related_extensions(JsonbParseState *state)
+add_related_extensions(JsonbInState *state)
 {
-	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_BEGIN_OBJECT, NULL);
 
 	for (size_t i = 0; i < sizeof(related_extensions) / sizeof(char *); i++)
 	{
@@ -600,7 +602,7 @@ add_related_extensions(JsonbParseState *state)
 		ts_jsonb_add_bool(state, ext, OidIsValid(get_extension_oid(ext, true)));
 	}
 
-	pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_END_OBJECT, NULL);
 }
 
 static char *
@@ -664,16 +666,15 @@ format_iso8601(Datum value)
 #define REQ_RELKIND_CAGG_NESTED "num_caggs_nested"
 
 static JsonbValue *
-add_compression_stats_object(JsonbParseState *parse_state, StatsRelType reltype,
-							 const HyperStats *hs)
+add_compression_stats_object(JsonbInState *parse_state, StatsRelType reltype, const HyperStats *hs)
 {
 	JsonbValue name = {
 		.type = jbvString,
 		.val.string.val = pstrdup("compression"),
 		.val.string.len = strlen("compression"),
 	};
-	pushJsonbValue(&parse_state, WJB_KEY, &name);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_KEY, &name);
+	pushJsonbValueCompat(parse_state, WJB_BEGIN_OBJECT, NULL);
 
 	ts_jsonb_add_int64(parse_state, REQ_RELKIND_COMPRESSED_CHUNKS, hs->compressed_chunk_count);
 
@@ -708,20 +709,21 @@ add_compression_stats_object(JsonbParseState *parse_state, StatsRelType reltype,
 					   REQ_RELKIND_UNCOMPRESSED_INDEXES_SIZE,
 					   hs->uncompressed_indexes_size);
 
-	return pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_END_OBJECT, NULL);
+	return parse_state->result;
 }
 
 static JsonbValue *
-add_relkind_stats_object(JsonbParseState *parse_state, const char *relkindname,
-						 const BaseStats *stats, StatsRelType reltype, StatsType statstype)
+add_relkind_stats_object(JsonbInState *parse_state, const char *relkindname, const BaseStats *stats,
+						 StatsRelType reltype, StatsType statstype)
 {
 	JsonbValue name = {
 		.type = jbvString,
 		.val.string.val = pstrdup(relkindname),
 		.val.string.len = strlen(relkindname),
 	};
-	pushJsonbValue(&parse_state, WJB_KEY, &name);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_KEY, &name);
+	pushJsonbValueCompat(parse_state, WJB_BEGIN_OBJECT, NULL);
 
 	ts_jsonb_add_int64(parse_state, REQ_RELKIND_COUNT, stats->relcount);
 
@@ -756,11 +758,12 @@ add_relkind_stats_object(JsonbParseState *parse_state, const char *relkindname,
 		ts_jsonb_add_int64(parse_state, REQ_RELKIND_CAGG_NESTED, cs->nested);
 	}
 
-	return pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_END_OBJECT, NULL);
+	return parse_state->result;
 }
 
 static void
-add_function_call_telemetry(JsonbParseState *state)
+add_function_call_telemetry(JsonbInState *state)
 {
 	fn_telemetry_entry_vec *functions;
 	const char *visible_extensions[(sizeof(related_extensions) / sizeof(char *)) + 1];
@@ -771,7 +774,7 @@ add_function_call_telemetry(JsonbParseState *state)
 			.type = jbvNull,
 		};
 
-		pushJsonbValue(&state, WJB_VALUE, &value);
+		pushJsonbValueCompat(state, WJB_VALUE, &value);
 		return;
 	}
 
@@ -784,7 +787,7 @@ add_function_call_telemetry(JsonbParseState *state)
 	functions =
 		ts_function_telemetry_read(visible_extensions, sizeof(visible_extensions) / sizeof(char *));
 
-	pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_BEGIN_OBJECT, NULL);
 
 	if (functions)
 	{
@@ -796,11 +799,11 @@ add_function_call_telemetry(JsonbParseState *state)
 		}
 	}
 
-	pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_END_OBJECT, NULL);
 }
 
 static void
-add_replication_telemetry(JsonbParseState *state)
+add_replication_telemetry(JsonbInState *state)
 {
 	ReplicationInfo info = ts_telemetry_replication_info_gather();
 	if (info.got_num_wal_senders)
@@ -852,7 +855,7 @@ add_replication_telemetry(JsonbParseState *state)
  * }
  */
 static void
-add_query_result_dict(JsonbParseState *state, const char *query)
+add_query_result_dict(JsonbInState *state, const char *query)
 {
 	MemoryContext orig_context = CurrentMemoryContext;
 
@@ -871,7 +874,7 @@ add_query_result_dict(JsonbParseState *state, const char *query)
 
 	MemoryContext spi_context = MemoryContextSwitchTo(orig_context);
 
-	(void) pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+	(void) pushJsonbValueCompat(state, WJB_BEGIN_OBJECT, NULL);
 	for (uint64 r = 0; r < SPI_processed; r++)
 	{
 		char *key_string = SPI_getvalue(SPI_tuptable->vals[r], SPI_tuptable->tupdesc, 1);
@@ -881,9 +884,9 @@ add_query_result_dict(JsonbParseState *state, const char *query)
 			.val.string.len = strlen(key_string),
 		};
 
-		(void) pushJsonbValue(&state, WJB_KEY, &key);
+		(void) pushJsonbValueCompat(state, WJB_KEY, &key);
 
-		(void) pushJsonbValue(&state, WJB_BEGIN_OBJECT, NULL);
+		(void) pushJsonbValueCompat(state, WJB_BEGIN_OBJECT, NULL);
 		for (int c = 1; c < SPI_tuptable->tupdesc->natts; ++c)
 		{
 			bool isnull;
@@ -899,7 +902,7 @@ add_query_result_dict(JsonbParseState *state, const char *query)
 				ts_jsonb_add_value(state, key_string, &value);
 			}
 		}
-		pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+		pushJsonbValueCompat(state, WJB_END_OBJECT, NULL);
 	}
 
 	/* Restore search_path */
@@ -908,154 +911,154 @@ add_query_result_dict(JsonbParseState *state, const char *query)
 	MemoryContextSwitchTo(spi_context);
 	res = SPI_finish();
 	Assert(res == SPI_OK_FINISH);
-	(void) pushJsonbValue(&state, WJB_END_OBJECT, NULL);
+	(void) pushJsonbValueCompat(state, WJB_END_OBJECT, NULL);
 }
 
 static Jsonb *
 build_telemetry_report()
 {
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 	JsonbValue key;
 	JsonbValue *result;
 	TelemetryStats relstats;
 	VersionOSInfo osinfo;
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
-	ts_jsonb_add_int32(parse_state, REQ_TELEMETRY_VERSION, TS_TELEMETRY_VERSION);
-	ts_jsonb_add_str(parse_state,
+	ts_jsonb_add_int32(&parse_state, REQ_TELEMETRY_VERSION, TS_TELEMETRY_VERSION);
+	ts_jsonb_add_str(&parse_state,
 					 REQ_DB_UUID,
 					 DatumGetCString(DirectFunctionCall1(uuid_out, ts_metadata_get_uuid())));
-	ts_jsonb_add_str(parse_state,
+	ts_jsonb_add_str(&parse_state,
 					 REQ_EXPORTED_DB_UUID,
 					 DatumGetCString(
 						 DirectFunctionCall1(uuid_out, ts_metadata_get_exported_uuid())));
-	ts_jsonb_add_str(parse_state,
+	ts_jsonb_add_str(&parse_state,
 					 REQ_INSTALL_TIME,
 					 format_iso8601(ts_metadata_get_install_timestamp()));
-	ts_jsonb_add_str(parse_state, REQ_INSTALL_METHOD, TIMESCALEDB_INSTALL_METHOD);
+	ts_jsonb_add_str(&parse_state, REQ_INSTALL_METHOD, TIMESCALEDB_INSTALL_METHOD);
 
 	if (ts_version_get_os_info(&osinfo))
 	{
-		ts_jsonb_add_str(parse_state, REQ_OS, osinfo.sysname);
-		ts_jsonb_add_str(parse_state, REQ_OS_VERSION, osinfo.version);
-		ts_jsonb_add_str(parse_state, REQ_OS_RELEASE, osinfo.release);
+		ts_jsonb_add_str(&parse_state, REQ_OS, osinfo.sysname);
+		ts_jsonb_add_str(&parse_state, REQ_OS_VERSION, osinfo.version);
+		ts_jsonb_add_str(&parse_state, REQ_OS_RELEASE, osinfo.release);
 		if (osinfo.has_pretty_version)
 		{
-			ts_jsonb_add_str(parse_state, REQ_OS_VERSION_PRETTY, osinfo.pretty_version);
+			ts_jsonb_add_str(&parse_state, REQ_OS_VERSION_PRETTY, osinfo.pretty_version);
 		}
 	}
 	else
 	{
-		ts_jsonb_add_str(parse_state, REQ_OS, "Unknown");
+		ts_jsonb_add_str(&parse_state, REQ_OS, "Unknown");
 	}
 
-	ts_jsonb_add_str(parse_state, REQ_PS_VERSION, get_pgversion_string());
-	ts_jsonb_add_str(parse_state, REQ_TS_VERSION, TIMESCALEDB_VERSION_MOD);
-	ts_jsonb_add_str(parse_state, REQ_BUILD_OS, BUILD_OS_NAME);
-	ts_jsonb_add_str(parse_state, REQ_BUILD_OS_VERSION, BUILD_OS_VERSION);
-	ts_jsonb_add_str(parse_state, REQ_BUILD_ARCHITECTURE, BUILD_PROCESSOR);
-	ts_jsonb_add_int32(parse_state, REQ_BUILD_ARCHITECTURE_BIT_SIZE, get_architecture_bit_size());
-	ts_jsonb_add_int64(parse_state, REQ_DATA_VOLUME, get_database_size());
+	ts_jsonb_add_str(&parse_state, REQ_PS_VERSION, get_pgversion_string());
+	ts_jsonb_add_str(&parse_state, REQ_TS_VERSION, TIMESCALEDB_VERSION_MOD);
+	ts_jsonb_add_str(&parse_state, REQ_BUILD_OS, BUILD_OS_NAME);
+	ts_jsonb_add_str(&parse_state, REQ_BUILD_OS_VERSION, BUILD_OS_VERSION);
+	ts_jsonb_add_str(&parse_state, REQ_BUILD_ARCHITECTURE, BUILD_PROCESSOR);
+	ts_jsonb_add_int32(&parse_state, REQ_BUILD_ARCHITECTURE_BIT_SIZE, get_architecture_bit_size());
+	ts_jsonb_add_int64(&parse_state, REQ_DATA_VOLUME, get_database_size());
 	/* add job execution stats */
 	key.type = jbvString;
 	key.val.string.val = REQ_NUM_ERR_BY_SQLERRCODE;
 	key.val.string.len = strlen(REQ_NUM_ERR_BY_SQLERRCODE);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
-	add_errors_by_sqlerrcode(parse_state);
+	add_errors_by_sqlerrcode(&parse_state);
 
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 
 	key.type = jbvString;
 	key.val.string.val = REQ_JOB_STATS_BY_JOB_TYPE;
 	key.val.string.len = strlen(REQ_JOB_STATS_BY_JOB_TYPE);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
-	add_job_stats_by_job_type(parse_state);
+	add_job_stats_by_job_type(&parse_state);
 
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 
 	/* Add relation stats */
 	ts_telemetry_stats_gather(&relstats);
 	key.type = jbvString;
 	key.val.string.val = REQ_RELS;
 	key.val.string.len = strlen(REQ_RELS);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
-	add_relkind_stats_object(parse_state,
+	add_relkind_stats_object(&parse_state,
 							 REQ_RELS_TABLES,
 							 &relstats.tables.base,
 							 RELTYPE_TABLE,
 							 STATS_TYPE_STORAGE);
-	add_relkind_stats_object(parse_state,
+	add_relkind_stats_object(&parse_state,
 							 REQ_RELS_PARTITIONED_TABLES,
 							 &relstats.partitioned_tables.storage.base,
 							 RELTYPE_PARTITIONED_TABLE,
 							 STATS_TYPE_HYPER);
-	add_relkind_stats_object(parse_state,
+	add_relkind_stats_object(&parse_state,
 							 REQ_RELS_MATVIEWS,
 							 &relstats.materialized_views.base,
 							 RELTYPE_MATVIEW,
 							 STATS_TYPE_STORAGE);
-	add_relkind_stats_object(parse_state,
+	add_relkind_stats_object(&parse_state,
 							 REQ_RELS_VIEWS,
 							 &relstats.views,
 							 RELTYPE_VIEW,
 							 STATS_TYPE_BASE);
-	add_relkind_stats_object(parse_state,
+	add_relkind_stats_object(&parse_state,
 							 REQ_RELS_HYPERTABLES,
 							 &relstats.hypertables.storage.base,
 							 RELTYPE_HYPERTABLE,
 							 STATS_TYPE_HYPER);
 
-	add_relkind_stats_object(parse_state,
+	add_relkind_stats_object(&parse_state,
 							 REQ_RELS_CONTINUOUS_AGGS,
 							 &relstats.continuous_aggs.hyp.storage.base,
 							 RELTYPE_CONTINUOUS_AGG,
 							 STATS_TYPE_CAGG);
 
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 
-	add_job_counts(parse_state);
+	add_job_counts(&parse_state);
 
 	/* Add related extensions, which is a nested JSON */
 	key.type = jbvString;
 	key.val.string.val = REQ_RELATED_EXTENSIONS;
 	key.val.string.len = strlen(REQ_RELATED_EXTENSIONS);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	add_related_extensions(parse_state);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	add_related_extensions(&parse_state);
 
 	/* license */
 	key.type = jbvString;
 	key.val.string.val = REQ_LICENSE_INFO;
 	key.val.string.len = strlen(REQ_LICENSE_INFO);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 	if (ts_license_is_apache())
 	{
-		ts_jsonb_add_str(parse_state, REQ_LICENSE_EDITION, REQ_LICENSE_EDITION_APACHE);
+		ts_jsonb_add_str(&parse_state, REQ_LICENSE_EDITION, REQ_LICENSE_EDITION_APACHE);
 	}
 	else
 	{
-		ts_jsonb_add_str(parse_state, REQ_LICENSE_EDITION, REQ_LICENSE_EDITION_COMMUNITY);
+		ts_jsonb_add_str(&parse_state, REQ_LICENSE_EDITION, REQ_LICENSE_EDITION_COMMUNITY);
 	}
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 
 	/* add tuned info, which is optional */
 	char *last_tune_time = GetConfigOptionByName("timescaledb.last_tune_time", NULL, true);
 	if (last_tune_time != NULL)
 	{
-		ts_jsonb_add_str(parse_state, REQ_TS_LAST_TUNE_TIME, last_tune_time);
+		ts_jsonb_add_str(&parse_state, REQ_TS_LAST_TUNE_TIME, last_tune_time);
 	}
 
 	char *last_tune_version = GetConfigOptionByName("timescaledb.last_tune_version", NULL, true);
 	if (last_tune_version != NULL)
 	{
-		ts_jsonb_add_str(parse_state, REQ_TS_LAST_TUNE_VERSION, last_tune_version);
+		ts_jsonb_add_str(&parse_state, REQ_TS_LAST_TUNE_VERSION, last_tune_version);
 	}
 
 	/* add cloud to telemetry when set */
@@ -1064,50 +1067,51 @@ build_telemetry_report()
 		key.type = jbvString;
 		key.val.string.val = REQ_INSTANCE_METADATA;
 		key.val.string.len = strlen(REQ_INSTANCE_METADATA);
-		pushJsonbValue(&parse_state, WJB_KEY, &key);
+		pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
 
-		pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-		ts_jsonb_add_str(parse_state, REQ_TS_TELEMETRY_CLOUD, ts_telemetry_cloud);
-		pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+		pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+		ts_jsonb_add_str(&parse_state, REQ_TS_TELEMETRY_CLOUD, ts_telemetry_cloud);
+		pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 	}
 
 	/* Add additional content from metadata */
 	key.type = jbvString;
 	key.val.string.val = REQ_METADATA;
 	key.val.string.len = strlen(REQ_METADATA);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-	ts_telemetry_metadata_add_values(parse_state);
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	ts_telemetry_metadata_add_values(&parse_state);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 
 	/* Add function call telemetry */
 	key.type = jbvString;
 	key.val.string.val = REQ_FUNCTIONS_USED;
 	key.val.string.len = strlen(REQ_FUNCTIONS_USED);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
-	add_function_call_telemetry(parse_state);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	add_function_call_telemetry(&parse_state);
 
 	/* Add replication object */
 	key.type = jbvString;
 	key.val.string.val = REQ_REPLICATION;
 	key.val.string.len = strlen(REQ_REPLICATION);
-	pushJsonbValue(&parse_state, WJB_KEY, &key);
+	pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-	add_replication_telemetry(parse_state);
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	add_replication_telemetry(&parse_state);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 
 	key.type = jbvString;
 	key.val.string.val = REQ_ACCESS_METHODS;
 	key.val.string.len = strlen(REQ_ACCESS_METHODS);
-	(void) pushJsonbValue(&parse_state, WJB_KEY, &key);
-	add_query_result_dict(parse_state,
+	(void) pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
+	add_query_result_dict(&parse_state,
 						  "SELECT amname AS name, sum(relpages) AS pages, count(*) AS "
 						  "instances FROM pg_class JOIN pg_am ON relam = pg_am.oid "
 						  "GROUP BY amname");
 
 	/* end of telemetry object */
-	result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	result = parse_state.result;
 
 	return JsonbValueToJsonb(result);
 }

--- a/src/telemetry/telemetry_metadata.c
+++ b/src/telemetry/telemetry_metadata.c
@@ -21,7 +21,7 @@
  * add all entries from _timescaledb_catalog.metadata
  */
 void
-ts_telemetry_metadata_add_values(JsonbParseState *state)
+ts_telemetry_metadata_add_values(JsonbInState *state)
 {
 	Datum key, value;
 	bool key_isnull, value_isnull, include_entry;

--- a/src/telemetry/telemetry_metadata.h
+++ b/src/telemetry/telemetry_metadata.h
@@ -10,4 +10,6 @@
 
 #include <export.h>
 
-extern void ts_telemetry_metadata_add_values(JsonbParseState *state);
+#include "jsonb_utils.h"
+
+extern void ts_telemetry_metadata_add_values(JsonbInState *state);

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -886,12 +886,12 @@ compression_settings_tuple_update(TupleInfo *ti, void *data)
 }
 
 void
-ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state, SparseIndexConfigBase *config)
+ts_convert_sparse_index_config_to_jsonb(JsonbInState *parse_state, SparseIndexConfigBase *config)
 {
 	MinmaxIndexColumnConfig *minmax_config = NULL;
 	BloomFilterConfig *bloom_config = NULL;
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_BEGIN_OBJECT, NULL);
 	ts_jsonb_add_str(parse_state,
 					 ts_sparse_index_common_keys[SparseIndexKeyType],
 					 ts_sparse_index_type_names[config->type]); /* type */
@@ -942,7 +942,7 @@ ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state, SparseInde
 	ts_jsonb_add_str(parse_state,
 					 ts_sparse_index_common_keys[SparseIndexKeySource],
 					 ts_sparse_index_source_names[config->source]); /* source */
-	pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(parse_state, WJB_END_OBJECT, NULL);
 }
 
 bool
@@ -1092,7 +1092,7 @@ ts_add_orderby_sparse_index(CompressionSettings *settings)
 {
 	Datum datum;
 	bool isnull;
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 	JsonbIterator *it_json;
 	JsonbValue v;
 	JsonbIteratorToken r;
@@ -1104,7 +1104,7 @@ ts_add_orderby_sparse_index(CompressionSettings *settings)
 		return sparse_index;
 	}
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
 
 	/* add existing sparse index */
 	if (settings->fd.index)
@@ -1114,7 +1114,7 @@ ts_add_orderby_sparse_index(CompressionSettings *settings)
 		while ((r = JsonbIteratorNext(&it_json, &v, true)) != WJB_END_ARRAY)
 		{
 			Assert(r == WJB_ELEM);
-			pushJsonbValue(&parse_state, r, &v);
+			pushJsonbValueCompat(&parse_state, r, &v);
 		}
 	}
 
@@ -1144,25 +1144,26 @@ ts_add_orderby_sparse_index(CompressionSettings *settings)
 		minmax_config.base.type = _SparseIndexTypeEnumMinmax;
 		minmax_config.base.source = _SparseIndexSourceEnumOrderby;
 		minmax_config.col = col_name;
-		ts_convert_sparse_index_config_to_jsonb(parse_state,
+		ts_convert_sparse_index_config_to_jsonb(&parse_state,
 												(SparseIndexConfigBase *) &minmax_config);
 
 		FirstLastIndexColumnConfig firstlast_config;
 		firstlast_config.base.type = _SparseIndexTypeEnumFirstLast;
 		firstlast_config.base.source = _SparseIndexSourceEnumOrderby;
 		firstlast_config.col = col_name;
-		ts_convert_sparse_index_config_to_jsonb(parse_state,
+		ts_convert_sparse_index_config_to_jsonb(&parse_state,
 												(SparseIndexConfigBase *) &firstlast_config);
 	}
 
-	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
+	pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
+	return JsonbValueToJsonb(parse_state.result);
 }
 
 /* removed orderby sparse index settings from fd.index */
 Jsonb *
 ts_remove_orderby_sparse_index(CompressionSettings *settings)
 {
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 	JsonbContainer *container;
 	JsonbIterator *it_json;
 	JsonbIteratorToken r;
@@ -1180,7 +1181,7 @@ ts_remove_orderby_sparse_index(CompressionSettings *settings)
 		return sparse_index;
 	}
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
 
 	it_json = JsonbIteratorInit(&sparse_index->root);
 	JsonbIteratorNext(&it_json, &v, false); /* WJB_BEGIN_ARRAY */
@@ -1200,7 +1201,7 @@ ts_remove_orderby_sparse_index(CompressionSettings *settings)
 		}
 
 		has_object = true;
-		pushJsonbValue(&parse_state, r, &v);
+		pushJsonbValueCompat(&parse_state, r, &v);
 	}
 
 	/* this is a possible edge case, log it just in case */
@@ -1209,7 +1210,8 @@ ts_remove_orderby_sparse_index(CompressionSettings *settings)
 		elog(LOG, "orderby settings existed, but no orderby sparse index was removed");
 	}
 
-	return has_object ? JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL)) : NULL;
+	pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
+	return has_object ? JsonbValueToJsonb(parse_state.result) : NULL;
 }
 
 int
@@ -1500,7 +1502,7 @@ ts_convert_to_sparse_index_settings(Jsonb *jsonb)
 Jsonb *
 ts_convert_from_sparse_index_settings(SparseIndexSettings *settings)
 {
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
 	Assert(settings != NULL);
 	if (settings == NULL)
@@ -1513,10 +1515,10 @@ ts_convert_from_sparse_index_settings(SparseIndexSettings *settings)
 		return NULL;
 	}
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
 	foreach_ptr(SparseIndexSettingsObject, obj, settings->objects)
 	{
-		pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+		pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 		Assert(list_length(obj->pairs) > 0);
 		foreach_ptr(SparseIndexSettingsPair, pair, obj->pairs)
 		{
@@ -1525,7 +1527,7 @@ ts_convert_from_sparse_index_settings(SparseIndexSettings *settings)
 			JsonbValue key = { .type = jbvString,
 							   .val = {
 								   .string = { .val = pair->key, .len = strlen(pair->key) } } };
-			pushJsonbValue(&parse_state, WJB_KEY, &key);
+			pushJsonbValueCompat(&parse_state, WJB_KEY, &key);
 
 			if (list_length(pair->values) == 1)
 			{
@@ -1536,11 +1538,11 @@ ts_convert_from_sparse_index_settings(SparseIndexSettings *settings)
 				JsonbValue value_jsonb = {
 					.type = jbvString, .val = { .string = { .val = pstrdup(value), .len = len } }
 				};
-				pushJsonbValue(&parse_state, WJB_VALUE, &value_jsonb);
+				pushJsonbValueCompat(&parse_state, WJB_VALUE, &value_jsonb);
 			}
 			else
 			{
-				pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+				pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
 				foreach_ptr(const char, value, pair->values)
 				{
 					Assert(value != NULL);
@@ -1549,14 +1551,15 @@ ts_convert_from_sparse_index_settings(SparseIndexSettings *settings)
 					JsonbValue value_jsonb = { .type = jbvString,
 											   .val = { .string = { .val = pstrdup(value),
 																	.len = len } } };
-					pushJsonbValue(&parse_state, WJB_ELEM, &value_jsonb);
+					pushJsonbValueCompat(&parse_state, WJB_ELEM, &value_jsonb);
 				}
-				pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL);
+				pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
 			}
 		}
-		pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+		pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
 	}
-	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
+	pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
+	return JsonbValueToJsonb(parse_state.result);
 }
 
 void

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -9,6 +9,7 @@
 #include <catalog/pg_type.h>
 
 #include "bmslist_utils.h"
+#include "jsonb_utils.h"
 #include "ts_catalog/catalog.h"
 
 typedef struct CompressionSettings
@@ -166,7 +167,7 @@ TSDLLEXPORT bool ts_sparse_index_is_orderby_source(SparseIndexSettingsObject *ob
 TSDLLEXPORT int ts_compression_settings_update(CompressionSettings *settings);
 TSDLLEXPORT void ts_compression_settings_rename_column_cascade(Oid parent_relid, const char *old,
 															   const char *new);
-TSDLLEXPORT void ts_convert_sparse_index_config_to_jsonb(JsonbParseState *parse_state,
+TSDLLEXPORT void ts_convert_sparse_index_config_to_jsonb(JsonbInState *parse_state,
 														 SparseIndexConfigBase *config);
 
 TSDLLEXPORT

--- a/src/utils.c
+++ b/src/utils.c
@@ -2010,86 +2010,87 @@ ts_relation_set_reloption(Relation rel, List *options, LOCKMODE lockmode)
 Jsonb *
 ts_errdata_to_jsonb(ErrorData *edata, Name proc_schema, Name proc_name)
 {
-	JsonbParseState *parse_state = NULL;
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	JsonbInState parse_state = { 0 };
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 	if (edata->sqlerrcode)
 	{
-		ts_jsonb_add_str(parse_state, "sqlerrcode", unpack_sql_state(edata->sqlerrcode));
+		ts_jsonb_add_str(&parse_state, "sqlerrcode", unpack_sql_state(edata->sqlerrcode));
 	}
 	if (edata->message)
 	{
-		ts_jsonb_add_str(parse_state, "message", edata->message);
+		ts_jsonb_add_str(&parse_state, "message", edata->message);
 	}
 	if (edata->detail)
 	{
-		ts_jsonb_add_str(parse_state, "detail", edata->detail);
+		ts_jsonb_add_str(&parse_state, "detail", edata->detail);
 	}
 	if (edata->hint)
 	{
-		ts_jsonb_add_str(parse_state, "hint", edata->hint);
+		ts_jsonb_add_str(&parse_state, "hint", edata->hint);
 	}
 	if (edata->filename)
 	{
-		ts_jsonb_add_str(parse_state, "filename", edata->filename);
+		ts_jsonb_add_str(&parse_state, "filename", edata->filename);
 	}
 	if (edata->lineno)
 	{
-		ts_jsonb_add_int32(parse_state, "lineno", edata->lineno);
+		ts_jsonb_add_int32(&parse_state, "lineno", edata->lineno);
 	}
 	if (edata->funcname)
 	{
-		ts_jsonb_add_str(parse_state, "funcname", edata->funcname);
+		ts_jsonb_add_str(&parse_state, "funcname", edata->funcname);
 	}
 	if (edata->domain)
 	{
-		ts_jsonb_add_str(parse_state, "domain", edata->domain);
+		ts_jsonb_add_str(&parse_state, "domain", edata->domain);
 	}
 	if (edata->context_domain)
 	{
-		ts_jsonb_add_str(parse_state, "context_domain", edata->context_domain);
+		ts_jsonb_add_str(&parse_state, "context_domain", edata->context_domain);
 	}
 	if (edata->context)
 	{
-		ts_jsonb_add_str(parse_state, "context", edata->context);
+		ts_jsonb_add_str(&parse_state, "context", edata->context);
 	}
 	if (edata->schema_name)
 	{
-		ts_jsonb_add_str(parse_state, "schema_name", edata->schema_name);
+		ts_jsonb_add_str(&parse_state, "schema_name", edata->schema_name);
 	}
 	if (edata->table_name)
 	{
-		ts_jsonb_add_str(parse_state, "table_name", edata->table_name);
+		ts_jsonb_add_str(&parse_state, "table_name", edata->table_name);
 	}
 	if (edata->column_name)
 	{
-		ts_jsonb_add_str(parse_state, "column_name", edata->column_name);
+		ts_jsonb_add_str(&parse_state, "column_name", edata->column_name);
 	}
 	if (edata->datatype_name)
 	{
-		ts_jsonb_add_str(parse_state, "datatype_name", edata->datatype_name);
+		ts_jsonb_add_str(&parse_state, "datatype_name", edata->datatype_name);
 	}
 	if (edata->constraint_name)
 	{
-		ts_jsonb_add_str(parse_state, "constraint_name", edata->constraint_name);
+		ts_jsonb_add_str(&parse_state, "constraint_name", edata->constraint_name);
 	}
 	if (edata->internalquery)
 	{
-		ts_jsonb_add_str(parse_state, "internalquery", edata->internalquery);
+		ts_jsonb_add_str(&parse_state, "internalquery", edata->internalquery);
 	}
 	if (edata->detail_log)
 	{
-		ts_jsonb_add_str(parse_state, "detail_log", edata->detail_log);
+		ts_jsonb_add_str(&parse_state, "detail_log", edata->detail_log);
 	}
 	if (strlen(NameStr(*proc_schema)) > 0)
 	{
-		ts_jsonb_add_str(parse_state, "proc_schema", NameStr(*proc_schema));
+		ts_jsonb_add_str(&parse_state, "proc_schema", NameStr(*proc_schema));
 	}
 	if (strlen(NameStr(*proc_name)) > 0)
 	{
-		ts_jsonb_add_str(parse_state, "proc_name", NameStr(*proc_name));
+		ts_jsonb_add_str(&parse_state, "proc_name", NameStr(*proc_name));
 	}
 	/* we add the schema qualified name here as well*/
-	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	JsonbValue *result = parse_state.result;
 	return JsonbValueToJsonb(result);
 }
 

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -534,7 +534,7 @@ column_name_list_as_string(BloomFilterConfig *config)
 /* parses the individual sparse index config entities. being called once for each sparse index
  * config entity in the list. */
 static void
-parse_sparse_index_config(JsonbParseState *parse_state, FuncCall *sparse_index_details,
+parse_sparse_index_config(JsonbInState *parse_state, FuncCall *sparse_index_details,
 						  Hypertable *hypertable, TsBmsList *sparse_index_columns)
 {
 	TypeCacheEntry *type_cache;
@@ -720,18 +720,19 @@ parse_sparse_index_config_list(char *inpstr, Hypertable *hypertable)
 	ListCell *lc;
 	SelectStmt *select;
 	RawStmt *raw;
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
 	/* sparse index can have empty input. Return [{"source":"config"}] jsonb */
 	if (strlen(inpstr) == 0)
 	{
-		pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
-		pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-		ts_jsonb_add_str(parse_state,
+		pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
+		pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+		ts_jsonb_add_str(&parse_state,
 						 ts_sparse_index_common_keys[SparseIndexKeySource],
 						 ts_sparse_index_source_names[_SparseIndexSourceEnumConfig]); /* source */
-		JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL));
-		return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
+		pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+		pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
+		return JsonbValueToJsonb(parse_state.result);
 	}
 
 	initStringInfo(&buf);
@@ -790,7 +791,7 @@ parse_sparse_index_config_list(char *inpstr, Hypertable *hypertable)
 	 * {"type": "minmax","source":"config", "column": "ts"},
 	 * {"type": "bloom", "source":"config", "column": ["age", "gender"]}]
 	 */
-	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
 
 	TsBmsList sparse_index_columns = ts_bmslist_create();
 	foreach (lc, select->targetList)
@@ -804,11 +805,12 @@ parse_sparse_index_config_list(char *inpstr, Hypertable *hypertable)
 
 		FuncCall *fc = (FuncCall *) target->val;
 
-		parse_sparse_index_config(parse_state, fc, hypertable, &sparse_index_columns);
+		parse_sparse_index_config(&parse_state, fc, hypertable, &sparse_index_columns);
 	}
 
 	ts_bmslist_free(sparse_index_columns);
-	return JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL));
+	pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
+	return JsonbValueToJsonb(parse_state.result);
 }
 
 /* returns List of CompressedParsedCol

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -292,10 +292,10 @@ policy_compression_add_internal(Oid user_rel_oid, Datum compress_after_datum,
 	namestrcpy(&check_schema, FUNCTIONS_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
 
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-	ts_jsonb_add_int32(parse_state, POLICY_CONFIG_KEY_HYPERTABLE_ID, hypertable->fd.id);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	ts_jsonb_add_int32(&parse_state, POLICY_CONFIG_KEY_HYPERTABLE_ID, hypertable->fd.id);
 	validate_compress_after_type(dim, partitioning_type, compress_after_type);
 
 	switch (compress_after_type)
@@ -303,29 +303,29 @@ policy_compression_add_internal(Oid user_rel_oid, Datum compress_after_datum,
 		case INTERVALOID:
 			if (created_before)
 			{
-				ts_jsonb_add_interval(parse_state,
+				ts_jsonb_add_interval(&parse_state,
 									  POL_COMPRESSION_CONF_KEY_COMPRESS_CREATED_BEFORE,
 									  created_before);
 			}
 			else
 			{
-				ts_jsonb_add_interval(parse_state,
+				ts_jsonb_add_interval(&parse_state,
 									  POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
 									  DatumGetIntervalP(compress_after_datum));
 			}
 			break;
 		case INT2OID:
-			ts_jsonb_add_int64(parse_state,
+			ts_jsonb_add_int64(&parse_state,
 							   POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
 							   DatumGetInt16(compress_after_datum));
 			break;
 		case INT4OID:
-			ts_jsonb_add_int64(parse_state,
+			ts_jsonb_add_int64(&parse_state,
 							   POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
 							   DatumGetInt32(compress_after_datum));
 			break;
 		case INT8OID:
-			ts_jsonb_add_int64(parse_state,
+			ts_jsonb_add_int64(&parse_state,
 							   POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
 							   DatumGetInt64(compress_after_datum));
 			break;
@@ -337,7 +337,8 @@ policy_compression_add_internal(Oid user_rel_oid, Datum compress_after_datum,
 							format_type_be(compress_after_type))));
 	}
 
-	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	JsonbValue *result = parse_state.result;
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	job_id = ts_bgw_job_insert_relation(&application_name,

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -268,7 +268,7 @@ policy_refresh_cagg_check(PG_FUNCTION_ARGS)
 }
 
 static void
-json_add_dim_interval_value(JsonbParseState *parse_state, const char *json_label, Oid dim_type,
+json_add_dim_interval_value(JsonbInState *parse_state, const char *json_label, Oid dim_type,
 							Datum value)
 {
 	switch (dim_type)
@@ -709,7 +709,7 @@ policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type, NullableDa
 	CaggPolicyConfig policyconf;
 	int32 job_id;
 	Oid owner_id;
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
 	/* Verify that the owner can create a background worker */
 	owner_id = ts_cagg_permissions_check(cagg_oid, GetUserId());
@@ -749,64 +749,65 @@ policy_refresh_cagg_add_internal(Oid cagg_oid, Oid start_offset_type, NullableDa
 	namestrcpy(&check_schema, FUNCTIONS_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-	ts_jsonb_add_int32(parse_state,
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	ts_jsonb_add_int32(&parse_state,
 					   POL_REFRESH_CONF_KEY_MAT_HYPERTABLE_ID,
 					   cagg->data.mat_hypertable_id);
 
 	if (!policyconf.offset_start.isnull)
 	{
-		json_add_dim_interval_value(parse_state,
+		json_add_dim_interval_value(&parse_state,
 									POL_REFRESH_CONF_KEY_START_OFFSET,
 									policyconf.offset_start.type,
 									policyconf.offset_start.value);
 	}
 	else
 	{
-		ts_jsonb_add_null(parse_state, POL_REFRESH_CONF_KEY_START_OFFSET);
+		ts_jsonb_add_null(&parse_state, POL_REFRESH_CONF_KEY_START_OFFSET);
 	}
 
 	if (!policyconf.offset_end.isnull)
 	{
-		json_add_dim_interval_value(parse_state,
+		json_add_dim_interval_value(&parse_state,
 									POL_REFRESH_CONF_KEY_END_OFFSET,
 									policyconf.offset_end.type,
 									policyconf.offset_end.value);
 	}
 	else
 	{
-		ts_jsonb_add_null(parse_state, POL_REFRESH_CONF_KEY_END_OFFSET);
+		ts_jsonb_add_null(&parse_state, POL_REFRESH_CONF_KEY_END_OFFSET);
 	}
 
 	if (!include_tiered_data.isnull)
 	{
-		ts_jsonb_add_bool(parse_state,
+		ts_jsonb_add_bool(&parse_state,
 						  POL_REFRESH_CONF_KEY_INCLUDE_TIERED_DATA,
 						  include_tiered_data.value);
 	}
 
 	if (!buckets_per_batch.isnull)
 	{
-		ts_jsonb_add_int32(parse_state,
+		ts_jsonb_add_int32(&parse_state,
 						   POL_REFRESH_CONF_KEY_BUCKETS_PER_BATCH,
 						   buckets_per_batch.value);
 	}
 
 	if (!max_batches_per_execution.isnull)
 	{
-		ts_jsonb_add_int32(parse_state,
+		ts_jsonb_add_int32(&parse_state,
 						   POL_REFRESH_CONF_KEY_MAX_BATCHES_PER_EXECUTION,
 						   max_batches_per_execution.value);
 	}
 
 	if (!refresh_newest_first.isnull)
 	{
-		ts_jsonb_add_bool(parse_state,
+		ts_jsonb_add_bool(&parse_state,
 						  POL_REFRESH_CONF_KEY_REFRESH_NEWEST_FIRST,
 						  refresh_newest_first.value);
 	}
 
-	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	JsonbValue *result = parse_state.result;
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	PolicyRefreshOffsetOverlapResult res = policy_refresh_cagg_check_for_overlaps(cagg, config, 0);

--- a/tsl/src/bgw_policy/policies_v2.c
+++ b/tsl/src/bgw_policy/policies_v2.c
@@ -686,8 +686,7 @@ policies_alter(PG_FUNCTION_ARGS)
 }
 
 static void
-push_to_json(Oid type, JsonbParseState *parse_state, BgwJob *job, char *json_label,
-			 char *show_config)
+push_to_json(Oid type, JsonbInState *parse_state, BgwJob *job, char *json_label, char *show_config)
 {
 	if (IS_INTEGER_TYPE(type))
 	{
@@ -725,7 +724,7 @@ policies_show(PG_FUNCTION_ARGS)
 	ListCell *lc;
 	FuncCallContext *funcctx;
 	static List *jobs;
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
 	ts_feature_flag_check(FEATURE_POLICY);
 
@@ -739,7 +738,7 @@ policies_show(PG_FUNCTION_ARGS)
 
 	type = IS_TIMESTAMP_TYPE(cagg->partition_type) ? INTERVALOID : cagg->partition_type;
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
 	if (SRF_IS_FIRSTCALL())
 	{
 		MemoryContext oldcontext;
@@ -772,48 +771,48 @@ policies_show(PG_FUNCTION_ARGS)
 
 		if (!namestrcmp(&(job->fd.proc_name), POLICY_REFRESH_CAGG_PROC_NAME))
 		{
-			ts_jsonb_add_str(parse_state,
+			ts_jsonb_add_str(&parse_state,
 							 SHOW_POLICY_KEY_POLICY_NAME,
 							 POLICY_REFRESH_CAGG_PROC_NAME);
 			push_to_json(type,
-						 parse_state,
+						 &parse_state,
 						 job,
 						 POL_REFRESH_CONF_KEY_START_OFFSET,
 						 SHOW_POLICY_KEY_REFRESH_START_OFFSET);
 			push_to_json(type,
-						 parse_state,
+						 &parse_state,
 						 job,
 						 POL_REFRESH_CONF_KEY_END_OFFSET,
 						 SHOW_POLICY_KEY_REFRESH_END_OFFSET);
-			ts_jsonb_add_interval(parse_state,
+			ts_jsonb_add_interval(&parse_state,
 								  SHOW_POLICY_KEY_REFRESH_INTERVAL,
 								  &(job->fd.schedule_interval));
 		}
 		else if (!namestrcmp(&(job->fd.proc_name), POLICY_COMPRESSION_PROC_NAME))
 		{
-			ts_jsonb_add_str(parse_state,
+			ts_jsonb_add_str(&parse_state,
 							 SHOW_POLICY_KEY_POLICY_NAME,
 							 POLICY_COMPRESSION_PROC_NAME);
 			push_to_json(type,
-						 parse_state,
+						 &parse_state,
 						 job,
 						 POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
 						 SHOW_POLICY_KEY_COMPRESS_AFTER);
 			/* POL_COMPRESSION_CONF_KEY_COMPRESS_CREATED_BEFORE not supported with caggs */
-			ts_jsonb_add_interval(parse_state,
+			ts_jsonb_add_interval(&parse_state,
 								  SHOW_POLICY_KEY_COMPRESS_INTERVAL,
 								  &(job->fd.schedule_interval));
 		}
 		else if (!namestrcmp(&(job->fd.proc_name), POLICY_RETENTION_PROC_NAME))
 		{
-			ts_jsonb_add_str(parse_state, SHOW_POLICY_KEY_POLICY_NAME, POLICY_RETENTION_PROC_NAME);
+			ts_jsonb_add_str(&parse_state, SHOW_POLICY_KEY_POLICY_NAME, POLICY_RETENTION_PROC_NAME);
 			push_to_json(type,
-						 parse_state,
+						 &parse_state,
 						 job,
 						 POL_RETENTION_CONF_KEY_DROP_AFTER,
 						 SHOW_POLICY_KEY_DROP_AFTER);
 			/* POL_RETENTION_CONF_KEY_DROP_CREATED_BEFORE not supported with caggs */
-			ts_jsonb_add_interval(parse_state,
+			ts_jsonb_add_interval(&parse_state,
 								  SHOW_POLICY_KEY_RETENTION_INTERVAL,
 								  &(job->fd.schedule_interval));
 		}
@@ -824,7 +823,8 @@ policies_show(PG_FUNCTION_ARGS)
 					 errmsg("\"%s\" unsupported proc", NameStr(job->fd.proc_name))));
 		}
 
-		JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+		pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+		JsonbValue *result = parse_state.result;
 
 		funcctx->user_fctx = lnext(jobs, (ListCell *) funcctx->user_fctx);
 		SRF_RETURN_NEXT(funcctx, PointerGetDatum(JsonbValueToJsonb(result)));

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -263,12 +263,13 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 	namestrcpy(&check_schema, FUNCTIONS_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
 
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-	ts_jsonb_add_int32(parse_state, POLICY_CONFIG_KEY_HYPERTABLE_ID, hypertable_id);
-	ts_jsonb_add_str(parse_state, CONFIG_KEY_INDEX_NAME, NameStr(*index_name));
-	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	ts_jsonb_add_int32(&parse_state, POLICY_CONFIG_KEY_HYPERTABLE_ID, hypertable_id);
+	ts_jsonb_add_str(&parse_state, CONFIG_KEY_INDEX_NAME, NameStr(*index_name));
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	JsonbValue *result = parse_state.result;
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	/* for the reorder policy, we choose a drifting schedule

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -289,39 +289,39 @@ policy_retention_add_internal(Oid ht_oid, Oid window_type, Datum window_datum,
 						 " with timestamp or UUID time dimension.")));
 	}
 
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
-	ts_jsonb_add_int32(parse_state, POLICY_CONFIG_KEY_HYPERTABLE_ID, hypertable->fd.id);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_OBJECT, NULL);
+	ts_jsonb_add_int32(&parse_state, POLICY_CONFIG_KEY_HYPERTABLE_ID, hypertable->fd.id);
 
 	switch (window_type)
 	{
 		case INTERVALOID:
 			if (created_before)
 			{
-				ts_jsonb_add_interval(parse_state,
+				ts_jsonb_add_interval(&parse_state,
 									  POL_RETENTION_CONF_KEY_DROP_CREATED_BEFORE,
 									  created_before);
 			}
 			else
 			{
-				ts_jsonb_add_interval(parse_state,
+				ts_jsonb_add_interval(&parse_state,
 									  POL_RETENTION_CONF_KEY_DROP_AFTER,
 									  DatumGetIntervalP(window_datum));
 			}
 			break;
 		case INT2OID:
-			ts_jsonb_add_int64(parse_state,
+			ts_jsonb_add_int64(&parse_state,
 							   POL_RETENTION_CONF_KEY_DROP_AFTER,
 							   DatumGetInt16(window_datum));
 			break;
 		case INT4OID:
-			ts_jsonb_add_int64(parse_state,
+			ts_jsonb_add_int64(&parse_state,
 							   POL_RETENTION_CONF_KEY_DROP_AFTER,
 							   DatumGetInt32(window_datum));
 			break;
 		case INT8OID:
-			ts_jsonb_add_int64(parse_state,
+			ts_jsonb_add_int64(&parse_state,
 							   POL_RETENTION_CONF_KEY_DROP_AFTER,
 							   DatumGetInt64(window_datum));
 			break;
@@ -333,7 +333,8 @@ policy_retention_add_internal(Oid ht_oid, Oid window_type, Datum window_datum,
 							format_type_be(window_type))));
 	}
 
-	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_END_OBJECT, NULL);
+	JsonbValue *result = parse_state.result;
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	/* Next, insert a new job into jobs table */

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -38,6 +38,7 @@
 #include "errors.h"
 #include "hypercube.h"
 #include "hypertable_cache.h"
+#include "jsonb_utils.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
 #include "utils.h"
@@ -52,13 +53,13 @@
  *  "device": [-9223372036854775808, 1073741823]}
  */
 static JsonbValue *
-hypercube_to_jsonb_value(Hypercube *hc, Hyperspace *hs, JsonbParseState **ps)
+hypercube_to_jsonb_value(Hypercube *hc, Hyperspace *hs, JsonbInState *state)
 {
 	int i;
 
 	Assert(hs->num_dimensions == hc->num_slices);
 
-	pushJsonbValue(ps, WJB_BEGIN_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_BEGIN_OBJECT, NULL);
 
 	for (i = 0; i < hc->num_slices; i++)
 	{
@@ -75,19 +76,20 @@ hypercube_to_jsonb_value(Hypercube *hc, Hyperspace *hs, JsonbParseState **ps)
 		k.val.string.len = strlen(dim_name);
 		k.val.string.val = dim_name;
 
-		pushJsonbValue(ps, WJB_KEY, &k);
-		pushJsonbValue(ps, WJB_BEGIN_ARRAY, NULL);
+		pushJsonbValueCompat(state, WJB_KEY, &k);
+		pushJsonbValueCompat(state, WJB_BEGIN_ARRAY, NULL);
 
 		v.type = jbvNumeric;
 		v.val.numeric = DatumGetNumeric(range_start);
-		pushJsonbValue(ps, WJB_ELEM, &v);
+		pushJsonbValueCompat(state, WJB_ELEM, &v);
 		v.val.numeric = DatumGetNumeric(range_end);
-		pushJsonbValue(ps, WJB_ELEM, &v);
+		pushJsonbValueCompat(state, WJB_ELEM, &v);
 
-		pushJsonbValue(ps, WJB_END_ARRAY, NULL);
+		pushJsonbValueCompat(state, WJB_END_ARRAY, NULL);
 	}
 
-	return pushJsonbValue(ps, WJB_END_OBJECT, NULL);
+	pushJsonbValueCompat(state, WJB_END_OBJECT, NULL);
+	return state->result;
 }
 
 /*
@@ -253,8 +255,8 @@ chunk_form_tuple(Chunk *chunk, Hypertable *ht, TupleDesc tupdesc, bool created)
 {
 	Datum values[Natts_create_chunk];
 	bool nulls[Natts_create_chunk] = { false };
-	JsonbParseState *ps = NULL;
-	JsonbValue *jv = hypercube_to_jsonb_value(chunk->cube, ht->space, &ps);
+	JsonbInState state = { 0 };
+	JsonbValue *jv = hypercube_to_jsonb_value(chunk->cube, ht->space, &state);
 
 	if (NULL == jv)
 	{

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -98,8 +98,7 @@ static void compression_settings_set_manually_for_alter(Hypertable *ht,
 														CompressionSettings *settings,
 														WithClauseResult *with_clause_options);
 static void create_default_composite_bloom(IndexInfo *index_info, Hypertable *ht,
-										   CompressionSettings *settings,
-										   JsonbParseState *parse_state,
+										   CompressionSettings *settings, JsonbInState *parse_state,
 										   TsBmsList *sparse_index_columns, bool *has_object);
 
 static char *
@@ -1838,7 +1837,7 @@ compression_setting_orderby_get_default(Hypertable *ht, ArrayType *segmentby)
 
 static void
 create_default_composite_bloom(IndexInfo *index_info, Hypertable *ht, CompressionSettings *settings,
-							   JsonbParseState *parse_state, TsBmsList *sparse_index_columns,
+							   JsonbInState *parse_state, TsBmsList *sparse_index_columns,
 							   bool *has_object)
 {
 	int num_cols = index_info->ii_NumIndexKeyAttrs;
@@ -1954,7 +1953,7 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 {
 	bool has_object = false;
 	TsBmsList sparse_index_columns = ts_bmslist_create();
-	JsonbParseState *parse_state = NULL;
+	JsonbInState parse_state = { 0 };
 
 	/*
 	 * Sparse indexes are only created automatically if they are not set in compression settings
@@ -1973,7 +1972,7 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 	ListCell *lc;
 	List *index_oids = RelationGetIndexList(rel);
 
-	pushJsonbValue(&parse_state, WJB_BEGIN_ARRAY, NULL);
+	pushJsonbValueCompat(&parse_state, WJB_BEGIN_ARRAY, NULL);
 	foreach (lc, index_oids)
 	{
 		Oid index_oid = lfirst_oid(lc);
@@ -2005,7 +2004,7 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 			create_default_composite_bloom(index_info,
 										   ht,
 										   settings,
-										   parse_state,
+										   &parse_state,
 										   &sparse_index_columns,
 										   &has_object);
 		}
@@ -2062,14 +2061,15 @@ compression_setting_sparse_index_get_default(Hypertable *ht, CompressionSettings
 			config->source = _SparseIndexSourceEnumDefault;
 
 			/* convert to json object */
-			ts_convert_sparse_index_config_to_jsonb(parse_state, config);
+			ts_convert_sparse_index_config_to_jsonb(&parse_state, config);
 			sparse_index_columns = ts_bmslist_add_member(sparse_index_columns, &attno, 1);
 			has_object = true;
 		}
 	}
 	table_close(rel, AccessShareLock);
 	ts_bmslist_free(sparse_index_columns);
-	return has_object ? JsonbValueToJsonb(pushJsonbValue(&parse_state, WJB_END_ARRAY, NULL)) : NULL;
+	pushJsonbValueCompat(&parse_state, WJB_END_ARRAY, NULL);
+	return has_object ? JsonbValueToJsonb(parse_state.result) : NULL;
 }
 
 void


### PR DESCRIPTION
PostgreSQL 19 reworked the way jsonb values are built. pushJsonbValue
now takes a JsonbInState pointer and returns nothing, leaving the
finished value in the state instead of returning it. Add a wrapper that
offers the new interface on all supported versions and switch our jsonb
building code and helpers over to it.

Upstream changes:
Revise APIs for pushJsonbValue() and associated routines.
https://github.com/postgres/postgres/commit/0986e95161

Disable-check: force-changelog-file
