### PR TITLE
Bugfix for direct delete with NULL array predicates

### DIFF
--- a/.unreleased/bugfix_10254
+++ b/.unreleased/bugfix_10254
@@ -1,0 +1,1 @@
+Fixes: #10254 Direct delete didn't handle array predicates with NULLs and deleted more than intended (#10129)

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -75,7 +75,7 @@ static BatchQualSummary batch_matches_vectorized(RowDecompressor *decompressor,
 static void process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							   ScanKeyData **mem_scankeys, int *num_mem_scankeys,
 							   List **heap_filters, List **index_filters, List **is_null,
-							   List **bloom_filters);
+							   List **bloom_filters, bool *all_predicates_enforced);
 static Relation find_matching_index(Relation comp_chunk_rel, List **index_filters,
 									List **heap_filters);
 static tuple_filtering_constraints *get_batch_keys_for_unique_constraints(Relation relation);
@@ -92,9 +92,8 @@ static void report_error(TM_Result result);
 
 static bool key_column_is_null(tuple_filtering_constraints *constraints, Relation chunk_rel,
 							   Oid ht_relid, TupleTableSlot *slot);
-static bool can_delete_without_decompression(ModifyHypertableState *ht_state,
-											 CompressionSettings *settings, Chunk *chunk,
-											 List *predicates);
+static bool is_null_or_contains_nulls(Const *const_value);
+static bool direct_delete_prerequisites(ModifyHypertableState *ht_state);
 static bool can_vectorize_constraint_checks(tuple_filtering_constraints *constraints,
 											CompressionSettings *settings, Relation chunk_rel,
 											Oid ht_relid, ScanKeyWithAttnos *mem_scankeys);
@@ -854,8 +853,23 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 
 	CompressionSettings *settings = ts_compression_settings_get(chunk->table_id);
 	bool delete_only = ht_state->mt->operation == CMD_DELETE && !plan_requires_decompression &&
-					   can_delete_without_decompression(ht_state, settings, chunk, predicates);
+					   direct_delete_prerequisites(ht_state);
 	InvalidationContext invalidation_ctx = { 0 };
+
+	bool all_predicates_enforced = true;
+	process_predicates(chunk,
+					   settings,
+					   predicates,
+					   &mem_scankeys,
+					   &num_mem_scankeys,
+					   &heap_filters,
+					   &index_filters,
+					   &is_null,
+					   &bloom_filters,
+					   &all_predicates_enforced);
+
+	/* direct delete is only supported if all predicates have a matching scan key */
+	delete_only &= all_predicates_enforced;
 
 	/*
 	 * Set up CAgg invalidation context if we're doing direct batch delete
@@ -899,16 +913,6 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 												 "max");
 		}
 	}
-
-	process_predicates(chunk,
-					   settings,
-					   predicates,
-					   &mem_scankeys,
-					   &num_mem_scankeys,
-					   &heap_filters,
-					   &index_filters,
-					   &is_null,
-					   &bloom_filters);
 
 	chunk_rel = table_open(chunk->table_id, RowExclusiveLock);
 	comp_chunk_rel = table_open(settings->fd.compress_relid, RowExclusiveLock);
@@ -1957,9 +1961,16 @@ get_batch_keys_for_unique_constraints(Relation relation)
 static void
 process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				   ScanKeyData **mem_scankeys, int *num_mem_scankeys, List **heap_filters,
-				   List **index_filters, List **is_null, List **bloom_filters)
+				   List **index_filters, List **is_null, List **bloom_filters,
+				   bool *all_predicates_enforced)
 {
 	ListCell *lc;
+	/* initialize the 'all_predicates_enforced' to true and handle the cases
+	 * when we can't enforce, and set it to 'false' below. this is telling the
+	 * caller when the scan keys are not enough to fully enforce the predicates.
+	 */
+	*all_predicates_enforced = true;
+
 	if (ts_guc_enable_dml_decompression_tuple_filtering)
 	{
 		*mem_scankeys = palloc0(sizeof(ScanKeyData) * list_length(predicates));
@@ -1986,15 +1997,23 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 
 				if (!ts_extract_expr_args(&opexpr->xpr, &var, &expr, &opno, &opcode))
 				{
+					*all_predicates_enforced = false;
 					continue;
 				}
 
 				if (!IsA(expr, Const))
 				{
+					*all_predicates_enforced = false;
 					continue;
 				}
 
 				arg_value = castNode(Const, expr);
+
+				if (arg_value->constisnull)
+				{
+					*all_predicates_enforced = false;
+					continue;
+				}
 
 				column_name = get_attname(ch->table_id, var->varattno, false);
 				TypeCacheEntry *tce = lookup_type_cache(var->vartype, TYPECACHE_BTREE_OPFAMILY);
@@ -2053,6 +2072,10 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 										   collation, /* need to use OpExpr input collation */
 										   opcode,
 										   arg_value->constisnull ? 0 : arg_value->constvalue);
