### PR TITLE
Release 2.29.0

### DIFF
--- a/.unreleased/allow-alter-extension-in-transaction
+++ b/.unreleased/allow-alter-extension-in-transaction
@@ -1,1 +1,0 @@
-Fixes: #10313 Allow running ALTER EXTENSION timescaledb UPDATE inside a transaction block

--- a/.unreleased/alter_job_config_merge
+++ b/.unreleased/alter_job_config_merge
@@ -1,1 +1,0 @@
-Implements: #10225 Add config_merge parameter to alter_job for merging JSONB into the existing job configuration

--- a/.unreleased/columnar-cache
+++ b/.unreleased/columnar-cache
@@ -1,1 +1,0 @@
-Implements: #9534 Speed up expression evaluation in the columnar pipeline by caching common subexpressions

--- a/.unreleased/fix_direct_compress_cansettag
+++ b/.unreleased/fix_direct_compress_cansettag
@@ -1,1 +1,0 @@
-Fixes: #10282 Only count directly compressed rows toward the command tag when the insert sets it

--- a/.unreleased/fix_direct_compress_exclusion
+++ b/.unreleased/fix_direct_compress_exclusion
@@ -1,1 +1,0 @@
-Fixes: #10281 Disable Direct Compress when the destination table has an exclusion constraint so the constraint is still enforced

--- a/.unreleased/fix_direct_compress_returning
+++ b/.unreleased/fix_direct_compress_returning
@@ -1,1 +1,0 @@
-Fixes: #10280 RETURNING clause returned no rows for INSERT using Direct Compress

--- a/.unreleased/fix_vacuum_compressed_chunk
+++ b/.unreleased/fix_vacuum_compressed_chunk
@@ -1,2 +1,0 @@
-Fixes: #10286 Propagate VACUUM on a chunk to the compressed relation when running on chunk directly
-Thanks: @h0rn3t for reporting a problem with VACUUM not propagating to the compressed relation

--- a/.unreleased/leak-direct
+++ b/.unreleased/leak-direct
@@ -1,1 +1,0 @@
-Implements: #10119 Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks

--- a/.unreleased/min-nan
+++ b/.unreleased/min-nan
@@ -1,1 +1,0 @@
-Fixes: #10052 Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain Postgres result

--- a/.unreleased/param-eval
+++ b/.unreleased/param-eval
@@ -1,2 +1,0 @@
-Implements: #9917 Decompress less data in DML on compressed hypertable by accounting for the prepared statement parameters
-Thanks: @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression

--- a/.unreleased/pr_10010
+++ b/.unreleased/pr_10010
@@ -1,1 +1,0 @@
-Implements: #10010 Skip classifying compressed relations to speed up planning

--- a/.unreleased/pr_10013
+++ b/.unreleased/pr_10013
@@ -1,1 +1,0 @@
-Fixes: #10013 Make ownership error messages on CAggs consistent

--- a/.unreleased/pr_10041
+++ b/.unreleased/pr_10041
@@ -1,1 +1,0 @@
-Implements: #10041 Remove support for PG15

--- a/.unreleased/pr_10048
+++ b/.unreleased/pr_10048
@@ -1,1 +1,0 @@
-Implements: #10048 Support concurrent refresh policies on hierarchical continuous aggregates

--- a/.unreleased/pr_10081
+++ b/.unreleased/pr_10081
@@ -1,1 +1,0 @@
-Implements: #10081 Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size

--- a/.unreleased/pr_10118
+++ b/.unreleased/pr_10118
@@ -1,1 +1,0 @@
-Implements: #10118 Don't track compressed relations as separate chunk

--- a/.unreleased/pr_10143
+++ b/.unreleased/pr_10143
@@ -1,1 +1,0 @@
-Fixes: #10143 Fix division by zero when planning time_bucket with zero width

--- a/.unreleased/pr_10163
+++ b/.unreleased/pr_10163
@@ -1,1 +1,0 @@
-Implements: #10163 Add a compaction policy for unordered chunks

--- a/.unreleased/pr_10175
+++ b/.unreleased/pr_10175
@@ -1,2 +1,0 @@
-Fixes: #10071 Prune the real-time branch of hierarchical continuous aggregates at any nesting depth
-Thanks: @viniciusrsouza for reporting the issue

