### PR TITLE
Stabilize constraint_exclusion_prepared test to always use Filter on metrics_compressed

### DIFF
--- a/tsl/test/shared/expected/constraint_exclusion_prepared-16.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-16.out
@@ -1160,6 +1160,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 DEALLOCATE prep;
 RESET plan_cache_mode;
 \set TEST_TABLE 'metrics_compressed'
+SET timescaledb.enable_bulk_decompression TO 'off';
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -1620,7 +1621,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1628,7 +1629,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1644,7 +1645,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1652,7 +1653,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1668,7 +1669,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1676,7 +1677,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1692,7 +1693,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1700,7 +1701,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1716,7 +1717,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1724,7 +1725,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1882,7 +1883,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=5.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          Rows Removed by Filter: 3996
          ->  Sort (actual rows=4.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
@@ -1893,7 +1894,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1901,7 +1902,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 30
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1914,7 +1915,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=5.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1924,7 +1925,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          Rows Removed by Filter: 4995
          ->  Sort (actual rows=5.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
@@ -1933,7 +1934,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 25
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1946,7 +1947,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=0.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1956,7 +1957,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1964,7 +1965,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 30
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1974,6 +1975,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
+SET timescaledb.enable_bulk_decompression TO 'on';
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/expected/constraint_exclusion_prepared-17.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-17.out
@@ -1160,6 +1160,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 DEALLOCATE prep;
 RESET plan_cache_mode;
 \set TEST_TABLE 'metrics_compressed'
+SET timescaledb.enable_bulk_decompression TO 'off';
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -1620,7 +1621,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1628,7 +1629,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1644,7 +1645,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1652,7 +1653,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1668,7 +1669,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1676,7 +1677,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1692,7 +1693,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1700,7 +1701,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1716,7 +1717,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1724,7 +1725,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1882,7 +1883,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=5.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          Rows Removed by Filter: 3996
          ->  Sort (actual rows=4.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
@@ -1893,7 +1894,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1901,7 +1902,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 30
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1914,7 +1915,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=5.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1924,7 +1925,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          Rows Removed by Filter: 4995
          ->  Sort (actual rows=5.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
@@ -1933,7 +1934,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 25
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1946,7 +1947,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=0.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1956,7 +1957,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1964,7 +1965,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 30
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1974,6 +1975,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
+SET timescaledb.enable_bulk_decompression TO 'on';
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/expected/constraint_exclusion_prepared-18.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared-18.out
@@ -1160,6 +1160,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 DEALLOCATE prep;
 RESET plan_cache_mode;
 \set TEST_TABLE 'metrics_compressed'
+SET timescaledb.enable_bulk_decompression TO 'off';
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -1188,34 +1189,11 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
+               Filter: ("time" < now())
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
-
-:PREFIX EXECUTE prep;
---- QUERY PLAN ---
- Limit (actual rows=100.00 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
-         Order: metrics_compressed."time"
-         Chunks excluded during startup: 0
-         ->  Merge Append (actual rows=100.00 loops=1)
-               Sort Key: metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Filter: ((device_id = 1) AND ("time" < now()))
-                     ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (actual rows=1.00 loops=1)
-                           Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
-               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-                     Index Cond: ((device_id = 1) AND ("time" < now()))
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
+               Filter: ("time" < now())
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
 
@@ -1234,34 +1212,11 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
+               Filter: ("time" < now())
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
-
-:PREFIX EXECUTE prep;
---- QUERY PLAN ---
- Limit (actual rows=100.00 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
-         Order: metrics_compressed."time"
-         Chunks excluded during startup: 0
-         ->  Merge Append (actual rows=100.00 loops=1)
-               Sort Key: metrics_compressed."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
-                     Filter: ((device_id = 1) AND ("time" < now()))
-                     ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (actual rows=1.00 loops=1)
-                           Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
-               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
-                     Index Cond: ((device_id = 1) AND ("time" < now()))
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
-               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
-                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
-         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
+               Filter: ("time" < now())
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
 
@@ -1280,11 +1235,57 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
+               Filter: ("time" < now())
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < now())
+               Filter: ("time" < now())
+               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
+                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
+
+:PREFIX EXECUTE prep;
+--- QUERY PLAN ---
+ Limit (actual rows=100.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
+         Order: metrics_compressed."time"
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: ((device_id = 1) AND ("time" < now()))
+                     ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (actual rows=1.00 loops=1)
+                           Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+               Filter: ("time" < now())
+               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
+                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+               Filter: ("time" < now())
+               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
+                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
+
+:PREFIX EXECUTE prep;
+--- QUERY PLAN ---
+ Limit (actual rows=100.00 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=100.00 loops=1)
+         Order: metrics_compressed."time"
+         Chunks excluded during startup: 0
+         ->  Merge Append (actual rows=100.00 loops=1)
+               Sort Key: metrics_compressed."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=1.00 loops=1)
+                     Filter: ((device_id = 1) AND ("time" < now()))
+                     ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (actual rows=1.00 loops=1)
+                           Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
+                     Index Cond: ((device_id = 1) AND ("time" < now()))
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+               Filter: ("time" < now())
+               ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
+                     Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
+         ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
+               Filter: ("time" < now())
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < now()))
 
@@ -1312,7 +1313,7 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone))
 
@@ -1331,7 +1332,7 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone))
 