+				}
+				else
+				{
+					*all_predicates_enforced = false;
 				}
 
 				/*
@@ -2186,15 +2209,30 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 				ScalarArrayOpExpr *sa_expr = castNode(ScalarArrayOpExpr, node);
 				if (!ts_extract_expr_args(&sa_expr->xpr, &var, &expr, &opno, &opcode))
 				{
+					*all_predicates_enforced = false;
 					continue;
 				}
 
 				if (!IsA(expr, Const))
 				{
+					*all_predicates_enforced = false;
 					continue;
 				}
 
 				Const *arg_value = castNode(Const, expr);
+				if (is_null_or_contains_nulls(arg_value))
+				{
+					*all_predicates_enforced = false;
+					continue;
+				}
+
+				/* the index search for array conditions are only fit for ANY (OR) conditions */
+				if (!sa_expr->useOr)
+				{
+					*all_predicates_enforced = false;
+					continue;
+				}
+
 				collation = sa_expr->inputcollid;
 
 				column_name = get_attname(ch->table_id, var->varattno, false);
@@ -2225,21 +2263,15 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							break;
 						}
 						default:
-							*heap_filters = lappend(*heap_filters,
-													make_batchfilter(column_name,
-																	 op_strategy,
-																	 collation,
-																	 opcode,
-																	 arg_value,
-																	 false, /* is_null_check */
-																	 false, /* is_null */
-																	 true	/* is_array_op */
-																	 ));
+							/* if we don't have a btree strategy, we can't scan the heap */
+							*all_predicates_enforced = false;
 							break;
 					}
 					continue;
 				}
 
+				/* there is no scan key produced */
+				*all_predicates_enforced = false;
 				break;
 			}
 			case T_NullTest:
@@ -2251,6 +2283,7 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 					/* ignore system-defined attributes */
 					if (var->varattno <= 0)
 					{
+						*all_predicates_enforced = false;
 						continue;
 					}
 					column_name = get_attname(ch->table_id, var->varattno, false);
@@ -2276,15 +2309,25 @@ process_predicates(Chunk *ch, CompressionSettings *settings, List *predicates,
 							*is_null = lappend_int(*is_null, 0);
 						}
 					}
+					else
+					{
+						*all_predicates_enforced = false;
+					}
 					/* We cannot optimize filtering decompression using ORDERBY
 					 * metadata and null check qualifiers. We could possibly do that by checking the
 					 * compressed data in combination with the ORDERBY nulls first setting and
 					 * verifying that the first or last tuple of a segment contains a NULL value.
 					 * This is left for future optimization */
 				}
+				else
+				{
+					*all_predicates_enforced = false;
+				}
 			}
 			break;
 			default:
+				/* if we can't recognize the expression, we can't create a scankey either */
+				*all_predicates_enforced = false;
 				break;
 		}
 	}
