### PR TITLE
Cache sort pathkeys per hypertable

### DIFF
--- a/.unreleased/pr_10213
+++ b/.unreleased/pr_10213
@@ -1,0 +1,1 @@
+Fixes: #10213 Cache sort pathkeys per hypertable

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1295,7 +1295,7 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 			 * Since the sort optimization adds new paths to the rel it has
 			 * to happen before any optimizations that replace pathlist.
 			 */
-			List *transformed_query_pathkeys = ts_sort_transform_get_pathkeys(root, rel, rte, ht);
+			List *transformed_query_pathkeys = ts_sort_transform_get_pathkeys(root, rel);
 			if (transformed_query_pathkeys != NIL)
 			{
 				List *orig_query_pathkeys = root->query_pathkeys;

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -40,6 +40,10 @@ typedef struct TimescaleDBPrivate
 
 	/* Cached equivalence members for compressed chunks. List of (EC, EM) Lists. */
 	List *compressed_ec_em_pairs;
+
+	/* Cached transformed pathkeys */
+	List *transformed_sort_pathkeys;
+	bool transformed_sort_pathkeys_valid;
 } TimescaleDBPrivate;
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte);

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -20,6 +20,7 @@
 #include "func_cache.h"
 #include "hypertable.h"
 #include "import/allpaths.h"
+#include "planner/planner.h"
 #include "sort_transform.h"
 
 /* This optimizations allows GROUP BY clauses that transform time in
@@ -439,9 +440,8 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig, Relids child_relids
  *	For example: an ORDER BY date_trunc('minute', time) can be implemented by
  *	an ordering of time.
  */
-List *
-ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte,
-							   Hypertable *ht)
+static List *
+sort_transform_compute_pathkeys(PlannerInfo *root, RelOptInfo *rel)
 {
 	/*
 	 * We attack this problem in three steps:
@@ -550,6 +550,50 @@ ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry
 	}
 
 	return transformed_query_pathkeys;
+}
+
+/*
+ * The transformed pathkeys are a function of the query's ORDER BY and the
+ * hypertable, not of the individual chunk (they reference query-global
+ * equivalence classes; the per-chunk expressions live in the eclass's child
+ * members). Computing them re-walks the whole ORDER BY eclass, whose membership
+ * grows with the chunk count, so doing it once per chunk is O(chunks^2). Cache
+ * the result on the parent hypertable rel and reuse it for every chunk.
+ */
+List *
+ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel)
+{
+	RelOptInfo *parent = NULL;
+
+	if (rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
+	{
+		AppendRelInfo *appinfo = root->append_rel_array[rel->relid];
+		RelOptInfo *candidate = root->simple_rel_array[appinfo->parent_relid];
+
+		/*
+		 * A standalone chunk pulled up from a subquery (UNION ALL or a
+		 * flattened LATERAL subquery) is also an OTHER_MEMBER_REL, but its
+		 * append parent is not a hypertable.
+		 */
+		if (candidate->fdw_private)
+		{
+			parent = candidate;
+		}
+	}
+
+	/* Standalone chunk (no parent to cache on). */
+	if (!parent)
+	{
+		return sort_transform_compute_pathkeys(root, rel);
+	}
+
+	TimescaleDBPrivate *pp = ts_get_private_reloptinfo(parent);
+	if (!pp->transformed_sort_pathkeys_valid)
+	{
+		pp->transformed_sort_pathkeys = sort_transform_compute_pathkeys(root, rel);
+		pp->transformed_sort_pathkeys_valid = true;
+	}
+	return pp->transformed_sort_pathkeys;
 }
 
 /*

--- a/src/sort_transform.h
+++ b/src/sort_transform.h
@@ -12,8 +12,7 @@
 
 extern Expr *ts_sort_transform_expr(Expr *expr);
 
-extern List *ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte,
-											Hypertable *ht);
+extern List *ts_sort_transform_get_pathkeys(PlannerInfo *root, RelOptInfo *rel);
 
 extern void ts_sort_transform_replace_pathkeys(void *node, List *transformed_pathkeys,
 											   List *original_pathkeys);


### PR DESCRIPTION
The transformed ORDER BY pathkeys only depend on the query and the
hypertable, not on the individual chunk. Computing them once per chunk
made planning time grow with the square of the chunk count. Cache the
result on the parent hypertable and reuse it for every chunk, so planning
grows linearly with the chunk count instead.

Warm planning time for SELECT * FROM t ORDER BY time (Release, PG18):

```
  chunks    before     after   speedup
   1000      44 ms     23 ms      1.9x
   5000     735 ms    143 ms      5.2x
  10000    2707 ms    287 ms      9.4x

```

Disable-check: force-changelog-file