### PR TITLE
Add timescaledb.direct_compress hypertable option

### DIFF
--- a/.unreleased/pr_10240
+++ b/.unreleased/pr_10240
@@ -1,0 +1,1 @@
+Implements: #10240 Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings.

--- a/src/copy.c
+++ b/src/copy.c
@@ -828,7 +828,7 @@ choose_copy_method(Hypertable *ht, CopyChunkState *ccstate, ResultRelInfo *resul
 		ereport(DEBUG1,
 				(errmsg("Using normal unbuffered copy operation (TS_CIM_SINGLE) "
 						"because triggers are defined on the destination table.")));
-		if (ts_guc_enable_direct_compress_copy)
+		if (ts_guc_enable_direct_compress_copy || TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(ht))
 		{
 			ereport(WARNING,
 					(errmsg("disabling direct compress copy due to presence of triggers on the "
@@ -837,7 +837,8 @@ choose_copy_method(Hypertable *ht, CopyChunkState *ccstate, ResultRelInfo *resul
 		return TS_CIM_SINGLE;
 	}
 
-	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht) && ts_guc_enable_direct_compress_copy)
+	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht) &&
+		(ts_guc_enable_direct_compress_copy || TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(ht)))
 	{
 		if (ts_indexing_relation_has_primary_or_unique_index(ccstate->rel))
 		{

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2408,8 +2408,17 @@ ts_hypertable_status_text(PG_FUNCTION_ARGS)
 								  CurrentMemoryContext);
 	}
 
+	if (status & HYPERTABLE_STATUS_DIRECT_COMPRESS)
+	{
+		astate = accumArrayResult(astate,
+								  CStringGetTextDatum("DIRECT_COMPRESS"),
+								  false,
+								  TEXTOID,
+								  CurrentMemoryContext);
+	}
+
 	if (status < 0 || status > (HYPERTABLE_STATUS_OSM | HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS |
-								HYPERTABLE_STATUS_COMPRESSION))
+								HYPERTABLE_STATUS_COMPRESSION | HYPERTABLE_STATUS_DIRECT_COMPRESS))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -2417,6 +2426,20 @@ ts_hypertable_status_text(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_DATUM(makeArrayResult(astate, CurrentMemoryContext));
+}
+
+/* Mark the hypertable as having opted into direct compress. */
+bool
+ts_hypertable_set_direct_compress(Hypertable *ht)
+{
+	return ts_hypertable_add_status(ht, HYPERTABLE_STATUS_DIRECT_COMPRESS);
+}
+
+/* Clear the direct compress status flag on the hypertable. */
+bool
+ts_hypertable_unset_direct_compress(Hypertable *ht)
+{
+	return ts_hypertable_clear_status(ht, HYPERTABLE_STATUS_DIRECT_COMPRESS);
 }
 
 DimensionSlice *

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -52,6 +52,9 @@ typedef struct ChunkRangeSpace ChunkRangeSpace;
 #define TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht)                                                  \
 	(((ht)->fd.status & HYPERTABLE_STATUS_COMPRESSION) != 0)
 
