### PR TITLE
Build PostgreSQL with ICU on Ubuntu

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -145,7 +145,7 @@ jobs:
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
         cd ~/$PG_SRC_DIR
         ./configure --prefix=$HOME/$PG_INSTALL_DIR --with-openssl \
-          --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}
+          --without-readline --without-zlib --without-libxml --with-icu ${{ matrix.pg_extra_args }}
         make -j $(getconf _NPROCESSORS_ONLN)
         for ext in ${{ matrix.pg_extensions }}; do
           make -j $(getconf _NPROCESSORS_ONLN) -C contrib/${ext}


### PR DESCRIPTION
Build PostgreSQL with ICU support on Linux platform so that we can test nondeterministic collations.

Disable-check: force-changelog-file