### PR TITLE
New catalogs for CAgg granular refresh

### DIFF
--- a/.unreleased/pr_10299
+++ b/.unreleased/pr_10299
@@ -1,0 +1,1 @@
+Implements: #10299 Add continuous_aggs_tenant_tracking and hypertable_cagg_settings catalogs

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -440,6 +440,35 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs
 
 CREATE INDEX continuous_aggs_jobs_refresh_ranges_idx ON _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges (materialization_id);
 
+-- Per-tenant invalidation tracking, used in granular refresh of contiuous aggregates.
+CREATE TABLE _timescaledb_catalog.continuous_aggs_tenant_tracking (
+  hypertable_id integer NOT NULL,
+  tenant_id text,
+  min_timestamp bigint NOT NULL,
+  max_timestamp bigint NOT NULL,
+  seqnum integer NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_tenant_tracking_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_tenant_tracking', '');
+
+CREATE INDEX continuous_aggs_tenant_tracking_idx ON _timescaledb_catalog.continuous_aggs_tenant_tracking (hypertable_id, seqnum);
+
+-- Per-hypertable settings for granular refresh of continuous aggregates.
+-- Row existence means granular refresh is configured for the hypertable.
+CREATE TABLE _timescaledb_catalog.hypertable_cagg_settings (
+  hypertable_id integer NOT NULL,
+  granular_refresh_column name NOT NULL,
+  granular_refresh_start_offset text,
+  granular_refresh_end_offset text,
+  -- table constraints
+  CONSTRAINT hypertable_cagg_settings_pkey PRIMARY KEY (hypertable_id),
+  CONSTRAINT hypertable_cagg_settings_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_cagg_settings', '');
+
 /* the source of this data is the enum from the source code that lists
  *  the algorithms. This table is NOT dumped.
  */

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -147,3 +147,28 @@ GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
 -- END add chunk.relid
 --
 
+-- add continuous_aggs_tenant_tracking
+CREATE TABLE _timescaledb_catalog.continuous_aggs_tenant_tracking (
+  hypertable_id integer NOT NULL,
+  tenant_id text,
+  min_timestamp bigint NOT NULL,
+  max_timestamp bigint NOT NULL,
+  seqnum integer NOT NULL,
+  CONSTRAINT continuous_aggs_tenant_tracking_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_tenant_tracking', '');
+
+CREATE INDEX continuous_aggs_tenant_tracking_idx ON _timescaledb_catalog.continuous_aggs_tenant_tracking (hypertable_id, seqnum);
+
+-- add hypertable_cagg_settings
+CREATE TABLE _timescaledb_catalog.hypertable_cagg_settings (
+  hypertable_id integer NOT NULL,
+  granular_refresh_column name NOT NULL,
+  granular_refresh_start_offset text,
+  granular_refresh_end_offset text,
+  CONSTRAINT hypertable_cagg_settings_pkey PRIMARY KEY (hypertable_id),
+  CONSTRAINT hypertable_cagg_settings_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_cagg_settings', '');

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -260,3 +260,10 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.policy_compaction_check(JSONB);
 
 DROP FUNCTION IF EXISTS @extschema@.alter_job(job_id INTEGER, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL, scheduled BOOL, config JSONB, next_start TIMESTAMPTZ, if_exists BOOL, check_config REGPROC, fixed_schedule BOOL, initial_start TIMESTAMPTZ, timezone TEXT, job_name TEXT, config_merge JSONB);
 
+-- drop continuous_aggs_tenant_tracking
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_aggs_tenant_tracking;
+DROP TABLE _timescaledb_catalog.continuous_aggs_tenant_tracking;
+
+-- drop hypertable_cagg_settings
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable_cagg_settings;
+DROP TABLE _timescaledb_catalog.hypertable_cagg_settings;

--- a/src/ts_catalog/CMakeLists.txt
+++ b/src/ts_catalog/CMakeLists.txt
@@ -7,7 +7,9 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/compression_settings.c
     ${CMAKE_CURRENT_SOURCE_DIR}/continuous_agg.c
     ${CMAKE_CURRENT_SOURCE_DIR}/continuous_aggs_jobs_refresh_ranges.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/continuous_aggs_tenant_tracking.c
     ${CMAKE_CURRENT_SOURCE_DIR}/continuous_aggs_watermark.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_cagg_settings.c
     ${CMAKE_CURRENT_SOURCE_DIR}/metadata.c
     ${CMAKE_CURRENT_SOURCE_DIR}/tablespace.c)
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -93,6 +93,14 @@ static const TableInfoDef catalog_table_names[_MAX_CATALOG_TABLES + 1] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = CONTINUOUS_AGGS_JOBS_REFRESH_RANGES_TABLE_NAME,
 	},
+	[CONTINUOUS_AGGS_TENANT_TRACKING] = {
+		.schema_name = CATALOG_SCHEMA_NAME,
+		.table_name = CONTINUOUS_AGGS_TENANT_TRACKING_TABLE_NAME,
+	},
+	[HYPERTABLE_CAGG_SETTINGS] = {
+		.schema_name = CATALOG_SCHEMA_NAME,
+		.table_name = HYPERTABLE_CAGG_SETTINGS_TABLE_NAME,
+	},
 	[COMPRESSION_SETTINGS] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = COMPRESSION_SETTINGS_TABLE_NAME,
@@ -240,6 +248,18 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_CONTINUOUS_AGGS_JOBS_REFRESH_RANGES_INDEX,
 		.names = (char *[]) {
 			[CONTINUOUS_AGGS_JOBS_REFRESH_RANGES_IDX] = "continuous_aggs_jobs_refresh_ranges_idx",
+		},
+	},
+	[CONTINUOUS_AGGS_TENANT_TRACKING] = {
+		.length = _MAX_CONTINUOUS_AGGS_TENANT_TRACKING_INDEX,
+		.names = (char *[]) {
+			[CONTINUOUS_AGGS_TENANT_TRACKING_IDX] = "continuous_aggs_tenant_tracking_idx",
+		},
+	},
+	[HYPERTABLE_CAGG_SETTINGS] = {
+		.length = _MAX_HYPERTABLE_CAGG_SETTINGS_INDEX,
+		.names = (char *[]) {
+			[HYPERTABLE_CAGG_SETTINGS_PKEY] = "hypertable_cagg_settings_pkey",
 		},
 	},
 	[CONTINUOUS_AGGS_WATERMARK] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -49,6 +49,8 @@ typedef enum CatalogTable
 	CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
 	CONTINUOUS_AGGS_MATERIALIZATION_RANGES,
 	CONTINUOUS_AGGS_JOBS_REFRESH_RANGES,
+	CONTINUOUS_AGGS_TENANT_TRACKING,
+	HYPERTABLE_CAGG_SETTINGS,
 	COMPRESSION_SETTINGS,
 	COMPRESSION_CHUNK_SIZE,
 	CONTINUOUS_AGGS_BUCKET_FUNCTION,
@@ -1079,6 +1081,84 @@ enum
 	CONTINUOUS_AGGS_JOBS_REFRESH_RANGES_IDX = 0,
 	_MAX_CONTINUOUS_AGGS_JOBS_REFRESH_RANGES_INDEX,
 };
