### PR TITLE
Fix unused attribute placement for PostgreSQL 19

### DIFF
--- a/tsl/src/compression/algorithms/array.c
+++ b/tsl/src/compression/algorithms/array.c
@@ -49,8 +49,7 @@ array_compressed_has_nulls(const CompressedDataHeader *header)
 	return ac->has_nulls;
 }
 
-static void
-pg_attribute_unused() assertions(void)
+pg_attribute_unused() static void assertions(void)
 {
 	ArrayCompressed test_val = { .vl_len_ = { 0 } };
 	Simple8bRleSerialized test_simple8b = { 0 };

--- a/tsl/src/compression/algorithms/deltadelta.c
+++ b/tsl/src/compression/algorithms/deltadelta.c
@@ -40,8 +40,7 @@ typedef struct DeltaDeltaCompressed
 	char delta_deltas[FLEXIBLE_ARRAY_MEMBER];
 } DeltaDeltaCompressed;
 
-static void
-pg_attribute_unused() assertions(void)
+pg_attribute_unused() static void assertions(void)
 {
 	DeltaDeltaCompressed test_val = { .vl_len_ = { 0 } };
 	/* make sure no padding bytes make it to disk */

--- a/tsl/src/compression/algorithms/dictionary.c
+++ b/tsl/src/compression/algorithms/dictionary.c
@@ -58,8 +58,7 @@ dictionary_compressed_has_nulls(const CompressedDataHeader *header)
 	return dc->has_nulls;
 }
 
-static void
-pg_attribute_unused() assertions(void)
+pg_attribute_unused() static void assertions(void)
 {
 	DictionaryCompressed test_val;
 	/* make sure no padding bytes make it to disk */

--- a/tsl/src/compression/algorithms/gorilla.c
+++ b/tsl/src/compression/algorithms/gorilla.c
@@ -71,8 +71,7 @@ gorilla_compressed_has_nulls(const CompressedDataHeader *header)
 	return gc->has_nulls;
 }
 
-static void
-pg_attribute_unused() assertions(void)
+pg_attribute_unused() static void assertions(void)
 {
 	GorillaCompressed test_val = { .vl_len_ = { 0 } };
 	/* make sure no padding bytes make it to disk */

--- a/tsl/src/compression/algorithms/simple8b_rle.h
+++ b/tsl/src/compression/algorithms/simple8b_rle.h
@@ -94,8 +94,7 @@ typedef struct Simple8bRleSerialized
 	uint64 slots[FLEXIBLE_ARRAY_MEMBER];
 } Simple8bRleSerialized;
 
-static void
-pg_attribute_unused() simple8brle_size_assertions(void)
+pg_attribute_unused() static void simple8brle_size_assertions(void)
 {
 	Simple8bRleSerialized test_val = { 0 };
 	/* ensure no padding bits make it to disk */

--- a/tsl/src/compression/algorithms/simple8b_rle_bitmap.h
+++ b/tsl/src/compression/algorithms/simple8b_rle_bitmap.h
@@ -48,8 +48,8 @@ simple8brle_bitmap_num_ones(const Simple8bRleBitmap *bitmap)
  * useful for gorilla decompression. Can be unused by other users of this
  * header.
  */
-static Simple8bRleBitmap simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)
-	pg_attribute_unused();
+pg_attribute_unused() static Simple8bRleBitmap
+	simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed);
 
 static Simple8bRleBitmap
 simple8brle_bitmap_prefixsums(Simple8bRleSerialized *compressed)

--- a/tsl/src/compression/algorithms/simple8b_rle_decompress_all.h
+++ b/tsl/src/compression/algorithms/simple8b_rle_decompress_all.h
@@ -156,9 +156,8 @@ FUNCTION_NAME(simple8brle_decompress_all_buf,
  * an input. We mark it as possibly unused because it is used not for every
  * element type we have.
  */
-static ELEMENT_TYPE *FUNCTION_NAME(simple8brle_decompress_all,
-								   ELEMENT_TYPE)(Simple8bRleSerialized *compressed, uint32 *n_)
-	pg_attribute_unused();
+pg_attribute_unused() static ELEMENT_TYPE *FUNCTION_NAME(simple8brle_decompress_all, ELEMENT_TYPE)(
+	Simple8bRleSerialized *compressed, uint32 *n_);
 
 static ELEMENT_TYPE *
 FUNCTION_NAME(simple8brle_decompress_all, ELEMENT_TYPE)(Simple8bRleSerialized *compressed,

--- a/tsl/src/compression/algorithms/uuid_compress.c
+++ b/tsl/src/compression/algorithms/uuid_compress.c
@@ -44,8 +44,7 @@ typedef struct UuidCompressed
 	uint64 alignment_sentinel[FLEXIBLE_ARRAY_MEMBER];
 } UuidCompressed;
 
-static void
-pg_attribute_unused() assertions(void)
+pg_attribute_unused() static void assertions(void)
 {
 	StaticAssertStmt(sizeof(UuidCompressed) == 16, "UuidCompressed wrong size");
 	StaticAssertStmt(offsetof(UuidCompressed, alignment_sentinel) % MAXIMUM_ALIGNOF == 0,
@@ -763,8 +762,7 @@ decompression_iterator_init(UuidDecompressionIterator *iter, void *compressed, O
 	};
 }
 
-static void
-pg_attribute_unused() silence_unused_warning(void)
+pg_attribute_unused() static void silence_unused_warning(void)
 {
 	simple8brle_serialized_recv(NULL);
 }

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -354,8 +354,7 @@ extern Datum tsl_compressed_data_column_size(PG_FUNCTION_ARGS);
 extern Datum tsl_compressed_data_to_array(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_batch(PG_FUNCTION_ARGS);
 
-static void
-pg_attribute_unused() assert_num_compression_algorithms_sane(void)
+pg_attribute_unused() static void assert_num_compression_algorithms_sane(void)
 {
 	/* make sure not too many compression algorithms   */
 	StaticAssertStmt(_END_COMPRESSION_ALGORITHMS <= _MAX_NUM_COMPRESSION_ALGORITHMS,


### PR DESCRIPTION
On PostgreSQL 19 the pg_attribute_unused() macro expands to the C23
attribute [[maybe_unused]] instead of the GNU __attribute__((unused)).
The C23 attribute is ignored when placed in the middle of a declaration,
so the compiler dropped it and then warned that the functions were
defined but not used. Move the attribute to the front of the declaration
where it applies to the function for both spellings.

Disable-check: approval-count
Disable-check: force-changelog-file
