### PR TITLE
Truncate constraint name before trying to rename

### DIFF
--- a/.unreleased/pr_10265
+++ b/.unreleased/pr_10265
@@ -1,0 +1,1 @@
+Fixes: #10265 Truncate constraint name before trying to rename

--- a/sql/updates/2.27.2--2.28.0.sql
+++ b/sql/updates/2.27.2--2.28.0.sql
@@ -44,7 +44,7 @@ BEGIN
         SELECT pg_catalog.format('%I.%I', c.schema_name, c.table_name) AS chunk_table,
                cc.constraint_name AS old_name,
                CASE WHEN parent.contype = 'f' THEN cc.hypertable_constraint_name
-                    ELSE format('%s_%s', c.id, cc.hypertable_constraint_name)
+                    ELSE format('%s_%s', c.id, cc.hypertable_constraint_name)::name
                END AS new_name
         FROM _timescaledb_catalog.chunk_constraint cc
         JOIN _timescaledb_catalog.chunk c ON c.id = cc.chunk_id


### PR DESCRIPTION
The check whether to rename a constraint would operate on the
untruncated names which resulting in an error when the constraint
name would be the same after truncation.