+#define TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(ht)                                              \
+	(((ht)->fd.status & HYPERTABLE_STATUS_DIRECT_COMPRESS) != 0)
+
 typedef struct Hypertable
 {
 	FormData_hypertable fd;
@@ -148,6 +151,8 @@ extern bool ts_is_partitioning_column(const Hypertable *ht, AttrNumber column_at
 extern bool ts_is_partitioning_column_name(const Hypertable *ht, NameData column_name);
 extern TSDLLEXPORT bool ts_hypertable_set_compression(Hypertable *ht);
 extern TSDLLEXPORT bool ts_hypertable_unset_compression(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_set_direct_compress(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_unset_direct_compress(Hypertable *ht);
 extern TSDLLEXPORT bool ts_hypertable_set_compress_interval(Hypertable *ht,
 															int64 compress_interval);
 extern TSDLLEXPORT int64 ts_hypertable_get_open_dim_max_value(const Hypertable *ht,

--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -32,14 +32,14 @@ should_use_direct_compress(ModifyHypertableState *state)
 		return false;
 	}
 
-	if (!ts_guc_enable_direct_compress_insert)
-	{
-		return false;
-	}
-
 	ModifyTableState *mtstate = linitial_node(ModifyTableState, state->cscan_state.custom_ps);
 	ResultRelInfo *resultRelInfo = mtstate->resultRelInfo;
 	Hypertable *ht = state->ctr->hypertable;
+
+	if (!ts_guc_enable_direct_compress_insert && !TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(ht))
+	{
+		return false;
+	}
 
 	if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 	{

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -5639,7 +5639,9 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 		!parse_results[AlterTableFlagOrderBy].is_default ||
 		!parse_results[AlterTableFlagSegmentBy].is_default ||
 		!parse_results[AlterTableFlagCompressChunkTimeInterval].is_default ||
-		!parse_results[AlterTableFlagIndex].is_default)
+		!parse_results[AlterTableFlagIndex].is_default ||
+		!parse_results[AlterTableFlagDirectCompress].is_default ||
+		!parse_results[AlterTableFlagDirectCompressScheduleInterval].is_default)
 	{
 		ts_cm_functions->process_compress_table(ht, parse_results);
 	}

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1311,6 +1311,31 @@ typedef struct CatalogSecurityContext
 	int saved_security_context;
 } CatalogSecurityContext;
 
+#define HYPERTABLE_STATUS_DEFAULT 0
+/* flag set when hypertable has an attached OSM chunk */
+#define HYPERTABLE_STATUS_OSM 1
+/*
+ * Currently, the time slice range metadata is updated in
+ * the timescaledb catalog with the min and max of the range managed by OSM.
+ * However, this range has to be contiguous in order to
+ * update our catalog with its min and max value. If it is not contiguous,
+ * then we cannot store the min and max in our catalog because tuple routing
+ * will not work properly with gaps in the range.
+ * When attempting to insert into one of the gaps, which do not in fact contain
+ * tiered data, we error out because this is perceived as an attempt to insert
+ * into tiered chunks, which are immutable.
+ * When the range is noncontiguous, we store [INT64_MAX - 1, INT64_MAX) and set
+ * this flag.
+ * This flag also serves to allow or block the ordered append optimization. When
+ * the range covered by OSM is contiguous, then it is possible to do ordered
+ * append.
+ */
+#define HYPERTABLE_STATUS_OSM_CHUNK_NONCONTIGUOUS 2
+#define HYPERTABLE_STATUS_COMPRESSION 4
+/* flag set when the hypertable has opted into direct compress on insert/copy,
+ * independent of the instance-wide direct compress GUCs */
+#define HYPERTABLE_STATUS_DIRECT_COMPRESS 8
+
 extern void ts_catalog_table_info_init(CatalogTableInfo *tables, int max_table,
 									   const TableInfoDef *table_ary,
 									   const TableIndexDef *index_ary, const char **serial_id_ary);

--- a/src/with_clause/alter_table_with_clause.c
+++ b/src/with_clause/alter_table_with_clause.c
@@ -69,6 +69,15 @@ static const WithClauseDefinition alter_table_with_clause_def[] = {
 			.arg_names = {"granular_refresh_end_offset", NULL},
 			 .type_id = TEXTOID,
 		},
+		[AlterTableFlagDirectCompress] = {
+			.arg_names = {"direct_compress", NULL},
+			.type_id = BOOLOID,
+			.default_val = (Datum)false,
+		},
+		[AlterTableFlagDirectCompressScheduleInterval] = {
+			.arg_names = {"direct_compress_schedule_interval", NULL},
+			 .type_id = INTERVALOID,
+		},
 };
 
 static const WithClauseDefinition sparse_index_with_clause_def[] = {

--- a/src/with_clause/alter_table_with_clause.h
+++ b/src/with_clause/alter_table_with_clause.h
@@ -24,6 +24,8 @@ typedef enum AlterTableFlags
 	AlterTableFlagGranularRefreshColumn,
 	AlterTableFlagGranularRefreshStartOffset,
 	AlterTableFlagGranularRefreshEndOffset,
+	AlterTableFlagDirectCompress,
+	AlterTableFlagDirectCompressScheduleInterval,
 	AlterTableFlagsMax
 } AlterTableFlags;
 

--- a/src/with_clause/create_materialized_view_with_clause.c
+++ b/src/with_clause/create_materialized_view_with_clause.c
@@ -84,6 +84,8 @@ ts_continuous_agg_get_compression_defelems(const WithClauseResult *with_clauses)
 			case AlterTableFlagGranularRefreshColumn:
 			case AlterTableFlagGranularRefreshStartOffset:
 			case AlterTableFlagGranularRefreshEndOffset:
+			case AlterTableFlagDirectCompress:
+			case AlterTableFlagDirectCompressScheduleInterval:
 				continue;
 				break;
 			case AlterTableFlagColumnstore:

--- a/src/with_clause/create_table_with_clause.c
+++ b/src/with_clause/create_table_with_clause.c
@@ -23,6 +23,8 @@ static const WithClauseDefinition create_table_with_clauses_def[] = {
 	[CreateTableFlagSegmentBy] = { .arg_names = {"segmentby", "segment_by", "compress_segmentby", NULL}, .type_id = TEXTOID,},
 	[CreateTableFlagOrderBy] = { .arg_names = {"orderby", "order_by", "compress_orderby", NULL}, .type_id = TEXTOID,},
 	[CreateTableFlagIndex] = { .arg_names = {"compress_index", "compress_sparse_index", "index", "sparse_index", NULL}, .type_id = TEXTOID,},
+	[CreateTableFlagDirectCompress] = { .arg_names = {"direct_compress", NULL}, .type_id = BOOLOID, .default_val = (Datum)false,},
+	[CreateTableFlagDirectCompressScheduleInterval] = { .arg_names = {"direct_compress_schedule_interval", NULL}, .type_id = INTERVALOID,},
 };
 
 WithClauseResult *

--- a/src/with_clause/create_table_with_clause.h
+++ b/src/with_clause/create_table_with_clause.h
@@ -20,7 +20,9 @@ typedef enum CreateTableFlags
 	CreateTableFlagAssociatedTablePrefix,
 	CreateTableFlagOrderBy,
 	CreateTableFlagSegmentBy,
-	CreateTableFlagIndex
+	CreateTableFlagIndex,
+	CreateTableFlagDirectCompress,
+	CreateTableFlagDirectCompressScheduleInterval
 } CreateTableFlags;
 
 WithClauseResult *ts_create_table_with_clause_parse(const List *defelems);

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -24,10 +24,10 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 \set VERBOSITY default
 ALTER TABLE alter_before SET (tsdb.invalid_option = true);
 ERROR:  unrecognized parameter "tsdb.invalid_option"
-HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval, compress_index, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset
+HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval, compress_index, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset, direct_compress, direct_compress_schedule_interval
 ALTER TABLE alter_before SET (timescaledb.nonexistent = false);
 ERROR:  unrecognized parameter "timescaledb.nonexistent"
-HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval, compress_index, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset
+HINT:  Valid timescaledb parameters are: chunk_interval, compress, compress_segmentby, compress_orderby, compress_chunk_interval, compress_index, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset, direct_compress, direct_compress_schedule_interval
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
 INSERT INTO alter_before VALUES ('2017-03-22T09:18:22', 23.5, 1);

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1515,9 +1515,9 @@ SELECT pg_typeof(_timescaledb_functions.chunk_status_text(0));
 
 -- Test hypertable_status and hypertable_status_text functions
 CREATE TABLE hypertable_status_test(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.columnstore=false);
-SELECT _timescaledb_functions.hypertable_status_text(i) FROM generate_series(0,7) i;
-          hypertable_status_text           
--------------------------------------------
+SELECT _timescaledb_functions.hypertable_status_text(i) FROM generate_series(0,15) i;
+                  hypertable_status_text                   
+-----------------------------------------------------------
  {}
  {OSM}
  {OSM_CHUNK_NONCONTIGUOUS}
