### PR TITLE
Add support for REPACK

### DIFF
--- a/.unreleased/pr_10291
+++ b/.unreleased/pr_10291
@@ -1,0 +1,1 @@
+Implements: #10291 Add support for REPACK

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3979,11 +3979,17 @@ process_cluster_start(ProcessUtilityArgs *args)
 	Hypertable *ht;
 	DDLResult result = DDL_CONTINUE;
 	RangeVar *cluster_rv = stmt->relation ? stmt->relation->relation : NULL;
+	/*
+	 * CLUSTER and REPACK ... USING INDEX reorder each chunk by an index; plain
+	 * REPACK rewrites each chunk without an index, like VACUUM FULL.
+	 */
+	bool index_based = (stmt->command == REPACK_COMMAND_CLUSTER) || stmt->usingindex;
+	const char *cmdname = (stmt->command == REPACK_COMMAND_CLUSTER) ? "CLUSTER" : "REPACK";
 
 	Assert(IsA(stmt, RepackStmt));
 
-	/* We only intercept CLUSTER; let REPACK and VACUUM FULL fall through */
-	if (stmt->command != REPACK_COMMAND_CLUSTER)
+	/* VACUUM FULL arrives as a VacuumStmt, so it never reaches this handler */
+	if (stmt->command == REPACK_COMMAND_VACUUMFULL)
 	{
 		return DDL_CONTINUE;
 	}
@@ -3993,6 +3999,8 @@ process_cluster_start(ProcessUtilityArgs *args)
 	Hypertable *ht;
 	DDLResult result = DDL_CONTINUE;
 	RangeVar *cluster_rv = stmt->relation;
+	bool index_based = true;
+	const char *cmdname = "CLUSTER";
 
 	Assert(IsA(stmt, ClusterStmt));
 #endif
@@ -4009,68 +4017,84 @@ process_cluster_start(ProcessUtilityArgs *args)
 	if (NULL != ht)
 	{
 		bool is_top_level = (args->context == PROCESS_UTILITY_TOPLEVEL);
-		Oid index_relid;
-		Relation index_rel;
+		Oid index_relid = InvalidOid;
 		List *chunk_indexes;
 		ListCell *lc;
 		MemoryContext old, mcxt;
-		LockRelId cluster_index_lockid;
+		LockRelId cluster_index_lockid = { 0 };
+		bool have_index_lock = false;
 		ChunkIndexMapping **mappings = NULL;
 		int i;
 
 		ts_hypertable_permissions_check_by_id(ht->fd.id);
 
 		/*
-		 * If CLUSTER is run inside a user transaction block; we bail out or
-		 * otherwise we'd be holding locks way too long.
+		 * If run inside a user transaction block we bail out or otherwise we'd
+		 * be holding locks way too long.
 		 */
-		PreventInTransactionBlock(is_top_level, "CLUSTER");
+		PreventInTransactionBlock(is_top_level, cmdname);
 
-		if (NULL == stmt->indexname)
+#if PG19_GE
+		/*
+		 * CONCURRENTLY and ANALYZE would each need per-chunk handling we don't
+		 * do yet, so reject them clearly instead of silently ignoring them.
+		 */
+		foreach (lc, stmt->params)
 		{
-			index_relid = ts_indexing_find_clustered_index(ht->main_table_relid);
-			if (!OidIsValid(index_relid))
+			DefElem *opt = (DefElem *) lfirst(lc);
+
+			if ((strcmp(opt->defname, "concurrently") == 0 ||
+				 strcmp(opt->defname, "analyze") == 0) &&
+				defGetBoolean(opt))
 			{
 				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_OBJECT),
-						 errmsg("there is no previously clustered index for table \"%s\"",
-								get_rel_name(ht->main_table_relid))));
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("REPACK option \"%s\" is not supported on hypertables",
+								opt->defname)));
 			}
 		}
