### PR TITLE
Release 2.28.3

### DIFF
--- a/.unreleased/bugfix_10254
+++ b/.unreleased/bugfix_10254
@@ -1,1 +1,0 @@
-Fixes: #10254 Direct delete didn't handle array predicates with NULLs and deleted more than intended (#10129)

--- a/.unreleased/columnar-wrong-null
+++ b/.unreleased/columnar-wrong-null
@@ -1,1 +1,0 @@
-Fixes: #10082 Wrong result when evaluating a function returning NULL in the columnar query execution pipeline

--- a/.unreleased/enable-disable-trigger-columnstore
+++ b/.unreleased/enable-disable-trigger-columnstore
@@ -1,2 +1,0 @@
-Fixes: #10179 Allow enabling and disabling triggers on hypertables with columnstore enabled
-Thanks: @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled

--- a/.unreleased/pr_10178
+++ b/.unreleased/pr_10178
@@ -1,1 +1,0 @@
-Fixes: #10178 Fix incorrect usage of sort transformation for sort key expressions with negative constants 

--- a/.unreleased/pr_10182
+++ b/.unreleased/pr_10182
@@ -1,1 +1,0 @@
-Fixes: #10182 Fix columnstore sort pushdown to check for different query sortkey collation

--- a/.unreleased/pr_10212
+++ b/.unreleased/pr_10212
@@ -1,1 +1,0 @@
-Fixes: #10212 Fix race condition when enabling compression on a hypertable

--- a/.unreleased/pr_10230
+++ b/.unreleased/pr_10230
@@ -1,1 +1,0 @@
-Fixes: #10230 Batch filtering for compressed DML should respect collation

--- a/.unreleased/pr_10257
+++ b/.unreleased/pr_10257
@@ -1,1 +1,0 @@
-Fixes: #10257 Reuse existing dimension_slice ids when possible

--- a/.unreleased/pr_10265
+++ b/.unreleased/pr_10265
@@ -1,1 +1,0 @@
-Fixes: #10265 Truncate constraint name before trying to rename

--- a/.unreleased/wrong-stddev
+++ b/.unreleased/wrong-stddev
@@ -1,1 +1,0 @@
-Fixes: #10209 Potentially wrong result of stddev(float4/8) when used together with avg() in columnar query execution pipeline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@
 
 This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.
 
-
 **Bugfixes**
