### PR TITLE
Remove table and schema name from Chunk struct

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -154,6 +154,8 @@ chunk_formdata_make_tuple(const FormData_chunk *fd, TupleDesc desc)
 	Datum values[Natts_chunk];
 	bool nulls[Natts_chunk] = { false };
 
+	Assert(OidIsValid(fd->relid));
+
 	memset(values, 0, sizeof(Datum) * Natts_chunk);
 
 	values[AttrNumberGetAttrOffset(Anum_chunk_id)] = Int32GetDatum(fd->id);
@@ -171,46 +173,35 @@ ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 {
 	bool should_free;
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
-	bool nulls[Natts_chunk];
-	Datum values[Natts_chunk];
-
-	memset(fd, 0, sizeof(FormData_chunk));
-	heap_deform_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls);
-
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_id)]);
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_hypertable_id)]);
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_status)]);
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)]);
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_creation_time)]);
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_relid)]);
-
-	fd->id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_id)]);
-	fd->hypertable_id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_hypertable_id)]);
-	fd->status = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_status)]);
-	fd->osm_chunk = DatumGetBool(values[AttrNumberGetAttrOffset(Anum_chunk_osm_chunk)]);
-	fd->creation_time = DatumGetInt64(values[AttrNumberGetAttrOffset(Anum_chunk_creation_time)]);
-	fd->relid = DatumGetObjectId(values[AttrNumberGetAttrOffset(Anum_chunk_relid)]);
 
 	/*
-	 * schema_name and table_name are derived from the chunk relation so they
-	 * always reflect its current name. A visible chunk row always has a visible
-	 * relation, so the lookup succeeds; guard defensively regardless.
+	 * Every chunk column is fixed-length and NOT NULL, and the catalog table is
+	 * rebuilt rather than altered on upgrade, so a stored tuple always holds all
+	 * of its attributes. We can therefore copy the form directly.
 	 */
-	{
-		char *relname = get_rel_name(fd->relid);
-		Oid relnsp = get_rel_namespace(fd->relid);
-
-		if (relname != NULL && OidIsValid(relnsp))
-		{
-			namestrcpy(&fd->schema_name, get_namespace_name(relnsp));
-			namestrcpy(&fd->table_name, relname);
-		}
-	}
+	Assert(HeapTupleHeaderGetNatts(tuple->t_data) == Natts_chunk);
+	*fd = *(Form_chunk) GETSTRUCT(tuple);
 
 	if (should_free)
 	{
 		heap_freetuple(tuple);
 	}
+}
+
+/*
+ * A chunk's schema and table name are not stored in the catalog; they are
+ * looked up from the chunk relation on demand.
+ */
+char *
+ts_chunk_get_schema_name(const Chunk *chunk)
+{
+	return get_namespace_name(get_rel_namespace(chunk->fd.relid));
+}
+
+char *
+ts_chunk_get_table_name(const Chunk *chunk)
+{
+	return get_rel_name(chunk->fd.relid);
 }
 
 int64
@@ -231,13 +222,6 @@ chunk_insert_relation(Relation rel, const Chunk *chunk)
 	HeapTuple new_tuple;
 	CatalogSecurityContext sec_ctx;
 	FormData_chunk fd = chunk->fd;
-
-	/* The chunk relation is created before its catalog row, so its OID is the
-	 * canonical identity of the chunk. */
-	if (!OidIsValid(fd.relid))
-	{
-		fd.relid = chunk->table_id;
-	}
 
 	new_tuple = chunk_formdata_make_tuple(&fd, RelationGetDescr(rel));
 
@@ -661,7 +645,8 @@ copy_hypertable_acl_to_relid(const Hypertable *ht, const Oid owner_id, const Oid
  * instead needs the proper permissions on the database to create the schema.
  */
 Oid
-ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tablespacename)
+ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *schema_name,
+					  const char *table_name, const char *tablespacename)
 {
 	Relation rel;
 	ObjectAddress address;
@@ -675,9 +660,7 @@ ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tabl
 	 */
 	CreateStmt stmt = {
 		.type = T_CreateStmt,
-		.relation = makeRangeVar((char *) NameStr(chunk->fd.schema_name),
-								 (char *) NameStr(chunk->fd.table_name),
-								 0),
+		.relation = makeRangeVar((char *) schema_name, (char *) table_name, 0),
 		.tablespacename = tablespacename ? (char *) tablespacename : NULL,
 		.options =
 			(chunk->relkind == RELKIND_RELATION) ? ts_get_reloptions(ht->main_table_relid) : NIL,
@@ -717,7 +700,7 @@ ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tabl
 	 * If the chunk is created in the internal schema, become the catalog
 	 * owner, otherwise become the hypertable owner
 	 */
-	if (namestrcmp((Name) &chunk->fd.schema_name, INTERNAL_SCHEMA_NAME) == 0)
+	if (strcmp(schema_name, INTERNAL_SCHEMA_NAME) == 0)
 	{
 		uid = ts_catalog_database_info_get()->owner_uid;
 	}
@@ -822,62 +805,46 @@ prepare_cube_slices_for_chunk(Hypercube *cube, int32 chunk_id)
 }
 
 /*
+ * Pick a table name for a new chunk. The table name can be given explicitly, or
+ * generated from the hypertable's associated table prefix and the chunk id if
+ * table_name is NULL.
+ */
+static char *
+chunk_choose_table_name(const Hypertable *ht, int32 chunk_id, const char *table_name)
+{
+	if (NULL == table_name || table_name[0] == '\0')
+	{
+		const char *prefix = NameStr(ht->fd.associated_table_prefix);
+		char *name = psprintf("%s_%d_chunk", prefix, chunk_id);
+
+		if (strlen(name) >= NAMEDATALEN)
+		{
+			ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("chunk table name too long")));
+		}
+
+		return name;
+	}
+
+	return pstrdup(table_name);
+}
+
+/*
  * Create a chunk object from the dimensional constraints in the given hypercube.
  *
  * The chunk object is then used to create the actual chunk table and update the
  * metadata separately.
- *
- * The table name for the chunk can be given explicitly, or generated if
- * table_name is NULL. If the table name is generated, it will use the given
- * prefix or, if NULL, use the hypertable's associated table prefix. Similarly,
- * if schema_name is NULL it will use the hypertable's associated schema for
- * the chunk.
  */
 static Chunk *
-chunk_create_object(const Hypertable *ht, Hypercube *cube, const char *schema_name,
-					const char *table_name, const char *prefix, int32 chunk_id)
+chunk_create_object(const Hypertable *ht, Hypercube *cube, int32 chunk_id)
 {
 	const Hyperspace *hs = ht->space;
-	Chunk *chunk;
-	const char relkind = RELKIND_RELATION;
-
-	if (NULL == schema_name || schema_name[0] == '\0')
-	{
-		schema_name = NameStr(ht->fd.associated_schema_name);
-	}
 
 	/* Create a new chunk based on the hypercube */
-	chunk = ts_chunk_create_base(chunk_id, hs->num_dimensions, relkind);
+	Chunk *chunk = ts_chunk_create_base(chunk_id);
 
 	chunk->fd.hypertable_id = hs->hypertable_id;
 	chunk->cube = cube;
 	chunk->hypertable_relid = ht->main_table_relid;
-	namestrcpy(&chunk->fd.schema_name, schema_name);
-
-	if (NULL == table_name || table_name[0] == '\0')
-	{
-		int len;
-
-		if (NULL == prefix)
-		{
-			prefix = NameStr(ht->fd.associated_table_prefix);
-		}
-
-		len = snprintf(NameStr(chunk->fd.table_name),
-					   NAMEDATALEN,
-					   "%s_%d_chunk",
-					   prefix,
-					   chunk->fd.id);
-
-		if (len >= NAMEDATALEN)
-		{
-			ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("chunk table name too long")));
-		}
-	}
-	else
-	{
-		namestrcpy(&chunk->fd.table_name, table_name);
-	}
 
 	return chunk;
 }
@@ -890,7 +857,7 @@ static void
 chunk_set_replica_identity(const Chunk *chunk)
 {
 	Relation ht_rel = relation_open(chunk->hypertable_relid, AccessShareLock);
-	Relation ch_rel = relation_open(chunk->table_id, AccessShareLock);
+	Relation ch_rel = relation_open(chunk->fd.relid, AccessShareLock);
 
 	/* Do nothing if REPLICA IDENTITY of hypertable and chunk are equal */
 	if (ht_rel->rd_rel->relreplident == ch_rel->rd_rel->relreplident)
@@ -935,7 +902,7 @@ chunk_set_replica_identity(const Chunk *chunk)
 	}
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	ts_alter_table_with_event_trigger(chunk->table_id, NULL, list_make1(&cmd), false);
+	ts_alter_table_with_event_trigger(chunk->fd.relid, NULL, list_make1(&cmd), false);
 	ts_catalog_restore_user(&sec_ctx);
 	table_close(ch_rel, NoLock);
 	table_close(ht_rel, NoLock);
@@ -959,7 +926,7 @@ chunk_create_table_constraints(const Hypertable *ht, const Chunk *chunk)
 		ts_chunk_index_create_all(chunk->fd.hypertable_id,
 								  chunk->hypertable_relid,
 								  chunk->fd.id,
-								  chunk->table_id,
+								  chunk->fd.relid,
 								  InvalidOid);
 
 		chunk_set_replica_identity(chunk);
@@ -972,16 +939,17 @@ chunk_create_table_constraints(const Hypertable *ht, const Chunk *chunk)
 }
 
 static Oid
-chunk_create_table(Chunk *chunk, const Hypertable *ht)
+chunk_create_table(Chunk *chunk, const Hypertable *ht, const char *schema_name,
+				   const char *table_name)
 {
 	/* Create the actual table relation for the chunk */
 	const char *tablespace = ts_hypertable_select_tablespace_name(ht, chunk);
 
-	chunk->table_id = ts_chunk_create_table(chunk, ht, tablespace);
+	chunk->fd.relid = ts_chunk_create_table(chunk, ht, schema_name, table_name, tablespace);
 
-	Assert(OidIsValid(chunk->table_id));
+	Assert(OidIsValid(chunk->fd.relid));
 
-	return chunk->table_id;
+	return chunk->fd.relid;
 }
 
 /*
@@ -990,16 +958,19 @@ chunk_create_table(Chunk *chunk, const Hypertable *ht)
  */
 static Chunk *
 chunk_create_only_table_after_lock(const Hypertable *ht, Hypercube *cube, const char *schema_name,
-								   const char *table_name, const char *prefix, int32 chunk_id)
+								   const char *table_name, int32 chunk_id)
 {
-	Chunk *chunk;
-
 	Assert(table_name != NULL || chunk_id != INVALID_CHUNK_ID);
 
-	chunk = chunk_create_object(ht, cube, schema_name, table_name, prefix, chunk_id);
-	Assert(chunk != NULL);
+	if (!schema_name || schema_name[0] == '\0')
+	{
+		schema_name = NameStr(ht->fd.associated_schema_name);
+	}
 
-	chunk_create_table(chunk, ht);
+	Chunk *chunk = chunk_create_object(ht, cube, chunk_id);
+	char *chunk_table_name = chunk_choose_table_name(ht, chunk_id, table_name);
+
+	chunk_create_table(chunk, ht, schema_name, chunk_table_name);
 
 	return chunk;
 }
@@ -1059,7 +1030,7 @@ chunk_add_to_publication(Oid puboid, const Chunk *chunk)
 
 	get_hypertable_publication_filters(puboid, chunk, &columns, &whereClause);
 
-	chunk_rel = table_open(chunk->table_id, AccessShareLock);
+	chunk_rel = table_open(chunk->fd.relid, AccessShareLock);
 
 	pri.relation = chunk_rel;
 	pri.columns = columns;
@@ -1090,8 +1061,7 @@ chunk_add_to_publications(const Chunk *chunk)
 
 static Chunk *
 chunk_create_from_hypercube_after_lock(const Hypertable *ht, Hypercube *cube,
-									   const char *schema_name, const char *table_name,
-									   const char *prefix)
+									   const char *schema_name, const char *table_name)
 {
 	chunk_insert_check_hook_type osm_chunk_insert_hook = ts_get_osm_chunk_insert_hook();
 
@@ -1126,8 +1096,7 @@ chunk_create_from_hypercube_after_lock(const Hypertable *ht, Hypercube *cube,
 	}
 	int32 chunk_id = get_next_chunk_id();
 
-	Chunk *chunk =
-		chunk_create_only_table_after_lock(ht, cube, schema_name, table_name, prefix, chunk_id);
+	Chunk *chunk = chunk_create_only_table_after_lock(ht, cube, schema_name, table_name, chunk_id);
 
 	ts_chunk_insert_lock(chunk, RowExclusiveLock);
 	prepare_cube_slices_for_chunk(cube, chunk_id);
@@ -1170,8 +1139,8 @@ chunk_add_inheritance(Chunk *chunk, const Hypertable *ht)
 		.cmds = list_make1(&altercmd),
 		.missing_ok = false,
 		.objtype = OBJECT_TABLE,
-		.relation = makeRangeVar((char *) NameStr(chunk->fd.schema_name),
-								 (char *) NameStr(chunk->fd.table_name),
+		.relation = makeRangeVar((char *) ts_chunk_get_schema_name(chunk),
+								 (char *) ts_chunk_get_table_name(chunk),
 								 0),
 	};
 	LOCKMODE lockmode = AlterTableGetLockLevel(alterstmt.cmds);
@@ -1185,7 +1154,7 @@ chunk_add_inheritance(Chunk *chunk, const Hypertable *ht)
 static Chunk *
 chunk_create_from_hypercube_and_table_after_lock(const Hypertable *ht, Hypercube *cube,
 												 Oid chunk_table_relid, const char *schema_name,
-												 const char *table_name, const char *prefix)
+												 const char *table_name)
 {
 	Oid current_chunk_schemaid = get_rel_namespace(chunk_table_relid);
 	Oid new_chunk_schemaid = InvalidOid;
@@ -1243,11 +1212,16 @@ chunk_create_from_hypercube_and_table_after_lock(const Hypertable *ht, Hypercube
 
 	int32 chunk_id = get_next_chunk_id();
 
-	chunk = chunk_create_object(ht, cube, schema_name, table_name, prefix, chunk_id);
-	chunk->table_id = chunk_table_relid;
-	chunk->hypertable_relid = ht->main_table_relid;
+	if (!schema_name || schema_name[0] == '\0')
+	{
+		schema_name = NameStr(ht->fd.associated_schema_name);
+	}
 
-	new_chunk_schemaid = get_namespace_oid(NameStr(chunk->fd.schema_name), false);
+	chunk = chunk_create_object(ht, cube, chunk_id);
+	char *chunk_table_name = chunk_choose_table_name(ht, chunk_id, table_name);
+	chunk->fd.relid = chunk_table_relid;
+
+	new_chunk_schemaid = get_namespace_oid(schema_name, false);
 
 	if (current_chunk_schemaid != new_chunk_schemaid)
 	{
@@ -1262,11 +1236,11 @@ chunk_create_from_hypercube_and_table_after_lock(const Hypertable *ht, Hypercube
 	}
 	table_close(chunk_rel, NoLock);
 
-	if (namestrcmp(&chunk->fd.table_name, get_rel_name(chunk_table_relid)) != 0)
+	if (strcmp(chunk_table_name, get_rel_name(chunk_table_relid)) != 0)
 	{
 		/* Renaming will acquire and keep an AccessExclusivelock on the chunk
 		 * table */
-		RenameRelationInternal(chunk_table_relid, NameStr(chunk->fd.table_name), true, false);
+		RenameRelationInternal(chunk_table_relid, chunk_table_name, true, false);
 		/* Make changes visible */
 		CommandCounterIncrement();
 	}
@@ -1300,8 +1274,7 @@ chunk_create_from_hypercube_and_table_after_lock(const Hypertable *ht, Hypercube
 }
 
 static Chunk *
-chunk_create_from_point_after_lock(const Hypertable *ht, const Point *p, const char *schema_name,
-								   const char *table_name, const char *prefix)
+chunk_create_from_point_after_lock(const Hypertable *ht, const Point *p)
 {
 	Hyperspace *hs = ht->space;
 	Hypercube *cube;
@@ -1316,7 +1289,7 @@ chunk_create_from_point_after_lock(const Hypertable *ht, const Point *p, const c
 	/* Resolve collisions with other chunks by cutting the new hypercube */
 	chunk_collision_resolve(ht, cube, p);
 
-	return chunk_create_from_hypercube_after_lock(ht, cube, schema_name, table_name, prefix);
+	return chunk_create_from_hypercube_after_lock(ht, cube, NULL, NULL);
 }
 
 Chunk *
@@ -1346,13 +1319,11 @@ ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc, const 
 																		 hc,
 																		 chunk_table_relid,
 																		 schema_name,
-																		 table_name,
-																		 NULL);
+																		 table_name);
 			}
 			else
 			{
-				chunk =
-					chunk_create_from_hypercube_after_lock(ht, hc, schema_name, table_name, NULL);
+				chunk = chunk_create_from_hypercube_after_lock(ht, hc, schema_name, table_name);
 			}
 
 			if (NULL != created)
@@ -1432,8 +1403,7 @@ ts_chunk_find_for_point(const Hypertable *ht, const Point *p, LOCKMODE lockmode)
  * chunk is locked with "chunk_lockmode".
  */
 Chunk *
-ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *schema,
-						  const char *prefix, LOCKMODE chunk_lockmode)
+ts_chunk_create_for_point(const Hypertable *ht, const Point *p, LOCKMODE chunk_lockmode)
 {
 	/*
 	 * Serialize chunk creation around a lock on the "main table" to avoid
@@ -1476,7 +1446,7 @@ ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *sche
 	}
 
 	/* Create the chunk normally. */
-	Chunk *chunk = chunk_create_from_point_after_lock(ht, p, schema, NULL, prefix);
+	Chunk *chunk = chunk_create_from_point_after_lock(ht, p);
 
 	ASSERT_IS_VALID_CHUNK(chunk);
 
@@ -1570,46 +1540,36 @@ ts_chunk_id_find_in_subspace(Hypertable *ht, List *dimension_vecs)
 }
 
 ChunkStub *
