### PR TITLE
Stabilize unit test for collation fix in PR10230

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -73,7 +73,6 @@ jobs:
           compress_observ-*
           compress_qualpushdown_saop
           compress_sort_transform
-          compressed_collation
           compression_allocation
           merge_append_partially_compressed
           net

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -150,11 +150,9 @@ select name from t9998 order by name collate "C";
 
 drop table t9998 cascade;
 -- Test issue #9997: batch filtering for compressed DML should respect collation
-create collation case_insensitive_icu
-    (provider=icu, locale='und-u-ks-level2', deterministic=false);
 create table t9997 (
     ts    timestamptz not null,
-    actor text collate case_insensitive_icu,
+    actor text collate :"COLLATION",
     note  int
 );
 select count(*) from create_hypertable('t9997', 'ts');
@@ -169,18 +167,17 @@ SELECT count(compress_chunk(chunk_name)) FROM show_chunks('t9997') chunk_name;
 -------
      1
 
--- SELECT respects the collation, returns 1 row
-select note from t9997 where actor = 'ALICE';
+-- SELECT respects different collation, returns 1 row
+select note from t9997 where actor = 'alice' collate "C";
  note 
 ------
     1
 
--- UPDATE respects the collation, updates 1 row
-update t9997 set note = 99 where actor = 'ALICE';
-select note from t9997 where actor = 'ALICE';
+-- UPDATE respects different collation, updates 1 row
+update t9997 set note = 99 where actor = 'alice' collate "C";
+select note from t9997 where actor = 'alice' collate "C";
  note 
 ------
    99
 
 drop table t9997 cascade;
-drop collation case_insensitive_icu;

--- a/tsl/test/sql/compressed_collation.sql
+++ b/tsl/test/sql/compressed_collation.sql
@@ -124,12 +124,9 @@ select name from t9998 order by name collate "C";
 drop table t9998 cascade;
 
 -- Test issue #9997: batch filtering for compressed DML should respect collation
-create collation case_insensitive_icu
-    (provider=icu, locale='und-u-ks-level2', deterministic=false);
-
 create table t9997 (
     ts    timestamptz not null,
-    actor text collate case_insensitive_icu,
+    actor text collate :"COLLATION",
     note  int
 );
 select count(*) from create_hypertable('t9997', 'ts');
@@ -139,12 +136,11 @@ insert into t9997 values ('2024-01-01', 'alice', 1);
 
 SELECT count(compress_chunk(chunk_name)) FROM show_chunks('t9997') chunk_name;
 
--- SELECT respects the collation, returns 1 row
-select note from t9997 where actor = 'ALICE';
+-- SELECT respects different collation, returns 1 row
+select note from t9997 where actor = 'alice' collate "C";
 
--- UPDATE respects the collation, updates 1 row
-update t9997 set note = 99 where actor = 'ALICE';
-select note from t9997 where actor = 'ALICE';
+-- UPDATE respects different collation, updates 1 row
+update t9997 set note = 99 where actor = 'alice' collate "C";
+select note from t9997 where actor = 'alice' collate "C";
 
 drop table t9997 cascade;
-drop collation case_insensitive_icu;


### PR DESCRIPTION
Disable-check: force-changelog-file

We need to reliably build CI configurations with ICU support before we can test ICU-provided non-deterministic collations. Until then the unit test for #10230 will be using different default collations in the equality predicate to test the fix. 