### PR TITLE
Fix some typos

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -610,7 +610,7 @@ bgw_job_stat_insert_relation(Relation rel, int32 bgw_job_id, bool mark_start,
 
 	if (mark_start)
 	{
-		/* This is udone by any of the end marks */
+		/* This is undone by any of the end marks */
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_last_run_success)] = BoolGetDatum(false);
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_total_crashes)] = Int64GetDatum(1);
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_consecutive_crashes)] = Int32GetDatum(1);

--- a/src/partition_chunk.c
+++ b/src/partition_chunk.c
@@ -400,7 +400,7 @@ partition_chunk_attach(const Hypertable *ht, const Chunk *chunk)
 }
 
 /*
- * ExecutoreEnd hook to attach cached partition chunks to their hypertables.
+ * ExecutorEnd hook to attach cached partition chunks to their hypertables.
  */
 
 static void

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1221,7 +1221,7 @@ chunk_fully_covered(HypertableRestrictInfo *hri, Chunk const *chunk)
 	}
 
 	/*
-	 * DimensionRetrictInfo strategy should only be one BTGreaterStrategyNumber
+	 * DimensionRestrictInfo strategy should only be one BTGreaterStrategyNumber
 	 * or BTGreaterEqualStrategyNumber on the lower boundary and
 	 * BTLessStrategyNumber or BTLessEqualStrategyNumber on the upper boundary.
 	 *

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -824,7 +824,7 @@ get_parent_rte(const PlannerInfo *root, Index rti)
  * related metadata: like chunk_status and pointer to hypertable entry.
  * It is okay to cache a pointer to the hypertable, since this cache is
  * confined to the lifetime of the query and not used across queries.
- * If the parent reolid is known, the caller can specify it to avoid the costly
+ * If the parent relid is known, the caller can specify it to avoid the costly
  * lookup. Otherwise pass InvalidOid.
  */
 static BaserelInfoEntry *

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -394,7 +394,7 @@ check_altertable_add_column_for_compressed(ParseState *parse_state, Hypertable *
 				case CONSTR_UNIQUE:
 					break;
 				/*
-				 * We can safelly ignore NULL constraints because it does nothing
+				 * We can safely ignore NULL constraints because it does nothing
 				 * and according to Postgres docs is useless and exist just for
 				 * compatibility with other database systems
 				 * https://www.postgresql.org/docs/current/ddl-constraints.html#id-1.5.4.6.6

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -54,7 +54,7 @@ extern void ts_process_utility_set_expect_chunk_modification(bool expect);
  * SPI_inside_nonatomic_context function, that would have been sufficient
  * for isTopLevel flag, but it currently returns false when SPI connection
  * is absent (that is a valid scenario when C procedures are called from
- * top-lelev SQL instead of PLPG procedures or DO blocks) so it cannot be
+ * top-level SQL instead of PLPG procedures or DO blocks) so it cannot be
  * used.
  *
  * To work around this the value of ProcessUtilityContext parameter is

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -1310,7 +1310,7 @@ ts_chunk_column_stats_get_chunk_ids_by_scan(DimensionRestrictInfo *dri)
 		 * (Entry is typically marked "invalid" when a compressed chunk becomes partial
 		 * due to DML in it.)
 		 *
-		 * Also, if we have a valid chunnk with -inf/+inf entries then it matches all
+		 * Also, if we have a valid chunk with -inf/+inf entries then it matches all
 		 * queries
 		 */
 		if (!fd.valid || (fd.range_start == PG_INT64_MIN && fd.range_end == PG_INT64_MAX))

--- a/src/ts_catalog/continuous_aggs_watermark.c
+++ b/src/ts_catalog/continuous_aggs_watermark.c
@@ -97,7 +97,7 @@ TS_FUNCTION_INFO_V1(ts_continuous_agg_watermark);
  * materialized data and real-time data in the UNION query.
  *
  * The watermark is stored into `_timescaledb_catalog.continuous_aggs_watermark`
- * catalog table by the `refresh_continuous_agregate` procedure. It is defined
+ * catalog table by the `refresh_continuous_aggregate` procedure. It is defined
  * as the end of the last (highest) bucket in the materialized hypertable of a
  * continuous aggregate.
  *

--- a/src/ts_stats/ts_stats_segment.c
+++ b/src/ts_stats/ts_stats_segment.c
@@ -519,8 +519,8 @@ ts_stats_chunk_segment_prepare_upsert(TsStatsChunkSegment *seg, TsStatsRelids re
 	}
 
 	/* at this point we haven't found the chunk so we first check the empty slots.
-	 * they may be taken conncurrently by another process, so they need to be checked
-	 * again. the order of the empty slots are somwewhat ordered as we gathered them
+	 * they may be taken concurrently by another process, so they need to be checked
+	 * again. the order of the empty slots are somewhat ordered as we gathered them
 	 * in the bucket recency order. best to traverse them in this recency order so
 	 * the buckets keep the recency property as much as possible.
 	 */

--- a/tsl/src/chunk_merge.c
+++ b/tsl/src/chunk_merge.c
@@ -528,7 +528,7 @@ merge_chunks_multidim_allowed(void)
  *
  * https://github.com/postgres/postgres/commit/9695835538c2c8e9cd0048028b8c85e1bbf5c79c
  *
- * The fix is part of PG 17.3. Howevever, this still leaves PG 17.0 - 17.2
+ * The fix is part of PG 17.3. However, this still leaves PG 17.0 - 17.2
  * with different behavior.
  *
  * To make the merge chunks code work for the "broken" versions we make PG

--- a/tsl/src/compression/algorithms/bool_compress.h
+++ b/tsl/src/compression/algorithms/bool_compress.h
@@ -9,7 +9,7 @@
  * bool_compress is used to encode boolean values using the simple8b_rle algorithm.
  *
  * The bool compressor differs from the other compressors in that it does store a value
- * even for nulls, which is the last value seen befere the null. With this the bool
+ * even for nulls, which is the last value seen before the null. With this the bool
  * compressor always creates a compressed block even for nulls only.
  *
  * The boolean compressor represents the boolean values in a batch with two parallel

--- a/tsl/src/compression/algorithms/uuid_compress.c
+++ b/tsl/src/compression/algorithms/uuid_compress.c
@@ -680,7 +680,7 @@ uuid_decompress_all(Datum compressed, Oid element_type, MemoryContext dest_mctx)
 
 	/*
 	 * At this point I combined the uncompressed data in the rand_b_and_variant array
-	 * and the freshly decompressed data from the delta delta bulk decompressison.
+	 * and the freshly decompressed data from the delta delta bulk decompression.
 	 * I now free the temp data. Note that `timestamp_values` is the same pointer
 	 * as timestamp_array->buffers[1] , the second buffer in the ArrowArray.
 	 * This will be replaced with the uuid array.

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -545,7 +545,7 @@ create_segment_filter_scankey(Relation in_rel, char *segment_filter_col_name,
 
 	/*
 	 * In PG versions <= 14 NULL values are always considered distinct
-	 * from other NULL values and therefore NULLABLE multi-columnn
+	 * from other NULL values and therefore NULLABLE multi-column
 	 * unique constraints might expose unexpected behaviour in the
 	 * presence of NULL values.
 	 * Since SK_SEARCHNULL is not supported by heap scans we cannot

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -552,7 +552,7 @@ fixup_userview_query_tlist(Query *userquery, List *tlist_aliases)
  * CREATE VIEW mcagg ...
  * AS  select a, min(b)+max(d) from foo group by a,timebucket(a);
  *
- * Step 1. create a materialiation table which stores the partials for the
+ * Step 1. create a materialization table which stores the partials for the
  * aggregates and the grouping columns + internal columns.
  * So we have a table like _materialization_hypertable
  * with columns:
@@ -575,7 +575,7 @@ fixup_userview_query_tlist(Query *userquery, List *tlist_aliases)
  * group by <internal-columns> , a , timebucket(a);
  *
  * Notes: ViewStmt->query is the raw parse tree
- * panquery is the output of running parse_anlayze( ViewStmt->query)
+ * panquery is the output of running parse_analyze( ViewStmt->query)
 
  * Since 1.7, we support real time aggregation.
  * If real time aggregation is off i.e. materialized only, the mcagg view is as described in Step 2.
@@ -625,7 +625,7 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	{
 		matpartcol_interval = bucket_info->htpartcol_interval_len;
 
-		/* Apply the factor just for non-Hierachical CAggs */
+		/* Apply the factor just for non-Hierarchical CAggs */
 		if (bucket_info->parent_mat_hypertable_id == INVALID_HYPERTABLE_ID)
 		{
 			matpartcol_interval *= MATPARTCOL_INTERVAL_FACTOR;

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -965,7 +965,7 @@ process_cagg_invalidations_for_refresh(const ContinuousAggInvalidationState *sta
 	 *     this will read all the logs starting from the beginning
 	 *      and < 80 so that it can process overlaps.
 	 * S1: locks row for tuple 45
-	 *                              S2 : acquires ShareUpdateExlcusiveLock
+	 *                              S2 : acquires ShareUpdateExclusiveLock
 	 *                              S2:  waits for lock for tuple 45
 	 * S1: needs to create a new chunk in mat hypertable
 	 *     blocks on S2's ShareUpdateExclusiveLock

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -590,7 +590,7 @@ continuous_agg_scan_refresh_window_ranges(const ContinuousAgg *cagg,
  * #buckets_in_window/2 (i.e., every other bucket is invalid).
  *
  * Since it might not be efficient to materialize a lot buckets separately
- * when there are many invalid (non-adjecent) buckets/ranges, we put a limit
+ * when there are many invalid (non-adjacent) buckets/ranges, we put a limit
  * on the number of individual materializations we do. This limit is
  * determined by the MATERIALIZATIONS_PER_REFRESH_WINDOW setting.
  *

--- a/tsl/src/nodes/columnar_scan/qual_pushdown.c
+++ b/tsl/src/nodes/columnar_scan/qual_pushdown.c
@@ -1599,7 +1599,7 @@ qual_pushdown_mutator(Node *orig_node, QualPushdownContext *context)
 			 * we can have false positives there, and combining false positives
 			 * with the original operator could lead to false negatives, which
 			 * would be a bug. Consider for example (x = 1) = (y = 1) in case
-			 * where both sides are false, but there's a false posistive for the
+			 * where both sides are false, but there's a false positive for the
 			 * pushed down version of the left side but not the right side.
 			 */
 			QualPushdownContext tmp_context = copy_context(context);

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -1006,7 +1006,7 @@ skip_scan_path_create(PlannerInfo *root, Path *child_path, DistinctPathInfo *dpi
 	 * filter.
 	 */
 	List *clauses_needing_scan = NULL;
-	/* If a filter is not pushed down into compessed indexed data, it's a filter for which we will
+	/* If a filter is not pushed down into compressed indexed data, it's a filter for which we will
 	 * need to scan and decompress until filter is passed */
 	if ((Path *) index_path != child_path)
 	{

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -140,7 +140,7 @@ tsl_set_rel_pathlist_query(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeT
 	/*
 	 * For a chunk, we can get here via a query on the hypertable that expands
 	 * to the chunk or by direct query on the chunk. In the former case,
-	 * reloptkind will be RELOPT_OTHER_MEMBER_REL (nember of hypertable) or in
+	 * reloptkind will be RELOPT_OTHER_MEMBER_REL (member of hypertable) or in
 	 * the latter case reloptkind will be RELOPT_BASEREL (standalone rel).
 	 *
 	 * These two cases are checked in ts_planner_chunk_fetch().

--- a/tsl/test/src/compression_sql_test.c
+++ b/tsl/test/src/compression_sql_test.c
@@ -198,7 +198,7 @@ ts_read_compressed_data_file(PG_FUNCTION_ARGS)
 TS_FUNCTION_INFO_V1(ts_read_compressed_data_directory);
 
 /*
- * Read and decomrpess all compressed data files from directory. Useful for
+ * Read and decompress all compressed data files from directory. Useful for
  * checking the fuzzing corpuses in the regression tests.
  */
 Datum

--- a/tsl/test/src/compression_unit_test.c
+++ b/tsl/test/src/compression_unit_test.c
@@ -976,7 +976,7 @@ bool_compressed_size(int num_values, int flip_nth)
 static void
 test_bool()
 {
-	/* code covareage and simple tests */
+	/* code coverage and simple tests */
 	test_empty_bool_compressor();
 	test_bool_compressor_extended();
 


### PR DESCRIPTION
I found these using cspell. It's much more eager than the codespell we run in CI now, so it complains about 718 different words. Most of these can be mechanically pulled from PG and TS source, but for now this looks too much to set up in CI. I'm filing the obvious typos though.

Disable-check: force-changelog-file