### PR TITLE
Run "Tests Fail on Old Code" check on PG 18.

### DIFF
--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set PostgreSQL version
       id: pg
       run: |
-        MAJOR=17
+        MAJOR=18
         echo "major=$MAJOR" >> $GITHUB_OUTPUT
 
         # Choose the latest version from config that matches our major version.


### PR DESCRIPTION
Some of our tests are already specific to PG18 and later versions, and they should be handled as well.


Verified here: https://github.com/timescale/timescaledb/actions/runs/30000144132/job/89183135718