@@ -1526,6 +1526,14 @@ SELECT _timescaledb_functions.hypertable_status_text(i) FROM generate_series(0,7
  {OSM,COMPRESSION}
  {OSM_CHUNK_NONCONTIGUOUS,COMPRESSION}
  {OSM,OSM_CHUNK_NONCONTIGUOUS,COMPRESSION}
+ {DIRECT_COMPRESS}
+ {OSM,DIRECT_COMPRESS}
+ {OSM_CHUNK_NONCONTIGUOUS,DIRECT_COMPRESS}
+ {OSM,OSM_CHUNK_NONCONTIGUOUS,DIRECT_COMPRESS}
+ {COMPRESSION,DIRECT_COMPRESS}
+ {OSM,COMPRESSION,DIRECT_COMPRESS}
+ {OSM_CHUNK_NONCONTIGUOUS,COMPRESSION,DIRECT_COMPRESS}
+ {OSM,OSM_CHUNK_NONCONTIGUOUS,COMPRESSION,DIRECT_COMPRESS}
 
 SELECT _timescaledb_functions.hypertable_status('hypertable_status_test');
  hypertable_status 
@@ -1550,8 +1558,8 @@ SELECT _timescaledb_functions.hypertable_status_text(NULL::regclass);
 \set ON_ERROR_STOP 0
 SELECT _timescaledb_functions.hypertable_status_text(-1);
 ERROR:  invalid hypertable status -1
-SELECT _timescaledb_functions.hypertable_status_text(8);
-ERROR:  invalid hypertable status 8
+SELECT _timescaledb_functions.hypertable_status_text(16);
+ERROR:  invalid hypertable status 16
 SELECT _timescaledb_functions.hypertable_status('pg_class'::regclass);
 ERROR:  table "pg_class" is not a hypertable
 \set ON_ERROR_STOP 1

--- a/test/expected/create_table_with.out
+++ b/test/expected/create_table_with.out
@@ -51,10 +51,10 @@ HINT:  To access all features and the best time-series experience, try out Times
 -- Test error hint for invalid timescaledb options during CREATE TABLE
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (tsdb.invalid_option = true);
 ERROR:  unrecognized parameter "tsdb.invalid_option"
-HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_column, chunk_interval, create_default_indexes, associated_schema, associated_table_prefix, orderby, segmentby, compress_index
+HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_column, chunk_interval, create_default_indexes, associated_schema, associated_table_prefix, orderby, segmentby, compress_index, direct_compress, direct_compress_schedule_interval
 CREATE TABLE t2(time timestamptz, device text, value float) WITH (timescaledb.nonexistent_param = false);
 ERROR:  unrecognized parameter "timescaledb.nonexistent_param"
-HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_column, chunk_interval, create_default_indexes, associated_schema, associated_table_prefix, orderby, segmentby, compress_index
+HINT:  Valid timescaledb parameters are: hypertable, columnstore, partition_column, chunk_interval, create_default_indexes, associated_schema, associated_table_prefix, orderby, segmentby, compress_index, direct_compress, direct_compress_schedule_interval
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
 BEGIN;

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -683,7 +683,7 @@ SELECT pg_typeof(_timescaledb_functions.chunk_status_text(0));
 
 -- Test hypertable_status and hypertable_status_text functions
 CREATE TABLE hypertable_status_test(time timestamptz) WITH (tsdb.hypertable,tsdb.partition_column='time',tsdb.columnstore=false);
-SELECT _timescaledb_functions.hypertable_status_text(i) FROM generate_series(0,7) i;
+SELECT _timescaledb_functions.hypertable_status_text(i) FROM generate_series(0,15) i;
 
 SELECT _timescaledb_functions.hypertable_status('hypertable_status_test');
 SELECT _timescaledb_functions.hypertable_status_text('hypertable_status_test'::regclass);
@@ -692,7 +692,7 @@ SELECT _timescaledb_functions.hypertable_status_text(NULL::int);
 SELECT _timescaledb_functions.hypertable_status_text(NULL::regclass);
 \set ON_ERROR_STOP 0
 SELECT _timescaledb_functions.hypertable_status_text(-1);
-SELECT _timescaledb_functions.hypertable_status_text(8);
+SELECT _timescaledb_functions.hypertable_status_text(16);
 SELECT _timescaledb_functions.hypertable_status('pg_class'::regclass);
 \set ON_ERROR_STOP 1
 

--- a/tsl/src/bgw_policy/compaction_api.c
+++ b/tsl/src/bgw_policy/compaction_api.c
@@ -100,45 +100,29 @@ policy_compaction_check(PG_FUNCTION_ARGS)
 }
 
 Datum
-policy_compaction_add(PG_FUNCTION_ARGS)
+policy_compaction_add_internal(Oid ht_oid, bool if_not_exists, Interval *user_schedule_interval,
+							   TimestampTz initial_start, bool fixed_schedule, text *timezone,
+							   int32 max_chunks, int32 max_batches, Interval *inactive_for)
 {
-	/* behave like a strict function for the required arguments */
-	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
-	{
-		PG_RETURN_NULL();
-	}
-
 	NameData application_name;
 	NameData proc_name, proc_schema, check_name, check_schema, owner;
 	int32 job_id;
 	Interval schedule_interval = DEFAULT_SCHEDULE_INTERVAL;
-	Oid ht_oid = PG_GETARG_OID(0);
-	bool if_not_exists = PG_GETARG_BOOL(1);
-	bool user_defined_schedule_interval = !PG_ARGISNULL(2);
-	int32 max_chunks = PG_ARGISNULL(5) ? 0 : PG_GETARG_INT32(5);
-	int32 max_batches = PG_ARGISNULL(6) ? 0 : PG_GETARG_INT32(6);
-	Interval *inactive_for = PG_ARGISNULL(7) ? NULL : PG_GETARG_INTERVAL_P(7);
 	Cache *hcache;
 	Hypertable *ht;
 	int32 hypertable_id;
 	Oid owner_id;
 	List *jobs;
-	TimestampTz initial_start = PG_ARGISNULL(3) ? DT_NOBEGIN : PG_GETARG_TIMESTAMPTZ(3);
-	bool fixed_schedule = !PG_ARGISNULL(3);
-	text *timezone = PG_ARGISNULL(4) ? NULL : PG_GETARG_TEXT_PP(4);
 	char *valid_timezone = NULL;
 
-	ts_feature_flag_check(FEATURE_POLICY);
-	TS_PREVENT_FUNC_IF_READ_ONLY();
-
-	if (user_defined_schedule_interval)
+	if (user_schedule_interval != NULL)
 	{
-		schedule_interval = *PG_GETARG_INTERVAL_P(2);
+		schedule_interval = *user_schedule_interval;
 	}
 
 	if (timezone != NULL)
 	{
-		valid_timezone = ts_bgw_job_validate_timezone(PG_GETARG_DATUM(4));
+		valid_timezone = ts_bgw_job_validate_timezone(PointerGetDatum(timezone));
 	}
 
 	if (max_chunks < 0)
@@ -261,15 +245,44 @@ policy_compaction_add(PG_FUNCTION_ARGS)
 }
 
 Datum
