### PR TITLE
Restrict bgw_log_level GUC to PostgreSQL 18 and earlier

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1134,7 +1134,9 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 
 	BackgroundWorkerInitializeConnectionByOid(db_oid, params.user_oid, 0);
 
+#if PG19_LT
 	log_min_messages = ts_guc_bgw_log_level;
+#endif
 
 	elog(DEBUG2, "job %d started execution", params.job_id);
 

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -855,7 +855,9 @@ ts_bgw_scheduler_process(int32 run_for_interval_ms,
 	TimestampTz start = ts_timer_get_current_timestamp();
 	TimestampTz quit_time = DT_NOEND;
 
+#if PG19_LT
 	log_min_messages = ts_guc_bgw_log_level;
+#endif
 
 	pgstat_report_activity(STATE_RUNNING, NULL);
 
@@ -916,7 +918,9 @@ ts_bgw_scheduler_process(int32 run_for_interval_ms,
 		{
 			got_SIGHUP = false;
 			ProcessConfigFile(PGC_SIGHUP);
+#if PG19_LT
 			log_min_messages = ts_guc_bgw_log_level;
+#endif
 		}
 
 		/*
@@ -1015,7 +1019,9 @@ ts_bgw_scheduler_register_signal_handlers(void)
 	/* Some SIGHUPS may already have been dropped, so we must load the file here */
 	got_SIGHUP = false;
 	ProcessConfigFile(PGC_SIGHUP);
+#if PG19_LT
 	log_min_messages = ts_guc_bgw_log_level;
+#endif
 }
 
 Datum

--- a/src/guc.c
+++ b/src/guc.c
@@ -50,6 +50,13 @@ static const struct config_enum_entry telemetry_level_options[] = {
 #endif
 
 /* Copied from contrib/auto_explain/auto_explain.c */
+#if PG19_LT
+/*
+ * PG19 lets log_min_messages be set per process type (e.g. "warning,
+ * bgworker:debug1"), which supersedes our timescaledb.bgw_log_level GUC, so we
+ * only define it on earlier versions.
+ * https://github.com/postgres/postgres/commit/38e0190ced
+ */
 static const struct config_enum_entry loglevel_options[] = {
 	{ "debug5", DEBUG5, false }, { "debug4", DEBUG4, false }, { "debug3", DEBUG3, false },
 	{ "debug2", DEBUG2, false }, { "debug1", DEBUG1, false }, { "debug", DEBUG2, true },
@@ -57,6 +64,7 @@ static const struct config_enum_entry loglevel_options[] = {
 	{ "log", LOG, false },		 { "error", ERROR, false },	  { "fatal", FATAL, false },
 	{ NULL, 0, false }
 };
+#endif
 
 static const struct config_enum_entry compress_truncate_behaviour_options[] = {
 	{ "truncate_only", COMPRESS_TRUNCATE_ONLY, false },
@@ -136,7 +144,9 @@ TSDLLEXPORT bool ts_guc_enable_compression_ratio_warnings = true;
  * disabled, regular sequence scans will be used instead. */
 TSDLLEXPORT bool ts_guc_enable_columnarscan = true;
 TSDLLEXPORT bool ts_guc_enable_columnarindexscan = true;
+#if PG19_LT
 TSDLLEXPORT int ts_guc_bgw_log_level = WARNING;
+#endif
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 TSDLLEXPORT bool ts_guc_enable_skip_scan_for_distinct_aggregates = true;
 TSDLLEXPORT bool ts_guc_enable_compressed_skip_scan = true;
@@ -1510,6 +1520,7 @@ _guc_init(void)
 							   /* assign_hook= */ ts_license_guc_assign_hook,
 							   /* show_hook= */ NULL);
 
+#if PG19_LT
 	DefineCustomEnumVariable(MAKE_EXTOPTION("bgw_log_level"),
 							 "Log level for the background worker subsystem",
 							 "Log level for the scheduler and workers of the background worker "
@@ -1522,6 +1533,7 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+#endif
 
 	/* this information is useful in general on customer deployments */
 	DefineCustomBoolVariable(/* name= */ MAKE_EXTOPTION("debug_compression_path_info"),

--- a/src/guc.h
+++ b/src/guc.h
@@ -117,7 +117,9 @@ extern TSDLLEXPORT bool ts_guc_enable_composite_bloom_indexes;
 extern TSDLLEXPORT bool ts_guc_read_legacy_bloom1_v1;
 extern TSDLLEXPORT bool ts_guc_enable_columnarscan;
 extern TSDLLEXPORT bool ts_guc_enable_columnarindexscan;
+#if PG19_LT
 extern TSDLLEXPORT int ts_guc_bgw_log_level;
+#endif
 
 /*
  * Exit code to use when scheduler exits.


### PR DESCRIPTION
PostgreSQL 19 allows log_min_messages to be set per process type, for example
"warning, bgworker:debug1", which supersedes our timescaledb.bgw_log_level
GUC. Only define the GUC and set the background worker log level from it on
earlier versions; on PostgreSQL 19 the native per-process-type setting is used
instead.

Upstream changes:
Allow log_min_messages to be set per process type.
https://github.com/postgres/postgres/commit/38e0190ced

Disable-check: force-changelog-file
