### PR TITLE
Use status field for all compression status of hypertable

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -49,17 +49,15 @@ CREATE TABLE _timescaledb_catalog.hypertable (
   chunk_sizing_func_schema name NOT NULL, -- unused
   chunk_sizing_func_name name NOT NULL, -- unused
   chunk_target_size bigint NOT NULL, -- unused
-  compression_state smallint NOT NULL DEFAULT 0,
-  compressed_hypertable_id integer,
+  compression_state smallint NOT NULL DEFAULT 0, --unused
+  compressed_hypertable_id integer, -- unused
   status int NOT NULL DEFAULT 0,
   -- table constraints
   CONSTRAINT hypertable_pkey PRIMARY KEY (id),
   CONSTRAINT hypertable_associated_schema_name_associated_table_prefix_key UNIQUE (associated_schema_name, associated_table_prefix),
   CONSTRAINT hypertable_table_name_schema_name_key UNIQUE (table_name, schema_name),
   CONSTRAINT hypertable_schema_name_check CHECK (schema_name != '_timescaledb_catalog'),
-  -- internal compressed hypertables have compression state = 2
-  CONSTRAINT hypertable_dim_compress_check CHECK (num_dimensions > 0 OR compression_state = 2),
-  CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL))
+  CONSTRAINT hypertable_num_dimensions_check CHECK (num_dimensions > 0)
 ) WITH (user_catalog_table = true);
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -410,7 +410,7 @@ SELECT
 FROM
     _timescaledb_catalog.hypertable AS srcht
     JOIN _timescaledb_catalog.chunk AS srcch ON srcht.id = srcch.hypertable_id
-        AND srcht.compression_state = 1
+        AND srcht.status & 4 = 4
     LEFT JOIN _timescaledb_catalog.compression_chunk_size map ON srcch.id = map.chunk_id;
 
 GRANT SELECT ON _timescaledb_internal.compressed_chunk_stats TO PUBLIC;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -57,3 +57,20 @@ $$;
 -- END hypertable.compressed_hypertable_id no longer used
 --
 
+--
+-- BEGIN set compression status flag on hypertables
+--
+
+UPDATE _timescaledb_catalog.hypertable
+SET status = status | 4, -- set compression bit
+    compression_state = 0
+WHERE compression_state = 1;
+
+--
+-- END set compression status flag on hypertables
+--
+
+ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT hypertable_dim_compress_check;
+ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_num_dimensions_check CHECK (num_dimensions > 0);
+ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT hypertable_compress_check;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -3,6 +3,23 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_uncompressed_size(regcla
 DROP FUNCTION IF EXISTS _timescaledb_functions.compact_chunk(REGCLASS);
 
 --
+-- BEGIN compression status flag on hypertables
+--
+
+UPDATE _timescaledb_catalog.hypertable
+SET compression_state = 1,
+    status = status & ~4 -- clear compression bit
+WHERE status & 4 <> 0;
+
+--
+-- END compression status flag on hypertables
+--
+
+ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT hypertable_num_dimensions_check;
+ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_dim_compress_check CHECK (num_dimensions > 0 OR compression_state = 2);
+ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL));
+
+--
 -- BEGIN restore internal compressed hypertables
 --
 

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -10,9 +10,9 @@ CREATE OR REPLACE VIEW timescaledb_information.hypertables AS
 WITH
   hypertable_info AS (
     SELECT hypertable_id, schema_name, table_name,
-           num_dimensions, compression_state, column_name,
+           num_dimensions, status, column_name,
            column_type, interval_length,
-           (compression_state = 1) AS compression_enabled,
+           (status & 4 = 4) AS compression_enabled,
            row_number() OVER (PARTITION BY hypertable_id ORDER BY di.id) AS dimension_num
       FROM _timescaledb_catalog.hypertable ht
       JOIN _timescaledb_catalog.dimension di ON ht.id = di.hypertable_id
@@ -40,8 +40,8 @@ LEFT JOIN (
       array_agg(tablespace_name ORDER BY id) AS tablespace_list
     FROM _timescaledb_catalog.tablespace
     GROUP BY hypertable_id) srchtbs ON ht.hypertable_id = srchtbs.hypertable_id
-WHERE ht.compression_state != 2 --> no internal compression tables
-  AND ca.mat_hypertable_id IS NULL
+WHERE
+  ca.mat_hypertable_id IS NULL
   AND ht.interval_length IS NOT NULL
   AND ht.dimension_num = 1;
 
@@ -123,10 +123,7 @@ SELECT ht.schema_name AS hypertable_schema,
   cagg.user_view_name AS view_name,
   viewinfo.viewowner AS view_owner,
   cagg.materialized_only,
-  CASE WHEN mat_ht.compression_state = 1
-       THEN TRUE
-       ELSE FALSE
-  END AS compression_enabled,
+  mat_ht.status & 4 = 4 AS compression_enabled,
   mat_ht.schema_name AS materialization_hypertable_schema,
   mat_ht.table_name AS materialization_hypertable_name,
   directview.viewdefinition AS view_definition
@@ -148,7 +145,7 @@ FROM _timescaledb_catalog.continuous_agg cagg,
     AND C.relname = cagg.direct_view_name
     AND N.nspname = cagg.direct_view_schema) directview,
   LATERAL (
-    SELECT schema_name, table_name, compression_state
+    SELECT schema_name, table_name, status
     FROM _timescaledb_catalog.hypertable
     WHERE cagg.mat_hypertable_id = id) mat_ht
 WHERE cagg.raw_hypertable_id = ht.id;
@@ -219,7 +216,7 @@ FROM (
       AND srcch.schema_name = cl.schema_name
     LEFT OUTER JOIN pg_tablespace pgtab ON pgtab.oid = reltablespace
   WHERE srcch.osm_chunk IS FALSE
-    AND ht.compression_state != 2 ) finalq
+  ) finalq
 WHERE chunk_dimension_num = 1;
 
 -- hypertable's dimension information

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4822,10 +4822,8 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	 * Once the data is moved into the OSM chunk, then our catalog should be
 	 * updated with proper API calls from the OSM extension.
 	 */
-	parent_ht->fd.status =
-		ts_set_flags_32(parent_ht->fd.status,
-						HYPERTABLE_STATUS_OSM | HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
-	ts_hypertable_update_status_osm(parent_ht);
+	ts_hypertable_add_status(parent_ht,
+							 HYPERTABLE_STATUS_OSM | HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
 }
 
 void
@@ -5293,10 +5291,8 @@ ts_chunk_drop_osm_chunk(PG_FUNCTION_ARGS)
 	ts_chunk_drop(osm_chunk, DROP_RESTRICT, LOG);
 
 	/* reset hypertable OSM status */
-	ht->fd.status =
-		ts_clear_flags_32(ht->fd.status,
-						  HYPERTABLE_STATUS_OSM | HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
-	ts_hypertable_update_status_osm(ht);
+	ts_hypertable_clear_status(ht,
+							   HYPERTABLE_STATUS_OSM | HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
 	ts_cache_release(&hcache);
 	PG_RETURN_BOOL(true);
 }

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -871,8 +871,7 @@ hypertable_insert_relation(Relation rel, FormData_hypertable *fd)
 
 static void
 hypertable_insert(int32 hypertable_id, Name schema_name, Name table_name,
-				  Name associated_schema_name, Name associated_table_prefix, int16 num_dimensions,
-				  bool compressed)
+				  Name associated_schema_name, Name associated_table_prefix, int16 num_dimensions)
 {
 	Catalog *catalog = ts_catalog_get();
 	Relation rel;
@@ -924,15 +923,7 @@ hypertable_insert(int32 hypertable_id, Name schema_name, Name table_name,
 	namestrcpy(&fd.chunk_sizing_func_schema, FUNCTIONS_SCHEMA_NAME);
 	namestrcpy(&fd.chunk_sizing_func_name, DEFAULT_CHUNK_SIZING_FUNC_NAME);
 	fd.chunk_target_size = 0;
-
-	if (compressed)
-	{
-		fd.compression_state = HypertableInternalCompressionTable;
-	}
-	else
-	{
-		fd.compression_state = HypertableCompressionOff;
-	}
+	fd.compression_state = 0;
 
 	/* when creating a hypertable, there is never an associated compressed dual */
 	fd.compressed_hypertable_id = INVALID_HYPERTABLE_ID;
@@ -1918,8 +1909,7 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 					  &table_name,
 					  associated_schema_name,
 					  associated_table_prefix,
-					  DIMENSION_INFO_IS_SET(closed_dim_info) ? 2 : 1,
-					  false);
+					  DIMENSION_INFO_IS_SET(closed_dim_info) ? 2 : 1);
 
 	/* Get the a Hypertable object via the cache */
 	time_dim_info->ht =
@@ -2176,40 +2166,6 @@ ts_hypertable_set_integer_now_func(PG_FUNCTION_ARGS)
 	PG_RETURN_NULL();
 }
 
-/*Assume permissions are already checked
- * set compression state as enabled
- */
-bool
-ts_hypertable_set_compressed(Hypertable *ht)
-{
-	FormData_hypertable form;
-	ItemPointerData tid;
-	/* lock the tuple entry in the catalog table */
-	bool found = lock_hypertable_tuple(ht->fd.id, &tid, &form);
-	Ensure(found, "hypertable id %d not found", ht->fd.id);
-
-	form.compression_state = HypertableCompressionEnabled;
-	hypertable_update_catalog_tuple(&tid, &form);
-	return true;
-}
-
-/* set compression_state as disabled and remove any
- * associated compressed hypertable id
- */
-bool
-ts_hypertable_unset_compressed(Hypertable *ht)
-{
-	FormData_hypertable form;
-	ItemPointerData tid;
-	/* lock the tuple entry in the catalog table */
-	bool found = lock_hypertable_tuple(ht->fd.id, &tid, &form);
-	Ensure(found, "hypertable id %d not found", ht->fd.id);
-
-	form.compression_state = HypertableCompressionOff;
-	hypertable_update_catalog_tuple(&tid, &form);
-	return true;
-}
-
 bool
 ts_hypertable_set_compress_interval(Hypertable *ht, int64 compress_interval)
 {
@@ -2217,64 +2173,6 @@ ts_hypertable_set_compress_interval(Hypertable *ht, int64 compress_interval)
 		ts_hyperspace_get_mutable_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);
 
 	return ts_dimension_set_compress_interval(time_dimension, compress_interval) > 0;
-}
-
-/* create a compressed hypertable
- * table_relid - already created table which we are going to
- *               set up as a compressed hypertable
- * hypertable_id - id to be used while creating hypertable with
- *                  compression property set
- * NOTE:
- * compressed hypertable has no dimensions.
- */
-bool
-ts_hypertable_create_compressed(Oid table_relid, int32 hypertable_id)
-{
-	Oid user_oid = GetUserId();
-	Oid tspc_oid = get_rel_tablespace(table_relid);
-	NameData schema_name, table_name, associated_schema_name;
-	LockRelationOid(table_relid, AccessExclusiveLock);
-	/*
-	 * Check that the user has permissions to make this table to a compressed
-	 * hypertable
-	 */
-	ts_hypertable_permissions_check(table_relid, user_oid);
-	if (ts_is_hypertable(table_relid))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_EXISTS),
-				 errmsg("table \"%s\" is already a hypertable", get_rel_name(table_relid))));
-	}
-
-	namestrcpy(&schema_name, get_namespace_name(get_rel_namespace(table_relid)));
-	namestrcpy(&table_name, get_rel_name(table_relid));
-
-	/* Checks pass, now we can create the catalog information */
-	namestrcpy(&schema_name, get_namespace_name(get_rel_namespace(table_relid)));
-	namestrcpy(&table_name, get_rel_name(table_relid));
-	namestrcpy(&associated_schema_name, INTERNAL_SCHEMA_NAME);
-
-	/* compressed hypertable has no dimensions of its own , shares the original hypertable dims*/
-	hypertable_insert(hypertable_id,
-					  &schema_name,
-					  &table_name,
-					  &associated_schema_name,
-					  NULL,
-					  0 /*num_dimensions*/,
-					  true);
-
-	/* No indexes are created for the compressed hypertable here */
-
-	/* Attach tablespace, if any */
-	if (OidIsValid(tspc_oid))
-	{
-		NameData tspc_name;
-
-		namestrcpy(&tspc_name, get_tablespace_name(tspc_oid));
-		ts_tablespace_attach_internal(&tspc_name, table_relid, false);
-	}
-
-	return true;
 }
 
 /*
@@ -2390,14 +2288,13 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 }
 
 /*
- * hypertable status update is done in two steps, similar to
- * chunk_update_status
- * This is again equivalent to a SELECT FOR UPDATE, followed by UPDATE
- * 1. RowShareLock to SELECT for UPDATE
- * 2. UPDATE status using RowExclusiveLock
+ * Set or clear the given status flags on the hypertable.
+ *
+ * The row is written back only if the status actually changed. Returns true if
+ * the status was modified.
  */
-bool
-ts_hypertable_update_status_osm(Hypertable *ht)
+static bool
+hypertable_update_status(Hypertable *ht, int32 flags, bool set)
 {
 	FormData_hypertable form;
 	ItemPointerData tid;
@@ -2405,12 +2302,44 @@ ts_hypertable_update_status_osm(Hypertable *ht)
 	bool found = lock_hypertable_tuple(ht->fd.id, &tid, &form);
 	Ensure(found, "hypertable id %d not found", ht->fd.id);
 
-	if (form.status != ht->fd.status)
+	/* apply the flags after locking the metadata tuple */
+	int32 old_status = form.status;
+	form.status = set ? ts_set_flags_32(form.status, flags) : ts_clear_flags_32(form.status, flags);
+	ht->fd.status = form.status;
+
+	if (old_status == form.status)
 	{
-		form.status = ht->fd.status;
-		hypertable_update_catalog_tuple(&tid, &form);
+		return false;
 	}
+
+	hypertable_update_catalog_tuple(&tid, &form);
 	return true;
+}
+
+bool
+ts_hypertable_add_status(Hypertable *ht, int32 status)
+{
+	return hypertable_update_status(ht, status, true);
+}
+
+bool
+ts_hypertable_clear_status(Hypertable *ht, int32 status)
+{
+	return hypertable_update_status(ht, status, false);
+}
+
+/* Mark the hypertable as having compression enabled. */
+bool
+ts_hypertable_set_compression(Hypertable *ht)
+{
+	return ts_hypertable_add_status(ht, HYPERTABLE_STATUS_COMPRESSION);
+}
+
+/* Clear the compression status flag on the hypertable. */
+bool
+ts_hypertable_unset_compression(Hypertable *ht)
+{
+	return ts_hypertable_clear_status(ht, HYPERTABLE_STATUS_COMPRESSION);
 }
 
 DimensionSlice *
@@ -2607,29 +2536,25 @@ ts_hypertable_osm_range_update(PG_FUNCTION_ARGS)
 				errhint("Range should be set to invalid for tiered chunk"));
 	}
 	range_invalid = ts_osm_chunk_range_is_invalid(range_start_internal, range_end_internal);
-	/* Update the hypertable flags regarding the validity of the OSM range */
+	/* Update the hypertable flags regarding the validity of the OSM range. The
+	 * flag is set or cleared under the catalog tuple lock so concurrent changes
+	 * to other status bits are not lost. */
 	if (range_invalid)
 	{
 		/* range is set to infinity so the OSM chunk is considered last */
 		range_start_internal = PG_INT64_MAX - 1;
 		range_end_internal = PG_INT64_MAX;
-		if (!osm_chunk_empty)
-		{
-			ht->fd.status =
-				ts_set_flags_32(ht->fd.status, HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
-		}
-		else
-		{
-			ht->fd.status =
-				ts_clear_flags_32(ht->fd.status, HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
-		}
+	}
+
+	if (range_invalid && !osm_chunk_empty)
+	{
+		ts_hypertable_add_status(ht, HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
 	}
 	else
 	{
-		ht->fd.status = ts_clear_flags_32(ht->fd.status, HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
+		ts_hypertable_clear_status(ht, HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS);
 	}
 
-	ts_hypertable_update_status_osm(ht);
 	ts_cache_release(&hcache);
 
 	slice->fd.range_start = range_start_internal;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -23,15 +23,8 @@ typedef struct Chunk Chunk;
 typedef struct Hypercube Hypercube;
 typedef struct ChunkRangeSpace ChunkRangeSpace;
 
-enum
-{
-	HypertableCompressionOff = 0,
-	HypertableCompressionEnabled = 1,
-	HypertableInternalCompressionTable = 2,
-};
-
 #define TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht)                                                  \
-	((ht)->fd.compression_state == HypertableCompressionEnabled)
+	(((ht)->fd.status & HYPERTABLE_STATUS_COMPRESSION) != 0)
 
 typedef struct Hypertable
 {
@@ -78,7 +71,6 @@ extern TSDLLEXPORT bool ts_hypertable_create_from_info(Oid table_relid, int32 hy
 													   DimensionInfo *closed_dim_info,
 													   Name associated_schema_name,
 													   Name associated_table_prefix);
-extern TSDLLEXPORT bool ts_hypertable_create_compressed(Oid table_relid, int32 hypertable_id);
 
 extern TSDLLEXPORT Hypertable *ts_hypertable_get_by_id(int32 hypertable_id);
 extern Hypertable *ts_hypertable_get_by_name(const char *schema, const char *name);
@@ -94,7 +86,8 @@ extern Hypertable *ts_resolve_hypertable_from_table_or_cagg(Cache *hcache, Oid r
 extern int ts_hypertable_scan_with_memory_context(const char *schema, const char *table,
 												  tuple_found_func tuple_found, void *data,
 												  LOCKMODE lockmode, MemoryContext mctx);
-extern bool ts_hypertable_update_status_osm(Hypertable *ht);
+extern bool ts_hypertable_add_status(Hypertable *ht, int32 status);
+extern bool ts_hypertable_clear_status(Hypertable *ht, int32 status);
 extern int ts_hypertable_set_name(Hypertable *ht, const char *newname);
 extern int ts_hypertable_set_schema(Hypertable *ht, const char *newname);
 extern int ts_hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
@@ -127,8 +120,8 @@ extern TSDLLEXPORT bool ts_hypertable_has_chunks(Oid table_relid, LOCKMODE lockm
 extern void ts_hypertables_rename_schema_name(const char *old_name, const char *new_name);
 extern bool ts_is_partitioning_column(const Hypertable *ht, AttrNumber column_attno);
 extern bool ts_is_partitioning_column_name(const Hypertable *ht, NameData column_name);
-extern TSDLLEXPORT bool ts_hypertable_set_compressed(Hypertable *ht);
-extern TSDLLEXPORT bool ts_hypertable_unset_compressed(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_set_compression(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_unset_compression(Hypertable *ht);
 extern TSDLLEXPORT bool ts_hypertable_set_compress_interval(Hypertable *ht,
 															int64 compress_interval);
 extern TSDLLEXPORT int64 ts_hypertable_get_open_dim_max_value(const Hypertable *ht,

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1740,19 +1740,6 @@ replace_modify_hypertable_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 			RangeTblEntry *rte = planner_rt_fetch(mt->nominalRelation, root);
 			Hypertable *ht = ts_planner_get_hypertable(rte->relid, CACHE_FLAG_CHECK);
 
-			/* Direct INSERT into internal compressed hypertable is not supported.
-			 * Compressed chunks have no dimensions so we could not do tuple routing.
-			 * Additionally internal compressed hypertable has no columns so you
-			 * couldn't even insert any actual data.
-			 */
-			if (ht && ht->fd.compression_state == HypertableInternalCompressionTable)
-			{
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("direct insert into internal compressed hypertable is not "
-								"supported")));
-			}
-
 			/* Check for DML on chunk directly */
 			if (!ht)
 			{

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1336,6 +1336,7 @@ typedef struct CatalogSecurityContext
  * append.
  */
 #define HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS 2
+#define HYPERTABLE_STATUS_COMPRESSION 4
 
 extern void ts_catalog_table_info_init(CatalogTableInfo *tables, int max_table,
 									   const TableInfoDef *table_ary,

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -54,51 +54,6 @@ static void create_compressed_chunk_indexes(Oid relid, CompressionSettings *sett
 static void set_toast_tuple_target_on_chunk(Oid compressed_table_id);
 static void set_statistics_on_compressed_chunk(Oid compressed_table_id);
 
-int32
-compression_hypertable_create(Hypertable *ht, Oid owner, Oid tablespace_oid)
-{
-	ObjectAddress tbladdress;
-	char relnamebuf[NAMEDATALEN];
-	CatalogSecurityContext sec_ctx;
-	Oid compress_relid;
-
-	CreateStmt *create;
-	RangeVar *compress_rel;
-	int32 compress_hypertable_id;
-
-	Assert(!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
-
-	create = makeNode(CreateStmt);
-	create->tableElts = NIL;
-	create->inhRelations = NIL;
-	create->ofTypename = NULL;
-	create->constraints = NIL;
-	create->options = NULL;
-	create->oncommit = ONCOMMIT_NOOP;
-	create->tablespacename = get_tablespace_name(tablespace_oid);
-	create->if_not_exists = false;
-
-	/* Invalid tablespace_oid <=> NULL tablespace name */
-	Assert(!OidIsValid(tablespace_oid) == (create->tablespacename == NULL));
-
-	/* create the compression table */
-	/* NewRelationCreateToastTable calls CommandCounterIncrement */
-	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	compress_hypertable_id = ts_catalog_table_next_seq_id(ts_catalog_get(), HYPERTABLE);
-	PRINT_COMPRESSION_TABLE_NAME(relnamebuf, "_compressed_hypertable_%d", compress_hypertable_id);
-	compress_rel = makeRangeVar(pstrdup(INTERNAL_SCHEMA_NAME), pstrdup(relnamebuf), -1);
-
-	create->relation = compress_rel;
-	tbladdress = DefineRelation(create, RELKIND_RELATION, owner, NULL, NULL);
-	CommandCounterIncrement();
-	compress_relid = tbladdress.objectId;
-	ts_copy_relation_acl(ht->main_table_relid, compress_relid, owner);
-	ts_catalog_restore_user(&sec_ctx);
-	ts_hypertable_create_compressed(compress_relid, compress_hypertable_id);
-
-	return compress_hypertable_id;
-}
-
 Oid
 compression_table_create(Chunk *src_chunk, List *column_defs, Oid tablespace_oid,
 						 CompressionSettings *settings)

--- a/tsl/src/compression/compression_storage.h
+++ b/tsl/src/compression/compression_storage.h
@@ -15,7 +15,6 @@
 #include "chunk.h"
 #include "hypertable.h"
 
-int32 compression_hypertable_create(Hypertable *ht, Oid owner, Oid tablespace_oid);
 Oid compression_table_create(Chunk *src_chunk, List *column_defs, Oid tablespace_oid,
 							 CompressionSettings *settings);
 void modify_compressed_toast_table_storage(CompressionSettings *settings, List *coldefs,

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1193,7 +1193,7 @@ disable_compression(Hypertable *ht, WithClauseResult *with_clause_options)
 				 errmsg("cannot disable columnstore on hypertable with columnstore chunks")));
 	}
 
-	ts_hypertable_unset_compressed(ht);
+	ts_hypertable_unset_compression(ht);
 	ts_compression_settings_delete(ht->main_table_relid);
 
 	return true;
@@ -1437,7 +1437,7 @@ tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options
 		validate_existing_constraints(ht, settings);
 		validate_existing_indexes(ht, settings);
 
-		ts_hypertable_set_compressed(ht);
+		ts_hypertable_set_compression(ht);
 	}
 
 	/*
@@ -2558,7 +2558,7 @@ tsl_columnstore_setup(Hypertable *ht, WithClauseResult *with_clause_options)
 																   NULL);
 
 	compression_settings_set_manually_for_create(ht, settings, with_clause_options);
-	ts_hypertable_set_compressed(ht);
+	ts_hypertable_set_compression(ht);
 
 	/* Add default compression policy when compression is enabled via CREATE TABLE WITH */
 	/* Use the chunk interval as the compression interval */

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -889,7 +889,7 @@ SELECT _timescaledb_functions.drop_osm_chunk('ht_try');
 SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'ht_try';
  status 
 --------
-      0
+      4
 
 -- chunk and dimension slice should have been cleaned up
 SELECT FROM _timescaledb_catalog.chunk WHERE id = :osm_chunk_id;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -56,10 +56,10 @@ SET timescaledb.enable_columnarscan to ON;
 update foo set c = 40
 where  a = (SELECT max(a) FROM foo);
 SET timescaledb.enable_columnarscan to OFF;
-SELECT id, schema_name, table_name, compression_state as compressed FROM _timescaledb_catalog.hypertable ORDER BY id;
+SELECT id, schema_name, table_name, status & 4 = 4 as compressed FROM _timescaledb_catalog.hypertable ORDER BY id;
  id | schema_name | table_name | compressed 
 ----+-------------+------------+------------
-  1 | public      | foo        |          1
+  1 | public      | foo        | t
 
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::regclass;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                                                                                 index                                                                                                                  
@@ -263,10 +263,10 @@ insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 'klick', 55, 75;
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'NYC', 'klick', 55, 75;
-SELECT id, schema_name, table_name, compression_state as compressed FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions';
+SELECT id, schema_name, table_name, status & 4 = 4 as compressed FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions';
  id | schema_name | table_name | compressed 
 ----+-------------+------------+------------
-  4 | public      | conditions |          1
+  4 | public      | conditions | t
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'conditions'::regclass;
    relid    | compress_relid | segmentby  | orderby | orderby_desc | orderby_nullsfirst |                                                           index                                                           
@@ -832,10 +832,10 @@ SELECT count(compress_chunk(ch)) FROM show_chunks('datatype_test') ch;
 -------
      1
 
-select id, schema_name, table_name, compression_state as compressed from _timescaledb_catalog.hypertable where table_name = 'datatype_test';
+select id, schema_name, table_name, status & 4 = 4 as compressed from _timescaledb_catalog.hypertable where table_name = 'datatype_test';
  id | schema_name |  table_name   | compressed 
 ----+-------------+---------------+------------
-  7 | public      | datatype_test |          1
+  7 | public      | datatype_test | t
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='datatype_test'::regclass;
      relid     | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                           index                                                           

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -856,11 +856,11 @@ SELECT count(*) from test1 where new_colv  = '101t';
 
 CREATE INDEX new_index ON test1(new_colv);
 -- TEST 2:  ALTER TABLE rename column
-SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, compression_state, status
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, status
  from _timescaledb_catalog.hypertable WHERE table_name = 'test1';
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | compression_state | status 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+--------
-  8 | public      | test1      | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_functions   | calculate_chunk_interval |                 1 |      0
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | status 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+--------
+  8 | public      | test1      | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_functions   | calculate_chunk_interval |      4
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                           index                                                           
@@ -868,11 +868,11 @@ SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::reg
  test1 |                | {bntcol}  | {Time}  | {t}          | {t}                | [{"type": "minmax", "column": "Time", "source": "orderby"}, {"type": "firstlast", "column": "Time", "source": "orderby"}]
 
 ALTER TABLE test1 RENAME new_coli TO coli;
-SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, compression_state, status
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, status
  from _timescaledb_catalog.hypertable WHERE table_name = 'test1';
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | compression_state | status 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+--------
-  8 | public      | test1      | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_functions   | calculate_chunk_interval |                 1 |      0
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | status 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+--------
+  8 | public      | test1      | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_functions   | calculate_chunk_interval |      4
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
  relid | compress_relid | segmentby | orderby | orderby_desc | orderby_nullsfirst |                                                           index                                                           
@@ -1145,11 +1145,11 @@ SELECT * FROM test_drop ORDER BY 1;
 -- check dropped columns got removed from catalog
 -- only segmentby and orderby are in catalog which we dont support removing
 -- atm, so nothing to see here
-SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, compression_state, status
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, status
  from _timescaledb_catalog.hypertable WHERE table_name = 'test_drop';
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | compression_state | status 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+--------
- 10 | public      | test_drop  | _timescaledb_internal  | _hyper_10               |              1 | _timescaledb_functions   | calculate_chunk_interval |                 1 |      0
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | status 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+--------
+ 10 | public      | test_drop  | _timescaledb_internal  | _hyper_10               |              1 | _timescaledb_functions   | calculate_chunk_interval |      4
 
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_drop'::regclass;
    relid   | compress_relid | segmentby |   orderby    | orderby_desc | orderby_nullsfirst |                                                                                                                                                                                index                                                                                                                                                                                

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -33,7 +33,7 @@ update foo set c = 40
 where  a = (SELECT max(a) FROM foo);
 SET timescaledb.enable_columnarscan to OFF;
 
-SELECT id, schema_name, table_name, compression_state as compressed FROM _timescaledb_catalog.hypertable ORDER BY id;
+SELECT id, schema_name, table_name, status & 4 = 4 as compressed FROM _timescaledb_catalog.hypertable ORDER BY id;
 SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid::regclass;
 SELECT * FROM timescaledb_information.compression_settings ORDER BY hypertable_name;
 
@@ -126,7 +126,7 @@ select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'NYC', 'klick', 55, 75;
 
-SELECT id, schema_name, table_name, compression_state as compressed FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions';
+SELECT id, schema_name, table_name, status & 4 = 4 as compressed FROM _timescaledb_catalog.hypertable WHERE table_name = 'conditions';
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'conditions'::regclass;
 
 select attname, attstorage, typname from pg_attribute at, pg_class cl , pg_type ty
@@ -309,7 +309,7 @@ INSERT INTO datatype_test VALUES ('2000-01-01',2,4,8,4.0,8.0,'2000-01-01','2001-
 
 SELECT count(compress_chunk(ch)) FROM show_chunks('datatype_test') ch;
 
-select id, schema_name, table_name, compression_state as compressed from _timescaledb_catalog.hypertable where table_name = 'datatype_test';
+select id, schema_name, table_name, status & 4 = 4 as compressed from _timescaledb_catalog.hypertable where table_name = 'datatype_test';
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='datatype_test'::regclass;
 
 --TEST try to compress a hypertable that has a continuous aggregate

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -44,12 +44,12 @@ SELECT count(*) from test1 where new_colv  = '101t';
 CREATE INDEX new_index ON test1(new_colv);
 
 -- TEST 2:  ALTER TABLE rename column
-SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, compression_state, status
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, status
  from _timescaledb_catalog.hypertable WHERE table_name = 'test1';
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
 
 ALTER TABLE test1 RENAME new_coli TO coli;
-SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, compression_state, status
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, status
  from _timescaledb_catalog.hypertable WHERE table_name = 'test1';
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid='test1'::regclass;
 
@@ -191,7 +191,7 @@ SELECT * FROM test_drop ORDER BY 1;
 -- check dropped columns got removed from catalog
 -- only segmentby and orderby are in catalog which we dont support removing
 -- atm, so nothing to see here
-SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, compression_state, status
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix, num_dimensions, chunk_sizing_func_schema,  chunk_sizing_func_name, status
  from _timescaledb_catalog.hypertable WHERE table_name = 'test_drop';
 SELECT * FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_drop'::regclass;
 


### PR DESCRIPTION
Remove usage of compression_state and use status field of hypertable
instead for storing all status information.

Disable-check: force-changelog-file