### PR TITLE
Fix sort optimization on PostgreSQL 19

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1324,7 +1324,11 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 			if (transformed_query_pathkeys != NIL)
 			{
 				List *orig_query_pathkeys = root->query_pathkeys;
+				List *orig_sort_pathkeys = root->sort_pathkeys;
+				List *orig_window_pathkeys = root->window_pathkeys;
 				root->query_pathkeys = transformed_query_pathkeys;
+				root->sort_pathkeys = transformed_query_pathkeys;
+				root->window_pathkeys = transformed_query_pathkeys;
 
 				/* Create index paths with transformed pathkeys */
 				create_index_paths(root, rel);
@@ -1339,6 +1343,8 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 				}
 
 				root->query_pathkeys = orig_query_pathkeys;
+				root->sort_pathkeys = orig_sort_pathkeys;
+				root->window_pathkeys = orig_window_pathkeys;
 
 				/*
 				 * change returned paths to use original pathkeys. have to go through

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -2653,10 +2653,14 @@ create_compressed_scan_paths(PlannerInfo *root, RelOptInfo *compressed_rel,
 		 * out root->query_pathkeys to allow matching to pathkeys produces by
 		 * decompression
 		 */
-		List *orig_pathkeys = root->query_pathkeys;
+		List *orig_query_pathkeys = root->query_pathkeys;
+		List *orig_sort_pathkeys = root->sort_pathkeys;
+		List *orig_window_pathkeys = root->window_pathkeys;
 		List *orig_eq_classes = root->eq_classes;
 		Bitmapset *orig_eclass_indexes = compression_info->compressed_rel->eclass_indexes;
 		root->query_pathkeys = sort_info->required_compressed_pathkeys;
+		root->sort_pathkeys = sort_info->required_compressed_pathkeys;
+		root->window_pathkeys = sort_info->required_compressed_pathkeys;
 
 		/* We can optimize iterating over EquivalenceClasses by reducing them to
 		 * the subset which are from the compressed chunk. This only works if we don't
@@ -2680,7 +2684,9 @@ create_compressed_scan_paths(PlannerInfo *root, RelOptInfo *compressed_rel,
 
 		check_index_predicates(root, compressed_rel);
 		create_index_paths(root, compressed_rel);
-		root->query_pathkeys = orig_pathkeys;
+		root->query_pathkeys = orig_query_pathkeys;
+		root->sort_pathkeys = orig_sort_pathkeys;
+		root->window_pathkeys = orig_window_pathkeys;
 		root->eq_classes = orig_eq_classes;
 		compression_info->compressed_rel->eclass_indexes = orig_eclass_indexes;
 	}


### PR DESCRIPTION
The sort optimization lets an index provide the order requested by an
ORDER BY on time_bucket, avoiding a separate sort. It works by swapping
the query pathkeys for a simplified form while it builds index paths.

PostgreSQL 19 stopped looking at the query pathkeys when it decides which
index orderings are useful and looks at the sort pathkeys instead, so the
swap had no effect and no ordered index path was built. Swap the sort
pathkeys as well while building the paths.

Upstream changes:
Make truncate_useless_pathkeys() consider WindowFuncs.
https://github.com/postgres/postgres/commit/a5a68dd6d51

Disable-check: force-changelog-file