-		else
+#endif
+
+		if (index_based)
 		{
-			index_relid =
-				get_relname_relid(stmt->indexname, get_rel_namespace(ht->main_table_relid));
+			Relation index_rel;
+
+			if (NULL == stmt->indexname)
+			{
+				index_relid = ts_indexing_find_clustered_index(ht->main_table_relid);
+				if (!OidIsValid(index_relid))
+				{
+					ereport(ERROR,
+							(errcode(ERRCODE_UNDEFINED_OBJECT),
+							 errmsg("there is no previously clustered index for table \"%s\"",
+									get_rel_name(ht->main_table_relid))));
+				}
+			}
+			else
+			{
+				index_relid =
+					get_relname_relid(stmt->indexname, get_rel_namespace(ht->main_table_relid));
+			}
+
+			if (!OidIsValid(index_relid))
+			{
+				/* Let regular process utility handle */
+				ts_cache_release(&hcache);
+				return DDL_CONTINUE;
+			}
+
+			LockRelationOid(ht->main_table_relid, AccessShareLock);
+			index_rel = index_open(index_relid, AccessShareLock);
+			cluster_index_lockid = index_rel->rd_lockInfo.lockRelId;
+			index_close(index_rel, NoLock);
+
+			/* mark main table as clustered, so future calls to CLUSTER don't need to pass index */
+			ts_chunk_index_mark_clustered(ht->main_table_relid, index_relid);
+
+			/* keep index lock throughout CLUSTER */
+			LockRelationIdForSession(&cluster_index_lockid, AccessShareLock);
+			have_index_lock = true;
 		}
-
-		if (!OidIsValid(index_relid))
-		{
-			/* Let regular process utility handle */
-			ts_cache_release(&hcache);
-			return DDL_CONTINUE;
-		}
-
-		/*
-		 * DROP INDEX locks the table then the index, to prevent deadlocks we
-		 * lock them in the same order. The main table lock will be released
-		 * when the current transaction commits, and never taken again. We
-		 * will use the index relation to grab a session lock on the index,
-		 * which we will hold throughout CLUSTER
-		 */
-		LockRelationOid(ht->main_table_relid, AccessShareLock);
-		index_rel = index_open(index_relid, AccessShareLock);
-		cluster_index_lockid = index_rel->rd_lockInfo.lockRelId;
-
-		index_close(index_rel, NoLock);
-
-		/*
-		 * mark the main table as clustered, even though it has no data, so
-		 * future calls to CLUSTER don't need to pass in the index
-		 */
-		ts_chunk_index_mark_clustered(ht->main_table_relid, index_relid);
-
-		/* we will keep holding this lock throughout CLUSTER */
-		LockRelationIdForSession(&cluster_index_lockid, AccessShareLock);
 
 		/*
 		 * The list of chunks and their indexes need to be on a memory context
@@ -4079,11 +4103,26 @@ process_cluster_start(ProcessUtilityArgs *args)
 		mcxt = AllocSetContextCreate(PortalContext, "Hypertable cluster", ALLOCSET_DEFAULT_SIZES);
 
 		/*
-		 * Get a list of chunks and indexes that correspond to the
-		 * hypertable's index
+		 * Get a list of chunks to process. For an index-based rewrite we pair
+		 * each chunk with its matching index; a plain REPACK has no index.
 		 */
 		old = MemoryContextSwitchTo(mcxt);
-		chunk_indexes = ts_chunk_index_get_mappings(ht, index_relid);
+		if (index_based)
+		{
+			chunk_indexes = ts_chunk_index_get_mappings(ht, index_relid);
+		}
+		else
+		{
+			chunk_indexes = NIL;
+			foreach (lc, find_inheritance_children(ht->main_table_relid, NoLock))
+			{
+				ChunkIndexMapping *cim = palloc0(sizeof(ChunkIndexMapping));
+
+				cim->chunkoid = lfirst_oid(lc);
+				cim->indexoid = InvalidOid;
+				chunk_indexes = lappend(chunk_indexes, cim);
+			}
+		}
 
 		if (list_length(chunk_indexes) > 0)
 		{
@@ -4109,6 +4148,9 @@ process_cluster_start(ProcessUtilityArgs *args)
 
 		MemoryContextSwitchTo(old);
 
+		/* The options are the same for every chunk, so parse them once. */
+		ClusterParams *cluster_params = get_cluster_options(stmt->params);
+
 		hcache->release_on_commit = false;
 
 		/* Commit to get out of starting transaction */
@@ -4130,7 +4172,10 @@ process_cluster_start(ProcessUtilityArgs *args)
 			 * rechecked (due to new transaction) to already have that mark
 			 * set
 			 */
-			ts_chunk_index_mark_clustered(cim->chunkoid, cim->indexoid);
+			if (OidIsValid(cim->indexoid))
+			{
+				ts_chunk_index_mark_clustered(cim->chunkoid, cim->indexoid);
+			}
 
 			/* Do the job. */
 
@@ -4140,16 +4185,12 @@ process_cluster_start(ProcessUtilityArgs *args)
 			 */
 #if PG19_GE
 			Relation rel = table_open(cim->chunkoid, AccessExclusiveLock);
-			cluster_rel(REPACK_COMMAND_CLUSTER,
-						rel,
-						cim->indexoid,
-						get_cluster_options(stmt->params),
-						is_top_level);
+			cluster_rel(stmt->command, rel, cim->indexoid, cluster_params, is_top_level);
 #elif PG18_GE
 			Relation rel = table_open(cim->chunkoid, AccessExclusiveLock);
-			cluster_rel(rel, cim->indexoid, get_cluster_options(stmt->params));
+			cluster_rel(rel, cim->indexoid, cluster_params);
 #else
-			cluster_rel(cim->chunkoid, cim->indexoid, get_cluster_options(stmt->params));
+			cluster_rel(cim->chunkoid, cim->indexoid, cluster_params);
 #endif
 			PopActiveSnapshot();
 			CommitTransactionCommand();
@@ -4162,7 +4203,10 @@ process_cluster_start(ProcessUtilityArgs *args)
 		/* Clean up working storage */
 		MemoryContextDelete(mcxt);
 
-		UnlockRelationIdForSession(&cluster_index_lockid, AccessShareLock);
+		if (have_index_lock)
+		{
+			UnlockRelationIdForSession(&cluster_index_lockid, AccessShareLock);
+		}
 		result = DDL_DONE;
 	}
 

