### PR TITLE
Fix atomic val alignment on i386

### DIFF
--- a/src/ts_stats/ts_stats_srf.c
+++ b/src/ts_stats/ts_stats_srf.c
@@ -12,6 +12,7 @@
 #include <funcapi.h>
 #include <miscadmin.h>
 #include <utils/builtins.h>
+#include <utils/palloc.h>
 #include <utils/timestamp.h>
 #include <utils/tuplestore.h>
 
@@ -153,8 +154,8 @@ ts_stats_chunks(PG_FUNCTION_ARGS)
 		else
 		{
 			/* safe to read, take a snapshot */
-			slot_snap = palloc(sizeof(TsStatsChunk));
-			meta_snap = palloc(sizeof(TsStatsChunkMetadata));
+			slot_snap = palloc_aligned(sizeof(TsStatsChunk), 8, 0);
+			meta_snap = palloc_aligned(sizeof(TsStatsChunkMetadata), 8, 0);
 			memcpy(slot_snap, slot, sizeof(TsStatsChunk));
 			memcpy(meta_snap, meta, sizeof(TsStatsChunkMetadata));
 			snap_count = 1;
@@ -163,8 +164,8 @@ ts_stats_chunks(PG_FUNCTION_ARGS)
 	else if (uncomp_filter)
 	{
 		/* Linear scan of the metadata matching uncompressed_relid, but only one  */
-		slot_snap = palloc(sizeof(TsStatsChunk));
-		meta_snap = palloc(sizeof(TsStatsChunkMetadata));
+		slot_snap = palloc_aligned(sizeof(TsStatsChunk), 8, 0);
+		meta_snap = palloc_aligned(sizeof(TsStatsChunkMetadata), 8, 0);
 		retry_map = palloc0(sizeof(bool) * seg->num_slots);
 
 		for (uint32 i = 0; i < seg->num_slots; i++)
@@ -221,8 +222,8 @@ ts_stats_chunks(PG_FUNCTION_ARGS)
 	else
 	{
 		/* full scan in slot order. check since timestamp if needed. */
-		slot_snap = palloc(sizeof(TsStatsChunk) * seg->num_slots);
-		meta_snap = palloc(sizeof(TsStatsChunkMetadata) * seg->num_slots);
+		slot_snap = palloc_aligned(sizeof(TsStatsChunk) * seg->num_slots, 8, 0);
+		meta_snap = palloc_aligned(sizeof(TsStatsChunkMetadata) * seg->num_slots, 8, 0);
 		retry_map = palloc0(sizeof(bool) * seg->num_slots);
 
 		for (uint32 i = 0; i < seg->num_slots; i++)

--- a/tsl/test/expected/compress_stats.out
+++ b/tsl/test/expected/compress_stats.out
@@ -1,0 +1,539 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- This is the sister of the compress_observ test. The difference
+-- here is that the test displays a minimal set of platform and
+-- PG version independent values.
+CREATE TABLE t(ts timestamptz, a int, b int, c int, d int, seg int);
+SELECT create_hypertable('t', by_range('ts', interval '1 day'));
+ create_hypertable 
+-------------------
+ (1,t)
+
+CREATE VIEW observ AS
+SELECT
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_sum,             compressed_batch_rows_sqsum,
+      -- op counters
+      n_selects, n_inserts, n_updates, n_deletes
+      -- skip the below two for test stability:
+      -- first_update,
+      -- last_update
+FROM
+(
+      SELECT * FROM _timescaledb_functions.chunk_statistics()
+      ORDER BY last_update ASC, compressed_relid ASC, uncompressed_relid ASC
+) sub;
+CREATE VIEW observ_main_view AS
+SELECT
+      chunk,  compressed_chunk, hypertable,
+      -- compression stats
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev,
+      -- op counters
+      n_selects, n_inserts, n_updates, n_deletes
+      -- these will make the test flaky, so skip them:
+      -- first_update,
+      -- last_update
+FROM
+(
+      SELECT *
+      FROM timescaledb_information.stat_chunk_activity
+      ORDER BY last_update ASC, hypertable_id ASC, chunk_id ASC
+) sub;
+-- Initial config: bloom(a,b)
+ALTER TABLE t SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b), bloom(d)'
+);
+INSERT INTO t
+SELECT ts, (i % 10), (i % 5), (i % 3), i, 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+\pset expanded on
+SELECT compress_chunk(c) FROM show_chunks('t') c;
+-[ RECORD 1 ]--+---------------------------------------
+compress_chunk | _timescaledb_internal._hyper_1_1_chunk
+-[ RECORD 2 ]--+---------------------------------------
+compress_chunk | _timescaledb_internal._hyper_1_2_chunk
+-[ RECORD 3 ]--+---------------------------------------
+compress_chunk | _timescaledb_internal._hyper_1_3_chunk
+
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 0
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 0
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 0
+
+SELECT COUNT(*) FROM t;
+-[ RECORD 1 ]
+count | 4900
+
+SELECT count(*),min(ts),max(ts) from t where a % 19 = 9 or b % 19 = 9 or c % 19 = 2 or seg % 19 = 2;
+-[ RECORD 1 ]-----------------------
+count | 1960
+min   | Mon Jan 01 00:00:00 2024 PST
+max   | Wed Jan 03 00:00:00 2024 PST
+
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 0
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 0
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 0
+
+-- Test DELETE stats
+BEGIN;
+DELETE FROM t WHERE a % 19 = 2;
+ROLLBACK;
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 1
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 1
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 1
+
+-- Test UPDATE stats
+BEGIN;
+UPDATE t SET a = 42 WHERE a % 19 = 2;
+ROLLBACK;
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 1
+n_deletes                   | 1
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 1
+n_deletes                   | 1
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 1
+n_inserts                   | 0
+n_updates                   | 1
+n_deletes                   | 1
+
+-- Show the information schema view as well:
+SELECT * FROM observ_main_view;
+-[ RECORD 1 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_1_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_1_chunk_compressed
+hypertable                   | t
+compressed_batch_count       | 2
+compressed_block_count       | 10
+compressed_batch_rows_min    | 600
+compressed_batch_rows_max    | 1000
+compressed_batch_rows_avg    | 800
+compressed_batch_rows_stddev | 200
+n_selects                    | 1
+n_inserts                    | 0
+n_updates                    | 1
+n_deletes                    | 1
+-[ RECORD 2 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_2_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_2_chunk_compressed
+hypertable                   | t
+compressed_batch_count       | 3
+compressed_block_count       | 15
+compressed_batch_rows_min    | 400
+compressed_batch_rows_max    | 1000
+compressed_batch_rows_avg    | 800
+compressed_batch_rows_stddev | 282.842712474619
+n_selects                    | 1
+n_inserts                    | 0
+n_updates                    | 1
+n_deletes                    | 1
+-[ RECORD 3 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_3_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_3_chunk_compressed
+hypertable                   | t
+compressed_batch_count       | 1
+compressed_block_count       | 5
+compressed_batch_rows_min    | 900
+compressed_batch_rows_max    | 900
+compressed_batch_rows_avg    | 900
+compressed_batch_rows_stddev | 0
+n_selects                    | 1
+n_inserts                    | 0
+n_updates                    | 1
+n_deletes                    | 1
+
+-- Reset the stats and check how we re-populate them as we select from the chunk again:
+SELECT _timescaledb_functions.chunk_statistics_reset();
+-[ RECORD 1 ]----------+-
+chunk_statistics_reset | 
+
+SELECT count(*) FROM t where a % 19 = 9;
+-[ RECORD 1 ]
+count | 490
+
+-- Only care about compression stats here:
+SELECT
+      chunk,                                 compressed_chunk,
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev
+FROM observ_main_view;
+-[ RECORD 1 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_1_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_1_chunk_compressed
+compressed_batch_count       | 2
+compressed_block_count       | 2
+compressed_batch_rows_min    | 600
+compressed_batch_rows_max    | 1000
+compressed_batch_rows_avg    | 800
+compressed_batch_rows_stddev | 200
+-[ RECORD 2 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_2_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_2_chunk_compressed
+compressed_batch_count       | 3
+compressed_block_count       | 3
+compressed_batch_rows_min    | 400
+compressed_batch_rows_max    | 1000
+compressed_batch_rows_avg    | 800
+compressed_batch_rows_stddev | 282.842712474619
+-[ RECORD 3 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_3_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_3_chunk_compressed
+compressed_batch_count       | 0
+compressed_block_count       | 1
+compressed_batch_rows_min    | 
+compressed_batch_rows_max    | 
+compressed_batch_rows_avg    | 
+compressed_batch_rows_stddev | 
+
+-- Select more and check how things change:
+SELECT count(*),min(ts),max(ts) from t where a % 19 = 9 or b % 19 = 9 or c % 19 = 2 or seg % 19 = 2;
+-[ RECORD 1 ]-----------------------
+count | 1960
+min   | Mon Jan 01 00:00:00 2024 PST
+max   | Wed Jan 03 00:00:00 2024 PST
+
+SELECT
+      chunk,                                 compressed_chunk,
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev
+FROM observ_main_view;
+-[ RECORD 1 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_1_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_1_chunk_compressed
+compressed_batch_count       | 2
+compressed_block_count       | 8
+compressed_batch_rows_min    | 600
+compressed_batch_rows_max    | 1000
+compressed_batch_rows_avg    | 800
+compressed_batch_rows_stddev | 200
+-[ RECORD 2 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_2_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_2_chunk_compressed
+compressed_batch_count       | 3
+compressed_block_count       | 12
+compressed_batch_rows_min    | 400
+compressed_batch_rows_max    | 1000
+compressed_batch_rows_avg    | 800
+compressed_batch_rows_stddev | 282.842712474619
+-[ RECORD 3 ]----------------+--------------------------------------------------
+chunk                        | _timescaledb_internal._hyper_1_3_chunk
+compressed_chunk             | _timescaledb_internal._hyper_1_3_chunk_compressed
+compressed_batch_count       | 0
+compressed_block_count       | 4
+compressed_batch_rows_min    | 
+compressed_batch_rows_max    | 
+compressed_batch_rows_avg    | 
+compressed_batch_rows_stddev | 
+
+-- The stats should be evicted after we decompress and thus throwing away
+-- the compressed chunks.
+SELECT decompress_chunk(c) FROM show_chunks('t') c;
+-[ RECORD 1 ]----+---------------------------------------
+decompress_chunk | _timescaledb_internal._hyper_1_1_chunk
+-[ RECORD 2 ]----+---------------------------------------
+decompress_chunk | _timescaledb_internal._hyper_1_2_chunk
+-[ RECORD 3 ]----+---------------------------------------
+decompress_chunk | _timescaledb_internal._hyper_1_3_chunk
+
+-- This should be empty after the decompression
+SELECT
+      chunk,                                 compressed_chunk,
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev
+FROM observ_main_view;
+
+-- Re-compress before doing the bloom tests
+SELECT compress_chunk(c) FROM show_chunks('t') c;
+-[ RECORD 1 ]--+---------------------------------------
+compress_chunk | _timescaledb_internal._hyper_1_1_chunk
+-[ RECORD 2 ]--+---------------------------------------
+compress_chunk | _timescaledb_internal._hyper_1_2_chunk
+-[ RECORD 3 ]--+---------------------------------------
+compress_chunk | _timescaledb_internal._hyper_1_3_chunk
+
+-- Test DELETE stats with bloom filter matches
+BEGIN;
+DELETE FROM t WHERE a = 7 AND b = 2;
+ROLLBACK;
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 1
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 1
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 1
+
+-- Test DELETE stats with bloom filter misses
+BEGIN;
+DELETE FROM t WHERE d = 200;
+ROLLBACK;
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 2
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 2
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 0
+n_deletes                   | 2
+
+-- Test UPDATE stats with bloom filter matches
+BEGIN;
+UPDATE t SET a = 42 WHERE a = 7 AND b = 2;
+ROLLBACK;
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 1
+n_deletes                   | 2
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 1
+n_deletes                   | 2
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 1
+n_deletes                   | 2
+
+-- Test UPDATE stats with bloom filter misses
+BEGIN;
+UPDATE t SET a = 42 WHERE d = 200;
+ROLLBACK;
+SELECT * FROM observ; -- see view definition above
+-[ RECORD 1 ]---------------+--------
+compressed_batch_count      | 2
+compressed_block_count      | 10
+compressed_batch_rows_min   | 600
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 1600
+compressed_batch_rows_sqsum | 1360000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 2
+n_deletes                   | 2
+-[ RECORD 2 ]---------------+--------
+compressed_batch_count      | 3
+compressed_block_count      | 15
+compressed_batch_rows_min   | 400
+compressed_batch_rows_max   | 1000
+compressed_batch_rows_sum   | 2400
+compressed_batch_rows_sqsum | 2160000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 2
+n_deletes                   | 2
+-[ RECORD 3 ]---------------+--------
+compressed_batch_count      | 1
+compressed_block_count      | 5
+compressed_batch_rows_min   | 900
+compressed_batch_rows_max   | 900
+compressed_batch_rows_sum   | 900
+compressed_batch_rows_sqsum | 810000
+n_selects                   | 0
+n_inserts                   | 0
+n_updates                   | 2
+n_deletes                   | 2
+
+DROP VIEW observ;
+DROP VIEW observ_main_view;
+DROP TABLE t;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TEST_FILES
     compress_qualpushdown_saop.sql
     compress_sort_transform.sql
     compress_sparse_config.sql
+    compress_stats.sql
     compress_unordered_sort.sql
     compressed_collation.sql
     compressed_detoaster.sql

--- a/tsl/test/sql/compress_stats.sql
+++ b/tsl/test/sql/compress_stats.sql
@@ -1,0 +1,156 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- This is the sister of the compress_observ test. The difference
+-- here is that the test displays a minimal set of platform and
+-- PG version independent values.
+
+CREATE TABLE t(ts timestamptz, a int, b int, c int, d int, seg int);
+SELECT create_hypertable('t', by_range('ts', interval '1 day'));
+
+CREATE VIEW observ AS
+SELECT
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_sum,             compressed_batch_rows_sqsum,
+      -- op counters
+      n_selects, n_inserts, n_updates, n_deletes
+      -- skip the below two for test stability:
+      -- first_update,
+      -- last_update
+FROM
+(
+      SELECT * FROM _timescaledb_functions.chunk_statistics()
+      ORDER BY last_update ASC, compressed_relid ASC, uncompressed_relid ASC
+) sub;
+
+CREATE VIEW observ_main_view AS
+SELECT
+      chunk,  compressed_chunk, hypertable,
+      -- compression stats
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev,
+      -- op counters
+      n_selects, n_inserts, n_updates, n_deletes
+      -- these will make the test flaky, so skip them:
+      -- first_update,
+      -- last_update
+FROM
+(
+      SELECT *
+      FROM timescaledb_information.stat_chunk_activity
+      ORDER BY last_update ASC, hypertable_id ASC, chunk_id ASC
+) sub;
+
+-- Initial config: bloom(a,b)
+ALTER TABLE t SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'ts',
+    timescaledb.compress_index = 'bloom(a,b), bloom(d)'
+);
+
+INSERT INTO t
+SELECT ts, (i % 10), (i % 5), (i % 3), i, 1
+FROM generate_series('2024-01-01'::timestamptz, '2024-01-03', interval '1 hour') ts,
+     generate_series(1, 100) i;
+
+\pset expanded on
+
+SELECT compress_chunk(c) FROM show_chunks('t') c;
+
+SELECT * FROM observ; -- see view definition above
+
+SELECT COUNT(*) FROM t;
+SELECT count(*),min(ts),max(ts) from t where a % 19 = 9 or b % 19 = 9 or c % 19 = 2 or seg % 19 = 2;
+
+SELECT * FROM observ; -- see view definition above
+
+-- Test DELETE stats
+BEGIN;
+DELETE FROM t WHERE a % 19 = 2;
+ROLLBACK;
+
+SELECT * FROM observ; -- see view definition above
+
+-- Test UPDATE stats
+BEGIN;
+UPDATE t SET a = 42 WHERE a % 19 = 2;
+ROLLBACK;
+
+SELECT * FROM observ; -- see view definition above
+
+-- Show the information schema view as well:
+SELECT * FROM observ_main_view;
+
+-- Reset the stats and check how we re-populate them as we select from the chunk again:
+SELECT _timescaledb_functions.chunk_statistics_reset();
+SELECT count(*) FROM t where a % 19 = 9;
+
+-- Only care about compression stats here:
+SELECT
+      chunk,                                 compressed_chunk,
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev
+FROM observ_main_view;
+
+-- Select more and check how things change:
+SELECT count(*),min(ts),max(ts) from t where a % 19 = 9 or b % 19 = 9 or c % 19 = 2 or seg % 19 = 2;
+
+SELECT
+      chunk,                                 compressed_chunk,
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev
+FROM observ_main_view;
+
+-- The stats should be evicted after we decompress and thus throwing away
+-- the compressed chunks.
+SELECT decompress_chunk(c) FROM show_chunks('t') c;
+
+-- This should be empty after the decompression
+SELECT
+      chunk,                                 compressed_chunk,
+      compressed_batch_count,                compressed_block_count,
+      compressed_batch_rows_min,             compressed_batch_rows_max,
+      compressed_batch_rows_avg,             compressed_batch_rows_stddev
+FROM observ_main_view;
+
+-- Re-compress before doing the bloom tests
+SELECT compress_chunk(c) FROM show_chunks('t') c;
+
+-- Test DELETE stats with bloom filter matches
+BEGIN;
+DELETE FROM t WHERE a = 7 AND b = 2;
+ROLLBACK;
+
+SELECT * FROM observ; -- see view definition above
+
+-- Test DELETE stats with bloom filter misses
+BEGIN;
+DELETE FROM t WHERE d = 200;
+ROLLBACK;
+
+SELECT * FROM observ; -- see view definition above
+
+-- Test UPDATE stats with bloom filter matches
+BEGIN;
+UPDATE t SET a = 42 WHERE a = 7 AND b = 2;
+ROLLBACK;
+
+SELECT * FROM observ; -- see view definition above
+
+-- Test UPDATE stats with bloom filter misses
+BEGIN;
+UPDATE t SET a = 42 WHERE d = 200;
+ROLLBACK;
+
+SELECT * FROM observ; -- see view definition above
+
+
+DROP VIEW observ;
+DROP VIEW observ_main_view;
+DROP TABLE t;


### PR DESCRIPTION
The palloc alignment is not guaranteed to be 8 bytes on i386 which caused problems reading 64bit atomic values.

Disable-check: force-changelog-file