--- a/.unreleased/pr_10199
+++ b/.unreleased/pr_10199
@@ -1,1 +1,0 @@
-Fixes: #10199 Fix initial_start handling in build_job_info

--- a/.unreleased/pr_10204
+++ b/.unreleased/pr_10204
@@ -1,1 +1,0 @@
-Implements: #10204 Don't create separate hypertable catalog entry for hypertables with compression

--- a/.unreleased/pr_10213
+++ b/.unreleased/pr_10213
@@ -1,1 +1,0 @@
-Fixes: #10213 Cache sort pathkeys per hypertable

--- a/.unreleased/pr_10217
+++ b/.unreleased/pr_10217
@@ -1,1 +1,0 @@
-Implements: #10217 Initial placeholder version of granular refresh API

--- a/.unreleased/pr_10226
+++ b/.unreleased/pr_10226
@@ -1,1 +1,0 @@
-Implements: #10226 Add recompress_unordered columnstore policy option

--- a/.unreleased/pr_10231
+++ b/.unreleased/pr_10231
@@ -1,1 +1,0 @@
-Implements: #10231 Use regclass for storing relation reference in chunk table

--- a/.unreleased/pr_10237
+++ b/.unreleased/pr_10237
@@ -1,1 +1,0 @@
-Implements: #10237 Add helper functions for decoding hypertable status

--- a/.unreleased/pr_10240
+++ b/.unreleased/pr_10240
@@ -1,1 +1,0 @@
-Implements: #10240 Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings.

--- a/.unreleased/pr_10242
+++ b/.unreleased/pr_10242
@@ -1,2 +1,0 @@
-Fixes: #10221 Fix incremental refresh skipping the last bucket
-Thanks: @FrancescEthon and @ManuelEthon for reporting the issue

--- a/.unreleased/pr_10266
+++ b/.unreleased/pr_10266
@@ -1,1 +1,0 @@
-Implements: #10266 Add max_batches to compact_chunk

--- a/.unreleased/pr_10278
+++ b/.unreleased/pr_10278
@@ -1,2 +1,0 @@
-Fixes: #10278 Drop job_errors view in bgw_job_stat_history migration
-Thanks: @proddata for reporting a problem when upgrading from 2.15.3 to 2.28.2

--- a/.unreleased/pr_10299
+++ b/.unreleased/pr_10299
@@ -1,1 +1,0 @@
-Implements: #10299 Add continuous_aggs_tenant_tracking and hypertable_cagg_settings catalogs

--- a/.unreleased/pr_10302
+++ b/.unreleased/pr_10302
@@ -1,1 +1,0 @@
-Fixes: #10302 Fix useless-join removal and self-join elimination for hypertables

--- a/.unreleased/pr_10315
+++ b/.unreleased/pr_10315
@@ -1,1 +1,0 @@
-Fixes: #10315 Fix overlap detection with running max

--- a/.unreleased/pr_10324
+++ b/.unreleased/pr_10324
@@ -1,2 +1,0 @@
-Fixes: #10324 Fix stale index entries after rebuild_sparse_index() on compressed chunks
-Thanks: @tureba for reporting and fixing stale sparse-index entries after rebuild

