### PR TITLE
Minor restructuring in fastlanes

### DIFF
--- a/tsl/src/compression/algorithms/fastlanes/fastlanes.h
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes.h
@@ -39,8 +39,39 @@
  *   |  33..64  | FL64  | FL64   | FL64   | FL128  |
  *   |  65..128 | FL128 | FL128  | FL128  | FL128  |
  *   | 129..256 | FL256 | FL256  | FL256  | FL256  |
+ *
+ * T=64 routes straight to FL128/256 (better SIMD utilisation than
+ * FL64 for 64-bit values).
  */
-extern fl_tier_width_t fl_tier_select(uint32 n, fl_elem_width_t t);
+static inline fl_tier_width_t
+fl_tier_select(uint32 n, fl_elem_width_t t)
+{
+	if (t == FL_ELEM_W64)
+	{
+		return (n <= 128) ? FL_TIER_W128 : FL_TIER_W256;
+	}
+	if (n <= 8 && t == FL_ELEM_W8)
+	{
+		return FL_TIER_W8;
+	}
+	if (n <= 16 && (t == FL_ELEM_W8 || t == FL_ELEM_W16))
+	{
+		return FL_TIER_W16;
+	}
+	if (n <= 32)
+	{
+		return FL_TIER_W32;
+	}
+	if (n <= 64)
+	{
+		return FL_TIER_W64;
+	}
+	if (n <= 128)
+	{
+		return FL_TIER_W128;
+	}
+	return FL_TIER_W256;
+}
 
 /* Required size for the tier (selected by fl_tier_select(N, T)).
  * Determines the sizes of pack output and unpack input buffers exactly.
@@ -50,7 +81,20 @@ extern size_t fl_required_bytes(uint32 n, uint8 w, fl_elem_width_t t);
 /* Bytes the encoded output carries for N elements (<= fl_required_bytes).
  * Matches the return of fl_pack / fl_pack_ffor; useful for sizing the
  * truncated prefix without running the encoder. */
-extern size_t fl_result_bytes(uint32 n, uint8 w, fl_elem_width_t t);
+static inline size_t
+fl_result_bytes(uint32 n, uint8 w, fl_elem_width_t t)
+{
+	/* tier is defined as bitwidth */
+	uint32 tier = (uint32) fl_tier_select(n, t);
+	/* stride length is the number of 't' elems fit in the tier */
+	uint32 s = tier / (uint32) t;
+	/* r is the full strides needed to cover n */
+	uint32 r = (n + s - 1) / s;
+
+	/* the size is defined as the product of full strides and the encoding
+	 * bitwidth (w), in full tier widths, expressed in bytes */
+	return (size_t) ((r * w + (uint32) t - 1) / (uint32) t) * (tier / 8);
+}
 
 /* Required alignment for the _packed_ input and output buffers.
  * Recommended alignment for the input and output _values_.
@@ -96,3 +140,5 @@ extern size_t fl_pack_ffor(const void *values, void *packed, uint32 n, uint8 w, 
 						   uint64 base);
 extern void fl_unpack_ffor(const void *packed, void *values, uint32 n, uint8 w, fl_elem_width_t t,
 						   uint64 base);
+
+/* the inline implementation of fl_tier_select */

--- a/tsl/src/compression/algorithms/fastlanes/fastlanes_sizing.c
+++ b/tsl/src/compression/algorithms/fastlanes/fastlanes_sizing.c
@@ -57,48 +57,6 @@
 #include "fastlanes_tier_sizing.h"
 #undef FL_TIER
 
-/* Tier selection
- *
- *   |   0..8   T=8  -> FL8         T=16 -> FL16   T=32 -> FL32   T=64 -> FL128
- *   |   9..16  T=8  -> FL16        T=16 -> FL16   T=32 -> FL32   T=64 -> FL128
- *   |  17..32                      -> FL32                       T=64 -> FL128
- *   |  33..64                      -> FL64                       T=64 -> FL128
- *   |  65..128                     -> FL128                      T=64 -> FL128
- *   | 129..256                     -> FL256                      T=64 -> FL256
- *
- * T=64 routes straight to FL128/256 (better SIMD utilisation than
- * FL64 for 64-bit values).
- */
-fl_tier_width_t
-fl_tier_select(uint32 n, fl_elem_width_t t)
-{
-	if (t == FL_ELEM_W64)
-	{
-		return (n <= 128) ? FL_TIER_W128 : FL_TIER_W256;
-	}
-	if (n <= 8 && t == FL_ELEM_W8)
-	{
-		return FL_TIER_W8;
-	}
-	if (n <= 16 && (t == FL_ELEM_W8 || t == FL_ELEM_W16))
-	{
-		return FL_TIER_W16;
-	}
-	if (n <= 32)
-	{
-		return FL_TIER_W32;
-	}
-	if (n <= 64)
-	{
-		return FL_TIER_W64;
-	}
-	if (n <= 128)
-	{
-		return FL_TIER_W128;
-	}
-	return FL_TIER_W256;
-}
-
 /* Public sizing entry points */
 
 size_t
@@ -118,28 +76,6 @@ fl_required_bytes(uint32 n, uint8 w, fl_elem_width_t t)
 			return fl128_required_bytes(w, t);
 		case FL_TIER_W256:
 			return fl256_required_bytes(w, t);
-	}
-	Assert(false);
-	return 0;
-}
-
-size_t
-fl_result_bytes(uint32 n, uint8 w, fl_elem_width_t t)
-{
-	switch (fl_tier_select(n, t))
-	{
-		case FL_TIER_W8:
-			return fl8_result_bytes(n, w, t);
-		case FL_TIER_W16:
-			return fl16_result_bytes(n, w, t);
-		case FL_TIER_W32:
-			return fl32_result_bytes(n, w, t);
-		case FL_TIER_W64:
-			return fl64_result_bytes(n, w, t);
-		case FL_TIER_W128:
-			return fl128_result_bytes(n, w, t);
-		case FL_TIER_W256:
-			return fl256_result_bytes(n, w, t);
 	}
 	Assert(false);
 	return 0;


### PR DESCRIPTION
I made the fl_result_bytes function inline because this will be called in a loop in the upcoming integer compressor.

Disable-check: force-changelog-file