-ts_chunk_stub_create(int32 id, int16 num_constraints)
+ts_chunk_stub_create(int32 id)
 {
-	ChunkStub *stub;
+	ChunkStub *stub = palloc0(sizeof(*stub));
 
-	(void) num_constraints;
-	stub = palloc0(sizeof(*stub));
 	stub->id = id;
 
 	return stub;
 }
 
 Chunk *
-ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind)
+ts_chunk_create_base(int32 id)
 {
-	Chunk *chunk;
+	Chunk *chunk = palloc0(sizeof(Chunk));
 
-	(void) num_constraints;
-	chunk = palloc0(sizeof(Chunk));
 	chunk->fd.id = id;
-	chunk->relkind = relkind;
+	chunk->relkind = RELKIND_RELATION;
 	chunk->fd.creation_time = GetCurrentTimestamp();
 
 	return chunk;
 }
 
 /*
- * Build a chunk from a chunk tuple and a stub.
+ * Build a chunk from a chunk tuple.
  *
- * The stub allows the chunk to be constructed more efficiently. But if the stub
- * is not "valid", dimension slices and constraints are fully
- * rescanned/recreated.
+ * The dimension slices are scanned from the catalog to build the chunk's cube.
  */
 Chunk *
-ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkStub *stub,
-								   const ScanTupLock *slice_lock)
+ts_chunk_build_from_tuple(Chunk **chunkptr, TupleInfo *ti)
 {
 	Chunk *chunk = NULL;
-
-	(void) stub;
-	(void) slice_lock;
 
 	if (chunkptr == NULL)
 	{
@@ -1640,13 +1600,12 @@ ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkS
 	}
 
 	chunk->hypertable_relid = ts_hypertable_id_to_relid(chunk->fd.hypertable_id, false);
-	chunk->table_id = chunk->fd.relid;
 	chunk->relkind = get_rel_relkind(chunk->fd.relid);
 
 	Ensure(chunk->relkind > 0,
 		   "relkind for chunk \"%s\".\"%s\" is invalid",
-		   NameStr(chunk->fd.schema_name),
-		   NameStr(chunk->fd.table_name));
+		   ts_chunk_get_schema_name(chunk),
+		   ts_chunk_get_table_name(chunk));
 
 	return chunk;
 }
@@ -1673,7 +1632,7 @@ chunk_tuple_found(TupleInfo *ti, void *arg)
 		}
 	}
 
-	ts_chunk_build_from_tuple_and_stub(&stubctx->chunk, ti, stubctx->stub, stubctx->slice_lock);
+	ts_chunk_build_from_tuple(&stubctx->chunk, ti);
 
 	return SCAN_DONE;
 }
@@ -1768,7 +1727,7 @@ dimension_slice_join_chunks(ChunkScanCtx *scanctx, const DimensionVec *vec)
 
 		if (!found)
 		{
-			stub = ts_chunk_stub_create(chunk_id, hs->num_dimensions);
+			stub = ts_chunk_stub_create(chunk_id);
 			stub->cube = ts_hypercube_alloc(hs->num_dimensions);
 			entry->stub = stub;
 		}
@@ -2771,7 +2730,7 @@ ts_chunk_get_relid(int32 chunk_id, bool missing_ok)
 
 	if (chunk_simple_scan_by_id(chunk_id, &form, missing_ok))
 	{
-		relid = ts_get_relation_relid(NameStr(form.schema_name), NameStr(form.table_name), true);
+		relid = form.relid;
 	}
 
 	if (!OidIsValid(relid) && !missing_ok)
@@ -2800,7 +2759,7 @@ ts_chunk_get_schema_id(int32 chunk_id, bool missing_ok)
 		return InvalidOid;
 	}
 
-	return get_namespace_oid(NameStr(form.schema_name), missing_ok);
+	return get_rel_namespace(form.relid);
 }
 
 bool
@@ -2930,7 +2889,10 @@ chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool detach)
 		 * in pg_catalog. But that's OK, because compression settings will be
 		 * cleaned up when processing the eventtrigger.
 		 */
-		relid = ts_get_relation_relid(NameStr(form.schema_name), NameStr(form.table_name), true);
+		if (OidIsValid(form.relid) && SearchSysCacheExists1(RELOID, ObjectIdGetDatum(form.relid)))
+		{
+			relid = form.relid;
+		}
 	}
 
 	/*
@@ -3135,10 +3097,6 @@ ts_chunk_get_by_hypertable_id(int32 hypertable_id)
 		ts_chunk_formdata_fill(&chunk->fd, ti);
 
 		chunk->hypertable_relid = hypertable_relid;
-
-		chunk->table_id = ts_get_relation_relid(NameStr(chunk->fd.schema_name),
-												NameStr(chunk->fd.table_name),
-												false);
 
 		chunks = lappend(chunks, chunk);
 	}
@@ -3355,7 +3313,7 @@ ts_chunk_set_partial(Chunk *chunk)
 		ts_chunk_column_stats_set_invalid(chunk->fd.hypertable_id, chunk->fd.id);
 
 		/* changed chunk status, so invalidate plans involving this chunk */
-		CacheInvalidateRelcacheByRelid(chunk->table_id);
+		CacheInvalidateRelcacheByRelid(chunk->fd.relid);
 	}
 	return set_status;
 }
@@ -3579,11 +3537,11 @@ chunk_cmp(const void *ch1, const void *ch2)
 	{
 		return 1;
 	}
-	if (v1->table_id < v2->table_id)
+	if (v1->fd.relid < v2->fd.relid)
 	{
 		return -1;
 	}
-	if (v1->table_id > v2->table_id)
+	if (v1->fd.relid > v2->fd.relid)
 	{
 		return 1;
 	}
@@ -3646,7 +3604,7 @@ show_chunks_return_srf(FunctionCallInfo fcinfo)
 	/* do when there is more left to send */
 	if (call_cntr < funcctx->max_calls)
 	{
-		SRF_RETURN_NEXT(funcctx, result_set[call_cntr].table_id);
+		SRF_RETURN_NEXT(funcctx, result_set[call_cntr].fd.relid);
 	}
 	else /* do when there is no more left */
 	{
@@ -3659,28 +3617,25 @@ ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level)
 {
 	ObjectAddress objaddr = {
 		.classId = RelationRelationId,
-		.objectId = chunk->table_id,
+		.objectId = chunk->fd.relid,
 	};
+
+	const char *schema_name = ts_chunk_get_schema_name(chunk);
+	const char *table_name = ts_chunk_get_table_name(chunk);
 
 	if (log_level >= 0)
 	{
-		elog(log_level,
-			 "dropping chunk %s.%s",
-			 NameStr(chunk->fd.schema_name),
-			 NameStr(chunk->fd.table_name));
+		elog(log_level, "dropping chunk %s.%s", schema_name, table_name);
 	}
 
 	/* Remove the chunk from the chunk table */
-	ts_chunk_delete_by_relid_and_relname(chunk->table_id,
-										 NameStr(chunk->fd.schema_name),
-										 NameStr(chunk->fd.table_name),
-										 behavior);
+	ts_chunk_delete_by_relid_and_relname(chunk->fd.relid, schema_name, table_name, behavior);
 
 	/* Drop the table */
 	performDeletion(&objaddr, behavior, 0);
 
 	/* Evict the chunk stats from the shared memory */
-	ts_stats_chunk_evict(chunk->table_id);
+	ts_stats_chunk_evict(chunk->fd.relid);
 }
 
 void
@@ -3860,7 +3815,7 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 		 * refreshing. */
 		for (uint64 i = 0; i < num_chunks; i++)
 		{
-			LockRelationOid(chunks[i].table_id, ExclusiveLock);
+			LockRelationOid(chunks[i].fd.relid, ExclusiveLock);
 
 			Assert(hyperspace_get_open_dimension(ht->space, 0)->fd.id ==
 				   chunks[i].cube->slices[0]->fd.dimension_id);
@@ -3907,8 +3862,8 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 		}
 
 		/* store chunk name for output */
-		schema_name = quote_identifier(NameStr(chunks[i].fd.schema_name));
-		table_name = quote_identifier(NameStr(chunks[i].fd.table_name));
+		schema_name = quote_identifier(ts_chunk_get_schema_name(&chunks[i]));
+		table_name = quote_identifier(ts_chunk_get_table_name(&chunks[i]));
 		chunk_name = psprintf("%s.%s", schema_name, table_name);
 		dropped_chunk_names = lappend(dropped_chunk_names, chunk_name);
 
@@ -3928,7 +3883,7 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 		 * (e.g. from a retention policy). We call `GetFdwRoutineByRelId` to
 		 * ensure the library is loaded.
 		 */
-		if (!osm_drop_chunks_hook && GetFdwRoutineByRelId(osm_chunk->table_id))
+		if (!osm_drop_chunks_hook && GetFdwRoutineByRelId(osm_chunk->fd.relid))
 		{
 			osm_drop_chunks_hook = ts_get_osm_hypertable_drop_chunks_hook();
 		}
@@ -3940,7 +3895,7 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 			/* convert to PG timestamp from timescaledb internal format */
 			int64 range_start = ts_internal_to_time_int64(newer_than, dim->fd.column_type);
 			int64 range_end = ts_internal_to_time_int64(older_than, dim->fd.column_type);
-			List *osm_dropped_names = osm_drop_chunks_hook(osm_chunk->table_id,
+			List *osm_dropped_names = osm_drop_chunks_hook(osm_chunk->fd.relid,
 														   NameStr(ht->fd.schema_name),
 														   NameStr(ht->fd.table_name),
 														   range_start,
@@ -4384,7 +4339,7 @@ bool
 ts_chunk_validate_chunk_status_for_operation(const Chunk *chunk, ChunkOperation cmd,
 											 bool throw_error)
 {
-	Oid chunk_relid = chunk->table_id;
+	Oid chunk_relid = chunk->fd.relid;
 	int32 chunk_status = chunk->fd.status;
 
 	/*
@@ -4665,8 +4620,6 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	Catalog *catalog = ts_catalog_get();
 	CatalogSecurityContext sec_ctx;
 	Chunk *chunk;
-	char *relschema = get_namespace_name(get_rel_namespace(relid));
-	char *relname = get_rel_name(relid);
 
 	Oid ht_ownerid = ts_rel_get_owner(parent_ht->main_table_relid);
 
@@ -4686,9 +4639,7 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	}
 	/* Create a new chunk based on the hypercube */
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	chunk = ts_chunk_create_base(ts_catalog_table_next_seq_id(catalog, CHUNK),
-								 hs->num_dimensions,
-								 RELKIND_RELATION);
+	chunk = ts_chunk_create_base(ts_catalog_table_next_seq_id(catalog, CHUNK));
 	ts_catalog_restore_user(&sec_ctx);
 
 	/* fill in the correct table_name for the chunk*/
@@ -4696,11 +4647,8 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	chunk->fd.osm_chunk = true; /* this is an OSM chunk */
 	chunk->cube = fill_hypercube_for_osm_chunk(hs);
 	chunk->hypertable_relid = parent_ht->main_table_relid;
-	chunk->table_id = relid;
+	chunk->fd.relid = relid;
 	chunk->relkind = RELKIND_FOREIGN_TABLE;
-
-	namestrcpy(&chunk->fd.schema_name, relschema);
-	namestrcpy(&chunk->fd.table_name, relname);
 
 	/* Insert chunk */
 	ts_chunk_insert_lock(chunk, RowExclusiveLock);
@@ -4742,8 +4690,8 @@ ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk *chunk, const Chunk *mer
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot merge chunks from different hypertables"),
 				 errhint("chunk 1: \"%s\", chunk 2: \"%s\"",
-						 get_rel_name(chunk->table_id),
-						 get_rel_name(merge_chunk->table_id))));
+						 get_rel_name(chunk->fd.relid),
+						 get_rel_name(merge_chunk->fd.relid))));
 	}
 
 	for (int i = 0; i < chunk->cube->num_slices; i++)
@@ -4761,8 +4709,8 @@ ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk *chunk, const Chunk *mer
 					 errmsg("cannot merge chunks with different partitioning schemas"),
 					 errhint("chunk 1: \"%s\", chunk 2: \"%s\" have different slices on "
 							 "dimension ID %d",
-							 get_rel_name(chunk->table_id),
-							 get_rel_name(merge_chunk->table_id),
+							 get_rel_name(chunk->fd.relid),
+							 get_rel_name(merge_chunk->fd.relid),
 							 chunk->cube->slices[i]->fd.dimension_id)));
 		}
 	}
