### PR TITLE
Batch filtering for compressed DML should respect collation

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -73,6 +73,7 @@ jobs:
           compress_observ-*
           compress_qualpushdown_saop
           compress_sort_transform
+          compressed_collation
           compression_allocation
           merge_append_partially_compressed
           net

--- a/.unreleased/pr_10230
+++ b/.unreleased/pr_10230
@@ -1,0 +1,1 @@
+Fixes: #10230 Batch filtering for compressed DML should respect collation

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -2050,7 +2050,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 										   var->varattno,
 										   op_strategy,
 										   arg_value->consttype,
-										   arg_value->constcollid,
+										   collation, /* need to use OpExpr input collation */
 										   opcode,
 										   arg_value->constisnull ? 0 : arg_value->constvalue);
 				}

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -149,3 +149,38 @@ select name from t9998 order by name collate "C";
  a
 
 drop table t9998 cascade;
+-- Test issue #9997: batch filtering for compressed DML should respect collation
+create collation case_insensitive_icu
+    (provider=icu, locale='und-u-ks-level2', deterministic=false);
+create table t9997 (
+    ts    timestamptz not null,
+    actor text collate case_insensitive_icu,
+    note  int
+);
+select count(*) from create_hypertable('t9997', 'ts');
+ count 
+-------
+     1
+
+alter table t9997 set (timescaledb.compress);
+insert into t9997 values ('2024-01-01', 'alice', 1);
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('t9997') chunk_name;
+ count 
+-------
+     1
+
+-- SELECT respects the collation, returns 1 row
+select note from t9997 where actor = 'ALICE';
+ note 
+------
+    1
+
+-- UPDATE respects the collation, updates 1 row
+update t9997 set note = 99 where actor = 'ALICE';
+select note from t9997 where actor = 'ALICE';
+ note 
+------
+   99
+
+drop table t9997 cascade;
+drop collation case_insensitive_icu;

--- a/tsl/test/sql/compressed_collation.sql
+++ b/tsl/test/sql/compressed_collation.sql
@@ -122,3 +122,29 @@ select count(compress_chunk(ch)) from show_chunks('t9998') ch;
 select name from t9998 order by name collate "C";
 
 drop table t9998 cascade;
+
+-- Test issue #9997: batch filtering for compressed DML should respect collation
+create collation case_insensitive_icu
+    (provider=icu, locale='und-u-ks-level2', deterministic=false);
+
+create table t9997 (
+    ts    timestamptz not null,
+    actor text collate case_insensitive_icu,
+    note  int
+);
+select count(*) from create_hypertable('t9997', 'ts');
+alter table t9997 set (timescaledb.compress);
+
+insert into t9997 values ('2024-01-01', 'alice', 1);
+
+SELECT count(compress_chunk(chunk_name)) FROM show_chunks('t9997') chunk_name;
+
+-- SELECT respects the collation, returns 1 row
+select note from t9997 where actor = 'ALICE';
+
+-- UPDATE respects the collation, updates 1 row
+update t9997 set note = 99 where actor = 'ALICE';
+select note from t9997 where actor = 'ALICE';
+
+drop table t9997 cascade;
+drop collation case_insensitive_icu;


### PR DESCRIPTION
Fixes #9997