### PR TITLE
Drop job_errors view in bgw_job_stat_history migration

### DIFF
--- a/.unreleased/pr_10278
+++ b/.unreleased/pr_10278
@@ -1,0 +1,2 @@
+Fixes: #10278 Drop job_errors view in bgw_job_stat_history migration
+Thanks: @proddata for reporting a problem when upgrading from 2.15.3 to 2.28.2

--- a/sql/updates/2.28.0--2.28.1.sql
+++ b/sql/updates/2.28.0--2.28.1.sql
@@ -9,6 +9,7 @@ BEGIN
     -- START bgw_job_stat_history
     --
     DROP VIEW IF EXISTS timescaledb_information.job_history;
+    DROP VIEW IF EXISTS timescaledb_information.job_errors;
 
     CREATE TABLE _timescaledb_internal._tmp_bgw_job_stat_history AS SELECT * FROM _timescaledb_internal.bgw_job_stat_history;
     CREATE TABLE _timescaledb_internal._tmp_job_stat_history_id_seq AS SELECT last_value, is_called FROM _timescaledb_internal.bgw_job_stat_history_id_seq;


### PR DESCRIPTION
The 2.28.0--2.28.1 migration rebuilds bgw_job_stat_history to fix a
wrong id column type. It dropped the job_history view before rebuilding
the table but not the job_errors view, which also reads from that table.

On upgrade paths that start at or below 2.24.0 the views are not
detached first, so job_errors still depends on the table and the
DROP TABLE fails. The view must also be dropped so it can be recreated
with the corrected column types afterwards.

Fixes #10272