@@ -4773,8 +4721,8 @@ ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk *chunk, const Chunk *mer
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot find slice for merging dimension"),
 				 errhint("chunk 1: \"%s\", chunk 2: \"%s\", dimension ID %d",
-						 get_rel_name(chunk->table_id),
-						 get_rel_name(merge_chunk->table_id),
+						 get_rel_name(chunk->fd.relid),
+						 get_rel_name(merge_chunk->fd.relid),
 						 dimension_id)));
 	}
 
@@ -4784,8 +4732,8 @@ ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk *chunk, const Chunk *mer
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot merge non-adjacent chunks over supplied dimension"),
 				 errhint("chunk 1: \"%s\", chunk 2: \"%s\", dimension ID %d",
-						 get_rel_name(chunk->table_id),
-						 get_rel_name(merge_chunk->table_id),
+						 get_rel_name(chunk->fd.relid),
+						 get_rel_name(merge_chunk->fd.relid),
 						 dimension_id)));
 	}
 
@@ -4813,7 +4761,7 @@ ts_chunk_merge_on_dimension(const Hypertable *ht, Chunk *chunk, const Chunk *mer
 	 * is derived from the slice id. */
 	char old_check_name[NAMEDATALEN];
 	snprintf(old_check_name, NAMEDATALEN, "constraint_%d", old_slice_id);
-	Oid old_check_oid = get_relation_constraint_oid(chunk->table_id, old_check_name, true);
+	Oid old_check_oid = get_relation_constraint_oid(chunk->fd.relid, old_check_name, true);
 	if (OidIsValid(old_check_oid))
 	{
 		ObjectAddress constrobj = {
@@ -5027,11 +4975,8 @@ ts_chunk_vec_add_from_tuple(ChunkVec **chunks, TupleInfo *ti)
 		ts_hypercube_slice_sort(chunkptr->cube);
 	}
 
-	chunkptr->table_id = ts_get_relation_relid(NameStr(chunkptr->fd.schema_name),
-											   NameStr(chunkptr->fd.table_name),
-											   true);
 	chunkptr->hypertable_relid = ts_hypertable_id_to_relid(chunkptr->fd.hypertable_id, false);
-	chunkptr->relkind = get_rel_relkind(chunkptr->table_id);
+	chunkptr->relkind = get_rel_relkind(chunkptr->fd.relid);
 
 	return vec;
 }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -64,7 +64,6 @@ typedef struct Chunk
 {
 	FormData_chunk fd;
 	char relkind;
-	Oid table_id;
 	Oid hypertable_relid;
 
 	/*
@@ -153,12 +152,12 @@ extern void ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti);
 extern int32 ts_chunk_point_find_chunk_id(const Hypertable *ht, const Point *p,
 										  const ScanTupLock *slice_lock);
 extern Chunk *ts_chunk_find_for_point(const Hypertable *ht, const Point *p, LOCKMODE lockmode);
-extern Chunk *ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *schema,
-										const char *prefix, LOCKMODE chunk_lockmode);
+extern Chunk *ts_chunk_create_for_point(const Hypertable *ht, const Point *p,
+										LOCKMODE chunk_lockmode);
 List *ts_chunk_id_find_in_subspace(Hypertable *ht, List *dimension_vecs);
 
-extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind);
-extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);
+extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id);
+extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id);
 extern TSDLLEXPORT Chunk *ts_chunk_copy(const Chunk *chunk);
 extern TSDLLEXPORT Chunk *
 ts_chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name,
@@ -166,7 +165,15 @@ ts_chunk_get_by_name_with_memory_context(const char *schema_name, const char *ta
 										 MemoryContext mctx, bool fail_if_not_found);
 extern TSDLLEXPORT void ts_chunk_insert_lock(const Chunk *chunk, LOCKMODE lock);
 
+/*
+ * A chunk's schema and table name are not stored in the catalog; they are
+ * looked up from the chunk relation on demand.
+ */
+extern TSDLLEXPORT char *ts_chunk_get_schema_name(const Chunk *chunk);
+extern TSDLLEXPORT char *ts_chunk_get_table_name(const Chunk *chunk);
+
 extern TSDLLEXPORT Oid ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht,
+											 const char *schema_name, const char *table_name,
 											 const char *tablespacename);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_id_with_slice_lock(int32 id, LOCKMODE chunk_lockmode,
 															 const ScanTupLock *slice_lock,
@@ -228,9 +235,7 @@ extern TSDLLEXPORT List *ts_chunk_get_by_hypertable_id(int32 hypertable_id);
 extern TSDLLEXPORT int64 ts_chunk_primary_dimension_start(const Chunk *chunk);
 
 extern TSDLLEXPORT int64 ts_chunk_primary_dimension_end(const Chunk *chunk);
-extern Chunk *ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti,
-												 const ChunkStub *stub,
-												 const ScanTupLock *slice_lock);
+extern Chunk *ts_chunk_build_from_tuple(Chunk **chunkptr, TupleInfo *ti);
 
 extern TM_Result ts_chunk_lock_for_creating_compressed_chunk(Chunk *chunk);
 extern ScanIterator ts_chunk_scan_iterator_create(MemoryContext result_mcxt);
@@ -261,7 +266,7 @@ extern TSDLLEXPORT void ts_chunk_detach_by_relid(Oid relid);
 		Assert(chunk);                                                                             \
 		Assert((chunk)->fd.id > 0);                                                                \
 		Assert((chunk)->fd.hypertable_id > 0);                                                     \
-		Assert(OidIsValid((chunk)->table_id));                                                     \
+		Assert(OidIsValid((chunk)->fd.relid));                                                     \
 		Assert(OidIsValid((chunk)->hypertable_relid));                                             \
 		Assert((chunk)->cube);                                                                     \
 		Assert((chunk)->relkind == RELKIND_RELATION || (chunk)->relkind == RELKIND_FOREIGN_TABLE); \

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -260,7 +260,7 @@ inheritable_constraint_create(HeapTuple constraint_tuple, void *arg)
 
 	/* If the chunk already has an equivalent constraint, reuse it under its
 	 * existing name. */
-	chunk_rel = table_open(ctx->chunk->table_id, AccessShareLock);
+	chunk_rel = table_open(ctx->chunk->fd.relid, AccessShareLock);
 	matching_const = ts_constraint_find_matching(constraint_tuple, chunk_rel);
 	table_close(chunk_rel, NoLock);
 
@@ -275,7 +275,7 @@ inheritable_constraint_create(HeapTuple constraint_tuple, void *arg)
 	create_non_dimensional_constraint(ctx->chunk->fd.id,
 									  chunk_constraint_name,
 									  hypertable_constraint_name,
-									  ctx->chunk->table_id);
+									  ctx->chunk->fd.relid);
 	return CONSTR_PROCESSED;
 }
 
@@ -304,7 +304,7 @@ ts_chunk_constraints_create(const Hypertable *ht, const Chunk *chunk)
 		Assert(dim != NULL);
 		dimension_constraint_choose_name(name, slice->fd.id);
 
-		if (OidIsValid(get_relation_constraint_oid(chunk->table_id, name, true)))
+		if (OidIsValid(get_relation_constraint_oid(chunk->fd.relid, name, true)))
 		{
 			continue;
 		}
@@ -319,7 +319,7 @@ ts_chunk_constraints_create(const Hypertable *ht, const Chunk *chunk)
 	if (newconstrs != NIL)
 	{
 		List PG_USED_FOR_ASSERTS_ONLY *cookedconstrs = NIL;
-		Relation rel = table_open(chunk->table_id, AccessExclusiveLock);
+		Relation rel = table_open(chunk->fd.relid, AccessExclusiveLock);
 		cookedconstrs = AddRelationNewConstraints(rel,
 												  NIL /* List *newColDefaults */,
 												  newconstrs,
@@ -411,7 +411,7 @@ ts_chunk_constraint_create_on_chunk(const Hypertable *ht, const Chunk *chunk, Oi
 			create_non_dimensional_constraint(chunk->fd.id,
 											  chunk_constraint_name,
 											  NameStr(con->conname),
-											  chunk->table_id);
+											  chunk->fd.relid);
 		}
 	}
 
@@ -432,7 +432,7 @@ ts_chunk_constraints_recreate(const Hypertable *ht, const Chunk *chunk)
 		Oid constraint_oid;
 
 		dimension_constraint_choose_name(name, slice->fd.id);
-		constraint_oid = get_relation_constraint_oid(chunk->table_id, name, true);
+		constraint_oid = get_relation_constraint_oid(chunk->fd.relid, name, true);
 		if (OidIsValid(constraint_oid))
 		{
 			ObjectAddress addr = {
@@ -543,6 +543,6 @@ ts_chunk_constraint_check_violated(const Chunk *chunk, const Hyperspace *hs)
 		const Dimension *dim = ts_hyperspace_get_dimension_by_id(hs, slice->fd.dimension_id);
 
 		Assert(dim);
-		check_chunk_constraint_violated(chunk->table_id, dim, slice);
+		check_chunk_constraint_violated(chunk->fd.relid, dim, slice);
 	}
 }

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -456,19 +456,19 @@ ts_chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		if (!OidIsValid(chunk->table_id))
+		if (!OidIsValid(chunk->fd.relid))
 		{
 			continue;
 		}
 
-		Relation chunk_rel = table_open(chunk->table_id, AccessShareLock);
+		Relation chunk_rel = table_open(chunk->fd.relid, AccessShareLock);
 		Oid chunk_indexrelid =
 			ts_chunk_index_get_by_hypertable_indexrelid(chunk_rel, hypertable_indexrelid);
 		table_close(chunk_rel, AccessShareLock);
 		if (OidIsValid(chunk_indexrelid))
 		{
 			ChunkIndexMapping *cim = palloc0(sizeof(ChunkIndexMapping));
-			cim->chunkoid = chunk->table_id;
+			cim->chunkoid = chunk->fd.relid;
 			cim->indexoid = chunk_indexrelid;
 			cim->parent_indexoid = hypertable_indexrelid;
 			cim->hypertableoid = ht->fd.id;
@@ -507,12 +507,12 @@ ts_chunk_index_rename(Hypertable *ht, Oid hypertable_indexrelid, const char *ht_
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		if (!OidIsValid(chunk->table_id))
+		if (!OidIsValid(chunk->fd.relid))
 		{
 			continue;
 		}
 
-		Relation chunk_rel = table_open(chunk->table_id, AccessExclusiveLock);
+		Relation chunk_rel = table_open(chunk->fd.relid, AccessExclusiveLock);
 		Oid chunk_indexrelid =
 			ts_chunk_index_get_by_hypertable_indexrelid(chunk_rel, hypertable_indexrelid);
 		table_close(chunk_rel, NoLock);
@@ -520,9 +520,9 @@ ts_chunk_index_rename(Hypertable *ht, Oid hypertable_indexrelid, const char *ht_
 		/* If there is no matching index on the chunk, skip it */
 		if (OidIsValid(chunk_indexrelid))
 		{
-			Oid chunk_schemaoid = get_namespace_oid(NameStr(chunk->fd.schema_name), false);
+			Oid chunk_schemaoid = get_namespace_oid(ts_chunk_get_schema_name(chunk), false);
 			const char *chunk_new_name =
-				chunk_index_choose_name(NameStr(chunk->fd.table_name), ht_name, chunk_schemaoid);
+				chunk_index_choose_name(ts_chunk_get_table_name(chunk), ht_name, chunk_schemaoid);
 
 			RenameRelationInternal(chunk_indexrelid, chunk_new_name, false, true);
 		}
@@ -538,7 +538,7 @@ ts_chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, char *t
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		Relation chunk_rel = table_open(chunk->table_id, AccessExclusiveLock);
+		Relation chunk_rel = table_open(chunk->fd.relid, AccessExclusiveLock);
 		Oid chunk_indexrelid =
 			ts_chunk_index_get_by_hypertable_indexrelid(chunk_rel, hypertable_indexrelid);
 		table_close(chunk_rel, NoLock);

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -100,7 +100,6 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 
 		chunk->cube = NULL;
 		chunk->hypertable_relid = hs->main_table_relid;
-		chunk->table_id = chunk_reloid;
 
 		locked_chunks[locked_chunk_count] = chunk;
 		locked_chunk_count++;
@@ -118,7 +117,7 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 	for (int i = 0; i < locked_chunk_count; i++)
 	{
 		Chunk *chunk = locked_chunks[i];
-		chunk->relkind = get_rel_relkind(chunk->table_id);
+		chunk->relkind = get_rel_relkind(chunk->fd.relid);
 	}
 
 	/*
@@ -149,7 +148,7 @@ ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_DATA_CORRUPTED),
-					 errmsg("chunk %s has no dimension slices", get_rel_name(chunk->table_id))));
+					 errmsg("chunk %s has no dimension slices", get_rel_name(chunk->fd.relid))));
 		}
 
 		ts_hypercube_slice_sort(cube);

--- a/src/chunk_tuple_routing.c
+++ b/src/chunk_tuple_routing.c
@@ -105,7 +105,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 		 */
 		if (ctr->single_chunk_insert)
 		{
-			if (!chunk || chunk->table_id != RelationGetRelid(ctr->root_rri->ri_RelationDesc))
+			if (!chunk || chunk->fd.relid != RelationGetRelid(ctr->root_rri->ri_RelationDesc))
 			{
 				ereport(ERROR,
 						(errcode(ERRCODE_CHECK_VIOLATION),
@@ -119,7 +119,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot INSERT into frozen chunk \"%s\"",
-							get_rel_name(chunk->table_id))));
+							get_rel_name(chunk->fd.relid))));
 		}
 
 		if (chunk && IS_OSM_CHUNK(chunk))
@@ -152,7 +152,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 
 #ifdef USE_ASSERT_CHECKING
 		/* Ensure we always hold a lock on the chunk table at this point */
-		Relation chunk_rel = RelationIdGetRelation(chunk->table_id);
+		Relation chunk_rel = RelationIdGetRelation(chunk->fd.relid);
 		Assert(CheckRelationLockedByMe(chunk_rel, lockmode, true));
 		RelationClose(chunk_rel);
 #endif
@@ -204,7 +204,7 @@ ts_chunk_tuple_routing_find_chunk(ChunkTupleRouting *ctr, Point *point)
 			}
 		}
 