--- a/test/expected/repack.out
+++ b/test/expected/repack.out
@@ -1,0 +1,94 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- REPACK generalizes CLUSTER and VACUUM FULL on PostgreSQL 19. Make sure it
+-- rewrites every chunk of a hypertable instead of only the empty root table.
+CREATE TABLE repack_test(time timestamptz, temp float, location int);
+SELECT create_hypertable('repack_test', 'time', chunk_time_interval => interval '1 day');
+    create_hypertable     
+--------------------------
+ (1,public,repack_test,t)
+
+INSERT INTO repack_test
+SELECT t, 1.0, 1
+FROM generate_series('2017-01-20'::timestamptz, '2017-01-24', '1 hour') t;
+SELECT count(*) AS num_chunks FROM show_chunks('repack_test');
+ num_chunks 
+------------
+          5
+
+-- Remember each chunk's storage file so we can tell it was rewritten
+CREATE TABLE repack_files AS
+SELECT ch AS chunk, pg_relation_filenode(ch) AS filenode
+FROM show_chunks('repack_test') ch;
+-- Plain REPACK rewrites every chunk without ordering (like VACUUM FULL)
+REPACK repack_test;
+SELECT count(*) AS chunks_rewritten
+FROM repack_files f
+WHERE pg_relation_filenode(f.chunk) <> f.filenode;
+ chunks_rewritten 
+------------------
+                5
+
+-- REPACK ... USING INDEX orders each chunk by the index and marks it clustered
+REPACK repack_test USING INDEX repack_test_time_idx;
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered
+ORDER BY 1;
+                         indexrelid                          | indisclustered 
+-------------------------------------------------------------+----------------
+ repack_test_time_idx                                        | t
+ _timescaledb_internal._hyper_1_1_chunk_repack_test_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_repack_test_time_idx | t
+ _timescaledb_internal._hyper_1_3_chunk_repack_test_time_idx | t
+ _timescaledb_internal._hyper_1_4_chunk_repack_test_time_idx | t
+ _timescaledb_internal._hyper_1_5_chunk_repack_test_time_idx | t
+
+-- An implicit REPACK ... USING INDEX reuses the previously clustered index
+REPACK repack_test USING INDEX;
+-- Repacking a single chunk directly is handled by PostgreSQL
+SELECT ch::regclass::text AS chunk FROM show_chunks('repack_test') ch ORDER BY 1 LIMIT 1 \gset
+REPACK :chunk;
+-- VACUUM FULL still reaches every chunk (it stays a VacuumStmt, not a RepackStmt)
+SELECT ch AS chunk, pg_relation_filenode(ch) AS filenode
+FROM show_chunks('repack_test') ch ORDER BY 1 LIMIT 1 \gset
+VACUUM FULL repack_test;
+SELECT pg_relation_filenode(:'chunk') <> :filenode AS chunk_rewritten;
+ chunk_rewritten 
+-----------------
+ t
+
+-- REPACK on an empty hypertable is a no-op
+CREATE TABLE repack_empty(time timestamptz, v int);
+SELECT create_hypertable('repack_empty', 'time');
+     create_hypertable     
+---------------------------
+ (2,public,repack_empty,t)
+
+REPACK repack_empty;
+REPACK repack_empty USING INDEX repack_empty_time_idx;
+-- REPACK must not run inside a transaction block
+\set ON_ERROR_STOP 0
+BEGIN;
+REPACK repack_test;
+ERROR:  REPACK cannot run inside a transaction block
+ROLLBACK;
+\set ON_ERROR_STOP 1
+-- Only the owner may REPACK a hypertable
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+REPACK repack_test;
+ERROR:  must be owner of hypertable "repack_test"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Options we do not handle per-chunk yet are rejected with a clear error
+\set ON_ERROR_STOP 0
+REPACK (CONCURRENTLY) repack_test;
+ERROR:  REPACK option "concurrently" is not supported on hypertables
+REPACK (ANALYZE) repack_test;
+ERROR:  REPACK option "analyze" is not supported on hypertables
+\set ON_ERROR_STOP 1
+DROP TABLE repack_test;
+DROP TABLE repack_files;
+DROP TABLE repack_empty;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -133,6 +133,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "18"))
   list(APPEND TEST_FILES insert_returning_old_new.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "19"))