+
+/****** CONTINUOUS_AGGS_TENANT_TRACKING definitions */
+#define CONTINUOUS_AGGS_TENANT_TRACKING_TABLE_NAME "continuous_aggs_tenant_tracking"
+
+typedef enum Anum_continuous_aggs_tenant_tracking
+{
+	Anum_continuous_aggs_tenant_tracking_hypertable_id = 1,
+	Anum_continuous_aggs_tenant_tracking_tenant_id,
+	Anum_continuous_aggs_tenant_tracking_min_timestamp,
+	Anum_continuous_aggs_tenant_tracking_max_timestamp,
+	Anum_continuous_aggs_tenant_tracking_seqnum,
+	_Anum_continuous_aggs_tenant_tracking_max,
+} Anum_continuous_aggs_tenant_tracking;
+
+#define Natts_continuous_aggs_tenant_tracking (_Anum_continuous_aggs_tenant_tracking_max - 1)
+
+typedef struct FormData_continuous_aggs_tenant_tracking
+{
+	int32 hypertable_id;
+	text *tenant_id;
+	int64 min_timestamp;
+	int64 max_timestamp;
+	int32 seqnum;
+} FormData_continuous_aggs_tenant_tracking;
+
+typedef FormData_continuous_aggs_tenant_tracking *Form_continuous_aggs_tenant_tracking;
+
+enum
+{
+	CONTINUOUS_AGGS_TENANT_TRACKING_IDX = 0,
+	_MAX_CONTINUOUS_AGGS_TENANT_TRACKING_INDEX,
+};
+typedef enum Anum_continuous_aggs_tenant_tracking_idx
+{
+	Anum_continuous_aggs_tenant_tracking_idx_hypertable_id = 1,
+	Anum_continuous_aggs_tenant_tracking_idx_seqnum,
+	_Anum_continuous_aggs_tenant_tracking_idx_max,
+} Anum_continuous_aggs_tenant_tracking_idx;
+
+#define Natts_continuous_aggs_tenant_tracking_idx                                                  \
+	(_Anum_continuous_aggs_tenant_tracking_idx_max - 1)
+
+/****** HYPERTABLE_CAGG_SETTINGS definitions */
+#define HYPERTABLE_CAGG_SETTINGS_TABLE_NAME "hypertable_cagg_settings"
+
+typedef enum Anum_hypertable_cagg_settings
+{
+	Anum_hypertable_cagg_settings_hypertable_id = 1,
+	Anum_hypertable_cagg_settings_granular_refresh_column,
+	Anum_hypertable_cagg_settings_granular_refresh_start_offset,
+	Anum_hypertable_cagg_settings_granular_refresh_end_offset,
+	_Anum_hypertable_cagg_settings_max,
+} Anum_hypertable_cagg_settings;
+
+#define Natts_hypertable_cagg_settings (_Anum_hypertable_cagg_settings_max - 1)
+
+typedef struct FormData_hypertable_cagg_settings
+{
+	int32 hypertable_id;
+	NameData granular_refresh_column;
+	text *granular_refresh_start_offset;
+	text *granular_refresh_end_offset;
+} FormData_hypertable_cagg_settings;
+
+typedef FormData_hypertable_cagg_settings *Form_hypertable_cagg_settings;
+
+enum
+{
+	HYPERTABLE_CAGG_SETTINGS_PKEY = 0,
+	_MAX_HYPERTABLE_CAGG_SETTINGS_INDEX,
+};
+typedef enum Anum_hypertable_cagg_settings_pkey
+{
+	Anum_hypertable_cagg_settings_pkey_hypertable_id = 1,
+	_Anum_hypertable_cagg_settings_pkey_max,
+} Anum_hypertable_cagg_settings_pkey;
+
+#define Natts_hypertable_cagg_settings_pkey (_Anum_hypertable_cagg_settings_pkey_max - 1)
 
 typedef enum Anum_continuous_aggs_jobs_refresh_ranges_idx
 {

--- a/src/ts_catalog/continuous_aggs_tenant_tracking.c
+++ b/src/ts_catalog/continuous_aggs_tenant_tracking.c
@@ -1,0 +1,282 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <access/htup_details.h>
+#include <access/table.h>
+#include <access/xact.h>
+#include <utils/rel.h>
+
+#include "debug_assert.h"
+#include "scan_iterator.h"
+#include "ts_catalog/catalog.h"
+#include "ts_catalog/continuous_aggs_tenant_tracking.h"
+
+static void
+init_scan_by_hypertable_id(ScanIterator *iterator, const int32 hypertable_id)
+{
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(),
+											CONTINUOUS_AGGS_TENANT_TRACKING,
+											CONTINUOUS_AGGS_TENANT_TRACKING_IDX);
+
+	ts_scan_iterator_scan_key_init(iterator,
+								   Anum_continuous_aggs_tenant_tracking_idx_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(hypertable_id));
+}
+
+/*
+ * Insert one tenant tracking row into an already-open relation, without
+ * advancing the command counter (mirrors ts_catalog_insert_only). tenant_id is
+ * copied into a text value holding the exact tenant key bytes.
+ *
+ * Callers that need the row visible to later commands in the same transaction must run
+ * CommandCounterIncrement() themselves (see ts_cagg_tenant_tracking_insert).
+ */
+TSDLLEXPORT void
+ts_cagg_tenant_tracking_insert_only(Relation rel, int32 hypertable_id, text *tenant_id,
+									int64 min_timestamp, int64 max_timestamp, int32 seqnum)
+{
+	TupleDesc desc = RelationGetDescr(rel);
+	Datum values[Natts_continuous_aggs_tenant_tracking];
+	bool nulls[Natts_continuous_aggs_tenant_tracking] = { false };
+	CatalogSecurityContext sec_ctx;
+	HeapTuple tuple;
+
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_hypertable_id)] =
+		Int32GetDatum(hypertable_id);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_tenant_id)] =
+		PointerGetDatum(tenant_id);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_min_timestamp)] =
+		Int64GetDatum(min_timestamp);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_max_timestamp)] =
+		Int64GetDatum(max_timestamp);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_seqnum)] =
+		Int32GetDatum(seqnum);
+
+	tuple = heap_form_tuple(desc, values, nulls);
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_insert_only(rel, tuple);
+	ts_catalog_restore_user(&sec_ctx);
+	heap_freetuple(tuple);
+}
+
+/*
+ * Insert one tenant tracking row, opening the relation and making the row
+ * visible to later commands in this transaction by calling CommandCounterIncrement().
+ */
+TSDLLEXPORT void
+ts_cagg_tenant_tracking_insert(int32 hypertable_id, const char *tenant_id, int tenant_id_len,
+							   int64 min_timestamp, int64 max_timestamp, int32 seqnum)
+{
+	Catalog *catalog = ts_catalog_get();
+	Relation rel = table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_TENANT_TRACKING),
+							  RowExclusiveLock);
+	text *tenant_text = (text *) palloc(VARHDRSZ + tenant_id_len);
+
+	Ensure(tenant_id_len > 0, "tenant_id length must be > 0");
+
+	SET_VARSIZE(tenant_text, VARHDRSZ + tenant_id_len);
+	memcpy(VARDATA(tenant_text), tenant_id, tenant_id_len);
+
+	ts_cagg_tenant_tracking_insert_only(rel,
+										hypertable_id,
+										tenant_text,
+										min_timestamp,
+										max_timestamp,
+										seqnum);
+	/* Make the row visible to later commands in this transaction. */
+	CommandCounterIncrement();
+
+	table_close(rel, NoLock);
+}
+
+/*
+ * Streaming inserter state.  Holds the relation (kept open across the whole
+ * batch), the assumed catalog-owner context, and a single reusable varlena
+ * buffer for the tenant key that grows only when a longer key appears.
+ */
+typedef struct CaggTenantTrackingInserter
+{
+	Relation rel;
+	TupleDesc desc;
+	CatalogSecurityContext sec_ctx;
+	int32 hypertable_id;
+	int32 seqnum;
+	text *tenant_text; /* reusable key buffer, NULL until first row */
+	int buf_capacity;  /* key bytes (excludes VARHDRSZ) tenant_text can hold */
+} CaggTenantTrackingInserter;
+
+TSDLLEXPORT CaggTenantTrackingInserter *
+ts_cagg_tenant_tracking_insert_begin(int32 hypertable_id, int32 seqnum)
+{
+	Catalog *catalog = ts_catalog_get();
+	CaggTenantTrackingInserter *inserter = palloc0(sizeof(CaggTenantTrackingInserter));
+
+	inserter->rel = table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_TENANT_TRACKING),
+							   RowExclusiveLock);
+	inserter->desc = RelationGetDescr(inserter->rel);
+	inserter->hypertable_id = hypertable_id;
+	inserter->seqnum = seqnum;
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &inserter->sec_ctx);
+
+	return inserter;
+}
+
+TSDLLEXPORT void
+ts_cagg_tenant_tracking_insert_row(CaggTenantTrackingInserter *inserter, const char *tenant_id,
+								   int tenant_id_len, int64 min_timestamp, int64 max_timestamp)
+{
+	Datum values[Natts_continuous_aggs_tenant_tracking];
+	bool nulls[Natts_continuous_aggs_tenant_tracking] = { false };
+	HeapTuple tuple;
+	Ensure(tenant_id_len > 0, "tenant_id length must be > 0");
+	/*
+	 * Grow the reusable buffer only when a longer key shows up.  heap_form_tuple
+	 * copies the datum into the tuple, so the buffer is safe to overwrite on the
+	 * next row.
+	 */
+	if (tenant_id_len > inserter->buf_capacity)
+	{
+		if (inserter->tenant_text == NULL)
+		{
+			inserter->tenant_text = (text *) palloc(VARHDRSZ + tenant_id_len);
+		}
+		else
+		{
+			inserter->tenant_text =
+				(text *) repalloc(inserter->tenant_text, VARHDRSZ + tenant_id_len);
+		}
+		inserter->buf_capacity = tenant_id_len;
+	}
+
+	SET_VARSIZE(inserter->tenant_text, VARHDRSZ + tenant_id_len);
+	memcpy(VARDATA(inserter->tenant_text), tenant_id, tenant_id_len);
+
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_hypertable_id)] =
+		Int32GetDatum(inserter->hypertable_id);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_tenant_id)] =
+		PointerGetDatum(inserter->tenant_text);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_min_timestamp)] =
+		Int64GetDatum(min_timestamp);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_max_timestamp)] =
+		Int64GetDatum(max_timestamp);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_seqnum)] =
+		Int32GetDatum(inserter->seqnum);
+
+	tuple = heap_form_tuple(inserter->desc, values, nulls);
+	ts_catalog_insert_only(inserter->rel, tuple);
+	heap_freetuple(tuple);
+}
+
+TSDLLEXPORT void
+ts_cagg_tenant_tracking_insert_end(CaggTenantTrackingInserter *inserter)
+{
+	if (inserter->tenant_text != NULL)
+	{
+		pfree(inserter->tenant_text);
+	}
+
+	/* Publish all inserted rows to later commands in a single step. */
+	CommandCounterIncrement();
+
+	ts_catalog_restore_user(&inserter->sec_ctx);
+	table_close(inserter->rel, NoLock);
+
+	pfree(inserter);
+}
+
+/*
+ * Insert the "invalid" marker row <null, null, null, seqnum>, signalling that
+ * tenant tracking for this seqnum is incomplete and the refresh must fall back
+ * to the full invalidation log.
+ */
+TSDLLEXPORT void
+ts_cagg_tenant_tracking_insert_invalid_marker(int32 hypertable_id, int32 seqnum)
+{
+	Catalog *catalog = ts_catalog_get();
+	Relation rel = table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_TENANT_TRACKING),
+							  RowExclusiveLock);
+	TupleDesc desc = RelationGetDescr(rel);
+	Datum values[Natts_continuous_aggs_tenant_tracking] = { 0 };
+	bool nulls[Natts_continuous_aggs_tenant_tracking] = { false };
+	CatalogSecurityContext sec_ctx;
+
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_hypertable_id)] =
+		Int32GetDatum(hypertable_id);
+	nulls[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_tenant_id)] = true;
+	nulls[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_min_timestamp)] = true;
+	nulls[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_max_timestamp)] = true;
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_tenant_tracking_seqnum)] =
+		Int32GetDatum(seqnum);
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_insert_values(rel, desc, values, nulls);
+	ts_catalog_restore_user(&sec_ctx);
+
+	table_close(rel, NoLock);
+}
+
+TSDLLEXPORT bool
+ts_cagg_tenant_tracking_exists(int32 hypertable_id, int32 seqnum)
+{
+	bool found = false;
+	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_TENANT_TRACKING,
+													AccessShareLock,
+													CurrentMemoryContext);
+
+	iterator.ctx.index = catalog_get_index(ts_catalog_get(),
+										   CONTINUOUS_AGGS_TENANT_TRACKING,
+										   CONTINUOUS_AGGS_TENANT_TRACKING_IDX);
+	ts_scan_iterator_scan_key_init(&iterator,
+								   Anum_continuous_aggs_tenant_tracking_idx_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(hypertable_id));
+	ts_scan_iterator_scan_key_init(&iterator,
+								   Anum_continuous_aggs_tenant_tracking_idx_seqnum,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(seqnum));
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		bool isnull;
+
+		/* A real tracking row has a non-NULL tenant_id; invalid markers do not count. */
+		slot_getattr(ti->slot, Anum_continuous_aggs_tenant_tracking_tenant_id, &isnull);
+		if (!isnull)
+		{
+			found = true;
+			break;
+		}
+	}
+	ts_scan_iterator_close(&iterator);
+
+	return found;
+}
+
+/* Delete all tracking rows for a hypertable. */
+TSDLLEXPORT void
+ts_cagg_tenant_tracking_delete_by_hypertable_id(int32 hypertable_id)
+{
+	ScanIterator iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_TENANT_TRACKING,
+													RowExclusiveLock,
+													CurrentMemoryContext);
+
+	init_scan_by_hypertable_id(&iterator, hypertable_id);
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+
+		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+	}
+	ts_scan_iterator_close(&iterator);
+}