-		cis = ts_chunk_insert_state_create(chunk->table_id, ctr);
+		cis = ts_chunk_insert_state_create(chunk->fd.relid, ctr);
 		cis->needs_partial = needs_partial;
 		cis->created_compressed_chunk = created_compressed_chunk;
 		ts_subspace_store_add(ctr->subspace,

--- a/src/foreign_key.c
+++ b/src/foreign_key.c
@@ -152,7 +152,7 @@ clone_constraint_on_chunk(const Chunk *chunk, Relation parentRel, Form_pg_constr
 						  Oid parentDelTrigger, Oid parentUpdTrigger)
 {
 	AttrNumber mapped_confkey[INDEX_MAX_KEYS];
-	Relation pkrel = table_open(chunk->table_id, AccessShareLock);
+	Relation pkrel = table_open(chunk->fd.relid, AccessShareLock);
 
 	/* Map the foreign key columns on the hypertable side to the chunk columns */
 	AttrMap *attmap =
@@ -191,7 +191,7 @@ clone_constraint_on_chunk(const Chunk *chunk, Relation parentRel, Form_pg_constr
 									   numfks,
 									   InvalidOid,
 									   indexoid,
-									   chunk->table_id,
+									   chunk->fd.relid,
 									   mapped_confkey,
 									   conpfeqop,
 									   conppeqop,
@@ -222,7 +222,7 @@ clone_constraint_on_chunk(const Chunk *chunk, Relation parentRel, Form_pg_constr
 
 	createForeignKeyActionTriggers(fk,
 								   fk->conrelid,
-								   chunk->table_id,
+								   chunk->fd.relid,
 								   conoid,
 								   indexoid,
 								   parentDelTrigger,
@@ -631,7 +631,7 @@ void
 ts_chunk_drop_referencing_fk_by_chunk_id(Oid chunk_id)
 {
 	Chunk *chunk = ts_chunk_get_by_id(chunk_id, true);
-	List *fks = relation_get_referencing_fk(chunk->table_id);
+	List *fks = relation_get_referencing_fk(chunk->fd.relid);
 	ListCell *lc;
 
 	foreach (lc, fks)
@@ -662,7 +662,7 @@ ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 		elog(ERROR, "cache lookup failed for constraint %u", parent_fk_oid);
 	}
 
-	child_oid = get_relation_constraint_oid(chunk->table_id, parent_name, true);
+	child_oid = get_relation_constraint_oid(chunk->fd.relid, parent_name, true);
 	if (OidIsValid(child_oid))
 	{
 		/* Only adopt the existing constraint if it's a FK to the same target. */
@@ -685,7 +685,7 @@ ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
 					 errmsg("cannot inherit foreign key \"%s\" onto chunk \"%s\"",
 							parent_name,
-							get_rel_name(chunk->table_id)),
+							get_rel_name(chunk->fd.relid)),
 					 errdetail("A constraint with that name already exists on the chunk "
 							   "and does not match the hypertable's foreign key.")));
 		}
@@ -703,7 +703,7 @@ ts_chunk_inherit_outbound_fk_by_oid(const Chunk *chunk, Oid parent_fk_oid)
 	ts_process_utility_set_expect_chunk_modification(true);
 	CatalogInternalCall2(DDL_CONSTRAINT_CLONE,
 						 ObjectIdGetDatum(parent_fk_oid),
-						 ObjectIdGetDatum(chunk->table_id));
+						 ObjectIdGetDatum(chunk->fd.relid));
 	ts_process_utility_set_expect_chunk_modification(false);
 	ts_catalog_restore_user(&sec_ctx);
 	CommandCounterIncrement();

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1020,11 +1020,7 @@ ts_hypertable_create_chunk_for_point(const Hypertable *h, const Point *point,
 {
 	Assert(ts_subspace_store_get(h->chunk_cache, point) == NULL);
 
-	Chunk *chunk = ts_chunk_create_for_point(h,
-											 point,
-											 NameStr(h->fd.associated_schema_name),
-											 NameStr(h->fd.associated_table_prefix),
-											 chunk_lockmode);
+	Chunk *chunk = ts_chunk_create_for_point(h, point, chunk_lockmode);
 
 	/* Also add the chunk to the hypertable's chunk store */
 	Chunk *cached_chunk = ts_hypertable_chunk_store_add(h, chunk);
@@ -1059,7 +1055,7 @@ ts_hypertable_find_chunk_for_point(const Hypertable *h, const Point *point, LOCK
 			chunk = ts_hypertable_chunk_store_add(h, chunk);
 		}
 	}
-	else if (!ts_chunk_lock_if_exists(chunk->table_id, lockmode))
+	else if (!ts_chunk_lock_if_exists(chunk->fd.relid, lockmode))
 	{
 		return NULL;
 	}
@@ -1067,7 +1063,7 @@ ts_hypertable_find_chunk_for_point(const Hypertable *h, const Point *point, LOCK
 #ifdef USE_ASSERT_CHECKING
 	if (chunk)
 	{
-		Relation chunk_rel = RelationIdGetRelation(chunk->table_id);
+		Relation chunk_rel = RelationIdGetRelation(chunk->fd.relid);
 		Assert(CheckRelationLockedByMe(chunk_rel, lockmode, true));
 		RelationClose(chunk_rel);
 	}
@@ -1493,10 +1489,7 @@ ts_hypertable_create_internal(FunctionCallInfo fcinfo, Oid table_relid,
 
 		if (closed_dim_info && !closed_dim_info->num_slices_is_set)
 		{
-			/* If the number of partitions isn't specified, default to setting it
-			 * to the number of data nodes */
-			int16 num_partitions = closed_dim_info->num_slices;
-			closed_dim_info->num_slices = num_partitions;
+			/* Keep the default number of partitions when unspecified. */
 			closed_dim_info->num_slices_is_set = true;
 		}
 

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -1062,7 +1062,7 @@ ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri, Hype
 
 		if (NULL != nested_oids)
 		{
-			slot_chunk_oids = lappend_oid(slot_chunk_oids, chunk->table_id);
+			slot_chunk_oids = lappend_oid(slot_chunk_oids, chunk->fd.relid);
 		}
 
 		slice = chunk->cube->slices[0];

--- a/src/partition_chunk.c
+++ b/src/partition_chunk.c
@@ -369,8 +369,8 @@ partition_chunk_attach(const Hypertable *ht, const Chunk *chunk)
 	};
 	PartitionCmd partcmd = {
 		.type = T_PartitionCmd,
-		.name = makeRangeVar((char *) NameStr(chunk->fd.schema_name),
-							 (char *) NameStr(chunk->fd.table_name),
+		.name = makeRangeVar((char *) ts_chunk_get_schema_name(chunk),
+							 (char *) ts_chunk_get_table_name(chunk),
 							 0),
 		.bound = &pbspec,
 		.concurrent = false,

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -954,8 +954,8 @@ collect_quals_walker(Node *node, CollectQualCtx *ctx)
 static int
 chunk_cmp_chunk_reloid(const void *c1, const void *c2)
 {
-	Oid lhs = (*(Chunk **) c1)->table_id;
-	Oid rhs = (*(Chunk **) c2)->table_id;
+	Oid lhs = (*(Chunk **) c1)->fd.relid;
+	Oid rhs = (*(Chunk **) c2)->fd.relid;
 
 	if (lhs < rhs)
 	{
@@ -1343,7 +1343,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 		 * Add the information about chunks to the baserel info cache for
 		 * classify_relation().
 		 */
-		ts_add_baserel_cache_entry_for_chunk(chunks[i]->table_id, ht);
+		ts_add_baserel_cache_entry_for_chunk(chunks[i]->fd.relid, ht);
 	}
 
 	oldrelation = table_open(parent_oid, NoLock);
@@ -1357,7 +1357,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 	for (unsigned int i = 0; i < num_chunks; i++)
 	{
 		Chunk *chunk = chunks[i];
-		Oid child_oid = chunk->table_id;
+		Oid child_oid = chunk->fd.relid;
 		Relation newrelation;
 		RangeTblEntry *childrte;
 		Index child_rtindex;
@@ -1522,7 +1522,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 		 */
 		if (!IS_OSM_CHUNK(chunk))
 		{
-			Assert(chunk->table_id == root->simple_rte_array[child_rtindex]->relid);
+			Assert(chunk->fd.relid == root->simple_rte_array[child_rtindex]->relid);
 			ts_get_private_reloptinfo(child_rel)->cached_chunk_struct = chunk;
 		}
 	}

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1635,7 +1635,7 @@ timescaledb_get_relation_info(PlannerInfo *root, RelOptInfo *rel, bool inhparent
 									"current \"timescaledb.license\""),
 							 errdetail("Chunk \"%s\" is compressed and requires "
 									   "the TimescaleDB Community Edition to query.",
-									   get_rel_name(chunk->table_id)),
+									   get_rel_name(chunk->fd.relid)),
 							 errhint("Set timescaledb.license to 'timescale' and install the "
 									 "TimescaleDB Community Edition to query compressed data.")));
 				}

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1046,7 +1046,7 @@ chunk_has_missing_attrs(Chunk *chunk)
 {
 	bool has_missing_attrs = false;
 	Relation ht_rel = relation_open(chunk->hypertable_relid, AccessShareLock);
-	Relation chunk_rel = relation_open(chunk->table_id, AccessShareLock);
+	Relation chunk_rel = relation_open(chunk->fd.relid, AccessShareLock);
 	TupleDesc tupdesc = RelationGetDescr(chunk_rel);
 
 	for (int i = 0; i < tupdesc->natts; i++)
@@ -1091,8 +1091,8 @@ register_chunk_for_rebuild_if_needed(Oid chunk_relid, VacuumCtx *ctx)
 		 */
 		Ensure(!ts_chunk_is_frozen(chunk),
 			   "chunk \"%s.%s\" was altered unsafely after it was frozen",
-			   NameStr(chunk->fd.schema_name),
-			   NameStr(chunk->fd.table_name));
+			   ts_chunk_get_schema_name(chunk),
+			   ts_chunk_get_table_name(chunk));
 		ctx->rebuild_columnstore_chunk_oids =
 			lappend_oid(ctx->rebuild_columnstore_chunk_oids, chunk_relid);
 	}
@@ -1113,8 +1113,8 @@ add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
 	chunk = ts_chunk_get_by_relid(chunk_relid, true);
 
 	chunk_range_var = copyObject(ctx->ht_vacuum_rel->relation);
-	chunk_range_var->relname = NameStr(chunk->fd.table_name);
-	chunk_range_var->schemaname = NameStr(chunk->fd.schema_name);
+	chunk_range_var->relname = ts_chunk_get_table_name(chunk);
+	chunk_range_var->schemaname = ts_chunk_get_schema_name(chunk);
 	chunk_vacuum_rel =
 		makeVacuumRelation(chunk_range_var, chunk_relid, ctx->ht_vacuum_rel->va_cols);
 	ctx->chunk_rels = lappend(ctx->chunk_rels, chunk_vacuum_rel);
@@ -1122,7 +1122,7 @@ add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
 	/* If we have a compressed chunk make sure to analyze it as well */
 	if (ts_chunk_is_compressed(chunk))
 	{
-		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
+		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->fd.relid);
 		/* Compressed chunk might be missing due to concurrent operations */
 		if (OidIsValid(compressed_relid))
 		{
@@ -1532,7 +1532,7 @@ process_truncate(ProcessUtilityArgs *args)
 						if (ts_chunk_is_compressed(chunk))
 						{
 							Oid compressed_relid =
-								ts_relation_get_compressed_relid(chunk->table_id);
+								ts_relation_get_compressed_relid(chunk->fd.relid);
 							if (OidIsValid(compressed_relid))
 							{
 								/* Create list item into the same context of the list. */
@@ -1671,7 +1671,7 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 			 *  it would be blocked if there are dependent objects */
 			if (stmt->behavior == DROP_CASCADE && ts_chunk_is_compressed(chunk))
 			{
-				Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
+				Oid compressed_relid = ts_relation_get_compressed_relid(chunk->fd.relid);
 				/* The chunk may have been delete by a CASCADE */
 				if (OidIsValid(compressed_relid))
 				{
@@ -2581,7 +2581,7 @@ rename_hypertable_constraint(Hypertable *ht, Oid chunk_relid, void *arg)
 	RenameStmt *stmt = (RenameStmt *) arg;
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
 	RangeVar *chunk_rel =
-		makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0);
+		makeRangeVar(ts_chunk_get_schema_name(chunk), ts_chunk_get_table_name(chunk), 0);
 	char old_chunk_name[NAMEDATALEN];
 	char new_chunk_name[NAMEDATALEN];
 	Oid chunk_con_oid;
@@ -2711,7 +2711,8 @@ rename_hypertable_trigger(Hypertable *ht, Oid chunk_relid, void *arg)
 	RenameStmt *stmt = copyObject(castNode(RenameStmt, arg));
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
 
-	stmt->relation = makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0);
+	stmt->relation =
+		makeRangeVar(ts_chunk_get_schema_name(chunk), ts_chunk_get_table_name(chunk), 0);
 	renametrig(stmt);
 }
 
@@ -2869,15 +2870,15 @@ validate_index_constraints(Chunk *chunk, const IndexStmt *stmt)
 	if ((stmt->primary || stmt->unique) && ts_chunk_is_compressed(chunk))
 	{
 		StringInfoData command;
-		Oid nspcid = get_rel_namespace(chunk->table_id);
+		Oid nspcid = get_rel_namespace(chunk->fd.relid);
 		ListCell *lc;
-		List *dpcontext = deparse_context_for(get_rel_name(chunk->table_id), chunk->table_id);
+		List *dpcontext = deparse_context_for(get_rel_name(chunk->fd.relid), chunk->fd.relid);
 
 		initStringInfo(&command);
 		appendStringInfo(&command,
 						 "SELECT EXISTS(SELECT FROM %s.%s",
 						 quote_identifier(get_namespace_name(nspcid)),
-						 quote_identifier(get_rel_name(chunk->table_id)));
+						 quote_identifier(get_rel_name(chunk->fd.relid)));
 
 		if (!stmt->nulls_not_distinct)
 		{
@@ -2937,7 +2938,7 @@ validate_index_constraints(Chunk *chunk, const IndexStmt *stmt)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 (errmsg("could not verify unique constraint on \"%s\"",
-							 get_rel_name(chunk->table_id)))));
+							 get_rel_name(chunk->fd.relid)))));
 		}
 
 		bool isnull;
@@ -2969,8 +2970,8 @@ validate_check_constraint(Chunk *chunk, const char *conname, const char *deparse
 	if (ts_chunk_is_compressed(chunk))
 	{
 		StringInfoData command;
-		Oid nspcid = get_rel_namespace(chunk->table_id);
-		Relation rel = table_open(chunk->table_id, AccessExclusiveLock);
+		Oid nspcid = get_rel_namespace(chunk->fd.relid);
+		Relation rel = table_open(chunk->fd.relid, AccessExclusiveLock);
 
 		initStringInfo(&command);
 		appendStringInfo(&command,
@@ -2995,7 +2996,7 @@ validate_check_constraint(Chunk *chunk, const char *conname, const char *deparse
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 (errmsg("could not verify check constraint on \"%s\"",
-							 get_rel_name(chunk->table_id)))));
+							 get_rel_name(chunk->fd.relid)))));
 		}
 
 		bool isnull;
@@ -3173,7 +3174,7 @@ validate_set_not_null(Hypertable *ht, Oid chunk_relid, void *arg)
 	{
 		StringInfoData command;
 		AlterTableCmd *cmd = (AlterTableCmd *) arg;
-		const CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+		const CompressionSettings *settings = ts_compression_settings_get(chunk->fd.relid);
 		Oid nspcid = get_rel_namespace(settings->fd.compress_relid);
 
 		initStringInfo(&command);
@@ -3710,8 +3711,8 @@ process_index_start(ProcessUtilityArgs *args)
 					 * and cannot be passed to deparse_expression directly, so run the
 					 * standard PostgreSQL transformation first.
 					 */
-					Relation rel = table_open(chunk->table_id, AccessShareLock);
-					IndexStmt *transformed = transformIndexStmt(chunk->table_id, stmt, NULL);
+					Relation rel = table_open(chunk->fd.relid, AccessShareLock);
+					IndexStmt *transformed = transformIndexStmt(chunk->fd.relid, stmt, NULL);
 					table_close(rel, NoLock);
 					validate_index_constraints(chunk, transformed);
 				}