-* [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning NULL in the columnar query execution pipeline
+* [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning `NULL` in the columnar query execution pipeline
 * [#10178](https://github.com/timescale/timescaledb/pull/10178) Fix incorrect usage of sort transformation for sort key expressions with negative constants
 * [#10179](https://github.com/timescale/timescaledb/pull/10179) Allow enabling and disabling triggers on hypertables with columnstore enabled
-* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query `sortkey` collation
+* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query sort key collation
+* [#10209](https://github.com/timescale/timescaledb/pull/10209) Fix potentially wrong results for `stddev(float4)` and `stddev(float8)` when used with `avg()` in the columnar query execution pipeline
 * [#10212](https://github.com/timescale/timescaledb/pull/10212) Fix race condition when enabling compression on a hypertable
-* [#10230](https://github.com/timescale/timescaledb/pull/10230) Batch filtering for compressed DML should respect collation
-* [#10254](https://github.com/timescale/timescaledb/pull/10254) Direct delete didn't handle array predicates with NULLs and deleted more than intended ([#10129](https://github.com/timescale/timescaledb/pull/10129))
-* [#10257](https://github.com/timescale/timescaledb/pull/10257) Reuse existing `dimension_slice` ids when possible
+* [#10230](https://github.com/timescale/timescaledb/pull/10230) Batch filtering for compressed `DML` should respect collation
+* [#10254](https://github.com/timescale/timescaledb/pull/10254) Direct delete failed to handle array predicates with `NULL` values and deleted more rows than intended ([#10129](https://github.com/timescale/timescaledb/pull/10129))
+* [#10257](https://github.com/timescale/timescaledb/pull/10257) Reuse existing `dimension_slice` IDs when possible
 * [#10265](https://github.com/timescale/timescaledb/pull/10265) Truncate constraint name before trying to rename
 
 **Thanks**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.28.3 (2026-07-16)
+
+This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.28.3**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning NULL in the columnar query execution pipeline
+* [#10178](https://github.com/timescale/timescaledb/pull/10178) Fix incorrect usage of sort transformation for sort key expressions with negative constants 
+* [#10179](https://github.com/timescale/timescaledb/pull/10179) Allow enabling and disabling triggers on hypertables with columnstore enabled
+* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query sortkey collation
+* [#10212](https://github.com/timescale/timescaledb/pull/10212) Fix race condition when enabling compression on a hypertable
+* [#10230](https://github.com/timescale/timescaledb/pull/10230) Batch filtering for compressed DML should respect collation
+* [#10254](https://github.com/timescale/timescaledb/pull/10254) Direct delete didn't handle array predicates with NULLs and deleted more than intended ([#10129](https://github.com/timescale/timescaledb/pull/10129))
+* [#10257](https://github.com/timescale/timescaledb/pull/10257) Reuse existing dimension_slice ids when possible
+* [#10265](https://github.com/timescale/timescaledb/pull/10265) Truncate constraint name before trying to rename
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled
+
 ## 2.28.2 (2026-06-30)
 
 This release contains bug fixes since the 2.28.1 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,17 @@
 
 This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.28.3**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
 
 **Bugfixes**
 * [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning NULL in the columnar query execution pipeline
-* [#10178](https://github.com/timescale/timescaledb/pull/10178) Fix incorrect usage of sort transformation for sort key expressions with negative constants 
+* [#10178](https://github.com/timescale/timescaledb/pull/10178) Fix incorrect usage of sort transformation for sort key expressions with negative constants
 * [#10179](https://github.com/timescale/timescaledb/pull/10179) Allow enabling and disabling triggers on hypertables with columnstore enabled
-* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query sortkey collation
+* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query `sortkey` collation
 * [#10212](https://github.com/timescale/timescaledb/pull/10212) Fix race condition when enabling compression on a hypertable
 * [#10230](https://github.com/timescale/timescaledb/pull/10230) Batch filtering for compressed DML should respect collation
 * [#10254](https://github.com/timescale/timescaledb/pull/10254) Direct delete didn't handle array predicates with NULLs and deleted more than intended ([#10129](https://github.com/timescale/timescaledb/pull/10129))
-* [#10257](https://github.com/timescale/timescaledb/pull/10257) Reuse existing dimension_slice ids when possible
+* [#10257](https://github.com/timescale/timescaledb/pull/10257) Reuse existing `dimension_slice` ids when possible
 * [#10265](https://github.com/timescale/timescaledb/pull/10265) Truncate constraint name before trying to rename
-
-**New Settings**
-
-**GUCs**
 
 **Thanks**
 * @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled


### PR DESCRIPTION
# TimescaleDB Changelog

**Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**

## 2.28.3 (2026-07-16)

This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#10082](https://github.com/timescale/timescaledb/pull/10082) Wrong result when evaluating a function returning `NULL` in the columnar query execution pipeline
* [#10178](https://github.com/timescale/timescaledb/pull/10178) Fix incorrect usage of sort transformation for sort key expressions with negative constants
* [#10179](https://github.com/timescale/timescaledb/pull/10179) Allow enabling and disabling triggers on hypertables with columnstore enabled
* [#10182](https://github.com/timescale/timescaledb/pull/10182) Fix columnstore sort pushdown to check for different query sort key collation
* [#10209](https://github.com/timescale/timescaledb/pull/10209) Fix potentially wrong results for `stddev(float4)` and `stddev(float8)` when used with `avg()` in the columnar query execution pipeline
* [#10212](https://github.com/timescale/timescaledb/pull/10212) Fix race condition when enabling compression on a hypertable
* [#10230](https://github.com/timescale/timescaledb/pull/10230) Batch filtering for compressed `DML` should respect collation
* [#10254](https://github.com/timescale/timescaledb/pull/10254) Direct delete failed to handle array predicates with `NULL` values and deleted more rows than intended ([#10129](https://github.com/timescale/timescaledb/pull/10129))
* [#10257](https://github.com/timescale/timescaledb/pull/10257) Reuse existing `dimension_slice` IDs when possible
* [#10265](https://github.com/timescale/timescaledb/pull/10265) Truncate constraint name before trying to rename

**Thanks**
* @juantxorena for reporting that triggers could not be enabled or disabled on hypertables with columnstore enabled