--- a/src/ts_catalog/continuous_aggs_tenant_tracking.h
+++ b/src/ts_catalog/continuous_aggs_tenant_tracking.h
@@ -1,0 +1,65 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+#include <utils/relcache.h>
+
+#include "export.h"
+
+/*
+ * Catalog access for _timescaledb_catalog.continuous_aggs_tenant_tracking.
+ *
+ * Rows are flushed here from the shared-memory per-tenant invalidation tracker
+ * during a continuous aggregate refresh (Transaction 2).  tenant_id holds the
+ * canonical text form of the tenant key; min/max_timestamp are internal time
+ * values.  The "invalid marker" row (tenant_id/min/max NULL) signals that tenant tracking
+ * for that seqnum is incomplete, forcing a fall back to the full invalidation
+ * log.
+ */
+
+extern TSDLLEXPORT void ts_cagg_tenant_tracking_insert_only(Relation rel, int32 hypertable_id,
+															text *tenant_id, int64 min_timestamp,
+															int64 max_timestamp, int32 seqnum);
+
+extern TSDLLEXPORT void ts_cagg_tenant_tracking_insert(int32 hypertable_id, const char *tenant_id,
+													   int tenant_id_len, int64 min_timestamp,
+													   int64 max_timestamp, int32 seqnum);
+
+/*
+ * Streaming insert for the refresh hot path: open the relation once
+ * (_begin), feed rows one at a time straight from their source -- e.g. the
+ * shared-memory tenant tracker's quiesced generation, read in place with no
+ * intermediate array -- then close once (_end).  The relation stays open and
+ * the catalog owner role assumed for the whole span, so the per-cagg
+ * serialization lock is held for as short a time as possible.  Each row's
+ * tenant_id text is copied into the tuple by _insert_row; the caller need
+ * not keep its own copy.  The inserter state is opaque and allocated by
+ * _begin; _end frees it.
+ */
+typedef struct CaggTenantTrackingInserter CaggTenantTrackingInserter;
+
+extern TSDLLEXPORT CaggTenantTrackingInserter *
+ts_cagg_tenant_tracking_insert_begin(int32 hypertable_id, int32 seqnum);
+
+extern TSDLLEXPORT void ts_cagg_tenant_tracking_insert_row(CaggTenantTrackingInserter *inserter,
+														   const char *tenant_id, int tenant_id_len,
+														   int64 min_timestamp,
+														   int64 max_timestamp);
+
+extern TSDLLEXPORT void ts_cagg_tenant_tracking_insert_end(CaggTenantTrackingInserter *inserter);
+
+extern TSDLLEXPORT void ts_cagg_tenant_tracking_insert_invalid_marker(int32 hypertable_id,
+																	  int32 seqnum);
+
+extern TSDLLEXPORT void ts_cagg_tenant_tracking_delete_by_hypertable_id(int32 hypertable_id);
+
+/*
+ * Whether at least one real (non-marker) tenant-tracking row exists for the
+ * given hypertable and seqnum. A seqnum with only an invalid-marker row (or no
+ * row) returns false, so the refresh falls back to a full refresh.
+ */
+extern TSDLLEXPORT bool ts_cagg_tenant_tracking_exists(int32 hypertable_id, int32 seqnum);