@@ -4574,8 +4575,8 @@ process_altertable_chunk_replica_identity(Hypertable *ht, Oid chunk_relid, void 
 		{
 			elog(ERROR,
 				 "chunk \"%s.%s\" has no index corresponding to hypertable index \"%s\"",
-				 NameStr(chunk->fd.schema_name),
-				 NameStr(chunk->fd.table_name),
+				 ts_chunk_get_schema_name(chunk),
+				 ts_chunk_get_table_name(chunk),
 				 stmt->name);
 		}
 

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -125,8 +125,8 @@ create_trigger_handler(const Trigger *trigger, void *arg)
 	if (trigger && TRIGGER_FOR_ROW(trigger->tgtype) && !trigger->tgisinternal)
 	{
 		ts_trigger_create_on_chunk(trigger->tgoid,
-								   NameStr(chunk->fd.schema_name),
-								   NameStr(chunk->fd.table_name));
+								   ts_chunk_get_schema_name(chunk),
+								   ts_chunk_get_table_name(chunk));
 	}
 
 	return true;

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -393,10 +393,6 @@ typedef struct FormData_chunk
 	int32 id;
 	Oid relid;
 	int32 hypertable_id;
-	/* schema_name and table_name are not stored in the catalog; they are
-	 * derived from the chunk relation when the form is filled. */
-	NameData schema_name;
-	NameData table_name;
 	int32 status;
 	bool osm_chunk;
 	TimestampTz creation_time;

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -829,13 +829,16 @@ chunk_get_minmax(const Chunk *chunk, Oid col_type, const char *col_name, Datum *
 	int save_nestlevel = NewGUCNestLevel();
 	RestrictSearchPath();
 
+	const char *schema_name = ts_chunk_get_schema_name(chunk);
+	const char *table_name = ts_chunk_get_table_name(chunk);
+
 	initStringInfo(&command);
 	appendStringInfo(&command,
 					 "SELECT pg_catalog.min(%s), pg_catalog.max(%s) FROM %s.%s",
 					 quote_identifier(col_name),
 					 quote_identifier(col_name),
-					 quote_identifier(NameStr(chunk->fd.schema_name)),
-					 quote_identifier(NameStr(chunk->fd.table_name)));
+					 quote_identifier(schema_name),
+					 quote_identifier(table_name));
 
 	/*
 	 * SPI_connect will switch MemoryContext so we need to keep track
@@ -856,8 +859,8 @@ chunk_get_minmax(const Chunk *chunk, Oid col_type, const char *col_name, Datum *
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 (errmsg("could not get the min/max values for column \"%s\" of chunk \"%s.%s\"",
 						 col_name,
-						 NameStr(chunk->fd.schema_name),
-						 NameStr(chunk->fd.table_name)))));
+						 schema_name,
+						 table_name))));
 	}
 
 	pfree(command.data);
@@ -933,8 +936,8 @@ ts_chunk_column_stats_calculate(const Hypertable *ht, const Chunk *chunk)
 		Oid col_type;
 
 		attno = get_attnum(ht->main_table_relid, col_name);
-		attno = ts_map_attno(ht->main_table_relid, chunk->table_id, attno);
-		col_type = get_atttype(chunk->table_id, attno);
+		attno = ts_map_attno(ht->main_table_relid, chunk->fd.relid, attno);
+		col_type = get_atttype(chunk->fd.relid, attno);
 
 		/* calculate the min/max range for this column on this chunk */
 		if (chunk_get_minmax(chunk, col_type, col_name, minmax))
@@ -1035,7 +1038,7 @@ ts_chunk_column_stats_insert(const Hypertable *ht, const Chunk *chunk)
 
 		/* Get the attribute number in the HT for this column, and map to the chunk */
 		attno = get_attnum(ht->main_table_relid, col_name);
-		attno = ts_map_attno(ht->main_table_relid, chunk->table_id, attno);
+		attno = ts_map_attno(ht->main_table_relid, chunk->fd.relid, attno);
 
 		/* insert an entry for this ht_id, chunk_id for this col_name with -inf/+inf range */
 		fd.hypertable_id = ht->fd.id;

--- a/test/src/test_scanner.c
+++ b/test/src/test_scanner.c
@@ -5,6 +5,8 @@
  */
 #include <postgres.h>
 
+#include <utils/lsyscache.h>
+
 #include "chunk.h"
 #include "scan_iterator.h"
 #include "scanner.h"
@@ -33,7 +35,10 @@ TS_TEST_FN(ts_test_scanner)
 
 		ts_chunk_formdata_fill(&fd, ti);
 
-		elog(NOTICE, "1. Scan: \"%s.%s\"", NameStr(fd.schema_name), NameStr(fd.table_name));
+		elog(NOTICE,
+			 "1. Scan: \"%s.%s\"",
+			 get_namespace_name(get_rel_namespace(fd.relid)),
+			 get_rel_name(fd.relid));
 
 		if (i < lengthof(chunk_id) && chunk_id[i] == -1)
 		{
@@ -60,8 +65,8 @@ TS_TEST_FN(ts_test_scanner)
 
 		elog(NOTICE,
 			 "2. Scan with filter: \"%s.%s\"",
-			 NameStr(fd.schema_name),
-			 NameStr(fd.table_name));
+			 get_namespace_name(get_rel_namespace(fd.relid)),
+			 get_rel_name(fd.relid));
 	}
 
 	/* Rescan */
@@ -80,7 +85,10 @@ TS_TEST_FN(ts_test_scanner)
 
 		ts_chunk_formdata_fill(&fd, ti);
 
-		elog(NOTICE, "3. ReScan: \"%s.%s\"", NameStr(fd.schema_name), NameStr(fd.table_name));
+		elog(NOTICE,
+			 "3. ReScan: \"%s.%s\"",
+			 get_namespace_name(get_rel_namespace(fd.relid)),
+			 get_rel_name(fd.relid));
 	}
 
 	ts_scan_iterator_end(&it);
@@ -97,7 +105,10 @@ TS_TEST_FN(ts_test_scanner)
 
 		ts_chunk_formdata_fill(&fd, ti);
 
-		elog(NOTICE, "4. IndexScan: \"%s.%s\"", NameStr(fd.schema_name), NameStr(fd.table_name));
+		elog(NOTICE,
+			 "4. IndexScan: \"%s.%s\"",
+			 get_namespace_name(get_rel_namespace(fd.relid)),
+			 get_rel_name(fd.relid));
 	}
 
 	ts_scan_iterator_close(&it);

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -245,15 +245,11 @@ policy_reorder_execute(int32 job_id, Jsonb *config)
 	 * chunk.
 	 */
 	chunk = ts_chunk_get_by_id(chunk_id, false);
-	elog(DEBUG1,
-		 "reordering chunk %s.%s",
-		 NameStr(chunk->fd.schema_name),
-		 NameStr(chunk->fd.table_name));
-	reorder_chunk(chunk->table_id, policy.index_relid, false, InvalidOid, InvalidOid, InvalidOid);
-	elog(DEBUG1,
-		 "completed reordering chunk %s.%s",
-		 NameStr(chunk->fd.schema_name),
-		 NameStr(chunk->fd.table_name));
+	const char *schema_name = ts_chunk_get_schema_name(chunk);
+	const char *table_name = ts_chunk_get_table_name(chunk);
+	elog(DEBUG1, "reordering chunk %s.%s", schema_name, table_name);
+	reorder_chunk(chunk->fd.relid, policy.index_relid, false, InvalidOid, InvalidOid, InvalidOid);
+	elog(DEBUG1, "completed reordering chunk %s.%s", schema_name, table_name);
 
 	/* Now update chunk_stats table */
 	ts_bgw_policy_chunk_stats_record_job_run(job_id, chunk_id, ts_timer_get_current_timestamp());
@@ -497,8 +493,8 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 
 				elog(DEBUG1,
 					 "compressed chunk \"%s.%s\" after continuous aggregate refresh",
-					 NameStr(chunk->fd.schema_name),
-					 NameStr(chunk->fd.table_name));
+					 ts_chunk_get_schema_name(chunk),
+					 ts_chunk_get_table_name(chunk));
 
 				PopActiveSnapshot();
 				CommitTransactionCommand();
@@ -695,8 +691,8 @@ policy_recompression_execute(int32 job_id, Jsonb *config)
 
 		elog(LOG,
 			 "completed recompressing chunk \"%s.%s\"",
-			 NameStr(chunk->fd.schema_name),
-			 NameStr(chunk->fd.table_name));
+			 ts_chunk_get_schema_name(chunk),
+			 ts_chunk_get_table_name(chunk));
 	}
 
 	elog(DEBUG1, "job %d completed recompressing chunk", job_id);

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -263,13 +263,16 @@ chunk_form_tuple(Chunk *chunk, Hypertable *ht, TupleDesc tupdesc, bool created)
 		return NULL;
 	}
 
+	NameData schema_name;
+	NameData table_name;
+	namestrcpy(&schema_name, ts_chunk_get_schema_name(chunk));
+	namestrcpy(&table_name, ts_chunk_get_table_name(chunk));
+
 	values[AttrNumberGetAttrOffset(Anum_create_chunk_id)] = Int32GetDatum(chunk->fd.id);
 	values[AttrNumberGetAttrOffset(Anum_create_chunk_hypertable_id)] =
 		Int32GetDatum(chunk->fd.hypertable_id);
-	values[AttrNumberGetAttrOffset(Anum_create_chunk_schema_name)] =
-		NameGetDatum(&chunk->fd.schema_name);
-	values[AttrNumberGetAttrOffset(Anum_create_chunk_table_name)] =
-		NameGetDatum(&chunk->fd.table_name);
+	values[AttrNumberGetAttrOffset(Anum_create_chunk_schema_name)] = NameGetDatum(&schema_name);
+	values[AttrNumberGetAttrOffset(Anum_create_chunk_table_name)] = NameGetDatum(&table_name);
 	values[AttrNumberGetAttrOffset(Anum_create_chunk_relkind)] = CharGetDatum(chunk->relkind);
 	values[AttrNumberGetAttrOffset(Anum_create_chunk_slices)] =
 		JsonbPGetDatum(JsonbValueToJsonb(jv));
@@ -492,7 +495,7 @@ chunk_detach(PG_FUNCTION_ARGS)
 		.relation = makeRangeVar(NameStr(ht->fd.schema_name), NameStr(ht->fd.table_name), 0),
 	};
 
-	ts_alter_table_with_event_trigger(chunk->table_id, (Node *) &stmt, list_make1(&cmd), false);
+	ts_alter_table_with_event_trigger(chunk->fd.relid, (Node *) &stmt, list_make1(&cmd), false);
 
 	ts_chunk_detach_by_relid(chunk_relid);
 

--- a/tsl/src/chunk_merge.c
+++ b/tsl/src/chunk_merge.c
@@ -427,7 +427,7 @@ chunk_update_constraints(const Chunk *chunk, const Hypercube *new_cube)
 		 * pattern. */
 		char old_check_name[NAMEDATALEN];
 		snprintf(old_check_name, NAMEDATALEN, "constraint_%d", old_slice_id);
-		Oid old_check_oid = get_relation_constraint_oid(chunk->table_id, old_check_name, true);
+		Oid old_check_oid = get_relation_constraint_oid(chunk->fd.relid, old_check_name, true);
 		if (OidIsValid(old_check_oid))
 		{
 			ObjectAddress constrobj = {
@@ -453,7 +453,7 @@ chunk_update_constraints(const Chunk *chunk, const Hypercube *new_cube)
 	{
 		/* Adding a constraint should require AccessExclusivelock. It should
 		 * already be taken at this point, but specify it to be sure. */
-		Relation rel = table_open(chunk->table_id, AccessExclusiveLock);
+		Relation rel = table_open(chunk->fd.relid, AccessExclusiveLock);
 		AddRelationNewConstraints(rel,
 								  NIL /* List *newColDefaults */,
 								  new_constraints,
@@ -1166,8 +1166,8 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot merge frozen chunk \"%s.%s\" scheduled for tiering",
-							NameStr(chunk->fd.schema_name),
-							NameStr(chunk->fd.table_name)),
+							ts_chunk_get_schema_name(chunk),
+							ts_chunk_get_table_name(chunk)),
 					 errhint("Untier the chunk before merging.")));
 		}
 
@@ -1240,7 +1240,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 		 */
 		if (ts_chunk_is_compressed(chunk))
 		{
-			Oid crelid = ts_relation_get_compressed_relid(chunk->table_id);
+			Oid crelid = ts_relation_get_compressed_relid(chunk->fd.relid);
 			Relation crel = table_open(crelid, lockmode);
 			rellocks = append_rellock(rellocks, crel, lockmode, merge_cxt);
 			table_close(crel, NoLock);
@@ -1257,7 +1257,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 			{
 				elog(WARNING,
 					 "missing compression chunk size stats for compressed chunk \"%s\"",
-					 NameStr(chunk->fd.table_name));
+					 ts_chunk_get_table_name(chunk));
 			}
 		}
 
@@ -1276,9 +1276,9 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 					 errmsg("cannot merge chunks across different hypertables"),
 					 errdetail("Chunk \"%s\" is part of hypertable \"%s\" while chunk \"%s\" is "
 							   "part of hypertable \"%s\"",
-							   get_rel_name(chunk->table_id),
+							   get_rel_name(chunk->fd.relid),
 							   get_rel_name(chunk->hypertable_relid),
-							   get_rel_name(relinfos[i - 1].chunk->table_id),
+							   get_rel_name(relinfos[i - 1].chunk->fd.relid),
 							   get_rel_name(relinfos[i - 1].chunk->hypertable_relid))));
 		}
 
@@ -1364,7 +1364,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 			RelationMergeInfo *crelinfo = &crelinfos[i];
 			/* Merging the compressed relation only needs its relid, not a full Chunk. */
 			crelinfo->chunk = NULL;
-			crelinfo->relid = ts_relation_get_compressed_relid(chunk->table_id);
+			crelinfo->relid = ts_relation_get_compressed_relid(chunk->fd.relid);
 			crelinfo->rel = table_open(crelinfo->relid, lockmode);
 			crelinfo->isresult = relinfos[i].isresult;
 			crelinfo->iscompressed_rel = true;
@@ -1394,7 +1394,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 
 		if (ts_chunk_is_compressed(result_chunk))
 		{
-			result_settings = ts_compression_settings_get(result_chunk->table_id);
+			result_settings = ts_compression_settings_get(result_chunk->fd.relid);
 		}
 
 		for (int i = 0; i < nrelids; i++)
@@ -1407,7 +1407,7 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 				continue;
 			}
 
-			settings = ts_compression_settings_get(chunk->table_id);
+			settings = ts_compression_settings_get(chunk->fd.relid);
 
 			if (result_settings == NULL ||
 				!ts_compression_settings_equal(result_settings, settings))
@@ -1418,8 +1418,8 @@ chunk_merge_chunks(PG_FUNCTION_ARGS)
 								"compression settings"),
 						 errdetail("Chunk \"%s\" was compressed with different "
 								   "settings than chunk \"%s\".",
-								   get_rel_name(chunk->table_id),
-								   get_rel_name(result_chunk->table_id)),
+								   get_rel_name(chunk->fd.relid),
+								   get_rel_name(result_chunk->fd.relid)),
 						 errhint("Decompress the affected chunks and recompress them "
 								 "with the current compression settings before merging.")));
 			}

--- a/tsl/src/chunk_split.c
+++ b/tsl/src/chunk_split.c
@@ -996,8 +996,8 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot split frozen chunk \"%s.%s\" scheduled for tiering",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name)),
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk)),
 				 errhint("Untier the chunk before splitting it.")));
 	}
 