--- a/.unreleased/pr_9315
+++ b/.unreleased/pr_9315
@@ -1,2 +1,0 @@
-Implements: #9315 Speed up the DML operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic Postgres inheritance hierarchy expansion.
-Setting: `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code instead of the generic Postgres inheritance hierarchy expansion. 

--- a/.unreleased/pr_9684
+++ b/.unreleased/pr_9684
@@ -1,1 +1,0 @@
-Implements: #9684 Add `decompress_batch` SQL function

--- a/.unreleased/pr_9957
+++ b/.unreleased/pr_9957
@@ -1,1 +1,0 @@
-Implements: #9957 Add compact_chunk function

--- a/.unreleased/row-by-row
+++ b/.unreleased/row-by-row
@@ -1,1 +1,0 @@
-Implements: #9732 Speed up some queries with small LIMIT by switching to row-by-row query execution pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,50 +6,48 @@
 
 This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.29.0**
-* 
-
 **Backward-Incompatible Changes**
+* [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PostgreSQL 15
 
 **Features**
 * [#10010](https://github.com/timescale/timescaledb/pull/10010) Skip classifying compressed relations to speed up planning
-* [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PG15
 * [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
-* [#10081](https://github.com/timescale/timescaledb/pull/10081) Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size
+* [#10081](https://github.com/timescale/timescaledb/pull/10081) Add `samplerate` argument to `_timescaledb_functions.estimate_uncompressed_size()`
 * [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk
-* [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks
+* [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of `INSERT` queries using direct compress and spanning multiple chunks
 * [#10163](https://github.com/timescale/timescaledb/pull/10163) Add a compaction policy for unordered chunks
 * [#10204](https://github.com/timescale/timescaledb/pull/10204) Don't create separate hypertable catalog entry for hypertables with compression
 * [#10217](https://github.com/timescale/timescaledb/pull/10217) Initial placeholder version of granular refresh API
-* [#10225](https://github.com/timescale/timescaledb/pull/10225) Add config_merge parameter to alter_job for merging JSONB into the existing job configuration
-* [#10226](https://github.com/timescale/timescaledb/pull/10226) Add recompress_unordered columnstore policy option
-* [#10231](https://github.com/timescale/timescaledb/pull/10231) Use regclass for storing relation reference in chunk table
+* [#10225](https://github.com/timescale/timescaledb/pull/10225) Add `config_merge` parameter to `alter_job()` for merging `jsonb` into the existing job configuration
+* [#10226](https://github.com/timescale/timescaledb/pull/10226) Add `recompress_unordered` columnstore policy option
+* [#10231](https://github.com/timescale/timescaledb/pull/10231) Use `regclass` for storing relation reference in chunk table
 * [#10237](https://github.com/timescale/timescaledb/pull/10237) Add helper functions for decoding hypertable status
-* [#10240](https://github.com/timescale/timescaledb/pull/10240) Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings.
-* [#10266](https://github.com/timescale/timescaledb/pull/10266) Add max_batches to compact_chunk
-* [#9315](https://github.com/timescale/timescaledb/pull/9315) Speed up the DML operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic Postgres inheritance hierarchy expansion.
+* [#10240](https://github.com/timescale/timescaledb/pull/10240) Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings
+* [#10266](https://github.com/timescale/timescaledb/pull/10266) Add `max_batches` to `compact_chunk()`
+* [#9315](https://github.com/timescale/timescaledb/pull/9315) Speed up `DML` operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic PostgreSQL inheritance hierarchy expansion
 * [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
-* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `decompress_batch` SQL function
-* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small LIMIT by switching to row-by-row query execution pipeline
-* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in DML on compressed hypertable by accounting for the prepared statement parameters
-* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add compact_chunk function
+* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `_timescaledb_functions.decompress_batch()` SQL function
+* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small `LIMIT` by switching to row-by-row query execution pipeline
+* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in `DML` on compressed hypertables by accounting for prepared statement parameters
+* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add `compact_chunk()` function
 
 **Bugfixes**
-* [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on CAggs consistent
-* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain Postgres result
-* [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning time_bucket with zero width
-* [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix initial_start handling in build_job_info
+* [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on continuous aggregates consistent
+* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain PostgreSQL result
+* [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning `time_bucket` with zero width
+* [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix `initial_start` handling in `build_job_info`
 * [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable
 * [#10221](https://github.com/timescale/timescaledb/pull/10221) Fix incremental refresh skipping the last bucket
-* [#10278](https://github.com/timescale/timescaledb/pull/10278) Drop job_errors view in bgw_job_stat_history migration
-* [#10280](https://github.com/timescale/timescaledb/pull/10280) RETURNING clause returned no rows for INSERT using Direct Compress
-* [#10281](https://github.com/timescale/timescaledb/pull/10281) Disable Direct Compress when the destination table has an exclusion constraint so the constraint is still enforced
-* [#10282](https://github.com/timescale/timescaledb/pull/10282) Only count directly compressed rows toward the command tag when the insert sets it
+* [#10278](https://github.com/timescale/timescaledb/pull/10278) Drop `job_errors` view in `bgw_job_stat_history` migration
+* [#10280](https://github.com/timescale/timescaledb/pull/10280) `RETURNING` clause returned no rows for `INSERT` using direct compress
+* [#10281](https://github.com/timescale/timescaledb/pull/10281) Disable direct compress when the destination table has an exclusion constraint so the constraint is still enforced
+* [#10282](https://github.com/timescale/timescaledb/pull/10282) Only count directly compressed rows toward the command tag when the `INSERT` sets it
 
 **New Settings**
-* `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code instead of the generic Postgres inheritance hierarchy expansion. 
+* `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code for `UPDATE` and `DELETE` instead of the generic PostgreSQL inheritance hierarchy expansion. On by default.
 
 **GUCs**
+* `timescaledb.enable_hypertable_expansion_for_dml`: enable TimescaleDB hypertable expansion for `DML`. Default: `true`
 
 **Thanks**
 * @FrancescEthon and @ManuelEthon for reporting the issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.
 
+**Important: PostgreSQL 15 Support Removed**
+TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports PostgreSQL 16, 17, and 18. If you are still running PostgreSQL 15, upgrade PostgreSQL before upgrading to TimescaleDB 2.29.0.
+
 **Backward-Incompatible Changes**
 * [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PostgreSQL 15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.
 
 **Release Highlights**
-* Chunk exclusion for DML operations: drastically improving the performance of `UPDATE` and `DELETE` statements on hypertables. By acquiring exclusive locks only on the specific chunks being modified rather than the entire hypertable, this enhancement eliminates massive lock contention and keeps high-concurrency workloads running smoothly without unnecessary slowdowns.
-* Intelligent **row-by-row decompression**: allowing the query planner to decompress data row-by-row rather than in large batches when an operation prioritizes a fast initial response (such as queries with `LIMIT` clauses). This dramatically reduces memory overhead and query latency, ensuring lightning-fast performance when you only need to retrieve a small subset of records from your compressed hypertables.
+* **Chunk exclusion for DML operations** drastically improves the performance of `UPDATE` and `DELETE` statements on hypertables. By acquiring exclusive locks only on the specific chunks being modified rather than the entire hypertable, this enhancement eliminates massive lock contention and keeps high-concurrency workloads running smoothly without unnecessary slowdowns.
+* Intelligent **row-by-row decompression** enables the query planner to decompress data row-by-row rather than in large batches when an operation prioritizes a fast initial response (such as queries with `LIMIT` clauses). This dramatically reduces memory overhead and query latency, ensuring lightning-fast performance when you only need to retrieve a small subset of records from your compressed hypertables.
 
 **Important: PostgreSQL 15 Support Removed**
 TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports PostgreSQL 16, 17, and 18. If you are still running PostgreSQL 15, upgrade PostgreSQL before upgrading to TimescaleDB 2.29.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PostgreSQL 15
 
 **Features**
-* [#10010](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
+* [#10100](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
 * [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
 * [#10081](https://github.com/timescale/timescaledb/pull/10081) Add `samplerate` argument to `_timescaledb_functions.estimate_uncompressed_size()`
 * [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PostgreSQL 15
 
 **Features**
-* [#10010](https://github.com/timescale/timescaledb/pull/10010) Skip classifying compressed relations to speed up planning
+* [#10010](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
 * [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
 * [#10081](https://github.com/timescale/timescaledb/pull/10081) Add `samplerate` argument to `_timescaledb_functions.estimate_uncompressed_size()`
 * [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PostgreSQL 15
 
 **Features**
+* [#9315](https://github.com/timescale/timescaledb/pull/9315) Speed up `DML` operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic PostgreSQL inheritance hierarchy expansion
+* [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
+* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `_timescaledb_functions.decompress_batch()` SQL function
+* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small `LIMIT` by switching to row-by-row query execution pipeline
+* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in `DML` on compressed hypertables by accounting for prepared statement parameters
+* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add `compact_chunk()` function
 * [#10100](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
 * [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
 * [#10081](https://github.com/timescale/timescaledb/pull/10081) Add `samplerate` argument to `_timescaledb_functions.estimate_uncompressed_size()`
@@ -31,12 +37,6 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10237](https://github.com/timescale/timescaledb/pull/10237) Add helper functions for decoding hypertable status
 * [#10240](https://github.com/timescale/timescaledb/pull/10240) Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings
 * [#10266](https://github.com/timescale/timescaledb/pull/10266) Add `max_batches` to `compact_chunk()`
-* [#9315](https://github.com/timescale/timescaledb/pull/9315) Speed up `DML` operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic PostgreSQL inheritance hierarchy expansion
-* [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
-* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `_timescaledb_functions.decompress_batch()` SQL function
-* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small `LIMIT` by switching to row-by-row query execution pipeline
-* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in `DML` on compressed hypertables by accounting for prepared statement parameters
-* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add `compact_chunk()` function
 
 **Bugfixes**
 * [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on continuous aggregates consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.29.0 (2026-07-21)
+
+This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.29.0**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+* [#10010](https://github.com/timescale/timescaledb/pull/10010) Skip classifying compressed relations to speed up planning
+* [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PG15
+* [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
+* [#10081](https://github.com/timescale/timescaledb/pull/10081) Add samplerate argument to _timescaledb_functions.estimate_uncompressed_size
+* [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk
+* [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of INSERT queries using Direct Compress and spanning multiple chunks
+* [#10163](https://github.com/timescale/timescaledb/pull/10163) Add a compaction policy for unordered chunks
+* [#10204](https://github.com/timescale/timescaledb/pull/10204) Don't create separate hypertable catalog entry for hypertables with compression
+* [#10217](https://github.com/timescale/timescaledb/pull/10217) Initial placeholder version of granular refresh API
+* [#10225](https://github.com/timescale/timescaledb/pull/10225) Add config_merge parameter to alter_job for merging JSONB into the existing job configuration
+* [#10226](https://github.com/timescale/timescaledb/pull/10226) Add recompress_unordered columnstore policy option
+* [#10231](https://github.com/timescale/timescaledb/pull/10231) Use regclass for storing relation reference in chunk table
+* [#10237](https://github.com/timescale/timescaledb/pull/10237) Add helper functions for decoding hypertable status
+* [#10240](https://github.com/timescale/timescaledb/pull/10240) Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings.
+* [#10266](https://github.com/timescale/timescaledb/pull/10266) Add max_batches to compact_chunk
+* [#9315](https://github.com/timescale/timescaledb/pull/9315) Speed up the DML operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic Postgres inheritance hierarchy expansion.
+* [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
+* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `decompress_batch` SQL function
+* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small LIMIT by switching to row-by-row query execution pipeline
+* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in DML on compressed hypertable by accounting for the prepared statement parameters
+* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add compact_chunk function
+
+**Bugfixes**
+* [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on CAggs consistent
+* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain Postgres result
+* [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning time_bucket with zero width
+* [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix initial_start handling in build_job_info
+* [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable
+* [#10221](https://github.com/timescale/timescaledb/pull/10221) Fix incremental refresh skipping the last bucket
+* [#10278](https://github.com/timescale/timescaledb/pull/10278) Drop job_errors view in bgw_job_stat_history migration
+* [#10280](https://github.com/timescale/timescaledb/pull/10280) RETURNING clause returned no rows for INSERT using Direct Compress
+* [#10281](https://github.com/timescale/timescaledb/pull/10281) Disable Direct Compress when the destination table has an exclusion constraint so the constraint is still enforced
+* [#10282](https://github.com/timescale/timescaledb/pull/10282) Only count directly compressed rows toward the command tag when the insert sets it
+
+**New Settings**
+* `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code instead of the generic Postgres inheritance hierarchy expansion. 
+
+**GUCs**
+
+**Thanks**
+* @FrancescEthon and @ManuelEthon for reporting the issue
+* @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression
+* @proddata for reporting a problem when upgrading from 2.15.3 to 2.28.2
+
 ## 2.28.3 (2026-07-16)
 
 This release contains performance improvements and bug fixes since the 2.28.2 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.29.0 (2026-07-21)
+## 2.29.0 (2026-07-28)
 
 This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.
+
+**Release Highlights**
+* Chunk exclusion for DML operations: drastically improving the performance of `UPDATE` and `DELETE` statements on hypertables. By acquiring exclusive locks only on the specific chunks being modified rather than the entire hypertable, this enhancement eliminates massive lock contention and keeps high-concurrency workloads running smoothly without unnecessary slowdowns.
+* Intelligent **row-by-row decompression**: allowing the query planner to decompress data row-by-row rather than in large batches when an operation prioritizes a fast initial response (such as queries with `LIMIT` clauses). This dramatically reduces memory overhead and query latency, ensuring lightning-fast performance when you only need to retrieve a small subset of records from your compressed hypertables.
 
 **Important: PostgreSQL 15 Support Removed**
 TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports PostgreSQL 16, 17, and 18. If you are still running PostgreSQL 15, upgrade PostgreSQL before upgrading to TimescaleDB 2.29.0.
@@ -36,7 +40,7 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 
 **Bugfixes**
 * [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on continuous aggregates consistent
-* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of min/max aggregate functions in columnar aggregation pipeline possibly inconsistent with plain PostgreSQL result
+* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of `MIN` / `MAX` aggregate functions in columnar aggregation pipeline possibly inconsistent with plain PostgreSQL result
 * [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning `time_bucket` with zero width
 * [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix `initial_start` handling in `build_job_info`
 * [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable
@@ -48,9 +52,6 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 
 **New Settings**
 * `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code for `UPDATE` and `DELETE` instead of the generic PostgreSQL inheritance hierarchy expansion. On by default.
-
-**GUCs**
-* `timescaledb.enable_hypertable_expansion_for_dml`: enable TimescaleDB hypertable expansion for `DML`. Default: `true`
 
 **Thanks**
 * @FrancescEthon and @ManuelEthon for reporting the issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small `LIMIT` by switching to row-by-row query execution pipeline
 * [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in `DML` on compressed hypertables by accounting for prepared statement parameters
 * [#9957](https://github.com/timescale/timescaledb/pull/9957) Add `compact_chunk()` function
-* [#10100](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
 * [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
 * [#10081](https://github.com/timescale/timescaledb/pull/10081) Add `samplerate` argument to `_timescaledb_functions.estimate_uncompressed_size()`
+* [#10100](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
 * [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk
 * [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of `INSERT` queries using direct compress and spanning multiple chunks
 * [#10163](https://github.com/timescale/timescaledb/pull/10163) Add a compaction policy for unordered chunks
@@ -37,10 +37,12 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10237](https://github.com/timescale/timescaledb/pull/10237) Add helper functions for decoding hypertable status
 * [#10240](https://github.com/timescale/timescaledb/pull/10240) Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings
 * [#10266](https://github.com/timescale/timescaledb/pull/10266) Add `max_batches` to `compact_chunk()`
+* [#10299](https://github.com/timescale/timescaledb/pull/10299) Add `continuous_aggs_tenant_tracking` and `hypertable_cagg_settings` catalogs
 
 **Bugfixes**
 * [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on continuous aggregates consistent
 * [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of `MIN` / `MAX` aggregate functions in columnar aggregation pipeline possibly inconsistent with plain PostgreSQL result
+* [#10071](https://github.com/timescale/timescaledb/pull/10071) Prune the real-time branch of hierarchical continuous aggregates at any nesting depth
 * [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning `time_bucket` with zero width
 * [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix `initial_start` handling in `build_job_info`
 * [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable
@@ -49,14 +51,25 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10280](https://github.com/timescale/timescaledb/pull/10280) `RETURNING` clause returned no rows for `INSERT` using direct compress
 * [#10281](https://github.com/timescale/timescaledb/pull/10281) Disable direct compress when the destination table has an exclusion constraint so the constraint is still enforced
 * [#10282](https://github.com/timescale/timescaledb/pull/10282) Only count directly compressed rows toward the command tag when the `INSERT` sets it
+* [#10286](https://github.com/timescale/timescaledb/pull/10286) Propagate `VACUUM` on a chunk to the compressed relation when running on the chunk directly
+* [#10302](https://github.com/timescale/timescaledb/pull/10302) Fix useless-join removal and self-join elimination for hypertables
+* [#10313](https://github.com/timescale/timescaledb/pull/10313) Allow running `ALTER EXTENSION timescaledb UPDATE` inside a transaction block
+* [#10315](https://github.com/timescale/timescaledb/pull/10315) Fix overlap detection with running max
+* [#10324](https://github.com/timescale/timescaledb/pull/10324) Fix stale index entries after `rebuild_sparse_index()` on compressed chunks
 
 **New Settings**
 * `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code for `UPDATE` and `DELETE` instead of the generic PostgreSQL inheritance hierarchy expansion. On by default.
 
+**GUCs**
+* `timescaledb.enable_hypertable_expansion_for_dml`: Enable TimescaleDB hypertable expansion for `UPDATE` and `DELETE` queries. Default: `on`
+
 **Thanks**
 * @FrancescEthon and @ManuelEthon for reporting the issue
+* @h0rn3t for reporting a problem with `VACUUM` not propagating to the compressed relation
 * @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression
 * @proddata for reporting a problem when upgrading from 2.15.3 to 2.28.2
+* @tureba for reporting and fixing stale sparse-index entries after rebuild
+* @viniciusrsouza for reporting an issue with hierarchical continuous aggregates
 
 ## 2.28.3 (2026-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,11 +57,8 @@ TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports Post
 * [#10315](https://github.com/timescale/timescaledb/pull/10315) Fix overlap detection with running max
 * [#10324](https://github.com/timescale/timescaledb/pull/10324) Fix stale index entries after `rebuild_sparse_index()` on compressed chunks
 
-**New Settings**
-* `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code for `UPDATE` and `DELETE` instead of the generic PostgreSQL inheritance hierarchy expansion. On by default.
-
 **GUCs**
-* `timescaledb.enable_hypertable_expansion_for_dml`: Enable TimescaleDB hypertable expansion for `UPDATE` and `DELETE` queries. Default: `on`
+* `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code for `UPDATE` and `DELETE` instead of the generic PostgreSQL inheritance hierarchy expansion. On by default.
 
 **Thanks**
 * @FrancescEthon and @ManuelEthon for reporting the issue


### PR DESCRIPTION
## 2.29.0 (2026-07-28)

This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.

**Release Highlights**
* **Chunk exclusion for DML operations** drastically improves the performance of `UPDATE` and `DELETE` statements on hypertables. By acquiring exclusive locks only on the specific chunks being modified rather than the entire hypertable, this enhancement eliminates massive lock contention and keeps high-concurrency workloads running smoothly without unnecessary slowdowns.
* Intelligent **row-by-row decompression** enables the query planner to decompress data row-by-row rather than in large batches when an operation prioritizes a fast initial response (such as queries with `LIMIT` clauses). This dramatically reduces memory overhead and query latency, ensuring lightning-fast performance when you only need to retrieve a small subset of records from your compressed hypertables.

**Important: PostgreSQL 15 Support Removed**
TimescaleDB 2.29.0 removes support for PostgreSQL 15. This release supports PostgreSQL 16, 17, and 18. If you are still running PostgreSQL 15, upgrade PostgreSQL before upgrading to TimescaleDB 2.29.0.

**Backward-Incompatible Changes**
* [#10041](https://github.com/timescale/timescaledb/pull/10041) Remove support for PostgreSQL 15

**Features**
* [#9315](https://github.com/timescale/timescaledb/pull/9315) Speed up `DML` operations on hypertables by using the optimized TimescaleDB hypertable expansion code instead of the generic PostgreSQL inheritance hierarchy expansion
* [#9534](https://github.com/timescale/timescaledb/pull/9534) Speed up expression evaluation in the columnar pipeline by caching common subexpressions
* [#9684](https://github.com/timescale/timescaledb/pull/9684) Add `_timescaledb_functions.decompress_batch()` SQL function
* [#9732](https://github.com/timescale/timescaledb/pull/9732) Speed up some queries with small `LIMIT` by switching to row-by-row query execution pipeline
* [#9917](https://github.com/timescale/timescaledb/pull/9917) Decompress less data in `DML` on compressed hypertables by accounting for prepared statement parameters
* [#9957](https://github.com/timescale/timescaledb/pull/9957) Add `compact_chunk()` function
* [#10048](https://github.com/timescale/timescaledb/pull/10048) Support concurrent refresh policies on hierarchical continuous aggregates
* [#10081](https://github.com/timescale/timescaledb/pull/10081) Add `samplerate` argument to `_timescaledb_functions.estimate_uncompressed_size()`
* [#10100](https://github.com/timescale/timescaledb/pull/10100) Skip classifying compressed relations to speed up planning
* [#10118](https://github.com/timescale/timescaledb/pull/10118) Don't track compressed relations as separate chunk
* [#10119](https://github.com/timescale/timescaledb/pull/10119) Reduce memory usage of `INSERT` queries using direct compress and spanning multiple chunks
* [#10163](https://github.com/timescale/timescaledb/pull/10163) Add a compaction policy for unordered chunks
* [#10204](https://github.com/timescale/timescaledb/pull/10204) Don't create separate hypertable catalog entry for hypertables with compression
* [#10217](https://github.com/timescale/timescaledb/pull/10217) Initial placeholder version of granular refresh API
* [#10225](https://github.com/timescale/timescaledb/pull/10225) Add `config_merge` parameter to `alter_job()` for merging `jsonb` into the existing job configuration
* [#10226](https://github.com/timescale/timescaledb/pull/10226) Add `recompress_unordered` columnstore policy option
* [#10231](https://github.com/timescale/timescaledb/pull/10231) Use `regclass` for storing relation reference in chunk table
* [#10237](https://github.com/timescale/timescaledb/pull/10237) Add helper functions for decoding hypertable status
* [#10240](https://github.com/timescale/timescaledb/pull/10240) Add the `tsdb.direct_compress` storage parameter that allows enabling direct compress for a given hypertable independent of global settings
* [#10266](https://github.com/timescale/timescaledb/pull/10266) Add `max_batches` to `compact_chunk()`
* [#10299](https://github.com/timescale/timescaledb/pull/10299) Add `continuous_aggs_tenant_tracking` and `hypertable_cagg_settings` catalogs

**Bugfixes**
* [#10013](https://github.com/timescale/timescaledb/pull/10013) Make ownership error messages on continuous aggregates consistent
* [#10052](https://github.com/timescale/timescaledb/pull/10052) Result of `MIN` / `MAX` aggregate functions in columnar aggregation pipeline possibly inconsistent with plain PostgreSQL result
* [#10071](https://github.com/timescale/timescaledb/pull/10071) Prune the real-time branch of hierarchical continuous aggregates at any nesting depth
* [#10143](https://github.com/timescale/timescaledb/pull/10143) Fix division by zero when planning `time_bucket` with zero width
* [#10199](https://github.com/timescale/timescaledb/pull/10199) Fix `initial_start` handling in `build_job_info`
* [#10213](https://github.com/timescale/timescaledb/pull/10213) Cache sort pathkeys per hypertable
* [#10221](https://github.com/timescale/timescaledb/pull/10221) Fix incremental refresh skipping the last bucket
* [#10278](https://github.com/timescale/timescaledb/pull/10278) Drop `job_errors` view in `bgw_job_stat_history` migration
* [#10280](https://github.com/timescale/timescaledb/pull/10280) `RETURNING` clause returned no rows for `INSERT` using direct compress
* [#10281](https://github.com/timescale/timescaledb/pull/10281) Disable direct compress when the destination table has an exclusion constraint so the constraint is still enforced
* [#10282](https://github.com/timescale/timescaledb/pull/10282) Only count directly compressed rows toward the command tag when the `INSERT` sets it
* [#10286](https://github.com/timescale/timescaledb/pull/10286) Propagate `VACUUM` on a chunk to the compressed relation when running on the chunk directly
* [#10302](https://github.com/timescale/timescaledb/pull/10302) Fix useless-join removal and self-join elimination for hypertables
* [#10313](https://github.com/timescale/timescaledb/pull/10313) Allow running `ALTER EXTENSION timescaledb UPDATE` inside a transaction block
* [#10315](https://github.com/timescale/timescaledb/pull/10315) Fix overlap detection with running max
* [#10324](https://github.com/timescale/timescaledb/pull/10324) Fix stale index entries after `rebuild_sparse_index()` on compressed chunks

**GUCs**
* `timescaledb.enable_hypertable_expansion_for_dml`: allow using the optimized TimescaleDB hypertable expansion code for `UPDATE` and `DELETE` instead of the generic PostgreSQL inheritance hierarchy expansion. On by default.

**Thanks**
* @FrancescEthon and @ManuelEthon for reporting the issue
* @h0rn3t for reporting a problem with `VACUUM` not propagating to the compressed relation
* @MaximeEthon for reporting an issue with prepared statement parameters in DML decompression
* @proddata for reporting a problem when upgrading from 2.15.3 to 2.28.2
* @tureba for reporting and fixing stale sparse-index entries after rebuild
* @viniciusrsouza for reporting an issue with hierarchical continuous aggregates