### PR TITLE
Release 2.29.0

### DIFF
--- a/.unreleased/columnar-cache
+++ b/.unreleased/columnar-cache
@@ -1,1 +1,0 @@
-Implements: #9534 Speed up expression evaluation in the columnar pipeline by caching common subexpressions

--- a/.unreleased/columnar-wrong-null
+++ b/.unreleased/columnar-wrong-null
@@ -1,1 +1,0 @@
-Fixes: #10082 Wrong result when evaluating a function returning NULL in the columnar query execution pipeline

--- a/.unreleased/enable-disable-trigger-columnstore
+++ b/.unreleased/enable-disable-trigger-columnstore
@@ -1,2 +1,0 @@
-Fixes: #10179 Allow enabling and disabling triggers on hypertables with columnstore enabled
-Thanks: @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled

--- a/.unreleased/leak-direct
+++ b/.unreleased/leak-direct
@@ -1,1 +1,0 @@
-Implements: #10119 Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks

--- a/.unreleased/min-nan
+++ b/.unreleased/min-nan
@@ -1,1 +1,0 @@
-Fixes: #10052 Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain Postgres result

--- a/.unreleased/param-eval
+++ b/.unreleased/param-eval
@@ -1,2 +1,0 @@
-Implements: #9917 Decompress less data in DML on compressed hypertable by accounting for the prepared statement parameters
-Thanks: @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression

--- a/.unreleased/pr_10010
+++ b/.unreleased/pr_10010
@@ -1,1 +1,0 @@
-Implements: #10010 Skip classifying compressed relations to speed up planning

--- a/.unreleased/pr_10013
+++ b/.unreleased/pr_10013
@@ -1,1 +1,0 @@
-Fixes: #10013 Make ownership error messages on CAggs consistent

--- a/.unreleased/pr_10041
+++ b/.unreleased/pr_10041
@@ -1,1 +1,0 @@
-Implements: #10041 Remove support for PG15

--- a/.unreleased/pr_10048
+++ b/.unreleased/pr_10048
@@ -1,1 +1,0 @@
-Implements: #10048 Support concurrent refresh policies on hierarchical continuous aggregates

--- a/.unreleased/pr_10081
+++ b/.unreleased/pr_10081
@@ -1,1 +1,0 @@
-Implements: #10081 Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size

--- a/.unreleased/pr_10118
+++ b/.unreleased/pr_10118
@@ -1,1 +1,0 @@
-Implements: #10118 Don't track compressed relations as separate chunk

--- a/.unreleased/pr_10143
+++ b/.unreleased/pr_10143
@@ -1,1 +1,0 @@
-Fixes: #10143 Fix division by zero when planning time_bucket with zero width

--- a/.unreleased/pr_10182
+++ b/.unreleased/pr_10182
@@ -1,1 +1,0 @@
-Fixes: #10182 Fix columnstore sort pushdown to check for different query sortkey collation

--- a/.unreleased/pr_10199
+++ b/.unreleased/pr_10199
@@ -1,1 +1,0 @@
-Fixes: #10199 Fix initial_start handling in build_job_info

--- a/.unreleased/pr_10204
+++ b/.unreleased/pr_10204
@@ -1,1 +1,0 @@
-Implements: #10204 Don't create separate hypertable catalog entry for hypertables with compression

--- a/.unreleased/pr_10212
+++ b/.unreleased/pr_10212
@@ -1,1 +1,0 @@
-Fixes: #10212 Fix race condition when enabling compression on a hypertable

--- a/.unreleased/pr_10213
+++ b/.unreleased/pr_10213
@@ -1,1 +1,0 @@
-Fixes: #10213 Cache sort pathkeys per hypertable

--- a/.unreleased/pr_9684
+++ b/.unreleased/pr_9684
@@ -1,1 +1,0 @@
-Implements: #9684 Add `decompress_batch` SQL function

--- a/.unreleased/pr_9957
+++ b/.unreleased/pr_9957
@@ -1,1 +1,0 @@
-Implements: #9957 Add compact_chunk function

--- a/.unreleased/row-by-row
+++ b/.unreleased/row-by-row
@@ -1,1 +1,0 @@
-Implements: #9732 Speed up some queries with small LIMIT by switching to row-by-row query execution pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.29.0 (2026-07-07)
+
+This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.29.0**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+* [#10010](https://github.com/timescale/timescaledb/pull/10010) Skip classifying compressed relations to speed up planning
+* [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PG15
+* [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
+* [#10081](https://github.com/timescale/timescaledb/pull/10081) Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size
+* [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk
+* [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks
+* [#10204](https://github.com/timescale/timescaledb/pull/10204) Don't create separate hypertable catalog entry for hypertables with compression
+* [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
+* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `decompress_batch` SQL function
+* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small LIMIT by switching to row-by-row query execution pipeline
+* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in DML on compressed hypertable by accounting for the prepared statement parameters
+* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add compact_chunk function
+
+**Bugfixes**
+* [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on CAggs consistent
+* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain Postgres result
+* [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning NULL in the columnar query execution pipeline
+* [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning time_bucket with zero width
+* [#10179](https://github.com/timescale/timescaledb/pull/10179) Allow enabling and disabling triggers on hypertables with columnstore enabled
+* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query sortkey collation
+* [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix initial_start handling in build_job_info
+* [#10212](https://github.com/timescale/timescaledb/pull/10212) Fix race condition when enabling compression on a hypertable
+* [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression
+* @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled
+
 ## 2.28.2 (2026-06-30)
 
 This release contains bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.


### PR DESCRIPTION
# TimescaleDB Changelog

**Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**

## 2.29.0 (2026-07-07)

This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.

**Highlighted features in TimescaleDB v2.29.0**
* FILL THIS *

**Backward-Incompatible Changes**

**Features**
* [#10010](https://github.com/timescale/timescaledb/pull/10010) Skip classifying compressed relations to speed up planning
* [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PG15
* [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
* [#10081](https://github.com/timescale/timescaledb/pull/10081) Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size
* [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk
* [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks
* [#10204](https://github.com/timescale/timescaledb/pull/10204) Don't create separate hypertable catalog entry for hypertables with compression
* [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `decompress_batch` SQL function
* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small LIMIT by switching to row-by-row query execution pipeline
* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in DML on compressed hypertable by accounting for the prepared statement parameters
* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add compact_chunk function

**Bugfixes**
* [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on CAggs consistent
* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain Postgres result
* [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning NULL in the columnar query execution pipeline
* [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning time_bucket with zero width
* [#10179](https://github.com/timescale/timescaledb/pull/10179) Allow enabling and disabling triggers on hypertables with columnstore enabled
* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query sortkey collation
* [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix initial_start handling in build_job_info
* [#10212](https://github.com/timescale/timescaledb/pull/10212) Fix race condition when enabling compression on a hypertable
* [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable

**New Settings**

**GUCs**

**Thanks**
* @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression
* @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled