### PR TITLE
Add recompress_unordered columnstore policy option

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -121,10 +121,12 @@ jobs:
           pip install --upgrade pip
           pip install black prospector pylint dodgy \
             mccabe pycodestyle pyflakes \
-            psutil pygithub pglast testgres more_itertools
+            psutil pygithub testgres more_itertools
           # pinning snowballstemmer to version 2.2.0 due to:
           # https://github.com/prospector-dev/prospector/issues/763
           pip install --force-reinstall --no-deps snowballstemmer==2.2.0
+          # pinning pglast due to build issues
+          pip install --force-reinstall --no-deps pglast==7.16
           pip list
           pip list --user
 

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -33,6 +33,8 @@ jobs:
         --proc-without-search-path '_timescaledb_internal.policy_compression(job_id integer,config jsonb)'
         --proc-without-search-path '_timescaledb_functions.policy_compression(job_id integer,config jsonb)'
         --proc-without-search-path '_timescaledb_functions.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean,reindex_enabled boolean,use_creation_time boolean)'
+        --proc-without-search-path 
+        '_timescaledb_functions.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean,reindex_enabled boolean,use_creation_time boolean,recompress_unordered boolean)'
         --proc-without-search-path '_timescaledb_functions.policy_compaction(job_id integer,config jsonb)'
 
     steps:

--- a/.unreleased/pr_10226
+++ b/.unreleased/pr_10226
@@ -1,0 +1,1 @@
+Implements: #10226 Add recompress_unordered columnstore policy option

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -136,7 +136,8 @@ _timescaledb_functions.policy_compression_execute(
   verbose_log         BOOLEAN,
   recompress_enabled  BOOLEAN,
   reindex_enabled     BOOLEAN,
-  use_creation_time   BOOLEAN
+  use_creation_time   BOOLEAN,
+  recompress_unordered BOOLEAN
 )
 AS $$
 DECLARE
@@ -151,6 +152,7 @@ DECLARE
   status_fully_compressed int := 1;
   -- chunk status bits:
   bit_uncompressed int := 0;
+  bit_unordered int := 2;
   bit_frozen int := 4;
   bit_compressed_partial int := 8;
   creation_lag INTERVAL := NULL;
@@ -195,6 +197,13 @@ BEGIN
     -- Checking for chunks which are not fully compressed and not frozen
     AND ch.status != status_fully_compressed
     AND ch.status & bit_frozen = 0
+    -- When recompress_unordered is off, skip unordered chunks unless they
+    -- are also partial, since partial chunks always need recompression.
+    AND (
+      recompress_unordered
+      OR ch.status & bit_unordered = 0
+      OR ch.status & bit_compressed_partial = bit_compressed_partial
+    )
   LOOP
     BEGIN
       IF chunk_rec.status = bit_uncompressed OR recompress_enabled IS TRUE THEN
@@ -283,6 +292,7 @@ DECLARE
   numchunks           INTEGER := 1;
   recompress_enabled  BOOL;
   reindex_enabled     BOOL;
+  recompress_unordered BOOL;
   use_creation_time   BOOL := FALSE;
 BEGIN
 
@@ -303,6 +313,7 @@ BEGIN
   maxchunks           := COALESCE(jsonb_object_field_text(config, 'maxchunks_to_compress')::INTEGER, 0);
   recompress_enabled  := COALESCE(jsonb_object_field_text(config, 'recompress')::BOOLEAN, TRUE);
   reindex_enabled     := COALESCE(jsonb_object_field_text(config, 'reindex')::BOOLEAN, TRUE);
+  recompress_unordered := COALESCE(jsonb_object_field_text(config, 'recompress_unordered')::BOOLEAN, TRUE);
 
   -- find primary dimension type --
   SELECT dim.column_type INTO dimtype
@@ -328,13 +339,13 @@ BEGIN
   -- execute the properly type casts for the lag value
   CASE dimtype
     WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype, 'DATE'::regtype, 'INTERVAL' ::regtype, 'UUID'::regtype THEN
-      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time);
+      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time, recompress_unordered);
     WHEN 'BIGINT'::regtype THEN
-      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::BIGINT, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time);
+      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::BIGINT, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time, recompress_unordered);
     WHEN 'INTEGER'::regtype THEN
-      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTEGER, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time);
+      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTEGER, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time, recompress_unordered);
     WHEN 'SMALLINT'::regtype THEN
-      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::SMALLINT, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time);
+      CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::SMALLINT, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time, recompress_unordered);
   END CASE;
   COMMIT;
 END;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,6 +1,8 @@
 
 DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_uncompressed_size(regclass);
 
+DROP PROCEDURE IF EXISTS _timescaledb_functions.policy_compression_execute(INTEGER, INTEGER, ANYELEMENT, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
+
 --
 -- BEGIN chunk.compressed_chunk_id no longer used
 --

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,6 +1,7 @@
 DROP FUNCTION IF EXISTS _timescaledb_functions.decompress_batch(record);
 DROP FUNCTION IF EXISTS _timescaledb_functions.estimate_uncompressed_size(regclass, double precision);
 DROP FUNCTION IF EXISTS _timescaledb_functions.compact_chunk(REGCLASS);
+DROP PROCEDURE IF EXISTS _timescaledb_functions.policy_compression_execute(INTEGER, INTEGER, ANYELEMENT, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
 
 --
 -- BEGIN compression status flag on hypertables

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -613,6 +613,19 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk, CHUNK_DECOMPRESS, true);
 	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
 
+	/*
+	 * The chunk is marked as compressed but its compressed relation is
+	 * missing. This can happen with a corrupted chunk status.
+	 */
+	if (!OidIsValid(compressed_relid))
+	{
+		ts_cache_release(&hcache);
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("chunk \"%s\" is missing its compressed relation",
+						get_rel_name(uncompressed_chunk->table_id))));
+	}
+
 	ereport(DEBUG1,
 			(errmsg("acquiring locks for converting to rowstore \"%s.%s\"",
 					NameStr(uncompressed_chunk->fd.schema_name),

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -857,9 +857,9 @@ SET client_min_messages TO ERROR;
 CALL run_job(:compressjob_id);
 ERROR:  columnstore policy failure
 DETAIL:  Failed to convert '31' chunks to columnstore. Successfully converted '0' chunks.
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean) line 119 at RAISE
-SQL statement "CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time)"
-PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 62 at CALL
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean,boolean) line 127 at RAISE
+SQL statement "CALL _timescaledb_functions.policy_compression_execute(job_id, htid, lag_value::INTERVAL, maxchunks, verbose_log, recompress_enabled, reindex_enabled, use_creation_time, recompress_unordered)"
+PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 64 at CALL
 \set VERBOSITY terse
 \set ON_ERROR_STOP 1
 -- 31 uncompressed chunks (0 - uncompressed, 1 - compressed)
@@ -877,3 +877,80 @@ ORDER BY 2 DESC;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REVOKE CREATE ON SCHEMA public FROM NOLOGIN_ROLE;
 DROP ROLE NOLOGIN_ROLE;
+--TEST 9
+-- recompress_unordered controls whether the policy touches unordered chunks,
+-- but partial chunks are always recompressed regardless of the setting
+CREATE TABLE test_recompress_unordered(time TIMESTAMPTZ, val SMALLINT);
+SELECT create_hypertable('test_recompress_unordered', 'time', chunk_time_interval => '1 day'::interval);
+            create_hypertable            
+-----------------------------------------
+ (13,public,test_recompress_unordered,t)
+
+ALTER TABLE test_recompress_unordered SET (timescaledb.compress, timescaledb.compress_segmentby = 'val', timescaledb.compress_orderby = 'time');
+INSERT INTO test_recompress_unordered SELECT time, (random()*10)::smallint
+FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-04 00:00'::timestamp, '10 min') AS time;
+-- compress every chunk so they all start fully compressed
+SET client_min_messages TO ERROR;
+SELECT count(compress_chunk(c)) FROM show_chunks('test_recompress_unordered') c;
+ count 
+-------
+     4
+
+-- turn one chunk unordered and another both unordered and partial through inserts.
+-- a direct compress insert that is not client sorted marks the chunk unordered;
+-- a following plain insert leaves uncompressed rows behind and marks it partial.
+SET timescaledb.enable_direct_compress_insert = true;
+SET timescaledb.enable_direct_compress_insert_client_sorted = false;
+INSERT INTO test_recompress_unordered
+SELECT '2018-12-01 00:05'::timestamptz + (i || ' second')::interval, 1 FROM generate_series(1, 50) i;
+INSERT INTO test_recompress_unordered
+SELECT '2018-12-02 00:05'::timestamptz + (i || ' second')::interval, 1 FROM generate_series(1, 50) i;
+SET timescaledb.enable_direct_compress_insert = false;
+INSERT INTO test_recompress_unordered VALUES ('2018-12-02 00:06', 1);
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+SET client_min_messages TO NOTICE;
+SELECT c.status, count(*)
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable h ON h.id = c.hypertable_id
+WHERE h.table_name = 'test_recompress_unordered'
+GROUP BY c.status ORDER BY c.status;
+ status | count 
+--------+-------
+      1 |     2
+      3 |     1
+     11 |     1
+
+SELECT add_compression_policy('test_recompress_unordered', '1 minute'::interval) AS unordered_job \gset
+SELECT config AS unordered_config FROM _timescaledb_catalog.bgw_job WHERE id = :unordered_job \gset
+-- with recompress_unordered off, the unordered chunk is left untouched but the
+-- partial chunk is still recompressed
+SELECT FROM alter_job(:unordered_job, config => jsonb_set(:'unordered_config'::jsonb, '{recompress_unordered}', 'false'));
+--
+
+CALL run_job(:unordered_job);
+SELECT c.status, count(*)
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable h ON h.id = c.hypertable_id
+WHERE h.table_name = 'test_recompress_unordered'
+GROUP BY c.status ORDER BY c.status;
+ status | count 
+--------+-------
+      1 |     2
+      3 |     2
+
+-- default behaviour recompresses the remaining unordered chunk
+SELECT FROM alter_job(:unordered_job, config => jsonb_set(:'unordered_config'::jsonb, '{recompress_unordered}', 'true'));
+--
+
+CALL run_job(:unordered_job);
+SELECT c.status, count(*)
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable h ON h.id = c.hypertable_id
+WHERE h.table_name = 'test_recompress_unordered'
+GROUP BY c.status ORDER BY c.status;
+ status | count 
+--------+-------
+      1 |     4
+
+DROP TABLE test_recompress_unordered;

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -528,7 +528,7 @@ SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :compressjob_id;
 --should fail
 CALL run_job(:compressjob_id);
 ERROR:  job 1000 config must have compress_after or compress_created_before
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 50 at RAISE
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 52 at RAISE
 SELECT remove_compression_policy('test_table_int');
  remove_compression_policy 
 ---------------------------
@@ -548,7 +548,7 @@ SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :compressjob_id;
 --should fail
 CALL run_job(:compressjob_id);
 ERROR:  job 1001 config must have hypertable_id
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 30 at RAISE
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 31 at RAISE
 UPDATE _timescaledb_catalog.bgw_job
 SET config = NULL
 WHERE id = :compressjob_id;
@@ -560,7 +560,7 @@ SELECT config FROM _timescaledb_catalog.bgw_job WHERE id = :compressjob_id;
 --should fail
 CALL run_job(:compressjob_id);
 ERROR:  job 1001 has null config
-CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 25 at RAISE
+CONTEXT:  PL/pgSQL function _timescaledb_functions.policy_compression(integer,jsonb) line 26 at RAISE
 -- test ADD COLUMN IF NOT EXISTS
 CREATE TABLE metric (time TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, dev_id INT4 NOT NULL);
 SELECT create_hypertable('metric', 'time', 'dev_id', 10);

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -110,7 +110,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.policy_compaction_check(jsonb)
  _timescaledb_functions.policy_compression(integer,jsonb)
  _timescaledb_functions.policy_compression_check(jsonb)
- _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean)
+ _timescaledb_functions.policy_compression_execute(integer,integer,anyelement,integer,boolean,boolean,boolean,boolean,boolean)
  _timescaledb_functions.policy_job_stat_history_retention(integer,jsonb)
  _timescaledb_functions.policy_job_stat_history_retention_check(jsonb)
  _timescaledb_functions.policy_recompression(integer,jsonb)

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -431,3 +431,64 @@ ORDER BY 2 DESC;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 REVOKE CREATE ON SCHEMA public FROM NOLOGIN_ROLE;
 DROP ROLE NOLOGIN_ROLE;