--- a/src/ts_catalog/hypertable_cagg_settings.c
+++ b/src/ts_catalog/hypertable_cagg_settings.c
@@ -1,0 +1,43 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+
+#include "scan_iterator.h"
+#include "ts_catalog/catalog.h"
+#include "ts_catalog/hypertable_cagg_settings.h"
+
+static void
+init_scan_by_hypertable_id(ScanIterator *iterator, const int32 hypertable_id)
+{
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(),
+											HYPERTABLE_CAGG_SETTINGS,
+											HYPERTABLE_CAGG_SETTINGS_PKEY);
+
+	ts_scan_iterator_scan_key_init(iterator,
+								   Anum_hypertable_cagg_settings_pkey_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(hypertable_id));
+}
+
+/* Delete the settings row for a hypertable, if any. */
+TSDLLEXPORT void
+ts_hypertable_cagg_settings_delete(int32 hypertable_id)
+{
+	ScanIterator iterator =
+		ts_scan_iterator_create(HYPERTABLE_CAGG_SETTINGS, RowExclusiveLock, CurrentMemoryContext);
+
+	init_scan_by_hypertable_id(&iterator, hypertable_id);
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+
+		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+	}
+	ts_scan_iterator_close(&iterator);
+}

--- a/src/ts_catalog/hypertable_cagg_settings.h
+++ b/src/ts_catalog/hypertable_cagg_settings.h
@@ -1,0 +1,20 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#pragma once
+
+#include <postgres.h>
+
+#include "export.h"
+
+/*
+ * Catalog access for _timescaledb_catalog.hypertable_cagg_settings.
+ *
+ * Per-hypertable settings for granular refresh of continuous
+ * aggregates. Row existence means granular refresh is configured for the
+ * hypertable.
+ */
+
+extern TSDLLEXPORT void ts_hypertable_cagg_settings_delete(int32 hypertable_id);

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -195,10 +195,12 @@ SELECT schema, name FROM test.relation WHERE schema IN ('public', '_timescaledb_
  _timescaledb_catalog  | continuous_aggs_jobs_refresh_ranges
  _timescaledb_catalog  | continuous_aggs_materialization_invalidation_log
  _timescaledb_catalog  | continuous_aggs_materialization_ranges
+ _timescaledb_catalog  | continuous_aggs_tenant_tracking
  _timescaledb_catalog  | continuous_aggs_watermark
  _timescaledb_catalog  | dimension
  _timescaledb_catalog  | dimension_slice
  _timescaledb_catalog  | hypertable
+ _timescaledb_catalog  | hypertable_cagg_settings
  _timescaledb_catalog  | metadata
  _timescaledb_catalog  | tablespace
  _timescaledb_internal | bgw_job_stat

--- a/tsl/test/expected/explain_wal.out
+++ b/tsl/test/expected/explain_wal.out
@@ -26,9 +26,9 @@ INSERT INTO metrics SELECT '2025-01-01', 'd1', i::float FROM generate_series(0,1
 --- QUERY PLAN ---
  Custom Scan (ModifyHypertable) (actual rows=0.00 loops=1)
    Direct Compress: true
-   WAL: records=3 bytes=487
+   WAL: records=2 bytes=401
    ->  Insert on metrics (actual rows=0.00 loops=1)
-         WAL: records=3 bytes=487
+         WAL: records=2 bytes=401
          ->  Function Scan on generate_series i (actual rows=11.00 loops=1)
 
 EXPLAIN (ANALYZE, BUFFERS OFF, COSTS OFF, SUMMARY OFF, TIMING OFF, WAL ON)


### PR DESCRIPTION
Add catalog definitions and helper functions for
continuous_aggs_tenant_tracking.

- continuous_aggs_tenant_tracking catalog to store tenant-based
granular trackings.
- hypertable_cagg_settings catalog to store tenant tracking column,
start and end offsets to calculate tracking window for granular refresh.