@@ -1164,7 +1164,7 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 	bool created = false;
 	Chunk *new_chunk = ts_chunk_find_or_create_without_cuts(ht,
 															new_cube,
-															NameStr(chunk->fd.schema_name),
+															ts_chunk_get_schema_name(chunk),
 															NULL,
 															InvalidOid,
 															&created);
@@ -1195,7 +1195,7 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 	 */
 	SplitRelationInfo split_relations[SPLIT_FACTOR] = {
 		[0] = { .relid = relid, .chunk_id = chunk->fd.id, .heap_swap = true },
-		[1] = { .relid = new_chunk->table_id, .chunk_id = new_chunk->fd.id, .heap_swap = false }
+		[1] = { .relid = new_chunk->fd.relid, .chunk_id = new_chunk->fd.id, .heap_swap = false }
 	};
 	SplitRelationInfo csplit_relations[SPLIT_FACTOR] = {};
 	SplitRelationInfo *compressed_split_relations = NULL;

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -334,7 +334,7 @@ find_chunk_to_merge_into(Hypertable *ht, Chunk *current_chunk)
 	}
 
 	/* Get reloid of the previous compressed chunk via settings */
-	CompressionSettings *prev_comp_settings = ts_compression_settings_get(previous_chunk->table_id);
+	CompressionSettings *prev_comp_settings = ts_compression_settings_get(previous_chunk->fd.relid);
 	CompressionSettings *ht_comp_settings = ts_compression_settings_get(ht->main_table_relid);
 	if (!ts_compression_settings_equal_with_defaults(ht_comp_settings, prev_comp_settings))
 	{
@@ -422,7 +422,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 					get_namespace_name(get_rel_namespace(chunk_relid)),
 					get_rel_name(chunk_relid))));
 	LockRelationOid(cxt.srcht->main_table_relid, AccessShareLock);
-	LockRelationOid(cxt.srcht_chunk->table_id, ExclusiveLock);
+	LockRelationOid(cxt.srcht_chunk->fd.relid, ExclusiveLock);
 
 	/* acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
@@ -482,8 +482,8 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	else
 	{
 		/* use an existing compressed chunk to compress into */
-		compress_chunk_relid = ts_relation_get_compressed_relid(mergable_chunk->table_id);
-		result_chunk_id = mergable_chunk->table_id;
+		compress_chunk_relid = ts_relation_get_compressed_relid(mergable_chunk->fd.relid);
+		result_chunk_id = mergable_chunk->fd.relid;
 		ereport(DEBUG1,
 				(errmsg("merge into existing columnstore chunk \"%s.%s\"",
 						get_namespace_name(get_rel_namespace(compress_chunk_relid)),
@@ -515,9 +515,9 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 			HEAP_INSERT_FROZEN :
 			0;
 
-	before_size = ts_relation_size_impl(cxt.srcht_chunk->table_id);
+	before_size = ts_relation_size_impl(cxt.srcht_chunk->fd.relid);
 
-	cstat = compress_chunk(cxt.srcht_chunk->table_id, compress_chunk_relid, insert_options);
+	cstat = compress_chunk(cxt.srcht_chunk->fd.relid, compress_chunk_relid, insert_options);
 	after_size = ts_relation_size_impl(compress_chunk_relid);
 
 	if (cxt.srcht->range_space)
@@ -604,14 +604,14 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 		ereport((if_compressed ? NOTICE : ERROR),
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s\" is not converted to columnstore",
-						get_rel_name(uncompressed_chunk->table_id))));
+						get_rel_name(uncompressed_chunk->fd.relid))));
 		return;
 	}
 
 	write_logical_replication_msg_decompression_start();
 
 	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk, CHUNK_DECOMPRESS, true);
-	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
+	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->fd.relid);
 
 	/*
 	 * The chunk is marked as compressed but its compressed relation is
@@ -623,13 +623,16 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s\" is missing its compressed relation",
-						get_rel_name(uncompressed_chunk->table_id))));
+						get_rel_name(uncompressed_chunk->fd.relid))));
 	}
+
+	const char *uncompressed_schema_name = ts_chunk_get_schema_name(uncompressed_chunk);
+	const char *uncompressed_table_name = ts_chunk_get_table_name(uncompressed_chunk);
 
 	ereport(DEBUG1,
 			(errmsg("acquiring locks for converting to rowstore \"%s.%s\"",
-					NameStr(uncompressed_chunk->fd.schema_name),
-					NameStr(uncompressed_chunk->fd.table_name))));
+					uncompressed_schema_name,
+					uncompressed_table_name)));
 	/* acquire locks on src and compress hypertable and src chunk */
 	LockRelationOid(uncompressed_hypertable->main_table_relid, AccessShareLock);
 
@@ -647,15 +650,15 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	 *       chunk. See the comments in function about the concurrency of
 	 *       operations.
 	 */
-	LockRelationOid(uncompressed_chunk->table_id, ExclusiveLock);
+	LockRelationOid(uncompressed_chunk->fd.relid, ExclusiveLock);
 	LockRelationOid(compressed_relid, ExclusiveLock);
 
 	/* acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
 	ereport(DEBUG1,
 			(errmsg("locks acquired for converting to rowstore \"%s.%s\"",
-					NameStr(uncompressed_chunk->fd.schema_name),
-					NameStr(uncompressed_chunk->fd.table_name))));
+					uncompressed_schema_name,
+					uncompressed_table_name)));
 
 	DEBUG_WAITPOINT("decompress_chunk_impl_start");
 
@@ -670,12 +673,12 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	/* Throw error if chunk has invalid status for operation */
 	ts_chunk_validate_chunk_status_for_operation(chunk_state_after_lock, CHUNK_DECOMPRESS, true);
 
-	decompress_chunk(compressed_relid, uncompressed_chunk->table_id);
+	decompress_chunk(compressed_relid, uncompressed_chunk->fd.relid);
 
 	/* Delete the compressed chunk */
 	ts_compression_chunk_size_delete(uncompressed_chunk->fd.id);
 	ts_chunk_clear_compressed(uncompressed_chunk);
-	ts_compression_settings_delete(uncompressed_chunk->table_id);
+	ts_compression_settings_delete(uncompressed_chunk->fd.relid);
 
 	/*
 	 * Lock the compressed chunk that is going to be deleted. At this point,
@@ -687,7 +690,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	 * also requests an AccessExclusiveLock on the compressed_chunk. However,
 	 * this call makes the lock on the chunk explicit.
 	 */
-	LockRelationOid(uncompressed_chunk->table_id, AccessExclusiveLock);
+	LockRelationOid(uncompressed_chunk->fd.relid, AccessExclusiveLock);
 	LockRelationOid(compressed_relid, AccessExclusiveLock);
 	ts_chunk_drop_by_relid(compressed_relid, DROP_RESTRICT, -1);
 	ts_cache_release(&hcache);
@@ -718,7 +721,7 @@ is_chunk_orderby_nullhandling(CompressionSettings *settings)
 static bool
 recompress_chunk_impl(Chunk *chunk, bool recompress)
 {
-	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->fd.relid);
 	bool recompressed = false;
 
 	if (!chunk_settings || !chunk_settings->fd.orderby)
@@ -726,8 +729,8 @@ recompress_chunk_impl(Chunk *chunk, bool recompress)
 		elog(NOTICE,
 			 "in-memory recompression is disabled due to no order by, "
 			 "performing decompress/compress on chunk \"%s.%s\"",
-			 NameStr(chunk->fd.schema_name),
-			 NameStr(chunk->fd.table_name));
+			 ts_chunk_get_schema_name(chunk),
+			 ts_chunk_get_table_name(chunk));
 		return false;
 	}
 	else if (!get_compressed_chunk_index_for_recompression(chunk))
@@ -735,8 +738,8 @@ recompress_chunk_impl(Chunk *chunk, bool recompress)
 		elog(NOTICE,
 			 "in-memory recompression is disabled due to no compressed chunk index, "
 			 "performing decompress/compress on chunk \"%s.%s\"",
-			 NameStr(chunk->fd.schema_name),
-			 NameStr(chunk->fd.table_name));
+			 ts_chunk_get_schema_name(chunk),
+			 ts_chunk_get_table_name(chunk));
 		return false;
 	}
 
@@ -777,8 +780,8 @@ recompress_chunk_impl(Chunk *chunk, bool recompress)
 			elog(ts_guc_debug_compression_path_info ? INFO : DEBUG1,
 				 "in-memory recompression is disabled due to nullable order by with no firstlast, "
 				 "performing segmentwise decompress/compress on chunk \"%s.%s\"",
-				 NameStr(chunk->fd.schema_name),
-				 NameStr(chunk->fd.table_name));
+				 ts_chunk_get_schema_name(chunk),
+				 ts_chunk_get_table_name(chunk));
 		}
 		recompress_chunk_segmentwise_impl(chunk, orderby_not_handling_nulls);
 		recompressed = true;
@@ -844,7 +847,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 
 	/* Acquire locks on src and compress hypertable and src chunk */
 	LockRelationOid(cxt.srcht->main_table_relid, AccessShareLock);
-	LockRelationOid(cxt.srcht_chunk->table_id, ShareLock);
+	LockRelationOid(cxt.srcht_chunk->fd.relid, ShareLock);
 
 	/* Acquire locks on catalog tables to keep till end of txn */
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
@@ -869,7 +872,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 										  numrows_post_compression,
 										  0);
 
-	if (!chunk_was_compressed && ts_table_has_tuples(cxt.srcht_chunk->table_id, AccessShareLock))
+	if (!chunk_was_compressed && ts_table_has_tuples(cxt.srcht_chunk->fd.relid, AccessShareLock))
 	{
 		/* The chunk was not compressed before it had the compressed chunk
 		 * attached to it, and it contains rows, so we set it to be partial.
@@ -902,15 +905,15 @@ tsl_compress_chunk(PG_FUNCTION_ARGS)
 Oid
 tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress)
 {
-	Oid uncompressed_relid = chunk->table_id;
+	Oid uncompressed_relid = chunk->fd.relid;
 
 	if (ts_chunk_is_frozen(chunk))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s.%s\" is frozen, skipping compression",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name)),
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk)),
 				 errhint("Use _timescaledb_functions.unfreeze_chunk to unfreeze.")));
 		return uncompressed_relid;
 	}
@@ -919,7 +922,7 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 
 	if (ts_chunk_needs_compression(chunk))
 	{
-		uncompressed_relid = compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+		uncompressed_relid = compress_chunk_impl(chunk->hypertable_relid, chunk->fd.relid);
 	}
 	else if (recompress || ts_chunk_needs_recompression(chunk))
 	{
@@ -931,10 +934,10 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 			elog(DEBUG1,
 				 "falling back to compress/decompress, performing full "
 				 "recompression on chunk \"%s.%s\"",
-				 NameStr(chunk->fd.schema_name),
-				 NameStr(chunk->fd.table_name));
+				 ts_chunk_get_schema_name(chunk),
+				 ts_chunk_get_table_name(chunk));
 			decompress_chunk_impl(chunk, false);
-			compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+			compress_chunk_impl(chunk->hypertable_relid, chunk->fd.relid);
 		}
 	}
 	else
@@ -942,7 +945,7 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed, bool recompress
 		ereport((if_not_compressed ? NOTICE : ERROR),
 				(errcode(ERRCODE_DUPLICATE_OBJECT),
 				 errmsg("chunk \"%s\" is already converted to columnstore",
-						get_rel_name(chunk->table_id))));
+						get_rel_name(chunk->fd.relid))));
 	}
 
 	write_logical_replication_msg_compression_end();
@@ -992,7 +995,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 static bool
 can_use_in_memory_rebuild(Chunk *chunk)
 {
-	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->fd.relid);
 
 	/* check if we can allow in-memory recompression to rebuild columnstore */
 	if (!chunk_settings || !chunk_settings->fd.orderby)
@@ -1041,8 +1044,8 @@ tsl_rebuild_columnstore(PG_FUNCTION_ARGS)
 		ereport(NOTICE,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s.%s\" is uncompressed or frozen, skipping",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 		PG_RETURN_VOID();
 	}
 
@@ -1052,10 +1055,10 @@ tsl_rebuild_columnstore(PG_FUNCTION_ARGS)
 		elog(DEBUG1,
 			 "falling back to decompress/compress, performing full "
 			 "rebuild on chunk \"%s.%s\"",
-			 NameStr(chunk->fd.schema_name),
-			 NameStr(chunk->fd.table_name));
+			 ts_chunk_get_schema_name(chunk),
+			 ts_chunk_get_table_name(chunk));
 		decompress_chunk_impl(chunk, false);
-		compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+		compress_chunk_impl(chunk->hypertable_relid, chunk->fd.relid);
 	}
 
 	PG_RETURN_VOID();
@@ -1084,12 +1087,12 @@ tsl_rebuild_sparse_index(PG_FUNCTION_ARGS)
 		ereport(NOTICE,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s.%s\" is uncompressed or frozen, skipping",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 		PG_RETURN_VOID();
 	}
 
-	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->fd.relid);
 	CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
 
 	if (ht_settings->fd.index == NULL)
@@ -1098,8 +1101,8 @@ tsl_rebuild_sparse_index(PG_FUNCTION_ARGS)
 				(errmsg("no sparse index configured on hypertable \"%s\" for chunk \"%s.%s\", "
 						"skipping",
 						get_rel_name(chunk->hypertable_relid),
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 		PG_RETURN_VOID();
 	}
 
@@ -1108,8 +1111,8 @@ tsl_rebuild_sparse_index(PG_FUNCTION_ARGS)
 	{
 		ereport(NOTICE,
 				(errmsg("orderby settings for chunk \"%s.%s\" differ from hypertable \"%s\"",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name),
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk),
 						get_rel_name(chunk->hypertable_relid)),
 				 errhint("Use compress_chunk(chunk, recompress => true) to recompress.")));
 		PG_RETURN_VOID();
@@ -1120,8 +1123,8 @@ tsl_rebuild_sparse_index(PG_FUNCTION_ARGS)
 		ereport(NOTICE,
 				(errmsg("sparse index settings for chunk \"%s.%s\" already match hypertable, "
 						"skipping (use force => true to override)",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 		PG_RETURN_VOID();
 	}
 
@@ -1156,16 +1159,16 @@ tsl_get_compressed_chunk_index_for_recompression(PG_FUNCTION_ARGS)
 static Oid
 get_compressed_chunk_index_for_recompression(Chunk *uncompressed_chunk)
 {
-	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
+	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->fd.relid);
 	if (!OidIsValid(compressed_relid))
 	{
 		return InvalidOid;
 	}
 
-	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
+	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->fd.relid, AccessShareLock);
 	Relation compressed_chunk_rel = table_open(compressed_relid, AccessShareLock);
 
-	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->fd.relid);
 
 	CatalogIndexState indstate = CatalogOpenIndexes(compressed_chunk_rel);
 	Oid index_oid = get_compressed_chunk_index(indstate, settings);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1150,20 +1150,20 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 	}
 
 	/* Can happen for partial chunks, but problematic if happening otherwise */
