### PR TITLE
Normalize hypertable ids in update tests

### DIFF
--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -2,14 +2,28 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
--- Chunk relation names are not deterministic between a fresh install and a post-upgrade catalog.
+-- Chunk relation names are not deterministic between a fresh install and a
+-- post-upgrade catalog. The embedded hypertable id also shifts because a fresh
+-- install no longer creates internal compressed hypertables, so normalize both
+-- the hypertable id and the chunk id in relation names.
 CREATE OR REPLACE FUNCTION pg_temp.normalize_chunk(t text) RETURNS text
   LANGUAGE sql IMMUTABLE AS $$
   SELECT regexp_replace(
-           regexp_replace(t,
-             'compress_hyper_[0-9]+_[0-9]+_chunk|_hyper_[0-9]+_[0-9]+_chunk_compressed',
-             'compressed_chunk', 'g'),
-           '(_hyper_[0-9]+)_[0-9]+_chunk', '\1_X_chunk', 'g')
+           regexp_replace(
+             regexp_replace(t,
+               'compress_hyper_[0-9]+_[0-9]+_chunk|_hyper_[0-9]+_[0-9]+_chunk_compressed',
+               'compressed_chunk', 'g'),
+             '_hyper_[0-9]+_[0-9]+_chunk', '_hyper_X_X_chunk', 'g'),
+           '_compressed_hypertable_[0-9]+', '_compressed_hypertable_X', 'g')
+$$;
+
+-- Hypertable ids shift when internal compressed hypertables are present in one
+-- catalog but not the other. Map an id to the normalized name of its hypertable
+-- so the value is stable between a fresh install and a post-upgrade catalog.
+CREATE OR REPLACE FUNCTION pg_temp.normalize_hypertable_id(id int) RETURNS text
+  LANGUAGE sql STABLE AS $$
+  SELECT pg_temp.normalize_chunk(format('%I.%I', h.schema_name, h.table_name))
+  FROM _timescaledb_catalog.hypertable h WHERE h.id = normalize_hypertable_id.id
 $$;
 
 SELECT NOT (extversion >= '2.19.0' AND extversion <= '2.20.3') AS has_fixed_compression_algorithms
@@ -211,10 +225,10 @@ SELECT unnest(extconfig)::regclass::text, unnest(extcondition) FROM pg_extension
 
 -- Show chunks that include owner in the output. The chunk id is not
 -- deterministic post-upgrade, so drop it and normalize the chunk relation name.
-SELECT c.hypertable_id, c.schema_name, pg_temp.normalize_chunk(c.table_name) AS table_name, cl.relowner::regrole
+SELECT pg_temp.normalize_hypertable_id(c.hypertable_id) AS hypertable, c.schema_name, pg_temp.normalize_chunk(c.table_name) AS table_name, cl.relowner::regrole
 FROM  _timescaledb_catalog.chunk c
 INNER JOIN pg_class cl ON (cl.oid=format('%I.%I', schema_name, table_name)::regclass)
-ORDER BY c.hypertable_id, pg_temp.normalize_chunk(c.table_name);
+ORDER BY pg_temp.normalize_hypertable_id(c.hypertable_id), pg_temp.normalize_chunk(c.table_name);
 
 -- Per-chunk dimensional ranges. Slice ids are assigned by SERIAL and chunk ids
 -- are renumbered, so both differ between a fresh install and a post-upgrade

--- a/test/sql/updates/post.chunk_skipping.sql
+++ b/test/sql/updates/post.chunk_skipping.sql
@@ -8,6 +8,6 @@
 -- the output. We can still test that 0 chunk_ids are converted to
 -- NULL values during upgrades, however. The chunk id itself is renumbered
 -- across the upgrade, so report only whether it is set instead of its value.
-SELECT id, hypertable_id, (chunk_id IS NOT NULL) AS chunk_id_set, column_name, range_start, range_end, valid
+SELECT id, pg_temp.normalize_hypertable_id(hypertable_id) AS hypertable, (chunk_id IS NOT NULL) AS chunk_id_set, column_name, range_start, range_end, valid
 FROM _timescaledb_catalog.chunk_column_stats
 WHERE chunk_id IS NULL OR chunk_id > 0 ORDER BY id;

--- a/test/sql/updates/post.policies.sql
+++ b/test/sql/updates/post.policies.sql
@@ -4,5 +4,12 @@
 
 -- SELECT * FROM _timescaledb_config.bgw_job WHERE id <> 1 ORDER BY id;
 SELECT relnamespace::regnamespace "JOB_SCHEMA" FROM pg_class WHERE relname='bgw_job' and relkind = 'r' \gset
-SELECT id, application_name, schedule_interval, max_runtime, max_retries, retry_period, proc_schema, proc_name, owner, scheduled, hypertable_id, config FROM :JOB_SCHEMA.bgw_job WHERE id <> 1 ORDER BY id;
+-- hypertable_id shifts across the upgrade (internal compressed hypertables no
+-- longer consume ids), so normalize it both as a column and inside the config.
+SELECT id, application_name, schedule_interval, max_runtime, max_retries, retry_period, proc_schema, proc_name, owner, scheduled,
+       pg_temp.normalize_hypertable_id(hypertable_id) AS hypertable,
+       CASE WHEN config ? 'hypertable_id'
+            THEN jsonb_set(config, '{hypertable_id}', to_jsonb(pg_temp.normalize_hypertable_id((config->>'hypertable_id')::int)))
+            ELSE config END AS config
+FROM :JOB_SCHEMA.bgw_job WHERE id <> 1 ORDER BY id;
 

--- a/test/sql/updates/post.sequences.sql
+++ b/test/sql/updates/post.sequences.sql
@@ -11,10 +11,13 @@
 -- from a clean install even though the slice rows match.
 -- chunk_id_seq is excluded too: a fresh install no longer burns chunk ids for
 -- compressed relations, so the next id is lower than in a pre-upgrade catalog.
+-- hypertable_id_seq is excluded for the same reason: a fresh install no longer
+-- burns hypertable ids for internal compressed hypertables.
 SELECT seqrelid::regclass,
   CASE WHEN seqrelid::regclass::text IN ('_timescaledb_catalog.chunk_constraint_name',
                                          '_timescaledb_catalog.dimension_slice_id_seq',
-                                         '_timescaledb_catalog.chunk_id_seq')
+                                         '_timescaledb_catalog.chunk_id_seq',
+                                         '_timescaledb_catalog.hypertable_id_seq')
        THEN NULL ELSE nextval(seqrelid) END AS nextval,
   seqstart,
   seqincrement,


### PR DESCRIPTION
Hypertable ids shift across the update because a fresh install no longer
creates internal compressed hypertables that consume ids from the
sequence. Normalize the hypertable id in the compared output so the
update and downgrade tests do not report these harmless differences.

The chunk name normalization now also normalizes the embedded hypertable
id and the compressed hypertable relation name. A new helper maps a
hypertable id to the normalized name of its hypertable and is used for
the hypertable id columns and the id stored in job configs. The
hypertable id sequence is excluded from the sequence check for the same
reason the chunk id sequence already is.
