### PR TITLE
Honor canSetTag when counting direct compress inserts

### DIFF
--- a/.unreleased/fix_direct_compress_cansettag
+++ b/.unreleased/fix_direct_compress_cansettag
@@ -1,0 +1,1 @@
+Fixes: #10282 Only count directly compressed rows toward the command tag when the insert sets it

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -2521,7 +2521,8 @@ ExecModifyTable(CustomScanState *cs_node, PlanState *pstate)
 				}
 
 				ts_cm_functions->compressor_add_slot(ht_state->compressor, ht_state->bulk_writer, chunk_slot);
-				estate->es_processed++;
+				if (node->canSetTag)
+					estate->es_processed++;
 				continue;
 			}
 


### PR DESCRIPTION
The direct compress insert path bumped the processed row counter for
every row, even when the insert was not the statement that sets the
command tag (for example an insert in a data-modifying CTE). Every
other insert path guards this with canSetTag, so do the same here.