-policy_compaction_remove(PG_FUNCTION_ARGS)
+policy_compaction_add(PG_FUNCTION_ARGS)
 {
-	Oid hypertable_oid = PG_GETARG_OID(0);
-	bool if_exists = PG_GETARG_BOOL(1);
-	Hypertable *ht;
-	Cache *hcache;
+	/* behave like a strict function for the required arguments */
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+	{
+		ts_feature_flag_check(FEATURE_POLICY);
+		PG_RETURN_NULL();
+	}
+
+	Oid ht_oid = PG_GETARG_OID(0);
+	bool if_not_exists = PG_GETARG_BOOL(1);
+	Interval *user_schedule_interval = PG_ARGISNULL(2) ? NULL : PG_GETARG_INTERVAL_P(2);
+	TimestampTz initial_start = PG_ARGISNULL(3) ? DT_NOBEGIN : PG_GETARG_TIMESTAMPTZ(3);
+	bool fixed_schedule = !PG_ARGISNULL(3);
+	text *timezone = PG_ARGISNULL(4) ? NULL : PG_GETARG_TEXT_PP(4);
+	int32 max_chunks = PG_ARGISNULL(5) ? 0 : PG_GETARG_INT32(5);
+	int32 max_batches = PG_ARGISNULL(6) ? 0 : PG_GETARG_INT32(6);
+	Interval *inactive_for = PG_ARGISNULL(7) ? NULL : PG_GETARG_INTERVAL_P(7);
 
 	ts_feature_flag_check(FEATURE_POLICY);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
+
+	return policy_compaction_add_internal(ht_oid,
+										  if_not_exists,
+										  user_schedule_interval,
+										  initial_start,
+										  fixed_schedule,
+										  timezone,
+										  max_chunks,
+										  max_batches,
+										  inactive_for);
+}
+
+bool
+policy_compaction_remove_internal(Oid hypertable_oid, bool if_exists)
+{
+	Hypertable *ht;
+	Cache *hcache;
 
 	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, CACHE_FLAG_NONE, &hcache);
 	int32 ht_id = ht->fd.id;
@@ -294,12 +307,26 @@ policy_compaction_remove(PG_FUNCTION_ARGS)
 		ereport(NOTICE,
 				(errmsg("compaction policy not found for hypertable \"%s\", skipping",
 						get_rel_name(hypertable_oid))));
-		PG_RETURN_NULL();
+		return false;
 	}
 	Assert(list_length(jobs) == 1);
 	BgwJob *job = linitial(jobs);
 
 	ts_bgw_job_delete_by_id(job->fd.id);
+
+	return true;
+}
+
+Datum
+policy_compaction_remove(PG_FUNCTION_ARGS)
+{
+	Oid hypertable_oid = PG_GETARG_OID(0);
+	bool if_exists = PG_GETARG_BOOL(1);
+
+	ts_feature_flag_check(FEATURE_POLICY);
+	TS_PREVENT_FUNC_IF_READ_ONLY();
+
+	policy_compaction_remove_internal(hypertable_oid, if_exists);
 
 	PG_RETURN_NULL();
 }

--- a/tsl/src/bgw_policy/compaction_api.h
+++ b/tsl/src/bgw_policy/compaction_api.h
@@ -6,8 +6,15 @@
 #pragma once
 
 #include <postgres.h>
+#include <utils/timestamp.h>
 
 /* User-facing API functions */
 extern Datum policy_compaction_add(PG_FUNCTION_ARGS);
 extern Datum policy_compaction_remove(PG_FUNCTION_ARGS);
 extern Datum policy_compaction_check(PG_FUNCTION_ARGS);
+
+Datum policy_compaction_add_internal(Oid ht_oid, bool if_not_exists,
+									 Interval *user_schedule_interval, TimestampTz initial_start,
+									 bool fixed_schedule, text *timezone, int32 max_chunks,
+									 int32 max_batches, Interval *inactive_for);
+bool policy_compaction_remove_internal(Oid hypertable_oid, bool if_exists);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -30,12 +30,17 @@
 #include <utils/array.h>
 #include <utils/builtins.h>
 #include <utils/datum.h>
+#include <utils/fmgrprotos.h>
 #include <utils/guc.h>
+#include <utils/jsonb.h>
 #include <utils/rel.h>
 #include <utils/syscache.h>
+#include <utils/timestamp.h>
 #include <utils/typcache.h>
 
 #include "compat/compat.h"
+#include "bgw/job.h"
+#include "bgw_policy/compaction_api.h"
 #include "bgw_policy/policies_v2.h"
 #include "chunk.h"
 #include "chunk_index.h"
@@ -45,6 +50,7 @@
 #include "create.h"
 #include "custom_type_cache.h"
 #include "dimension.h"
+#include "extension_constants.h"
 #include "foreach_ptr.h"
 #include "guc.h"
 #include "hypertable_cache.h"
@@ -100,6 +106,10 @@ static void compression_settings_set_manually_for_alter(Hypertable *ht,
 static void create_default_composite_bloom(IndexInfo *index_info, Hypertable *ht,
 										   CompressionSettings *settings, JsonbInState *parse_state,
 										   TsBmsList *sparse_index_columns, bool *has_object);
+static Interval *direct_compress_default_schedule_interval(void);
+static void enable_direct_compress_policies(Hypertable *ht, Interval *schedule_interval,
+											Datum compress_after_datum, Oid compress_after_type);
+static void disable_direct_compress_policies(Hypertable *ht);
 
 static char *
 compression_column_segment_metadata_name(const char *type, int16 column_index)
@@ -1193,7 +1203,13 @@ disable_compression(Hypertable *ht, WithClauseResult *with_clause_options)
 				 errmsg("cannot disable columnstore on hypertable with columnstore chunks")));
 	}
 
+	if (TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(ht))
+	{
+		disable_direct_compress_policies(ht);
+	}
+
 	ts_hypertable_unset_compression(ht);