+  list(APPEND TEST_FILES repack.sql)
+endif()
+
 # only test custom type if we are in 64-bit architecture
 if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
   list(APPEND TEST_FILES custom_type.sql)

--- a/test/sql/repack.sql
+++ b/test/sql/repack.sql
@@ -1,0 +1,78 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- REPACK generalizes CLUSTER and VACUUM FULL on PostgreSQL 19. Make sure it
+-- rewrites every chunk of a hypertable instead of only the empty root table.
+
+CREATE TABLE repack_test(time timestamptz, temp float, location int);
+SELECT create_hypertable('repack_test', 'time', chunk_time_interval => interval '1 day');
+
+INSERT INTO repack_test
+SELECT t, 1.0, 1
+FROM generate_series('2017-01-20'::timestamptz, '2017-01-24', '1 hour') t;
+
+SELECT count(*) AS num_chunks FROM show_chunks('repack_test');
+
+-- Remember each chunk's storage file so we can tell it was rewritten
+CREATE TABLE repack_files AS
+SELECT ch AS chunk, pg_relation_filenode(ch) AS filenode
+FROM show_chunks('repack_test') ch;
+
+-- Plain REPACK rewrites every chunk without ordering (like VACUUM FULL)
+REPACK repack_test;
+
+SELECT count(*) AS chunks_rewritten
+FROM repack_files f
+WHERE pg_relation_filenode(f.chunk) <> f.filenode;
+
+-- REPACK ... USING INDEX orders each chunk by the index and marks it clustered
+REPACK repack_test USING INDEX repack_test_time_idx;
+
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered
+ORDER BY 1;
+
+-- An implicit REPACK ... USING INDEX reuses the previously clustered index
+REPACK repack_test USING INDEX;
+
+-- Repacking a single chunk directly is handled by PostgreSQL
+SELECT ch::regclass::text AS chunk FROM show_chunks('repack_test') ch ORDER BY 1 LIMIT 1 \gset
+REPACK :chunk;
+
+-- VACUUM FULL still reaches every chunk (it stays a VacuumStmt, not a RepackStmt)
+SELECT ch AS chunk, pg_relation_filenode(ch) AS filenode
+FROM show_chunks('repack_test') ch ORDER BY 1 LIMIT 1 \gset
+VACUUM FULL repack_test;
+SELECT pg_relation_filenode(:'chunk') <> :filenode AS chunk_rewritten;
+
+-- REPACK on an empty hypertable is a no-op
+CREATE TABLE repack_empty(time timestamptz, v int);
+SELECT create_hypertable('repack_empty', 'time');
+REPACK repack_empty;
+REPACK repack_empty USING INDEX repack_empty_time_idx;
+
+-- REPACK must not run inside a transaction block
+\set ON_ERROR_STOP 0
+BEGIN;
+REPACK repack_test;
+ROLLBACK;
+\set ON_ERROR_STOP 1
+
+-- Only the owner may REPACK a hypertable
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
+\set ON_ERROR_STOP 0
+REPACK repack_test;
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- Options we do not handle per-chunk yet are rejected with a clear error
+\set ON_ERROR_STOP 0
+REPACK (CONCURRENTLY) repack_test;
+REPACK (ANALYZE) repack_test;
+\set ON_ERROR_STOP 1
+
+DROP TABLE repack_test;
+DROP TABLE repack_files;
+DROP TABLE repack_empty;

