### PR TITLE
Fix NOT NULL detection for chunks on PostgreSQL 19

### DIFF
--- a/src/import/ts_inherit.c
+++ b/src/import/ts_inherit.c
@@ -20,6 +20,7 @@
 #include <catalog/pg_type.h>
 #include <nodes/makefuncs.h>
 #include <optimizer/appendinfo.h>
+#include <optimizer/plancat.h>
 #include <optimizer/planner.h>
 #include <parser/parsetree.h>
 #include <utils/rel.h>
@@ -82,6 +83,16 @@ ts_expand_single_inheritance_child(PlannerInfo *root, RangeTblEntry *parentrte,
 	childRTindex = list_length(parse->rtable);
 	*childrte_p = childrte;
 	*childRTindex_p = childRTindex;
+
+#if PG19_GE
+	/*
+	 * PG19 caches each relation's NOT NULL columns in a per query hash during
+	 * inheritance expansion, which we bypass for chunks, so record the chunk
+	 * here the same way core does for get_relation_info to find later.
+	 */
+	if (childOID != parentOID)
+		get_relation_notnullatts(root, childrel);
+#endif
 
 	/*
 	 * Build an AppendRelInfo struct for each parent/child pair.


### PR DESCRIPTION
PG19 caches each relation's NOT NULL columns in a per query hash during
inheritance expansion, which we bypass for chunks, so record the chunk
same way core does for get_relation_info to find later.

Upstream changes:
Reduce "Var IS [NOT] NULL" quals during constant folding.
https://github.com/postgres/postgres/commit/e2debb64380

Disable-check: force-changelog-file
