### PR TITLE
Fix crash when enabling compression on a dropped table

### DIFF
--- a/.unreleased/pr_10212
+++ b/.unreleased/pr_10212
@@ -1,0 +1,1 @@
+Fixes: #10212 Fix race condition when enabling compression on a hypertable

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1415,6 +1415,17 @@ tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options
 	/* reload info after lock */
 	ht = ts_hypertable_get_by_id(ht->fd.id);
 
+	/*
+	 * If the reload returns nothing the hypertable was dropped while we were
+	 * waiting for the lock above.
+	 */
+	if (!ht)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("hypertable was dropped by a concurrent transaction")));
+	}
+
 	if (compress_disable)
 	{
 		return disable_compression(ht, with_clause_options);


### PR DESCRIPTION
Enabling compression looks up the hypertable and only takes the lock
on it a bit later. If another transaction drops the table in that
window, the lock is granted on a table that no longer exists and the
reloaded hypertable is empty. We now check for this and raise an error
instead of crashing.

Fixes: #10202