+	ts_hypertable_unset_direct_compress(ht);
 	ts_compression_settings_delete(ht->main_table_relid);
 
 	return true;
@@ -1348,6 +1364,112 @@ update_compress_chunk_time_interval(Hypertable *ht, WithClauseResult *with_claus
 	return ts_hypertable_set_compress_interval(ht, compress_interval_usec);
 }
 
+static Interval *
+direct_compress_default_schedule_interval(void)
+{
+	return DatumGetIntervalP(
+		DirectFunctionCall3(interval_in, CStringGetDatum("1 minute"), InvalidOid, -1));
+}
+
+/*
+ * Creates the compaction and compression policies that back direct compress:
+ * compaction to defragment the small batches direct compress writes, and
+ * compression as a backstop for handling any uncompressed tuples.
+ * Both run on the same schedule, and the compression policy is set
+ * to skip unordered chunks so it doesn't fight the compaction policy for the
+ * same chunk. If either policy already exists it is updated to the required
+ * schedule and config instead of being left alone.
+ */
+static void
+enable_direct_compress_policies(Hypertable *ht, Interval *schedule_interval,
+								Datum compress_after_datum, Oid compress_after_type)
+{
+	policy_compaction_add_internal(ht->main_table_relid,
+								   true /* if_not_exists */,
+								   schedule_interval,
+								   DT_NOBEGIN,
+								   false /* fixed_schedule */,
+								   NULL /* timezone */,
+								   0 /* max_chunks */,
+								   0 /* max_batches */,
+								   NULL /* inactive_for */);
+
+	List *compaction_jobs = ts_bgw_job_find_by_proc_and_hypertable_id(POLICY_COMPACTION_PROC_NAME,
+																	  FUNCTIONS_SCHEMA_NAME,
+																	  ht->fd.id);
+	Assert(list_length(compaction_jobs) == 1);
+	BgwJob *compaction_job = linitial(compaction_jobs);
+	compaction_job->fd.schedule_interval = *schedule_interval;
+	ts_bgw_job_update_by_id(compaction_job->fd.id, compaction_job);
+
+	policy_compression_add_internal(ht->main_table_relid,
+									compress_after_datum,
+									compress_after_type,
+									NULL /* created_before */,
+									schedule_interval,
+									true /* user_defined_schedule_interval */,
+									true /* if_not_exists */,
+									false /* fixed_schedule */,
+									DT_NOBEGIN,
+									NULL /* timezone */);
+
+	List *compression_jobs = ts_bgw_job_find_by_proc_and_hypertable_id(POLICY_COMPRESSION_PROC_NAME,
+																	   FUNCTIONS_SCHEMA_NAME,
+																	   ht->fd.id);
+	Assert(list_length(compression_jobs) == 1);
+	BgwJob *compression_job = linitial(compression_jobs);
+
+	JsonbInState merge_state = { 0 };
+	pushJsonbValueCompat(&merge_state, WJB_BEGIN_OBJECT, NULL);
+	switch (compress_after_type)
+	{
+		case INTERVALOID:
+			ts_jsonb_add_interval(&merge_state,
+								  POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
+								  DatumGetIntervalP(compress_after_datum));
+			break;
+		case INT2OID:
+			ts_jsonb_add_int64(&merge_state,
+							   POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
+							   DatumGetInt16(compress_after_datum));
+			break;
+		case INT4OID:
+			ts_jsonb_add_int64(&merge_state,
+							   POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
+							   DatumGetInt32(compress_after_datum));
+			break;
+		case INT8OID:
+			ts_jsonb_add_int64(&merge_state,
+							   POL_COMPRESSION_CONF_KEY_COMPRESS_AFTER,
+							   DatumGetInt64(compress_after_datum));
+			break;
+		default:
+			elog(ERROR, "unsupported compress_after type for direct compress");
+	}
+	ts_jsonb_add_bool(&merge_state, "recompress_unordered", false);
+	pushJsonbValueCompat(&merge_state, WJB_END_OBJECT, NULL);
+	Jsonb *config_merge = JsonbValueToJsonb(merge_state.result);
+
+	compression_job->fd.schedule_interval = *schedule_interval;
+	compression_job->fd.config =
+		DatumGetJsonbP(DirectFunctionCall2(jsonb_concat,
+										   JsonbPGetDatum(compression_job->fd.config),
+										   JsonbPGetDatum(config_merge)));
+	ts_bgw_job_update_by_id(compression_job->fd.id, compression_job);
+}
+
+/*
+ * Removes the compaction and compression policies that direct compress
+ * created. Called whenever direct compress is turned off, since the
+ * policies exist to support it and shouldn't keep running once it's gone.
+ */
+static void
+disable_direct_compress_policies(Hypertable *ht)
+{
+	policy_compaction_remove_internal(ht->main_table_relid, true /* if_exists */);
+	policy_compression_remove_internal(ht->main_table_relid, true /* if_exists */);
+}
+
 /*
  * enables compression for the passed in table by
  * creating a compression hypertable with special properties
@@ -1438,6 +1560,56 @@ tsl_process_compress_table(Hypertable *ht, WithClauseResult *with_clause_options
 		validate_existing_indexes(ht, settings);
 
 		ts_hypertable_set_compression(ht);
+	}
+
+	if (!with_clause_options[AlterTableFlagDirectCompressScheduleInterval].is_default &&
+		with_clause_options[AlterTableFlagDirectCompress].is_default)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("\"direct_compress_schedule_interval\" requires \"direct_compress\" to be "
+						"set in the same clause")));
+	}
+
+	if (!with_clause_options[AlterTableFlagDirectCompress].is_default)
+	{
+		bool enable_direct_compress =
+			DatumGetBool(with_clause_options[AlterTableFlagDirectCompress].parsed);
+
+		if (enable_direct_compress)
+		{
+			/* columnstore is enabled unconditionally above if it wasn't already, so this always
+			 * holds by this point */
+			Assert(TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
+
+			Interval *schedule_interval =
+				!with_clause_options[AlterTableFlagDirectCompressScheduleInterval].is_default ?
+					DatumGetIntervalP(
+						with_clause_options[AlterTableFlagDirectCompressScheduleInterval].parsed) :
+					direct_compress_default_schedule_interval();
+
+			/* Use the chunk interval as the compression interval, same as the
+			 * default compression policy added by CREATE TABLE ... WITH */
+			const Dimension *time_dim = hyperspace_get_open_dimension(ht->space, 0);
+			Oid compress_after_type = ts_dimension_get_partition_type(time_dim);
+			if (IS_TIMESTAMP_TYPE(compress_after_type) || IS_UUID_TYPE(compress_after_type))
+			{
+				compress_after_type = INTERVALOID;
+			}
+			Datum compress_after_datum =
+				ts_internal_to_interval_value(time_dim->fd.interval_length, compress_after_type);
+
+			ts_hypertable_set_direct_compress(ht);
+			enable_direct_compress_policies(ht,
+											schedule_interval,
+											compress_after_datum,
+											compress_after_type);
+		}
+		else if (TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(ht))
+		{
+			disable_direct_compress_policies(ht);
+			ts_hypertable_unset_direct_compress(ht);
+		}
 	}
 
 	/*
@@ -2563,10 +2735,11 @@ tsl_columnstore_setup(Hypertable *ht, WithClauseResult *with_clause_options)
 	/* Add default compression policy when compression is enabled via CREATE TABLE WITH */
 	/* Use the chunk interval as the compression interval */
 	const Dimension *time_dim = hyperspace_get_open_dimension(ht->space, 0);