@@ -1350,7 +1351,7 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone))
 
@@ -1369,7 +1370,7 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone))
 
@@ -1388,7 +1389,7 @@ LIMIT 100;
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=100.00 loops=1)
                      Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
          ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-               Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Scan Backward using _hyper_X_X_chunk_compressed_device_id__ts_meta_v2_first_ti_idx on _hyper_X_X_chunk_compressed (never executed)
                      Index Cond: ((device_id = 1) AND (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone))
 
@@ -1620,7 +1621,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1628,7 +1629,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1644,7 +1645,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1652,7 +1653,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1668,7 +1669,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1676,7 +1677,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1692,7 +1693,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1700,7 +1701,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1716,7 +1717,7 @@ FROM (
                      Sort Key: _hyper_X_X_chunk."time"
                      Sort Method: top-N heapsort 
                      ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=16392.00 loops=1)
-                           Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                           Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                            ->  Seq Scan on _hyper_X_X_chunk_compressed (actual rows=18.00 loops=1)
                                  Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
                ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_time_idx on _hyper_X_X_chunk (actual rows=21.00 loops=1)
@@ -1724,7 +1725,7 @@ FROM (
          ->  Sort (never executed)
                Sort Key: _hyper_X_X_chunk."time"
                ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (never executed)
-                     Vectorized Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+                     Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
                      ->  Seq Scan on _hyper_X_X_chunk_compressed (never executed)
                            Filter: (_ts_meta_v2_last_time < ('2000-01-10'::cstring)::timestamp with time zone)
 
@@ -1882,7 +1883,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=5.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=4.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          Rows Removed by Filter: 3996
          ->  Sort (actual rows=4.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
@@ -1893,7 +1894,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1901,7 +1902,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 30
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1914,7 +1915,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=5.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1924,7 +1925,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=5.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          Rows Removed by Filter: 4995
          ->  Sort (actual rows=5.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
@@ -1933,7 +1934,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 25
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1946,7 +1947,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
  Merge Append (actual rows=0.00 loops=1)
    Sort Key: metrics_compressed.device_id
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1956,7 +1957,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
    ->  Index Only Scan using _hyper_X_X_chunk_metrics_compressed_device_id_time_idx on _hyper_X_X_chunk (actual rows=0.00 loops=1)
          Index Cond: ("time" = $1)
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1964,7 +1965,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
                      Filter: ((_ts_meta_v2_last_time <= $1) AND (_ts_meta_v2_first_time >= $1))
                      Rows Removed by Filter: 30
    ->  Custom Scan (ColumnarScan) on _hyper_X_X_chunk (actual rows=0.00 loops=1)
-         Vectorized Filter: ("time" = $1)
+         Filter: ("time" = $1)
          ->  Sort (actual rows=0.00 loops=1)
                Sort Key: _hyper_X_X_chunk_compressed.device_id
                Sort Method: quicksort 
@@ -1974,6 +1975,7 @@ PREPARE prep(timestamptz) AS SELECT device_id, time FROM :TEST_TABLE WHERE time 
 
 DEALLOCATE prep;
 RESET plan_cache_mode;
+SET timescaledb.enable_bulk_decompression TO 'on';
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/shared/sql/constraint_exclusion_prepared.sql.in
+++ b/tsl/test/shared/sql/constraint_exclusion_prepared.sql.in
@@ -36,7 +36,9 @@ SET enable_memoize TO 'off';
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
 \set TEST_TABLE 'metrics_compressed'
+SET timescaledb.enable_bulk_decompression TO 'off';
 \ir :TEST_QUERY_NAME
+SET timescaledb.enable_bulk_decompression TO 'on';
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
 


### PR DESCRIPTION
The test was flipping between Vectorized Filter and Filter on runtime-excluded chunks. As it's not important for the test, disabled bulk decompression to always get Filter.

Disable-check: force-changelog-file