-	if (!CheckRelationOidLockedByMe(src_chunk->table_id, AccessExclusiveLock, false))
+	if (!CheckRelationOidLockedByMe(src_chunk->fd.relid, AccessExclusiveLock, false))
 	{
 		/* Since the segmentby rebuild is triggered by a DML, expect at least RowExclusiveLock */
-		Ensure(CheckRelationOidLockedByMe(src_chunk->table_id, RowExclusiveLock, true),
+		Ensure(CheckRelationOidLockedByMe(src_chunk->fd.relid, RowExclusiveLock, true),
 			   "hypertable chunk \"%s\".\"%s\" must have at least a RowExclusiveLock "
 			   "to apply segmentby",
-			   NameStr(src_chunk->fd.schema_name),
-			   NameStr(src_chunk->fd.table_name));
+			   ts_chunk_get_schema_name(src_chunk),
+			   ts_chunk_get_table_name(src_chunk));
 
 		elog(DEBUG1,
 			 "chunk \"%s\".\"%s\" does not have AccessExclusiveLock "
 			 "but trying to apply segmentby",
-			 NameStr(src_chunk->fd.schema_name),
-			 NameStr(src_chunk->fd.table_name));
+			 ts_chunk_get_schema_name(src_chunk),
+			 ts_chunk_get_table_name(src_chunk));
 	}
 
 	Ensure(CheckRelationOidLockedByMe(old_compressed_relid, AccessExclusiveLock, false),
@@ -1197,7 +1197,7 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 		return;
 	}
 
-	Relation in_rel = table_open(src_chunk->table_id, NoLock);
+	Relation in_rel = table_open(src_chunk->fd.relid, NoLock);
 
 	/* Create before drop. We must update settings first to point to the new chunk. */
 	rename_compressed_chunk_for_replacement(old_compressed_relid);

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -704,8 +704,8 @@ decompress_unique_update_conflict_batches(ModifyHypertableState *ht_state, Chunk
 		return false;
 	}
 
-	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
-	Oid chunk_relid = chunk->table_id;
+	CompressionSettings *settings = ts_compression_settings_get(chunk->fd.relid);
+	Oid chunk_relid = chunk->fd.relid;
 	bool batches_decompressed = false;
 
 	/*
@@ -851,7 +851,7 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	ScanKeyData *mem_scankeys = NULL;
 	List *bloom_filters = NIL;
 
-	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(chunk->fd.relid);
 	bool delete_only = ht_state->mt->operation == CMD_DELETE && !plan_requires_decompression &&
 					   direct_delete_prerequisites(ht_state);
 	InvalidationContext invalidation_ctx = { 0 };
@@ -879,10 +879,10 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	{
 		const Dimension *time_dim = hyperspace_get_open_dimension(ht_state->ht->space, 0);
 		const char *time_col_name = NameStr(time_dim->fd.column_name);
-		AttrNumber chunk_time_attno = get_attnum(chunk->table_id, time_col_name);
+		AttrNumber chunk_time_attno = get_attnum(chunk->fd.relid, time_col_name);
 
 		invalidation_ctx.hypertable_id = ht_state->ht->fd.id;
-		invalidation_ctx.chunk_relid = chunk->table_id;
+		invalidation_ctx.chunk_relid = chunk->fd.relid;
 		invalidation_ctx.time_type_oid = time_dim->fd.column_type;
 
 		if (ts_array_is_member(settings->fd.segmentby, time_col_name))
@@ -901,20 +901,20 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 		{
 			invalidation_ctx.min_time_attno =
 				compressed_column_metadata_attno(settings,
-												 chunk->table_id,
+												 chunk->fd.relid,
 												 chunk_time_attno,
 												 settings->fd.compress_relid,
 												 "min");
 			invalidation_ctx.max_time_attno =
 				compressed_column_metadata_attno(settings,
-												 chunk->table_id,
+												 chunk->fd.relid,
 												 chunk_time_attno,
 												 settings->fd.compress_relid,
 												 "max");
 		}
 	}
 
-	chunk_rel = table_open(chunk->table_id, RowExclusiveLock);
+	chunk_rel = table_open(chunk->fd.relid, RowExclusiveLock);
 	comp_chunk_rel = table_open(settings->fd.compress_relid, RowExclusiveLock);
 
 	if (index_filters)
@@ -2015,7 +2015,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 					continue;
 				}
 
-				column_name = get_attname(ch->table_id, var->varattno, false);
+				column_name = get_attname(ch->fd.relid, var->varattno, false);
 				TypeCacheEntry *tce = lookup_type_cache(var->vartype, TYPECACHE_BTREE_OPFAMILY);
 				int op_strategy = get_op_opfamily_strategy(opno, tce->btree_opf);
 
@@ -2116,7 +2116,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				}
 
 				int max_attno = compressed_column_metadata_attno(settings,
-																 ch->table_id,
+																 ch->fd.relid,
 																 var->varattno,
 																 settings->fd.compress_relid,
 																 "max");
@@ -2235,7 +2235,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 
 				collation = sa_expr->inputcollid;
 
-				column_name = get_attname(ch->table_id, var->varattno, false);
+				column_name = get_attname(ch->fd.relid, var->varattno, false);
 				TypeCacheEntry *tce = lookup_type_cache(var->vartype, TYPECACHE_BTREE_OPFAMILY);
 				int op_strategy = get_op_opfamily_strategy(opno, tce->btree_opf);
 				if (ts_array_is_member(settings->fd.segmentby, column_name))
@@ -2286,7 +2286,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 						*all_predicates_enforced = false;
 						continue;
 					}
-					column_name = get_attname(ch->table_id, var->varattno, false);
+					column_name = get_attname(ch->fd.relid, var->varattno, false);
 					if (ts_array_is_member(settings->fd.segmentby, column_name))
 					{
 						*index_filters =
@@ -2343,7 +2343,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 	{
 		SparseIndexSettings *parsed = ts_convert_to_sparse_index_settings(settings->fd.index);
 		TsBmsList per_column_attnos =
-			ts_resolve_columns_to_attnos_from_parsed_settings(parsed, ch->table_id);
+			ts_resolve_columns_to_attnos_from_parsed_settings(parsed, ch->fd.relid);
 
 		/* Build a Bitmapset of equality predicate attnums for bms_is_subset() */
 		Bitmapset *eq_pred_attnos = NULL;
@@ -2389,7 +2389,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 			int attnum = -1;
 			while ((attnum = bms_next_member(bloom_attnos, attnum)) >= 0)
 			{
-				type_oids[col_idx] = get_atttype(ch->table_id, attnum);
+				type_oids[col_idx] = get_atttype(ch->fd.relid, attnum);
 
 				/* Find the matching equality predicate for this attnum */
 				foreach_ptr(EqualityPredicate, ep, eq_preds)

--- a/tsl/src/compression/compression_storage.c
+++ b/tsl/src/compression/compression_storage.c
@@ -89,11 +89,11 @@ compression_table_create(Chunk *src_chunk, List *column_defs, Oid tablespace_oid
 	/* NewRelationCreateToastTable calls CommandCounterIncrement */
 	NameData relname = build_compressed_relation_name(src_chunk);
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	compress_rel = makeRangeVar(NameStr(src_chunk->fd.schema_name), NameStr(relname), -1);
+	compress_rel = makeRangeVar(ts_chunk_get_schema_name(src_chunk), NameStr(relname), -1);
 
 	create->relation = compress_rel;
 	/* Inherit the persistence (LOGGED or UNLOGGED) from the uncompressed chunk */
-	create->relation->relpersistence = get_rel_persistence(src_chunk->table_id);
+	create->relation->relpersistence = get_rel_persistence(src_chunk->fd.relid);
 
 	tbladdress = DefineRelation(create, RELKIND_RELATION, owner, NULL, NULL);
 	CommandCounterIncrement();

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -123,7 +123,7 @@ NameData
 build_compressed_relation_name(const Chunk *chunk)
 {
 	NameData name;
-	int ret = snprintf(NameStr(name), NAMEDATALEN, "%s_compressed", NameStr(chunk->fd.table_name));
+	int ret = snprintf(NameStr(name), NAMEDATALEN, "%s_compressed", ts_chunk_get_table_name(chunk));
 	if (ret < 0 || ret >= NAMEDATALEN)
 	{
 		ereport(ERROR, (errcode(ERRCODE_NAME_TOO_LONG), errmsg("chunk name too long")));
@@ -928,7 +928,7 @@ create_compress_chunk(Chunk *src_chunk, Oid table_id, bool skip_segmentby_defaul
 	 * on which to base this decision. We simply pick the same tablespace as the uncompressed chunk
 	 * for now.
 	 */
-	tablespace_oid = get_rel_tablespace(src_chunk->table_id);
+	tablespace_oid = get_rel_tablespace(src_chunk->fd.relid);
 	if (!settings_provided)
 	{
 		settings = ts_compression_settings_get(src_chunk->hypertable_relid);
@@ -962,7 +962,7 @@ create_compress_chunk(Chunk *src_chunk, Oid table_id, bool skip_segmentby_defaul
 
 	if (!OidIsValid(table_id))
 	{
-		List *column_defs = build_columndefs(settings, src_chunk->table_id);
+		List *column_defs = build_columndefs(settings, src_chunk->fd.relid);
 		table_id = compression_table_create(src_chunk, column_defs, tablespace_oid, settings);
 	}
 
@@ -974,7 +974,7 @@ create_compress_chunk(Chunk *src_chunk, Oid table_id, bool skip_segmentby_defaul
 	/* Materialize current compression settings for this chunk */
 	if (!settings_provided)
 	{
-		ts_compression_settings_materialize(settings, src_chunk->table_id, table_id);
+		ts_compression_settings_materialize(settings, src_chunk->fd.relid, table_id);
 	}
 	else
 	{
@@ -2213,7 +2213,7 @@ tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
+		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->fd.relid);
 		if (!OidIsValid(compressed_relid))
 		{
 			continue;
@@ -2268,7 +2268,7 @@ tsl_process_compress_table_drop_column(Hypertable *ht, char *name)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
+		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->fd.relid);
 		if (!OidIsValid(compressed_relid))
 		{
 			continue;
@@ -2385,7 +2385,7 @@ tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->table_id);
+		Oid compressed_relid = ts_relation_get_compressed_relid(chunk->fd.relid);
 		if (!OidIsValid(compressed_relid))
 		{
 			continue;

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -191,8 +191,8 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 		ereport(elevel,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("nothing to recompress in chunk %s.%s",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 	}
 	else
 	{
@@ -229,8 +229,8 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 			elog(ts_guc_debug_compression_path_info ? INFO : DEBUG1,
 				 "in-memory recompression is disabled due to nullable order by with no firstlast, "
 				 "performing segmentwise decompress/compress on chunk \"%s.%s\"",
-				 NameStr(chunk->fd.schema_name),
-				 NameStr(chunk->fd.table_name));
+				 ts_chunk_get_schema_name(chunk),
+				 ts_chunk_get_table_name(chunk));
 		}
 		recompress_chunk_segmentwise_impl(chunk, orderby_not_handling_nulls);
 	}
@@ -259,8 +259,8 @@ tsl_compact_chunk(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("trying to compact an uncompressed chunk %s.%s",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 	}
 
 	if (ts_chunk_is_partial(chunk))
@@ -268,8 +268,8 @@ tsl_compact_chunk(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("trying to compact a partially compressed chunk %s.%s",
-						NameStr(chunk->fd.schema_name),
-						NameStr(chunk->fd.table_name))));
+						ts_chunk_get_schema_name(chunk),
+						ts_chunk_get_table_name(chunk))));
 	}
 
 	uncompressed_relid = compact_chunk_impl(chunk);
@@ -435,7 +435,7 @@ void
 recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 								  bool fullrecompress /* do full decompress/compress segmentwise */)
 {
-	Oid uncompressed_relid = uncompressed_chunk->table_id;
+	Oid uncompressed_relid = uncompressed_chunk->fd.relid;
 
 	/*
 	 * only proceed if status in (3, 9, 11)
@@ -450,12 +450,12 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("unexpected chunk status %d in chunk %s.%s",
 						uncompressed_chunk->fd.status,
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk))));
 	}
 
 	/* need it to find the segby cols from the catalog */
-	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->fd.relid);
 
 	/* We should not do segment-wise recompression with empty orderby, see #7748
 	 */
@@ -463,14 +463,14 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 
 	ereport(DEBUG1,
 			(errmsg("acquiring locks for recompression: \"%s.%s\"",
-					NameStr(uncompressed_chunk->fd.schema_name),
-					NameStr(uncompressed_chunk->fd.table_name))));
+					ts_chunk_get_schema_name(uncompressed_chunk),
+					ts_chunk_get_table_name(uncompressed_chunk))));
 
 	LOCKMODE recompression_lockmode =
 		ts_guc_enable_exclusive_locking_recompression ? ExclusiveLock : ShareUpdateExclusiveLock;
 	/* lock both chunks, compressed and uncompressed */
 	Relation uncompressed_chunk_rel =
-		table_open(uncompressed_chunk->table_id, recompression_lockmode);
+		table_open(uncompressed_chunk->fd.relid, recompression_lockmode);
 	Relation compressed_chunk_rel = table_open(settings->fd.compress_relid, recompression_lockmode);
 
 	bool has_unique_constraints =
@@ -497,8 +497,8 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 			elog(WARNING,
 				 "skipping recompression of chunk %s.%s due to unique constraints and concurrent "
 				 "DML",
-				 NameStr(uncompressed_chunk->fd.schema_name),
-				 NameStr(uncompressed_chunk->fd.table_name));
+				 ts_chunk_get_schema_name(uncompressed_chunk),
+				 ts_chunk_get_table_name(uncompressed_chunk));
 
 			table_close(uncompressed_chunk_rel, NoLock);
 			table_close(compressed_chunk_rel, NoLock);
@@ -545,8 +545,8 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 	Relation index_rel = index_open(index_oid, index_lockmode);
 	ereport(DEBUG1,
 			(errmsg("locks acquired for recompression: \"%s.%s\"",
-					NameStr(uncompressed_chunk->fd.schema_name),
-					NameStr(uncompressed_chunk->fd.table_name))));
+					ts_chunk_get_schema_name(uncompressed_chunk),
+					ts_chunk_get_table_name(uncompressed_chunk))));
 
 	/* Need to populate recompress context of an uncompressed chunk */
 	RecompressContext *recompress_ctx =
@@ -1327,7 +1327,7 @@ compact_chunk_recompress_overlapping_batches(
 Oid
 compact_chunk_impl(Chunk *uncompressed_chunk)
 {
-	Oid uncompressed_chunk_id = uncompressed_chunk->table_id;
+	Oid uncompressed_chunk_id = uncompressed_chunk->fd.relid;
 
 	if (!ts_chunk_is_compressed(uncompressed_chunk))
 	{
@@ -1335,26 +1335,26 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("unexpected chunk status %d in chunk %s.%s",
 						uncompressed_chunk->fd.status,
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk))));
 	}
 
-	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->table_id);
+	Oid compressed_relid = ts_relation_get_compressed_relid(uncompressed_chunk->fd.relid);
 	Ensure(OidIsValid(compressed_relid),
 		   "compressed chunk not found for chunk \"%s\"",
-		   get_rel_name(uncompressed_chunk->table_id));
+		   get_rel_name(uncompressed_chunk->fd.relid));
 
 	ereport(DEBUG1,
 			(errmsg("acquiring locks for recompression: \"%s.%s\"",
-					NameStr(uncompressed_chunk->fd.schema_name),
-					NameStr(uncompressed_chunk->fd.table_name))));
+					ts_chunk_get_schema_name(uncompressed_chunk),
+					ts_chunk_get_table_name(uncompressed_chunk))));
 
 	/* Taking a ShareExclusiveLock on compressed chunk mostly to block DDL,
 	 * this could potentially be a RowExclusiveLock with enough testing.
 	 *
 	 * For uncompressed chunk, we just need to read so AccessShareLock is fine.
 	 */