+	Datum compress_after_datum = 0;
+	Oid compress_after_type = InvalidOid;
 	if (time_dim != NULL)
 	{
-		Oid compress_after_type = ts_dimension_get_partition_type(time_dim);
-		Datum compress_after_datum;
+		compress_after_type = ts_dimension_get_partition_type(time_dim);
 		if (IS_TIMESTAMP_TYPE(compress_after_type) || IS_UUID_TYPE(compress_after_type))
 		{
 			compress_after_type = INTERVALOID;
@@ -2587,5 +2760,30 @@ tsl_columnstore_setup(Hypertable *ht, WithClauseResult *with_clause_options)
 			false,								   /* fixed_schedule */
 			GetCurrentTimestamp() + USECS_PER_DAY, /* initial_start */
 			NULL /* timezone */);
+	}
+
+	if (!with_clause_options[CreateTableFlagDirectCompressScheduleInterval].is_default &&
+		with_clause_options[CreateTableFlagDirectCompress].is_default)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("\"direct_compress_schedule_interval\" requires \"direct_compress\" to be "
+						"set in the same clause")));
+	}
+
+	if (!with_clause_options[CreateTableFlagDirectCompress].is_default &&
+		DatumGetBool(with_clause_options[CreateTableFlagDirectCompress].parsed))
+	{
+		Interval *schedule_interval =
+			!with_clause_options[CreateTableFlagDirectCompressScheduleInterval].is_default ?
+				DatumGetIntervalP(
+					with_clause_options[CreateTableFlagDirectCompressScheduleInterval].parsed) :
+				direct_compress_default_schedule_interval();
+
+		ts_hypertable_set_direct_compress(ht);
+		enable_direct_compress_policies(ht,
+										schedule_interval,
+										compress_after_datum,
+										compress_after_type);
 	}
 }

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -420,7 +420,8 @@ build_order_by_clause(MaterializationContext *context)
 static inline bool
 has_direct_compress_on_cagg_refresh_enabled(MaterializationContext *context)
 {
-	return ts_guc_enable_direct_compress_on_cagg_refresh &&
+	return (ts_guc_enable_direct_compress_on_cagg_refresh ||
+			TS_HYPERTABLE_HAS_DIRECT_COMPRESS_ENABLED(context->mat_ht)) &&
 		   TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(context->mat_ht);
 }
 