@@ -2624,11 +2667,36 @@ key_column_is_null(tuple_filtering_constraints *constraints, Relation chunk_rel,
 }
 
 static bool
-can_delete_without_decompression(ModifyHypertableState *ht_state, CompressionSettings *settings,
-								 Chunk *chunk, List *predicates)
+is_null_or_contains_nulls(Const *const_value)
 {
-	ListCell *lc;
+	Assert(const_value != NULL);
+	Assert(IsA(const_value, Const));
 
+	if (const_value->constisnull)
+	{
+		return true;
+	}
+
+	if (type_is_array(const_value->consttype))
+	{
+		ArrayType *arr = DatumGetArrayTypeP(const_value->constvalue);
+		if (ARR_NDIM(arr) == 0)
+		{
+			return false;
+		}
+
+		if (ARR_HASNULL(arr))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool
+direct_delete_prerequisites(ModifyHypertableState *ht_state)
+{
 	if (!ts_guc_enable_compressed_direct_batch_delete || !ts_guc_enable_optimizations)
 	{
 		return false;
@@ -2657,43 +2725,6 @@ can_delete_without_decompression(ModifyHypertableState *ht_state, CompressionSet
 		return false;
 	}
 
-	foreach (lc, predicates)
-	{
-		Node *node = lfirst(lc);
-		Var *var;
-		Expr *arg_value;
-		Oid opno;
-
-		if (ts_extract_expr_args((Expr *) node, &var, &arg_value, &opno, NULL))
-		{
-			if (!IsA(arg_value, Const))
-			{
-				return false;
-			}
-			char *column_name = get_attname(chunk->table_id, var->varattno, false);
-			/* Can do direct DELETE if we are dealing with segmentby columns */
-			if (ts_array_is_member(settings->fd.segmentby, column_name))
-			{
-				continue;
-			}
-
-			/* Can do direct DELETE if we are using in-memory filtering but
-			 * only if we can actually create scankeys for filtering
-			 */
-			if (ts_guc_enable_dml_decompression_tuple_filtering)
-			{
-				switch (nodeTag(node))
-				{
-					case T_ScalarArrayOpExpr:
-					case T_NullTest:
-						return false;
-					default:
-						continue;
-				}
-			}
-		}
-		return false;
-	}
 	return true;
 }
 

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -536,7 +536,12 @@ create_segment_filter_scankey(Relation in_rel, char *segment_filter_col_name,
 		return false;
 	}
 
-	int flags = is_array_op ? SK_SEARCHARRAY : 0;
+	if (is_array_op)
+	{
+		return false;
+	}
+
+	int flags = 0;
 
 	/*
 	 * In PG versions <= 14 NULL values are always considered distinct

--- a/tsl/test/expected/compression_update_delete-16.out
+++ b/tsl/test/expected/compression_update_delete-16.out
@@ -667,8 +667,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |               CHUNK_NAME                
 --------------+-----------------------------------------
-            9 | _timescaledb_internal._hyper_5_10_chunk
-            9 | _timescaledb_internal._hyper_5_11_chunk
+            1 | _timescaledb_internal._hyper_5_10_chunk
+            1 | _timescaledb_internal._hyper_5_11_chunk
 
 DROP TABLE sample_table;
 -- test for IS NOT NULL values in SEGMENTBY column
@@ -3416,3 +3416,318 @@ SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
 
 RESET TIME ZONE;
 RESET
+-- github issue 10129: delete on compressed rows silently deletes
+-- rows when the predicate on a segmentby column is <> ANY(NULL::array)
+CREATE TABLE trade_ticks (
+    ts       timestamptz NOT NULL,
+    exchange int,
+    price    int
+);
+CREATE TABLE
+SELECT create_hypertable('trade_ticks', 'ts',
+                         chunk_time_interval => interval '1 day');
+     create_hypertable     
+---------------------------
+ (28,public,trade_ticks,t)
+
+ALTER TABLE trade_ticks SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'exchange',
+    timescaledb.compress_orderby   = 'ts'
+);
+ALTER TABLE
+INSERT INTO trade_ticks
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+INSERT 0 288
+SELECT compress_chunk(c) FROM show_chunks('trade_ticks') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_28_51_chunk
+ _timescaledb_internal._hyper_28_52_chunk
+
+-- Predicate matches zero rows:
+SELECT count(*) AS matching_rows
+FROM trade_ticks
+WHERE exchange <> ANY (NULL::int[]);
+ matching_rows 
+---------------
+             0
+
+-- matching_rows = 0
+-- Baseline: optimization off, correct result.
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- Bug: direct batch delete silently removes rows.
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+DELETE 0
+-- DELETE 216 if the bug exists, expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- rows_after = 72 if the bug exists, expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- only exchange=0 survives if the bug exists
+ROLLBACK;
+ROLLBACK
+-- Other variations, with NULL array members
+-- Baseline, deleting all exchanges except '0'
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+DELETE 216
+-- DELETE 216
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+            72
+
+-- rows_baseline = 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+
+-- only exchange=0 remains
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows, doesn't spare exchange=0
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+DELETE 216
+-- expected DELETE 216
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+         72
+
+-- expected 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+
+-- expected exchange=0
+ROLLBACK;
+ROLLBACK
+-- Baseline, should not delete anything with a single NULL member
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+DELETE 0
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- expected all exchanges
+ROLLBACK;
+ROLLBACK
+-- Baseline, check if we can handle multiple NULLs, should not delete anything
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+DELETE 0
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- expected all exchanges
+ROLLBACK;
+ROLLBACK
+-- This should keep exchange=0 and 1, and delete exchange=2 and 3
+DELETE FROM trade_ticks WHERE exchange <> ALL(ARRAY[0, 1]);
+DELETE 144
+SELECT exchange, count(*) AS cnt FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | cnt 
+----------+-----
+        0 |  72
+        1 |  72
+
+DROP TABLE trade_ticks;
+DROP TABLE
+-- LLM Fuzzer found that we need to test the UPDATE path against crashes
+CREATE TABLE crash_test (
+    ts  timestamptz NOT NULL,
+    seg int,
+    val int
+);
+CREATE TABLE
+SELECT create_hypertable('crash_test', 'ts',
+                         chunk_time_interval => interval '1 day');
+    create_hypertable     
+--------------------------
+ (29,public,crash_test,t)
+
+ALTER TABLE crash_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby   = 'ts'
+);
+ALTER TABLE
+INSERT INTO crash_test
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+INSERT 0 288
+SELECT compress_chunk(c) FROM show_chunks('crash_test') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_53_chunk
+ _timescaledb_internal._hyper_29_54_chunk
+
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(NULL::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(NULL::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[0,NULL]::int[]);
+UPDATE 72
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[0,NULL]::int[]);
+UPDATE 216
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL, NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL, NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+DROP TABLE crash_test;
+DROP TABLE

--- a/tsl/test/expected/compression_update_delete-17.out
+++ b/tsl/test/expected/compression_update_delete-17.out
@@ -667,8 +667,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |               CHUNK_NAME                
 --------------+-----------------------------------------
-            9 | _timescaledb_internal._hyper_5_10_chunk
-            9 | _timescaledb_internal._hyper_5_11_chunk
+            1 | _timescaledb_internal._hyper_5_10_chunk
+            1 | _timescaledb_internal._hyper_5_11_chunk
 
 DROP TABLE sample_table;
 -- test for IS NOT NULL values in SEGMENTBY column
@@ -3416,3 +3416,318 @@ SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
 
 RESET TIME ZONE;
 RESET
+-- github issue 10129: delete on compressed rows silently deletes
+-- rows when the predicate on a segmentby column is <> ANY(NULL::array)
+CREATE TABLE trade_ticks (
+    ts       timestamptz NOT NULL,
+    exchange int,
+    price    int
+);
+CREATE TABLE
+SELECT create_hypertable('trade_ticks', 'ts',
+                         chunk_time_interval => interval '1 day');
+     create_hypertable     
+---------------------------
+ (28,public,trade_ticks,t)
+
+ALTER TABLE trade_ticks SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'exchange',
+    timescaledb.compress_orderby   = 'ts'
+);
+ALTER TABLE
+INSERT INTO trade_ticks
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+INSERT 0 288
+SELECT compress_chunk(c) FROM show_chunks('trade_ticks') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_28_51_chunk
+ _timescaledb_internal._hyper_28_52_chunk
+
+-- Predicate matches zero rows:
+SELECT count(*) AS matching_rows
+FROM trade_ticks
+WHERE exchange <> ANY (NULL::int[]);
+ matching_rows 
+---------------
+             0
+
+-- matching_rows = 0
+-- Baseline: optimization off, correct result.
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- Bug: direct batch delete silently removes rows.
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+DELETE 0
+-- DELETE 216 if the bug exists, expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- rows_after = 72 if the bug exists, expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- only exchange=0 survives if the bug exists
+ROLLBACK;
+ROLLBACK
+-- Other variations, with NULL array members
+-- Baseline, deleting all exchanges except '0'
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+DELETE 216
+-- DELETE 216
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+            72
+
+-- rows_baseline = 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+
+-- only exchange=0 remains
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows, doesn't spare exchange=0
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+DELETE 216
+-- expected DELETE 216
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+         72
+
+-- expected 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+
+-- expected exchange=0
+ROLLBACK;
+ROLLBACK
+-- Baseline, should not delete anything with a single NULL member
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+DELETE 0
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- expected all exchanges
+ROLLBACK;
+ROLLBACK
+-- Baseline, check if we can handle multiple NULLs, should not delete anything
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+DELETE 0
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- expected all exchanges
+ROLLBACK;
+ROLLBACK
+-- This should keep exchange=0 and 1, and delete exchange=2 and 3
+DELETE FROM trade_ticks WHERE exchange <> ALL(ARRAY[0, 1]);
+DELETE 144
+SELECT exchange, count(*) AS cnt FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | cnt 
+----------+-----
+        0 |  72
+        1 |  72
+
+DROP TABLE trade_ticks;
+DROP TABLE
+-- LLM Fuzzer found that we need to test the UPDATE path against crashes
+CREATE TABLE crash_test (
+    ts  timestamptz NOT NULL,
+    seg int,
+    val int
+);
+CREATE TABLE
+SELECT create_hypertable('crash_test', 'ts',
+                         chunk_time_interval => interval '1 day');
+    create_hypertable     
+--------------------------
+ (29,public,crash_test,t)
+
+ALTER TABLE crash_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby   = 'ts'
+);
+ALTER TABLE
+INSERT INTO crash_test
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+INSERT 0 288
+SELECT compress_chunk(c) FROM show_chunks('crash_test') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_53_chunk
+ _timescaledb_internal._hyper_29_54_chunk
+
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(NULL::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(NULL::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[0,NULL]::int[]);
+UPDATE 72
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[0,NULL]::int[]);
+UPDATE 216
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL, NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL, NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+DROP TABLE crash_test;
+DROP TABLE

--- a/tsl/test/expected/compression_update_delete-18.out
+++ b/tsl/test/expected/compression_update_delete-18.out
@@ -667,8 +667,8 @@ FROM compressed_chunk_info_view
 WHERE hypertable_name = 'sample_table' ORDER BY chunk_name;
  chunk_status |               CHUNK_NAME                
 --------------+-----------------------------------------
-            9 | _timescaledb_internal._hyper_5_10_chunk
-            9 | _timescaledb_internal._hyper_5_11_chunk
+            1 | _timescaledb_internal._hyper_5_10_chunk
+            1 | _timescaledb_internal._hyper_5_11_chunk
 
 DROP TABLE sample_table;
 -- test for IS NOT NULL values in SEGMENTBY column
@@ -3416,3 +3416,318 @@ SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
 
 RESET TIME ZONE;
 RESET
+-- github issue 10129: delete on compressed rows silently deletes
+-- rows when the predicate on a segmentby column is <> ANY(NULL::array)
+CREATE TABLE trade_ticks (
+    ts       timestamptz NOT NULL,
+    exchange int,
+    price    int
+);
+CREATE TABLE
+SELECT create_hypertable('trade_ticks', 'ts',
+                         chunk_time_interval => interval '1 day');
+     create_hypertable     
+---------------------------
+ (28,public,trade_ticks,t)
+
+ALTER TABLE trade_ticks SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'exchange',
+    timescaledb.compress_orderby   = 'ts'
+);
+ALTER TABLE
+INSERT INTO trade_ticks
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+INSERT 0 288
+SELECT compress_chunk(c) FROM show_chunks('trade_ticks') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_28_51_chunk
+ _timescaledb_internal._hyper_28_52_chunk
+
+-- Predicate matches zero rows:
+SELECT count(*) AS matching_rows
+FROM trade_ticks
+WHERE exchange <> ANY (NULL::int[]);
+ matching_rows 
+---------------
+             0
+
+-- matching_rows = 0
+-- Baseline: optimization off, correct result.
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- Bug: direct batch delete silently removes rows.
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+DELETE 0
+-- DELETE 216 if the bug exists, expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- rows_after = 72 if the bug exists, expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- only exchange=0 survives if the bug exists
+ROLLBACK;
+ROLLBACK
+-- Other variations, with NULL array members
+-- Baseline, deleting all exchanges except '0'
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+DELETE 216
+-- DELETE 216
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+            72
+
+-- rows_baseline = 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+
+-- only exchange=0 remains
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows, doesn't spare exchange=0
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+DELETE 216
+-- expected DELETE 216
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+         72
+
+-- expected 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+
+-- expected exchange=0
+ROLLBACK;
+ROLLBACK
+-- Baseline, should not delete anything with a single NULL member
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+DELETE 0
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- expected all exchanges
+ROLLBACK;
+ROLLBACK
+-- Baseline, check if we can handle multiple NULLs, should not delete anything
+BEGIN;
+BEGIN
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+SET
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+DELETE 0
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+ rows_baseline 
+---------------
+           288
+
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+ROLLBACK;
+ROLLBACK
+-- The bug deletes all rows
+BEGIN;
+BEGIN
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+DELETE 0
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+ rows_after 
+------------
+        288
+
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | count 
+----------+-------
+        0 |    72
+        1 |    72
+        2 |    72
+        3 |    72
+
+-- expected all exchanges
+ROLLBACK;
+ROLLBACK
+-- This should keep exchange=0 and 1, and delete exchange=2 and 3
+DELETE FROM trade_ticks WHERE exchange <> ALL(ARRAY[0, 1]);
+DELETE 144
+SELECT exchange, count(*) AS cnt FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ exchange | cnt 
+----------+-----
+        0 |  72
+        1 |  72
+
+DROP TABLE trade_ticks;
+DROP TABLE
+-- LLM Fuzzer found that we need to test the UPDATE path against crashes
+CREATE TABLE crash_test (
+    ts  timestamptz NOT NULL,
+    seg int,
+    val int
+);
+CREATE TABLE
+SELECT create_hypertable('crash_test', 'ts',
+                         chunk_time_interval => interval '1 day');
+    create_hypertable     
+--------------------------
+ (29,public,crash_test,t)
+
+ALTER TABLE crash_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby   = 'ts'
+);
+ALTER TABLE
+INSERT INTO crash_test
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+INSERT 0 288
+SELECT compress_chunk(c) FROM show_chunks('crash_test') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_53_chunk
+ _timescaledb_internal._hyper_29_54_chunk
+
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(NULL::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(NULL::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[0,NULL]::int[]);
+UPDATE 72
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[0,NULL]::int[]);
+UPDATE 216
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL, NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+BEGIN;
+BEGIN
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL, NULL]::int[]);
+UPDATE 0
+ROLLBACK;
+ROLLBACK
+DROP TABLE crash_test;
+DROP TABLE

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -509,11 +509,10 @@ BEGIN;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    Batches scanned: 2
-   Batches decompressed: 2
-   Tuples decompressed: 2
+   Batches deleted: 2
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0.00 loops=1)
                Filter: (reading IS NULL)
 
 -- 6 tuples should still be there
@@ -529,11 +528,10 @@ BEGIN;
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    Batches scanned: 6
-   Batches decompressed: 6
-   Tuples decompressed: 6
+   Batches deleted: 6
    ->  Delete on direct_delete (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk direct_delete_1
-         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=6.00 loops=1)
+         ->  Seq Scan on _hyper_X_X_chunk direct_delete_1 (actual rows=0.00 loops=1)
                Filter: (reading IS NOT NULL)
 
 -- 2 tuples should still be there
@@ -991,18 +989,17 @@ BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    Batches scanned: 14
-   Batches decompressed: 14
-   Tuples decompressed: 12076
+   Batches deleted: 14
    ->  Delete on metrics_compressed (actual rows=0.00 loops=1)
          Delete on _hyper_X_X_chunk metrics_compressed_1
          Delete on _hyper_X_X_chunk metrics_compressed_2
          Delete on _hyper_X_X_chunk metrics_compressed_3
-         ->  Append (actual rows=13674.00 loops=1)
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_1 (actual rows=3598.00 loops=1)
+         ->  Append (actual rows=1598.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_1 (actual rows=1598.00 loops=1)
                      Filter: ((device_id IS NOT NULL) AND (device_id = 1))
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_2 (actual rows=5038.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_2 (actual rows=0.00 loops=1)
                      Filter: ((device_id IS NOT NULL) AND (device_id = 1))
-               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_3 (actual rows=5038.00 loops=1)
+               ->  Seq Scan on _hyper_X_X_chunk metrics_compressed_3 (actual rows=0.00 loops=1)
                      Filter: ((device_id IS NOT NULL) AND (device_id = 1))
 
 BEGIN; EXPLAIN (analyze, buffers off, costs off, timing off, summary off) DELETE FROM metrics_compressed where device_id <> 1 AND device_id <> 2;ROLLBACK;

--- a/tsl/test/sql/compression_update_delete.sql.in
+++ b/tsl/test/sql/compression_update_delete.sql.in
@@ -1795,3 +1795,180 @@ SELECT to_timestamp(lowest_modified_value / 1000000.0) AS lowest,
                          WHERE table_name = 'cagg_inval_segmentby_time');
 RESET TIME ZONE;
 
+-- github issue 10129: delete on compressed rows silently deletes
+-- rows when the predicate on a segmentby column is <> ANY(NULL::array)
+
+CREATE TABLE trade_ticks (
+    ts       timestamptz NOT NULL,
+    exchange int,
+    price    int
+);
+SELECT create_hypertable('trade_ticks', 'ts',
+                         chunk_time_interval => interval '1 day');
+ALTER TABLE trade_ticks SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'exchange',
+    timescaledb.compress_orderby   = 'ts'
+);
+
+INSERT INTO trade_ticks
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+
+SELECT compress_chunk(c) FROM show_chunks('trade_ticks') c;
+
+-- Predicate matches zero rows:
+SELECT count(*) AS matching_rows
+FROM trade_ticks
+WHERE exchange <> ANY (NULL::int[]);
+-- matching_rows = 0
+
+-- Baseline: optimization off, correct result.
+BEGIN;
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ROLLBACK;
+
+-- Bug: direct batch delete silently removes rows.
+BEGIN;
+DELETE FROM trade_ticks WHERE exchange <> ANY (NULL::int[]);
+-- DELETE 216 if the bug exists, expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+-- rows_after = 72 if the bug exists, expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+-- only exchange=0 survives if the bug exists
+ROLLBACK;
+
+-- Other variations, with NULL array members
+
+-- Baseline, deleting all exchanges except '0'
+BEGIN;
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+-- DELETE 216
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+-- rows_baseline = 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+-- only exchange=0 remains
+ROLLBACK;
+
+-- The bug deletes all rows, doesn't spare exchange=0
+BEGIN;
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[0, NULL]::int[]);
+-- expected DELETE 216
+SELECT count(*) AS rows_after FROM trade_ticks;
+-- expected 72
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+-- expected exchange=0
+ROLLBACK;
+
+
+-- Baseline, should not delete anything with a single NULL member
+BEGIN;
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ROLLBACK;
+
+-- The bug deletes all rows
+BEGIN;
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL]::int[]);
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+-- expected all exchanges
+ROLLBACK;
+
+
+-- Baseline, check if we can handle multiple NULLs, should not delete anything
+BEGIN;
+SET LOCAL timescaledb.enable_compressed_direct_batch_delete = off;
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+-- DELETE 0
+SELECT count(*) AS rows_baseline FROM trade_ticks;
+-- rows_baseline = 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+ROLLBACK;
+
+-- The bug deletes all rows
+BEGIN;
+DELETE FROM trade_ticks WHERE exchange <> ANY (ARRAY[NULL,NULL]::int[]);
+-- expected DELETE 0
+SELECT count(*) AS rows_after FROM trade_ticks;
+-- expected 288
+SELECT exchange, count(*) FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+-- expected all exchanges
+ROLLBACK;
+
+-- This should keep exchange=0 and 1, and delete exchange=2 and 3
+DELETE FROM trade_ticks WHERE exchange <> ALL(ARRAY[0, 1]);
+SELECT exchange, count(*) AS cnt FROM trade_ticks GROUP BY exchange ORDER BY exchange;
+
+DROP TABLE trade_ticks;
+
+-- LLM Fuzzer found that we need to test the UPDATE path against crashes
+CREATE TABLE crash_test (
+    ts  timestamptz NOT NULL,
+    seg int,
+    val int
+);
+
+SELECT create_hypertable('crash_test', 'ts',
+                         chunk_time_interval => interval '1 day');
+
+ALTER TABLE crash_test SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby   = 'ts'
+);
+
+INSERT INTO crash_test
+SELECT '2024-01-01'::timestamptz + (g * interval '5 minutes'),
+       g % 4, g
+FROM generate_series(0, 287) g;
+
+SELECT compress_chunk(c) FROM show_chunks('crash_test') c;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg = ANY(NULL::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(NULL::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[0,NULL]::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[0,NULL]::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL]::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL]::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg = ANY(ARRAY[NULL, NULL]::int[]);
+ROLLBACK;
+
+BEGIN;
+UPDATE crash_test SET val = 0 WHERE seg <> ANY(ARRAY[NULL, NULL]::int[]);
+ROLLBACK;
+
+DROP TABLE crash_test;
+


### PR DESCRIPTION
Fixes #10129: with the direct delete optimisation, where we try to determine when we can delete a complete batch without decompression, we had a bug that deleted more records than intended. This happened with a particular form of predicate filtering a segmentby column:

- segmentby_column <> ANY (NULL::int[])
- segmentby_column <> ANY (ARRAY[0, NULL]::int[])
- segmentby_column <> ANY (ARRAY[NULL]::int[])
- segmentby_column <> ANY (ARRAY[NULL, NULL]::int[])