-	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
+	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->fd.relid, AccessShareLock);
 	Relation compressed_chunk_rel = table_open(compressed_relid, ShareUpdateExclusiveLock);
 
 	int count;
@@ -1371,8 +1371,8 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 	{
 		elog(WARNING,
 			 "delaying compaction on chunk %s.%s due to concurrent DML",
-			 NameStr(uncompressed_chunk->fd.schema_name),
-			 NameStr(uncompressed_chunk->fd.table_name));
+			 ts_chunk_get_schema_name(uncompressed_chunk),
+			 ts_chunk_get_table_name(uncompressed_chunk));
 
 		/* Safe to drop the lock, we didn't change anything */
 		table_close(uncompressed_chunk_rel, NoLock);
@@ -1382,7 +1382,7 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 	}
 
 	TupleDesc uncompressed_rel_tupdesc = RelationGetDescr(uncompressed_chunk_rel);
-	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->fd.relid);
 
 	/*
 	 * Check if first orderby column is nullable. We need
@@ -1391,7 +1391,7 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 	int num_orderby = ts_array_length(settings->fd.orderby);
 	Ensure(num_orderby > 0,
 		   "trying to compact chunk \"%s\" with no orderby columns",
-		   get_rel_name(uncompressed_chunk->table_id));
+		   get_rel_name(uncompressed_chunk->fd.relid));
 
 	/*
 	 * Compaction reads each batch's exact boundary rows from the firstlast
@@ -1404,8 +1404,8 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 		{
 			ereport(WARNING,
 					(errmsg("skipping compaction on chunk %s.%s",
-							NameStr(uncompressed_chunk->fd.schema_name),
-							NameStr(uncompressed_chunk->fd.table_name)),
+							ts_chunk_get_schema_name(uncompressed_chunk),
+							ts_chunk_get_table_name(uncompressed_chunk)),
 					 errdetail("Orderby column \"%s\" has no firstlast sparse index.",
 							   ts_array_get_element_text(settings->fd.orderby, pos)),
 					 errhint("Recompress the chunk to add firstlast sparse index metadata for its "
@@ -1423,14 +1423,14 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("could not find index on compressed chunk \"%s.%s\" for compaction",
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk))));
 	}
 	Relation index_rel = index_open(index_oid, RowExclusiveLock);
 	ereport(DEBUG1,
 			(errmsg("locks acquired for compaction: \"%s.%s\"",
-					NameStr(uncompressed_chunk->fd.schema_name),
-					NameStr(uncompressed_chunk->fd.table_name))));
+					ts_chunk_get_schema_name(uncompressed_chunk),
+					ts_chunk_get_table_name(uncompressed_chunk))));
 
 	RecompressContext *recompress_ctx =
 		compress_chunk_populate_recompress_ctx(settings,
@@ -1532,12 +1532,12 @@ compact_chunk_impl(Chunk *uncompressed_chunk)
 			{
 				ereport(DEBUG1,
 						(errmsg("cleared unordered chunk status for compaction: \"%s.%s\"",
-								NameStr(uncompressed_chunk->fd.schema_name),
-								NameStr(uncompressed_chunk->fd.table_name))));
+								ts_chunk_get_schema_name(uncompressed_chunk),
+								ts_chunk_get_table_name(uncompressed_chunk))));
 			}
 
 			/* changed chunk status, so invalidate any plans involving this chunk */
-			CacheInvalidateRelcacheByRelid(uncompressed_chunk->table_id);
+			CacheInvalidateRelcacheByRelid(uncompressed_chunk->fd.relid);
 		}
 	}
 
@@ -1676,17 +1676,17 @@ perform_recompression(RecompressContext *recompress_ctx, Relation compressed_chu
 static CompressionSettings *
 resolve_recompression_settings(Chunk *uncompressed_chunk)
 {
-	CompressionSettings *chunk_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *chunk_settings = ts_compression_settings_get(uncompressed_chunk->fd.relid);
 	Ensure(chunk_settings != NULL,
 		   "compression settings not found for chunk \"%s\"",
-		   get_rel_name(uncompressed_chunk->table_id));
+		   get_rel_name(uncompressed_chunk->fd.relid));
 
 	/* get hypertable level settings */
 	CompressionSettings *new_settings =
 		ts_compression_settings_get(uncompressed_chunk->hypertable_relid);
 	Ensure(new_settings != NULL,
 		   "compression settings not found for hypertable of chunk \"%s\"",
-		   get_rel_name(uncompressed_chunk->table_id));
+		   get_rel_name(uncompressed_chunk->fd.relid));
 
 	new_settings->fd.relid = chunk_settings->fd.relid;
 	new_settings->fd.compress_relid = InvalidOid;
@@ -1742,17 +1742,17 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 		return false;
 	}
 
-	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *settings = ts_compression_settings_get(uncompressed_chunk->fd.relid);
 	Oid compressed_relid = settings->fd.compress_relid;
 
 	Ensure(settings && OidIsValid(compressed_relid),
 		   "compressed chunk not found for chunk \"%s\"",
-		   get_rel_name(uncompressed_chunk->table_id));
+		   get_rel_name(uncompressed_chunk->fd.relid));
 
 	Ensure(settings->fd.orderby, "empty order by, cannot recompress in-memory");
 
 	LOCKMODE lockmode = ExclusiveLock;
-	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->table_id, lockmode);
+	Relation uncompressed_chunk_rel = table_open(uncompressed_chunk->fd.relid, lockmode);
 	Relation compressed_chunk_rel = table_open(compressed_relid, lockmode);
 
 	CompressionSettings *new_settings = resolve_recompression_settings(uncompressed_chunk);
@@ -1804,15 +1804,15 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	table_close(compressed_chunk_rel, NoLock);
 	table_close(new_compressed_chunk_rel, NoLock);
 
-	LockRelationOid(uncompressed_chunk->table_id, AccessExclusiveLock);
+	LockRelationOid(uncompressed_chunk->fd.relid, AccessExclusiveLock);
 	LockRelationOid(compressed_relid, AccessExclusiveLock);
 	ts_chunk_drop_by_relid(compressed_relid, DROP_RESTRICT, -1);
 	if (ts_chunk_clear_status(uncompressed_chunk, CHUNK_STATUS_COMPRESSED_UNORDERED))
 	{
 		ereport(DEBUG1,
 				(errmsg("cleared chunk status for recompression: \"%s.%s\"",
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk))));
 	}
 
 	/* recompress successful */
@@ -2159,12 +2159,12 @@ try_updating_chunk_status(Chunk *uncompressed_chunk, Relation uncompressed_chunk
 		{
 			ereport(DEBUG1,
 					(errmsg("cleared chunk status for recompression: \"%s.%s\"",
-							NameStr(uncompressed_chunk->fd.schema_name),
-							NameStr(uncompressed_chunk->fd.table_name))));
+							ts_chunk_get_schema_name(uncompressed_chunk),
+							ts_chunk_get_table_name(uncompressed_chunk))));
 		}
 
 		/* changed chunk status, so invalidate any plans involving this chunk */
-		CacheInvalidateRelcacheByRelid(uncompressed_chunk->table_id);
+		CacheInvalidateRelcacheByRelid(uncompressed_chunk->fd.relid);
 	}
 }
 
@@ -2245,7 +2245,7 @@ static void
 add_sparse_index_columns(Chunk *chunk, Oid compressed_relid, List *index_objs)
 {
 	List *col_defs = NIL;
-	Relation uncompressed_rel = table_open(chunk->table_id, AccessShareLock);
+	Relation uncompressed_rel = table_open(chunk->fd.relid, AccessShareLock);
 	TupleDesc tupdesc = RelationGetDescr(uncompressed_rel);
 
 	foreach_ptr(SparseIndexSettingsObject, index_obj, index_objs)
@@ -2260,12 +2260,12 @@ add_sparse_index_columns(Chunk *chunk, Oid compressed_relid, List *index_objs)
 		List *attrs = NIL;
 		foreach_ptr(const char, colname, columns)
 		{
-			AttrNumber attno = get_attnum(chunk->table_id, colname);
+			AttrNumber attno = get_attnum(chunk->fd.relid, colname);
 			Ensure(AttributeNumberIsValid(attno),
 				   "column \"%s\" not found on chunk \"%s.%s\"",
 				   colname,
-				   NameStr(chunk->fd.schema_name),
-				   NameStr(chunk->fd.table_name));
+				   ts_chunk_get_schema_name(chunk),
+				   ts_chunk_get_table_name(chunk));
 			attrs = lappend(attrs, TupleDescAttr(tupdesc, attno - 1));
 		}
 
@@ -2403,7 +2403,7 @@ create_sparse_index_builders(Relation uncompressed_rel, Oid compressed_relid, Li
 static List *
 modify_compressed_table(Chunk *chunk, bool force)
 {
-	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->table_id);
+	CompressionSettings *chunk_settings = ts_compression_settings_get(chunk->fd.relid);
 	CompressionSettings *ht_settings = ts_compression_settings_get(chunk->hypertable_relid);
 
 	SparseIndexSettings *ht_index = ts_convert_to_sparse_index_settings(ht_settings->fd.index);
@@ -2583,21 +2583,21 @@ rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
 	Hypertable *ht = ts_hypertable_get_by_id(uncompressed_chunk->fd.hypertable_id);
 
 	LockRelationOid(ht->main_table_relid, AccessShareLock);
-	LockRelationOid(uncompressed_chunk->table_id, ShareUpdateExclusiveLock);
+	LockRelationOid(uncompressed_chunk->fd.relid, ShareUpdateExclusiveLock);
 
 	/* Re-read chunk state after locks — another process may have changed it */
-	uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk->table_id, true);
+	uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk->fd.relid, true);
 	if (!ts_chunk_is_compressed(uncompressed_chunk) || ts_chunk_is_frozen(uncompressed_chunk))
 	{
 		ereport(NOTICE,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("chunk \"%s.%s\" is no longer compressed or is frozen, skipping",
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk))));
 		return;
 	}
 
-	CompressionSettings *chunk_settings = ts_compression_settings_get(uncompressed_chunk->table_id);
+	CompressionSettings *chunk_settings = ts_compression_settings_get(uncompressed_chunk->fd.relid);
 	CompressionSettings *ht_settings =
 		ts_compression_settings_get(uncompressed_chunk->hypertable_relid);
 
@@ -2606,8 +2606,8 @@ rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
 	{
 		ereport(NOTICE,
 				(errmsg("orderby settings for chunk \"%s.%s\" differ from hypertable \"%s\"",
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name),
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk),
 						get_rel_name(uncompressed_chunk->hypertable_relid)),
 				 errhint("Use compress_chunk(chunk, recompress => true) to recompress.")));
 		return;
@@ -2618,8 +2618,8 @@ rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
 		ereport(NOTICE,
 				(errmsg("sparse index settings for chunk \"%s.%s\" already match hypertable "
 						"after acquiring locks, skipping",
-						NameStr(uncompressed_chunk->fd.schema_name),
-						NameStr(uncompressed_chunk->fd.table_name))));
+						ts_chunk_get_schema_name(uncompressed_chunk),
+						ts_chunk_get_table_name(uncompressed_chunk))));
 		return;
 	}
 
@@ -2635,7 +2635,7 @@ rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
 
 	/* Step 2: initialize builders and decompressor */
 	Relation compressed_rel = table_open(compressed_relid, RowExclusiveLock);
-	Relation uncompressed_rel = table_open(uncompressed_chunk->table_id, AccessShareLock);
+	Relation uncompressed_rel = table_open(uncompressed_chunk->fd.relid, AccessShareLock);
 	TupleDesc compressed_desc = RelationGetDescr(compressed_rel);
 
 	bool *repl = palloc0(sizeof(bool) * compressed_desc->natts);
@@ -2645,7 +2645,7 @@ rebuild_sparse_index_impl(Chunk *uncompressed_chunk, bool force)
 	RowDecompressor decompressor = build_decompressor(compressed_desc,
 													  RelationGetDescr(uncompressed_rel),
 													  compressed_relid,
-													  uncompressed_chunk->table_id);
+													  uncompressed_chunk->fd.relid);
 
 	/* Step 3: scan, decompress, populate, update */
 	populate_sparse_index_columns(compressed_rel, &decompressor, builders, repl);

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -676,7 +676,7 @@ build_compressioninfo(PlannerInfo *root, const Hypertable *ht, const Chunk *chun
 
 	info->chunk_rel = chunk_rel;
 	info->chunk_rte = planner_rt_fetch(chunk_rel->relid, root);
-	info->settings = ts_compression_settings_get(chunk->table_id);
+	info->settings = ts_compression_settings_get(chunk->fd.relid);
 
 	if (chunk_rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
 	{

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -298,8 +298,8 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 	 * because it expects indexes that need to be rechecked (due to new
 	 * transaction) to already have that mark set
 	 */
-	ts_chunk_index_mark_clustered(chunk->table_id, index_relid);
-	reorder_rel(chunk->table_id,
+	ts_chunk_index_mark_clustered(chunk->fd.relid, index_relid);
+	reorder_rel(chunk->fd.relid,
 				index_relid,
 				verbose,
 				wait_id,
@@ -345,14 +345,14 @@ chunk_get_reorder_index(Hypertable *ht, Chunk *chunk, Oid index_relid)
 
 	if (OidIsValid(index_relid))
 	{
-		if (index_belongs_to_relation(chunk->table_id, index_relid))
+		if (index_belongs_to_relation(chunk->fd.relid, index_relid))
 		{
 			return index_relid;
 		}
 
 		if (index_belongs_to_relation(ht->main_table_relid, index_relid))
 		{
-			Relation chunk_rel = table_open(chunk->table_id, AccessShareLock);
+			Relation chunk_rel = table_open(chunk->fd.relid, AccessShareLock);
 			Oid chunk_index_oid =
 				ts_chunk_index_get_by_hypertable_indexrelid(chunk_rel, index_relid);
 			table_close(chunk_rel, NoLock);
@@ -362,7 +362,7 @@ chunk_get_reorder_index(Hypertable *ht, Chunk *chunk, Oid index_relid)
 		return InvalidOid;
 	}
 
-	index_relid = ts_indexing_find_clustered_index(chunk->table_id);
+	index_relid = ts_indexing_find_clustered_index(chunk->fd.relid);
 	if (OidIsValid(index_relid))
 	{
 		return index_relid;
@@ -371,7 +371,7 @@ chunk_get_reorder_index(Hypertable *ht, Chunk *chunk, Oid index_relid)
 	index_relid = ts_indexing_find_clustered_index(ht->main_table_relid);
 	if (OidIsValid(index_relid))
 	{
-		Relation chunk_rel = table_open(chunk->table_id, AccessShareLock);
+		Relation chunk_rel = table_open(chunk->fd.relid, AccessShareLock);
 		Oid chunk_index_oid = ts_chunk_index_get_by_hypertable_indexrelid(chunk_rel, index_relid);
 		table_close(chunk_rel, NoLock);
 		return chunk_index_oid;


### PR DESCRIPTION
The previous change remove schema_name and table_name from chunk
catalog table and replaced it by relid. But the entries were left
in the Chunk struct to separate the catalog change from the code
change.

Disable-check: force-changelog-file