--- a/tsl/test/expected/repack.out
+++ b/tsl/test/expected/repack.out
@@ -1,0 +1,52 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- test REPACK on hypertable with compressed and uncompressed chunks
+CREATE TABLE repack_comp(time timestamptz, dev int, val float);
+SELECT create_hypertable('repack_comp', 'time', chunk_time_interval => interval '1 day');
+    create_hypertable     
+--------------------------
+ (1,public,repack_comp,t)
+
+ALTER TABLE repack_comp SET (timescaledb.compress, timescaledb.compress_segmentby = 'dev');
+INSERT INTO repack_comp
+SELECT t, dev, 1.0
+FROM generate_series('2020-01-01'::timestamptz, '2020-01-04', '1 hour') t,
+     generate_series(1, 3) dev;
+-- Compress the first two chunks, leaving the rest as rowstore
+SET client_min_messages TO ERROR;
+SELECT count(compress_chunk(c)) AS compressed_chunks
+FROM (SELECT show_chunks('repack_comp') c ORDER BY 1 LIMIT 2) s;
+ compressed_chunks 
+-------------------
+                 2
+
+RESET client_min_messages;
+SELECT count(*) AS rows_before FROM repack_comp;
+ rows_before 
+-------------
+         219
+
+-- Plain REPACK over the mix of compressed and uncompressed chunks
+REPACK repack_comp;
+SELECT count(*) AS rows_after_plain FROM repack_comp;
+ rows_after_plain 
+------------------
+              219
+
+-- REPACK ... USING INDEX over the same mix
+REPACK repack_comp USING INDEX repack_comp_time_idx;
+SELECT count(*) AS rows_after_index FROM repack_comp;
+ rows_after_index 
+------------------
+              219
+
+-- Data is still readable after decompression
+SELECT dev, count(*) FROM repack_comp GROUP BY dev ORDER BY dev;
+ dev | count 
+-----+-------
+   1 |    73
+   2 |    73
+   3 |    73
+
+DROP TABLE repack_comp;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -236,6 +236,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "18"))
   list(APPEND TEST_FILES constraints_not_valid.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "19"))
+  list(APPEND TEST_FILES repack.sql)
+endif()
+
 set(SOLO_TESTS
     # This interferes with other tests since it reloads the config to increase
     # log level.

--- a/tsl/test/sql/repack.sql
+++ b/tsl/test/sql/repack.sql
@@ -1,0 +1,34 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- test REPACK on hypertable with compressed and uncompressed chunks
+CREATE TABLE repack_comp(time timestamptz, dev int, val float);
+SELECT create_hypertable('repack_comp', 'time', chunk_time_interval => interval '1 day');
+ALTER TABLE repack_comp SET (timescaledb.compress, timescaledb.compress_segmentby = 'dev');
+
+INSERT INTO repack_comp
+SELECT t, dev, 1.0
+FROM generate_series('2020-01-01'::timestamptz, '2020-01-04', '1 hour') t,
+     generate_series(1, 3) dev;
+
+-- Compress the first two chunks, leaving the rest as rowstore
+SET client_min_messages TO ERROR;
+SELECT count(compress_chunk(c)) AS compressed_chunks
+FROM (SELECT show_chunks('repack_comp') c ORDER BY 1 LIMIT 2) s;
+RESET client_min_messages;
+
+SELECT count(*) AS rows_before FROM repack_comp;
+
+-- Plain REPACK over the mix of compressed and uncompressed chunks
+REPACK repack_comp;
+SELECT count(*) AS rows_after_plain FROM repack_comp;
+
+-- REPACK ... USING INDEX over the same mix
+REPACK repack_comp USING INDEX repack_comp_time_idx;
+SELECT count(*) AS rows_after_index FROM repack_comp;
+
+-- Data is still readable after decompression
+SELECT dev, count(*) FROM repack_comp GROUP BY dev ORDER BY dev;
+
+DROP TABLE repack_comp;


### PR DESCRIPTION
Add some basic support for REPACK. Block CONCURRENTLY and ANALYZE
for now similar to upstream support for partitioned tables.