--- a/tsl/test/expected/direct_compress_policy.out
+++ b/tsl/test/expected/direct_compress_policy.out
@@ -1,0 +1,276 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Tests for the timescaledb.direct_compress option, which enables direct
+-- compress on a hypertable and creates the compaction and compression
+-- policies that back it as a single command. Available both as an
+-- ALTER TABLE ... SET (...) option and as a CREATE TABLE ... WITH (...) option.
+----------------------------------------------------------------------
+-- ALTER TABLE: enabling direct_compress also enables columnstore and
+-- creates both policies
+----------------------------------------------------------------------
+-- create_hypertable() doesn't enable columnstore by default, so this table
+-- starts out with no compression and no policies.
+CREATE TABLE metrics (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics', 'time');
+  create_hypertable   
+----------------------
+ (1,public,metrics,t)
+
+ALTER TABLE metrics SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress
+);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics';
+ status 
+--------
+     12
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics')
+ORDER BY proc_name;
+     proc_name      | schedule_interval |                                      config                                       
+--------------------+-------------------+-----------------------------------------------------------------------------------
+ policy_compaction  | @ 1 min           | {"hypertable_id": 1}
+ policy_compression | @ 1 min           | {"hypertable_id": 1, "compress_after": "@ 7 days", "recompress_unordered": false}
+
+----------------------------------------------------------------------
+-- ALTER TABLE: direct_compress_schedule_interval is honored by both policies
+----------------------------------------------------------------------
+CREATE TABLE metrics2 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics2', 'time');
+   create_hypertable   
+-----------------------
+ (2,public,metrics2,t)
+
+ALTER TABLE metrics2 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress,
+  timescaledb.direct_compress_schedule_interval = '30 seconds'
+);
+SELECT proc_name, schedule_interval
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2')
+ORDER BY proc_name;
+     proc_name      | schedule_interval 
+--------------------+-------------------
+ policy_compaction  | @ 30 secs
+ policy_compression | @ 30 secs
+
+----------------------------------------------------------------------
+-- ALTER TABLE: re-running is idempotent and converges the existing
+-- policies to the new schedule
+----------------------------------------------------------------------
+ALTER TABLE metrics SET (
+  timescaledb.direct_compress,
+  timescaledb.direct_compress_schedule_interval = '10 seconds'
+);
+NOTICE:  compaction policy already exists on hypertable "metrics", skipping
+NOTICE:  columnstore policy already exists for hypertable "metrics", skipping
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics');
+ count 
+-------
+     2
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics')
+ORDER BY proc_name;
+     proc_name      | schedule_interval |                                      config                                       
+--------------------+-------------------+-----------------------------------------------------------------------------------
+ policy_compaction  | @ 10 secs         | {"hypertable_id": 1}
+ policy_compression | @ 10 secs         | {"hypertable_id": 1, "compress_after": "@ 7 days", "recompress_unordered": false}
+
+----------------------------------------------------------------------
+-- ALTER TABLE: direct_compress alone (no timescaledb.compress) auto-enables
+-- columnstore too
+----------------------------------------------------------------------
+CREATE TABLE metrics3 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics3', 'time');
+   create_hypertable   
+-----------------------
+ (3,public,metrics3,t)
+
+ALTER TABLE metrics3 SET (timescaledb.direct_compress);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics3';
+ status 
+--------
+     12
+
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics3');
+ count 
+-------
+     2
+
+----------------------------------------------------------------------
+-- ALTER TABLE: disabling direct_compress clears the status bit and
+-- removes the policies it created
+----------------------------------------------------------------------
+ALTER TABLE metrics SET (timescaledb.direct_compress = false);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics';
+ status 
+--------
+      4
+
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics');
+ count 
+-------
+     0
+
+----------------------------------------------------------------------
+-- ALTER TABLE: disabling columnstore also clears direct_compress and
+-- removes the policies
+----------------------------------------------------------------------
+ALTER TABLE metrics2 SET (timescaledb.direct_compress);
+NOTICE:  compaction policy already exists on hypertable "metrics2", skipping
+NOTICE:  columnstore policy already exists for hypertable "metrics2", skipping
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2';
+ status 
+--------
+     12
+
+ALTER TABLE metrics2 SET (timescaledb.compress = false);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2';
+ status 
+--------
+      0
+
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2');
+ count 
+-------
+     0
+
+----------------------------------------------------------------------
+-- ALTER TABLE: per-table flag turns on direct compress even with the
+-- instance GUC off
+----------------------------------------------------------------------
+SET timescaledb.enable_direct_compress_insert = false;
+CREATE TABLE metrics4 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics4', 'time');
+   create_hypertable   
+-----------------------
+ (4,public,metrics4,t)
+
+ALTER TABLE metrics4 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress
+);
+BEGIN;
+INSERT INTO metrics4 SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics4;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_4_1_chunk (actual rows=960.00 loops=1)
+         ->  Seq Scan on _hyper_4_1_chunk_compressed (actual rows=1.00 loops=1)
+   ->  Custom Scan (ColumnarScan) on _hyper_4_2_chunk (actual rows=2041.00 loops=1)
+         ->  Seq Scan on _hyper_4_2_chunk_compressed (actual rows=3.00 loops=1)
+
+ROLLBACK;
+-- without direct_compress set, the GUC being off means no direct compress
+CREATE TABLE metrics5 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics5', 'time');
+   create_hypertable   
+-----------------------
+ (5,public,metrics5,t)
+
+ALTER TABLE metrics5 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device'
+);
+BEGIN;
+INSERT INTO metrics5 SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics5;
+--- QUERY PLAN ---
+ Append (actual rows=3001.00 loops=1)
+   ->  Seq Scan on _hyper_5_3_chunk (actual rows=960.00 loops=1)
+   ->  Seq Scan on _hyper_5_4_chunk (actual rows=2041.00 loops=1)
+
+ROLLBACK;
+RESET timescaledb.enable_direct_compress_insert;
+----------------------------------------------------------------------
+-- CREATE TABLE ... WITH (tsdb.hypertable, tsdb.direct_compress, ...)
+----------------------------------------------------------------------
+CREATE TABLE metrics6 (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device', tsdb.direct_compress);
+NOTICE:  using column "time" as partitioning column
+NOTICE:  columnstore policy already exists for hypertable "metrics6", skipping
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics6';
+ status 
+--------
+     12
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics6')
+ORDER BY proc_name;
+     proc_name      | schedule_interval |                                      config                                       
+--------------------+-------------------+-----------------------------------------------------------------------------------
+ policy_compaction  | @ 1 min           | {"hypertable_id": 6}
+ policy_compression | @ 1 min           | {"hypertable_id": 6, "compress_after": "@ 7 days", "recompress_unordered": false}
+
+-- direct_compress_schedule_interval is honored at create time too
+CREATE TABLE metrics7 (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (
+    tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device',
+    tsdb.direct_compress, tsdb.direct_compress_schedule_interval='15 seconds'
+  );
+NOTICE:  using column "time" as partitioning column
+NOTICE:  columnstore policy already exists for hypertable "metrics7", skipping
+SELECT proc_name, schedule_interval
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics7')
+ORDER BY proc_name;
+     proc_name      | schedule_interval 
+--------------------+-------------------
+ policy_compaction  | @ 15 secs
+ policy_compression | @ 15 secs
+
+-- tsdb.hypertable without direct_compress doesn't set the status bit, but
+-- still gets the regular default compression policy (1 chunk interval,
+-- scheduled daily) since plain columnstore always adds one
+CREATE TABLE metrics8 (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device', tsdb.chunk_interval='1 day');
+NOTICE:  using column "time" as partitioning column
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics8';
+ status 
+--------
+      4
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics8')
+ORDER BY proc_name;
+     proc_name      | schedule_interval |                      config                       
+--------------------+-------------------+---------------------------------------------------
+ policy_compression | @ 1 day           | {"hypertable_id": 8, "compress_after": "@ 1 day"}
+
+----------------------------------------------------------------------
+-- disabling direct_compress and then just re-enabling plain compression
+-- (no direct_compress) leaves no policy: unlike CREATE TABLE WITH, plain
+-- ALTER TABLE compress on its own never adds a default compression policy
+----------------------------------------------------------------------
+CREATE TABLE metrics9 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics9', 'time');
+   create_hypertable   
+-----------------------
+ (9,public,metrics9,t)
+
+ALTER TABLE metrics9 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress
+);
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics9');
+ count 
+-------
+     2
+
+ALTER TABLE metrics9 SET (timescaledb.direct_compress = false);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics9';
+ status 
+--------
+      4
+
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics9');
+ count 
+-------
+     0
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TEST_FILES
     decompress_index.sql
     direct_compress_analyze_segmentby.sql
     direct_compress_insert.sql
+    direct_compress_policy.sql
     move.sql
     plan_skip_scan_notnull.sql
     plan_skip_scan_pg_partition.sql

--- a/tsl/test/sql/direct_compress_policy.sql
+++ b/tsl/test/sql/direct_compress_policy.sql
@@ -1,0 +1,183 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Tests for the timescaledb.direct_compress option, which enables direct
+-- compress on a hypertable and creates the compaction and compression
+-- policies that back it as a single command. Available both as an
+-- ALTER TABLE ... SET (...) option and as a CREATE TABLE ... WITH (...) option.
+
+----------------------------------------------------------------------
+-- ALTER TABLE: enabling direct_compress also enables columnstore and
+-- creates both policies
+----------------------------------------------------------------------
+
+-- create_hypertable() doesn't enable columnstore by default, so this table
+-- starts out with no compression and no policies.
+CREATE TABLE metrics (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics', 'time');
+
+ALTER TABLE metrics SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress
+);
+
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics';
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics')
+ORDER BY proc_name;
+
+----------------------------------------------------------------------
+-- ALTER TABLE: direct_compress_schedule_interval is honored by both policies
+----------------------------------------------------------------------
+
+CREATE TABLE metrics2 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics2', 'time');
+
+ALTER TABLE metrics2 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress,
+  timescaledb.direct_compress_schedule_interval = '30 seconds'
+);
+
+SELECT proc_name, schedule_interval
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2')
+ORDER BY proc_name;
+
+----------------------------------------------------------------------
+-- ALTER TABLE: re-running is idempotent and converges the existing
+-- policies to the new schedule
+----------------------------------------------------------------------
+
+ALTER TABLE metrics SET (
+  timescaledb.direct_compress,
+  timescaledb.direct_compress_schedule_interval = '10 seconds'
+);
+
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics');
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics')
+ORDER BY proc_name;
+
+----------------------------------------------------------------------
+-- ALTER TABLE: direct_compress alone (no timescaledb.compress) auto-enables
+-- columnstore too
+----------------------------------------------------------------------
+
+CREATE TABLE metrics3 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics3', 'time');
+ALTER TABLE metrics3 SET (timescaledb.direct_compress);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics3';
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics3');
+
+----------------------------------------------------------------------
+-- ALTER TABLE: disabling direct_compress clears the status bit and
+-- removes the policies it created
+----------------------------------------------------------------------
+
+ALTER TABLE metrics SET (timescaledb.direct_compress = false);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics';
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics');
+
+----------------------------------------------------------------------
+-- ALTER TABLE: disabling columnstore also clears direct_compress and
+-- removes the policies
+----------------------------------------------------------------------
+
+ALTER TABLE metrics2 SET (timescaledb.direct_compress);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2';
+ALTER TABLE metrics2 SET (timescaledb.compress = false);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2';
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics2');
+
+----------------------------------------------------------------------
+-- ALTER TABLE: per-table flag turns on direct compress even with the
+-- instance GUC off
+----------------------------------------------------------------------
+
+SET timescaledb.enable_direct_compress_insert = false;
+
+CREATE TABLE metrics4 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics4', 'time');
+ALTER TABLE metrics4 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress
+);
+
+BEGIN;
+INSERT INTO metrics4 SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics4;
+ROLLBACK;
+
+-- without direct_compress set, the GUC being off means no direct compress
+CREATE TABLE metrics5 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics5', 'time');
+ALTER TABLE metrics5 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device'
+);
+
+BEGIN;
+INSERT INTO metrics5 SELECT '2025-01-01'::timestamptz + (i || ' minute')::interval, 'd1', i::float FROM generate_series(0,3000) i;
+EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF) SELECT * FROM metrics5;
+ROLLBACK;
+
+RESET timescaledb.enable_direct_compress_insert;
+
+----------------------------------------------------------------------
+-- CREATE TABLE ... WITH (tsdb.hypertable, tsdb.direct_compress, ...)
+----------------------------------------------------------------------
+
+CREATE TABLE metrics6 (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device', tsdb.direct_compress);
+
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics6';
+
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics6')
+ORDER BY proc_name;
+
+-- direct_compress_schedule_interval is honored at create time too
+CREATE TABLE metrics7 (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (
+    tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device',
+    tsdb.direct_compress, tsdb.direct_compress_schedule_interval='15 seconds'
+  );
+
+SELECT proc_name, schedule_interval
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics7')
+ORDER BY proc_name;
+
+-- tsdb.hypertable without direct_compress doesn't set the status bit, but
+-- still gets the regular default compression policy (1 chunk interval,
+-- scheduled daily) since plain columnstore always adds one
+CREATE TABLE metrics8 (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device', tsdb.chunk_interval='1 day');
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics8';
+SELECT proc_name, schedule_interval, config
+FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics8')
+ORDER BY proc_name;
+
+----------------------------------------------------------------------
+-- disabling direct_compress and then just re-enabling plain compression
+-- (no direct_compress) leaves no policy: unlike CREATE TABLE WITH, plain
+-- ALTER TABLE compress on its own never adds a default compression policy
+----------------------------------------------------------------------
+
+CREATE TABLE metrics9 (time TIMESTAMPTZ NOT NULL, device TEXT, value float);
+SELECT create_hypertable('metrics9', 'time');
+ALTER TABLE metrics9 SET (
+  timescaledb.compress,
+  timescaledb.compress_segmentby = 'device',
+  timescaledb.direct_compress
+);
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics9');
+
+ALTER TABLE metrics9 SET (timescaledb.direct_compress = false);
+SELECT status FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics9';
+SELECT count(*) FROM _timescaledb_config.bgw_job WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'metrics9');


### PR DESCRIPTION
A hypertable can now opt into direct compress on its own, without flipping the instance-wide GUCs, via
ALTER TABLE ... SET (timescaledb.direct_compress) or CREATE TABLE ... WITH (tsdb.hypertable, tsdb.direct_compress).

Enabling it turns on columnstore if it isn't already, and creates (or converges, if already present) the compaction and compression policies that keep a direct-compress hypertable healthy: compaction defragments the small batches direct compress writes, compression compresses
anything that could have been potentially uncompressed due to
DML operations. Both default to a 1-minute schedule, overridable with
timescaledb.direct_compress_schedule_interval. The compression policy skips unordered chunks (recompress_unordered) so it doesn't fight the compaction policy over the same chunk.