+
+--TEST 9
+-- recompress_unordered controls whether the policy touches unordered chunks,
+-- but partial chunks are always recompressed regardless of the setting
+CREATE TABLE test_recompress_unordered(time TIMESTAMPTZ, val SMALLINT);
+SELECT create_hypertable('test_recompress_unordered', 'time', chunk_time_interval => '1 day'::interval);
+ALTER TABLE test_recompress_unordered SET (timescaledb.compress, timescaledb.compress_segmentby = 'val', timescaledb.compress_orderby = 'time');
+
+INSERT INTO test_recompress_unordered SELECT time, (random()*10)::smallint
+FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-04 00:00'::timestamp, '10 min') AS time;
+
+-- compress every chunk so they all start fully compressed
+SET client_min_messages TO ERROR;
+SELECT count(compress_chunk(c)) FROM show_chunks('test_recompress_unordered') c;
+
+-- turn one chunk unordered and another both unordered and partial through inserts.
+-- a direct compress insert that is not client sorted marks the chunk unordered;
+-- a following plain insert leaves uncompressed rows behind and marks it partial.
+SET timescaledb.enable_direct_compress_insert = true;
+SET timescaledb.enable_direct_compress_insert_client_sorted = false;
+INSERT INTO test_recompress_unordered
+SELECT '2018-12-01 00:05'::timestamptz + (i || ' second')::interval, 1 FROM generate_series(1, 50) i;
+INSERT INTO test_recompress_unordered
+SELECT '2018-12-02 00:05'::timestamptz + (i || ' second')::interval, 1 FROM generate_series(1, 50) i;
+SET timescaledb.enable_direct_compress_insert = false;
+INSERT INTO test_recompress_unordered VALUES ('2018-12-02 00:06', 1);
+RESET timescaledb.enable_direct_compress_insert;
+RESET timescaledb.enable_direct_compress_insert_client_sorted;
+SET client_min_messages TO NOTICE;
+
+SELECT c.status, count(*)
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable h ON h.id = c.hypertable_id
+WHERE h.table_name = 'test_recompress_unordered'
+GROUP BY c.status ORDER BY c.status;
+
+SELECT add_compression_policy('test_recompress_unordered', '1 minute'::interval) AS unordered_job \gset
+SELECT config AS unordered_config FROM _timescaledb_catalog.bgw_job WHERE id = :unordered_job \gset
+
+-- with recompress_unordered off, the unordered chunk is left untouched but the
+-- partial chunk is still recompressed
+SELECT FROM alter_job(:unordered_job, config => jsonb_set(:'unordered_config'::jsonb, '{recompress_unordered}', 'false'));
+CALL run_job(:unordered_job);
+
+SELECT c.status, count(*)
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable h ON h.id = c.hypertable_id
+WHERE h.table_name = 'test_recompress_unordered'
+GROUP BY c.status ORDER BY c.status;
+
+-- default behaviour recompresses the remaining unordered chunk
+SELECT FROM alter_job(:unordered_job, config => jsonb_set(:'unordered_config'::jsonb, '{recompress_unordered}', 'true'));
+CALL run_job(:unordered_job);
+
+SELECT c.status, count(*)
+FROM _timescaledb_catalog.chunk c
+JOIN _timescaledb_catalog.hypertable h ON h.id = c.hypertable_id
+WHERE h.table_name = 'test_recompress_unordered'
+GROUP BY c.status ORDER BY c.status;
+
+DROP TABLE test_recompress_unordered;


### PR DESCRIPTION
The columnstore policy recompresses every unordered chunk it finds, which rewrites the whole chunk and can be expensive. Add a recompress_unordered flag so a policy can keep compressing new and partial chunks while leaving unordered chunks alone.

Partial chunks are always recompressed, even when they also carry the unordered status, since the appended data still needs to be compressed. Only chunks that are unordered and not partial are skipped.

The flag lives in the job config and defaults to true, matching the current behavior.