### PR TITLE
Fix hypertables not getting removed from useless outer joins

### DIFF
--- a/.unreleased/pr_10302
+++ b/.unreleased/pr_10302
@@ -1,0 +1,1 @@
+Fixes: #10302 Fix useless-join removal and self-join elimination for hypertables

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,7 @@ set(IMPORTED_SOURCES
     import/createplan.c
     import/heapswap.c
     import/list.c
+    import/plancat.c
     import/planner.c
     import/setrefs.c
     import/ts_explain.c

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -727,6 +727,8 @@ initReadOnlyStringInfo(StringInfo str, char *data, int len)
 #define COMPARE_LT BTLessStrategyNumber
 #define COMPARE_GT BTGreaterStrategyNumber
 #define pk_cmptype pk_strategy
+#define get_opfamily_member_for_cmptype(opfamily, lefttype, righttype, cmptype)                    \
+	get_opfamily_member(opfamily, lefttype, righttype, cmptype)
 #endif
 
 /* PG18 adds is_merge_delete param to ExecBR{Delete|Update}Triggers function.

--- a/src/import/plancat.c
+++ b/src/import/plancat.c
@@ -1,0 +1,337 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ */
+#include <postgres.h>
+#include <access/amapi.h>
+#include <access/genam.h>
+#include <access/htup_details.h>
+#include <access/table.h>
+#include <access/tableam.h>
+#include <access/transam.h>
+#include <access/xact.h>
+#include <catalog/heap.h>
+#include <catalog/index.h>
+#include <catalog/pg_am.h>
+#include <catalog/pg_attribute.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <nodes/pathnodes.h>
+#include <optimizer/optimizer.h>
+#include <optimizer/plancat.h>
+#include <parser/parsetree.h>
+#include <rewrite/rewriteManip.h>
+#include <storage/bufmgr.h>
+#include <utils/lsyscache.h>
+#include <utils/rel.h>
+#include <utils/snapmgr.h>
+#include <utils/syscache.h>
+
+#include "compat/compat.h"
+#include "plancat.h"
+
+/*
+ * Copied verbatim from build_index_tlist() in
+ * src/backend/optimizer/util/plancat.c.
+ */
+static List *
+build_index_tlist(PlannerInfo *root, IndexOptInfo *index, Relation heapRelation)
+{
+	List *tlist = NIL;
+	Index varno = index->rel->relid;
+	ListCell *indexpr_item;
+	int i;
+
+	indexpr_item = list_head(index->indexprs);
+	for (i = 0; i < index->ncolumns; i++)
+	{
+		int indexkey = index->indexkeys[i];
+		Expr *indexvar;
+
+		if (indexkey != 0)
+		{
+			/* simple column */
+			const FormData_pg_attribute *att_tup;
+
+			if (indexkey < 0)
+				att_tup = SystemAttributeDefinition(indexkey);
+			else
+				att_tup = TupleDescAttr(heapRelation->rd_att, indexkey - 1);
+
+			indexvar = (Expr *) makeVar(varno,
+									   indexkey,
+									   att_tup->atttypid,
+									   att_tup->atttypmod,
+									   att_tup->attcollation,
+									   0);
+		}
+		else
+		{
+			/* expression column */
+			if (indexpr_item == NULL)
+				elog(ERROR, "wrong number of index expressions");
+			indexvar = (Expr *) lfirst(indexpr_item);
+			indexpr_item = lnext(index->indexprs, indexpr_item);
+		}
+
+		tlist = lappend(tlist, makeTargetEntry(indexvar, i + 1, NULL, false));
+	}
+	if (indexpr_item != NULL)
+		elog(ERROR, "wrong number of index expressions");
+
+	return tlist;
+}
+
+/*
+ * Copied and trimmed down from get_relation_info() in
+ * src/backend/optimizer/util/plancat.c. Postgres itself skips building
+ * rel->indexlist for a relation whose RTE it considers an inheritance parent.
+ *
+ * We call this to build the indexlist for hypertables ourselves because
+ * some planner optimizations that run before our own hypertable expansion
+ * (e.g. useless-join and self-join elimination) need a populated indexlist to
+ * prove the relation unique.
+ *
+ * Unlike get_relation_info(), this does not populate rel->tuples/pages (that
+ * stays 0 for a hypertable parent, to be filled in later from its chunks),
+ * so per-index tuple estimates copied from rel->tuples are unreliable here.
+ */
+void
+ts_build_indexlist(PlannerInfo *root, RelOptInfo *rel)
+{
+	Index varno = rel->relid;
+	RangeTblEntry *rte = planner_rt_fetch(varno, root);
+	Relation relation;
+	List *indexinfos = NIL;
+	List *indexoidlist;
+	LOCKMODE lmode;
+	ListCell *l;
+
+	relation = table_open(rte->relid, NoLock);
+
+	if (!relation->rd_rel->relhasindex)
+	{
+		table_close(relation, NoLock);
+		return;
+	}
+
+	indexoidlist = RelationGetIndexList(relation);
+	lmode = rte->rellockmode;
+
+	foreach (l, indexoidlist)
+	{
+		Oid indexoid = lfirst_oid(l);
+		Relation indexRelation;
+		Form_pg_index index;
+		const IndexAmRoutine *amroutine = NULL;
+		IndexOptInfo *info;
+		int ncolumns, nkeycolumns;
+		int i;
+
+		indexRelation = index_open(indexoid, lmode);
+		index = indexRelation->rd_index;
+
+		if (!index->indisvalid)
+		{
+			index_close(indexRelation, NoLock);
+			continue;
+		}
+
+		if (index->indcheckxmin &&
+			!TransactionIdPrecedes(HeapTupleHeaderGetXmin(indexRelation->rd_indextuple->t_data),
+									TransactionXmin))
+		{
+			root->glob->transientPlan = true;
+			index_close(indexRelation, NoLock);
+			continue;
+		}
+
+		info = makeNode(IndexOptInfo);
+
+		info->indexoid = index->indexrelid;
+		info->reltablespace = RelationGetForm(indexRelation)->reltablespace;
+		info->rel = rel;
+		info->ncolumns = ncolumns = index->indnatts;
+		info->nkeycolumns = nkeycolumns = index->indnkeyatts;
+
+		info->indexkeys = palloc_array(int, ncolumns);
+		info->indexcollations = palloc_array(Oid, nkeycolumns);
+		info->opfamily = palloc_array(Oid, nkeycolumns);
+		info->opcintype = palloc_array(Oid, nkeycolumns);
+		info->canreturn = palloc_array(bool, ncolumns);
+
+		for (i = 0; i < ncolumns; i++)
+		{
+			info->indexkeys[i] = index->indkey.values[i];
+			info->canreturn[i] = index_can_return(indexRelation, i + 1);
+		}
+
+		for (i = 0; i < nkeycolumns; i++)
+		{
+			info->opfamily[i] = indexRelation->rd_opfamily[i];
+			info->opcintype[i] = indexRelation->rd_opcintype[i];
+			info->indexcollations[i] = indexRelation->rd_indcollation[i];
+		}
+
+		info->relam = indexRelation->rd_rel->relam;
+
+		if (indexRelation->rd_rel->relkind != RELKIND_PARTITIONED_INDEX)
+		{
+			amroutine = indexRelation->rd_indam;
+			info->amcanorderbyop = amroutine->amcanorderbyop;
+			info->amoptionalkey = amroutine->amoptionalkey;
+			info->amsearcharray = amroutine->amsearcharray;
+			info->amsearchnulls = amroutine->amsearchnulls;
+			info->amcanparallel = amroutine->amcanparallel;
+			info->amhasgettuple = (amroutine->amgettuple != NULL);
+			info->amhasgetbitmap =
+				amroutine->amgetbitmap != NULL && relation->rd_tableam->scan_bitmap_next_tuple != NULL;
+			info->amcanmarkpos =
+				(amroutine->ammarkpos != NULL && amroutine->amrestrpos != NULL);
+			info->amcostestimate = amroutine->amcostestimate;
+			Assert(info->amcostestimate != NULL);
+
+			info->opclassoptions = RelationGetIndexAttOptions(indexRelation, true);
+
+			if (info->relam == BTREE_AM_OID)
+			{
+				Assert(amroutine->amcanorder);
+
+				info->sortopfamily = info->opfamily;
+				info->reverse_sort = palloc_array(bool, nkeycolumns);
+				info->nulls_first = palloc_array(bool, nkeycolumns);
+
+				for (i = 0; i < nkeycolumns; i++)
+				{
+					int16 opt = indexRelation->rd_indoption[i];
+
+					info->reverse_sort[i] = (opt & INDOPTION_DESC) != 0;
+					info->nulls_first[i] = (opt & INDOPTION_NULLS_FIRST) != 0;
+				}
+			}
+			else if (amroutine->amcanorder)
+			{
+				info->sortopfamily = palloc_array(Oid, nkeycolumns);
+				info->reverse_sort = palloc_array(bool, nkeycolumns);
+				info->nulls_first = palloc_array(bool, nkeycolumns);
+
+				for (i = 0; i < nkeycolumns; i++)
+				{
+					int16 opt = indexRelation->rd_indoption[i];
+					Oid ltopr;
+					Oid opfamily;
+					Oid opcintype;
+					CompareType cmptype;
+
+					info->reverse_sort[i] = (opt & INDOPTION_DESC) != 0;
+					info->nulls_first[i] = (opt & INDOPTION_NULLS_FIRST) != 0;
+
+					ltopr = get_opfamily_member_for_cmptype(info->opfamily[i],
+															info->opcintype[i],
+															info->opcintype[i],
+															COMPARE_LT);
+					if (OidIsValid(ltopr) &&
+						get_ordering_op_properties(ltopr, &opfamily, &opcintype, &cmptype) &&
+						opcintype == info->opcintype[i] && cmptype == COMPARE_LT)
+					{
+						info->sortopfamily[i] = opfamily;
+					}
+					else
+					{
+						info->sortopfamily = NULL;
+						info->reverse_sort = NULL;
+						info->nulls_first = NULL;
+						break;
+					}
+				}
+			}
+			else
+			{
+				info->sortopfamily = NULL;
+				info->reverse_sort = NULL;
+				info->nulls_first = NULL;
+			}
+		}
+		else
+		{
+			info->amcanorderbyop = false;
+			info->amoptionalkey = false;
+			info->amsearcharray = false;
+			info->amsearchnulls = false;
+			info->amcanparallel = false;
+			info->amhasgettuple = false;
+			info->amhasgetbitmap = false;
+			info->amcanmarkpos = false;
+			info->amcostestimate = NULL;
+
+			info->sortopfamily = NULL;
+			info->reverse_sort = NULL;
+			info->nulls_first = NULL;
+		}
+
+		info->indexprs = RelationGetIndexExpressions(indexRelation);
+		info->indpred = RelationGetIndexPredicate(indexRelation);
+		if (info->indexprs && varno != 1)
+			ChangeVarNodes((Node *) info->indexprs, 1, varno, 0);
+		if (info->indpred && varno != 1)
+			ChangeVarNodes((Node *) info->indpred, 1, varno, 0);
+
+		info->indextlist = build_index_tlist(root, info, relation);
+
+		info->indrestrictinfo = NIL;
+		info->predOK = false;
+		info->unique = index->indisunique;
+#if PG18_GE
+		info->nullsnotdistinct = index->indnullsnotdistinct;
+#endif
+		info->immediate = index->indimmediate;
+		info->hypothetical = false;
+
+		if (indexRelation->rd_rel->relkind != RELKIND_PARTITIONED_INDEX)
+		{
+			if (info->indpred == NIL)
+			{
+				info->pages = RelationGetNumberOfBlocks(indexRelation);
+				info->tuples = rel->tuples;
+			}
+			else
+			{
+				double allvisfrac; /* dummy */
+
+				estimate_rel_size(indexRelation, NULL, &info->pages, &info->tuples, &allvisfrac);
+				if (info->tuples > rel->tuples)
+					info->tuples = rel->tuples;
+			}
+
+#if PG18_GE
+			if (amroutine->amgettreeheight)
+				info->tree_height = amroutine->amgettreeheight(indexRelation);
+			else
+#endif
+				info->tree_height = -1;
+		}
+		else
+		{
+			info->pages = 0;
+			info->tuples = 0.0;
+			info->tree_height = -1;
+		}
+
+		index_close(indexRelation, NoLock);
+
+		indexinfos = lcons(info, indexinfos);
+	}
+
+	list_free(indexoidlist);
+	table_close(relation, NoLock);
+
+	rel->indexlist = indexinfos;
+}

--- a/src/import/plancat.h
+++ b/src/import/plancat.h
@@ -1,0 +1,18 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ */
+#pragma once
+
+#include <postgres.h>
+#include <nodes/pathnodes.h>
+
+extern void ts_build_indexlist(PlannerInfo *root, RelOptInfo *rel);

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -50,6 +50,7 @@
 #include "hypertable.h"
 #include "hypertable_cache.h"
 #include "import/allpaths.h"
+#include "import/plancat.h"
 #include "license_guc.h"
 #include "nodes/chunk_append/chunk_append.h"
 #include "nodes/constraint_aware_append/constraint_aware_append.h"
@@ -1615,6 +1616,17 @@ timescaledb_get_relation_info(PlannerInfo *root, RelOptInfo *rel, bool inhparent
 			 * for dummy tables, but only at later stages.
 			 */
 			Assert(!IS_DUMMY_REL(rel));
+
+			/*
+			 * Postgres skips building rel->indexlist for a relation it
+			 * considers an inheritance parent. But useless-join and self-join
+			 * elimination need a populated indexlist to prove this relation is
+			 * unique.
+			 */
+			if (ts_guc_enable_optimizations && inhparent)
+			{
+				ts_build_indexlist(root, rel);
+			}
 
 			/*
 			 * Mark hypertable RTEs we'd like to expand ourselves. We do this

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -1748,7 +1748,7 @@ DROP INDEX :INDEX_NAME;
  Limit (actual rows=3.00 loops=1)
    ->  Merge Join (actual rows=3.00 loops=1)
          Merge Cond: (m2."time" = m1."time")
-         Join Filter: (m1.device_id = m2.device_id)
+         Join Filter: (m2.device_id = m1.device_id)
          Rows Removed by Join Filter: 4
          ->  Custom Scan (ChunkAppend) on join_limit m2 (actual rows=3.00 loops=1)
                Order: m2."time", m2.device_id

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -1743,7 +1743,7 @@ DROP INDEX :INDEX_NAME;
  Limit (actual rows=3.00 loops=1)
    ->  Merge Join (actual rows=3.00 loops=1)
          Merge Cond: (m2."time" = m1."time")
-         Join Filter: (m1.device_id = m2.device_id)
+         Join Filter: (m2.device_id = m1.device_id)
          Rows Removed by Join Filter: 4
          ->  Custom Scan (ChunkAppend) on join_limit m2 (actual rows=3.00 loops=1)
                Order: m2."time", m2.device_id

--- a/test/expected/append-18.out
+++ b/test/expected/append-18.out
@@ -1746,7 +1746,7 @@ DROP INDEX :INDEX_NAME;
  Limit (actual rows=3.00 loops=1)
    ->  Merge Join (actual rows=3.00 loops=1)
          Merge Cond: (m2."time" = m1."time")
-         Join Filter: (m1.device_id = m2.device_id)
+         Join Filter: (m2.device_id = m1.device_id)
          Rows Removed by Join Filter: 4
          ->  Custom Scan (ChunkAppend) on join_limit m2 (actual rows=3.00 loops=1)
                Order: m2."time", m2.device_id

--- a/test/expected/append-19.out
+++ b/test/expected/append-19.out
@@ -1746,7 +1746,7 @@ DROP INDEX :INDEX_NAME;
  Limit (actual rows=3.00 loops=1)
    ->  Merge Join (actual rows=3.00 loops=1)
          Merge Cond: (m2."time" = m1."time")
-         Join Filter: (m1.device_id = m2.device_id)
+         Join Filter: (m2.device_id = m1.device_id)
          Rows Removed by Join Filter: 4
          ->  Custom Scan (ChunkAppend) on join_limit m2 (actual rows=3.00 loops=1)
                Order: m2."time", m2.device_id

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -3671,4 +3671,53 @@ EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT * FROM
    ->  Index Scan using _hyper_21_203_chunk_metrics_space_time_idx on _hyper_21_203_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" >= 'Sun Jan 02 00:00:00 2000 UTC'::timestamp with time zone)
 
+CREATE TABLE join_removal_main(time timestamptz NOT NULL, device int, val float);
+SELECT create_hypertable('join_removal_main', 'time');
+        create_hypertable        
+---------------------------------
+ (22,public,join_removal_main,t)
+
+CREATE TABLE join_removal_aux(time timestamptz NOT NULL, device int NOT NULL, extra float);
+SELECT create_hypertable('join_removal_aux', 'time');
+       create_hypertable        
+--------------------------------
+ (23,public,join_removal_aux,t)
+
+CREATE UNIQUE INDEX join_removal_aux_uq ON join_removal_aux (device, time);
+INSERT INTO join_removal_main VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+INSERT INTO join_removal_aux VALUES ('2021-01-01', 1, 10.0), ('2021-01-02', 2, 20.0);
+ANALYZE join_removal_main, join_removal_aux;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT m.time, m.device, m.val
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
+CREATE TABLE self_join_test(time timestamptz NOT NULL, device int NOT NULL, val float);
+SELECT create_hypertable('self_join_test', 'time');
+      create_hypertable       
+------------------------------
+ (24,public,self_join_test,t)
+
+CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
+INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+ANALYZE self_join_test;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+FROM self_join_test t1, self_join_test t2
+WHERE t1.device = t2.device AND t1.time = t2.time;
+--- QUERY PLAN ---
+ Hash Join (actual rows=2.00 loops=1)
+   Hash Cond: ((t1.device = t2.device) AND (t1."time" = t2."time"))
+   ->  Seq Scan on _hyper_24_206_chunk t1 (actual rows=2.00 loops=1)
+   ->  Hash (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+
+CREATE VIEW join_removal_view AS
+SELECT m.time, m.device, m.val, a.extra
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT time, device, val FROM join_removal_view;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
 --TEST END--

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -3671,4 +3671,53 @@ EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT * FROM
    ->  Index Scan using _hyper_21_203_chunk_metrics_space_time_idx on _hyper_21_203_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" >= 'Sun Jan 02 00:00:00 2000 UTC'::timestamp with time zone)
 
+CREATE TABLE join_removal_main(time timestamptz NOT NULL, device int, val float);
+SELECT create_hypertable('join_removal_main', 'time');
+        create_hypertable        
+---------------------------------
+ (22,public,join_removal_main,t)
+
+CREATE TABLE join_removal_aux(time timestamptz NOT NULL, device int NOT NULL, extra float);
+SELECT create_hypertable('join_removal_aux', 'time');
+       create_hypertable        
+--------------------------------
+ (23,public,join_removal_aux,t)
+
+CREATE UNIQUE INDEX join_removal_aux_uq ON join_removal_aux (device, time);
+INSERT INTO join_removal_main VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+INSERT INTO join_removal_aux VALUES ('2021-01-01', 1, 10.0), ('2021-01-02', 2, 20.0);
+ANALYZE join_removal_main, join_removal_aux;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT m.time, m.device, m.val
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
+CREATE TABLE self_join_test(time timestamptz NOT NULL, device int NOT NULL, val float);
+SELECT create_hypertable('self_join_test', 'time');
+      create_hypertable       
+------------------------------
+ (24,public,self_join_test,t)
+
+CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
+INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+ANALYZE self_join_test;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+FROM self_join_test t1, self_join_test t2
+WHERE t1.device = t2.device AND t1.time = t2.time;
+--- QUERY PLAN ---
+ Hash Join (actual rows=2.00 loops=1)
+   Hash Cond: ((t1.device = t2.device) AND (t1."time" = t2."time"))
+   ->  Seq Scan on _hyper_24_206_chunk t1 (actual rows=2.00 loops=1)
+   ->  Hash (actual rows=2.00 loops=1)
+         ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+
+CREATE VIEW join_removal_view AS
+SELECT m.time, m.device, m.val, a.extra
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT time, device, val FROM join_removal_view;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
 --TEST END--

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -3671,4 +3671,50 @@ EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT * FROM
    ->  Index Scan using _hyper_21_203_chunk_metrics_space_time_idx on _hyper_21_203_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" >= 'Sun Jan 02 00:00:00 2000 UTC'::timestamp with time zone)
 
+CREATE TABLE join_removal_main(time timestamptz NOT NULL, device int, val float);
+SELECT create_hypertable('join_removal_main', 'time');
+        create_hypertable        
+---------------------------------
+ (22,public,join_removal_main,t)
+
+CREATE TABLE join_removal_aux(time timestamptz NOT NULL, device int NOT NULL, extra float);
+SELECT create_hypertable('join_removal_aux', 'time');
+       create_hypertable        
+--------------------------------
+ (23,public,join_removal_aux,t)
+
+CREATE UNIQUE INDEX join_removal_aux_uq ON join_removal_aux (device, time);
+INSERT INTO join_removal_main VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+INSERT INTO join_removal_aux VALUES ('2021-01-01', 1, 10.0), ('2021-01-02', 2, 20.0);
+ANALYZE join_removal_main, join_removal_aux;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT m.time, m.device, m.val
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
+CREATE TABLE self_join_test(time timestamptz NOT NULL, device int NOT NULL, val float);
+SELECT create_hypertable('self_join_test', 'time');
+      create_hypertable       
+------------------------------
+ (24,public,self_join_test,t)
+
+CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
+INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+ANALYZE self_join_test;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+FROM self_join_test t1, self_join_test t2
+WHERE t1.device = t2.device AND t1.time = t2.time;
+--- QUERY PLAN ---
+ Result (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+
+CREATE VIEW join_removal_view AS
+SELECT m.time, m.device, m.val, a.extra
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT time, device, val FROM join_removal_view;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
 --TEST END--

--- a/test/expected/plan_expand_hypertable-19.out
+++ b/test/expected/plan_expand_hypertable-19.out
@@ -3670,4 +3670,50 @@ EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT * FROM
    ->  Index Scan using _hyper_21_203_chunk_metrics_space_time_idx on _hyper_21_203_chunk (actual rows=1.00 loops=1)
          Index Cond: ("time" >= 'Sun Jan 02 00:00:00 2000 UTC'::timestamp with time zone)
 
+CREATE TABLE join_removal_main(time timestamptz NOT NULL, device int, val float);
+SELECT create_hypertable('join_removal_main', 'time');
+        create_hypertable        
+---------------------------------
+ (22,public,join_removal_main,t)
+
+CREATE TABLE join_removal_aux(time timestamptz NOT NULL, device int NOT NULL, extra float);
+SELECT create_hypertable('join_removal_aux', 'time');
+       create_hypertable        
+--------------------------------
+ (23,public,join_removal_aux,t)
+
+CREATE UNIQUE INDEX join_removal_aux_uq ON join_removal_aux (device, time);
+INSERT INTO join_removal_main VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+INSERT INTO join_removal_aux VALUES ('2021-01-01', 1, 10.0), ('2021-01-02', 2, 20.0);
+ANALYZE join_removal_main, join_removal_aux;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT m.time, m.device, m.val
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
+CREATE TABLE self_join_test(time timestamptz NOT NULL, device int NOT NULL, val float);
+SELECT create_hypertable('self_join_test', 'time');
+      create_hypertable       
+------------------------------
+ (24,public,self_join_test,t)
+
+CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
+INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+ANALYZE self_join_test;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+FROM self_join_test t1, self_join_test t2
+WHERE t1.device = t2.device AND t1.time = t2.time;
+--- QUERY PLAN ---
+ Result (actual rows=2.00 loops=1)
+   ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+
+CREATE VIEW join_removal_view AS
+SELECT m.time, m.device, m.val, a.extra
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT time, device, val FROM join_removal_view;
+--- QUERY PLAN ---
+ Seq Scan on _hyper_22_204_chunk m (actual rows=2.00 loops=1)
+
 --TEST END--

--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -322,12 +322,10 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) >= :'chunk_range_end'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: _hyper_1_8_chunk.id DESC
-   ->  HashAggregate
-         Group Key: _hyper_1_8_chunk.id
-         ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (time_bucket('@ 1 day'::interval, id) >= 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: _hyper_1_8_chunk.id
+   ->  Index Scan Backward using "8_uuid_events_pkey" on _hyper_1_8_chunk
+         Filter: (time_bucket('@ 1 day'::interval, id) >= 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) >= :'chunk_range_end'
@@ -363,15 +361,14 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) < :'chunk_range_end'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: uuid_events.id DESC
-   ->  HashAggregate
-         Group Key: uuid_events.id
-         ->  Append
-               ->  Seq Scan on _hyper_1_7_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_6_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: uuid_events.id
+   ->  Custom Scan (ChunkAppend) on uuid_events
+         Order: uuid_events.id DESC
+         ->  Index Scan Backward using "7_uuid_events_pkey" on _hyper_1_7_chunk
+               Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "6_uuid_events_pkey" on _hyper_1_6_chunk
+               Filter: (time_bucket('@ 1 day'::interval, id) < 'Thu Jan 02 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) < :'chunk_range_end'
@@ -387,18 +384,17 @@ EXPLAIN (COSTS OFF) SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) <= :'chunk_range_start'
 GROUP BY id ORDER BY id DESC;
 --- QUERY PLAN ---
- Sort
-   Sort Key: uuid_events.id DESC
-   ->  HashAggregate
-         Group Key: uuid_events.id
-         ->  Append
-               ->  Index Scan Backward using "8_uuid_events_pkey" on _hyper_1_8_chunk
-                     Index Cond: (id <= '01942976-3400-7000-8000-000000000000'::uuid)
-                     Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_7_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_6_chunk
-                     Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+ GroupAggregate
+   Group Key: uuid_events.id
+   ->  Custom Scan (ChunkAppend) on uuid_events
+         Order: uuid_events.id DESC
+         ->  Index Scan Backward using "8_uuid_events_pkey" on _hyper_1_8_chunk
+               Index Cond: (id <= '01942976-3400-7000-8000-000000000000'::uuid)
+               Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "7_uuid_events_pkey" on _hyper_1_7_chunk
+               Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
+         ->  Index Scan Backward using "6_uuid_events_pkey" on _hyper_1_6_chunk
+               Filter: (time_bucket('@ 1 day'::interval, id) <= 'Wed Jan 01 16:00:00 2025 PST'::timestamp with time zone)
 
 SELECT time_bucket('1 day', id) AS day, avg(temp)
 FROM uuid_events WHERE time_bucket('1 day', id) <= :'chunk_range_start'

--- a/test/sql/plan_expand_hypertable.sql.in
+++ b/test/sql/plan_expand_hypertable.sql.in
@@ -172,4 +172,44 @@ INSERT INTO metrics_space SELECT '2000-01-01'::timestamptz + format('%s day',i):
 -- no contraints removed due to space partitioning
 :PREFIX SELECT * FROM metrics_space WHERE time >= '2000-01-02';
 
+-- test that a useless LEFT JOIN to a hypertable is eliminated when none of
+-- its columns are selected and the join clause matches a unique index
+CREATE TABLE join_removal_main(time timestamptz NOT NULL, device int, val float);
+SELECT create_hypertable('join_removal_main', 'time');
+
+CREATE TABLE join_removal_aux(time timestamptz NOT NULL, device int NOT NULL, extra float);
+SELECT create_hypertable('join_removal_aux', 'time');
+CREATE UNIQUE INDEX join_removal_aux_uq ON join_removal_aux (device, time);
+
+INSERT INTO join_removal_main VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+INSERT INTO join_removal_aux VALUES ('2021-01-01', 1, 10.0), ('2021-01-02', 2, 20.0);
+ANALYZE join_removal_main, join_removal_aux;
+
+:PREFIX SELECT m.time, m.device, m.val
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+
+-- test that a self-join on a hypertable is eliminated when the join clause
+-- matches a unique index (PG18+ only)
+CREATE TABLE self_join_test(time timestamptz NOT NULL, device int NOT NULL, val float);
+SELECT create_hypertable('self_join_test', 'time');
+CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
+
+INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
+ANALYZE self_join_test;
+
+:PREFIX SELECT t1.val
+FROM self_join_test t1, self_join_test t2
+WHERE t1.device = t2.device AND t1.time = t2.time;
+
+-- test that the same useless-join elimination still fires when the
+-- hypertable is only reached through an inlined view, not referenced
+-- directly in the outer query's FROM clause
+CREATE VIEW join_removal_view AS
+SELECT m.time, m.device, m.val, a.extra
+FROM join_removal_main m
+LEFT JOIN join_removal_aux a ON a.device = m.device AND a.time = m.time;
+
+:PREFIX SELECT time, device, val FROM join_removal_view;
+
 \qecho '--TEST END--'

--- a/tsl/test/expected/transparent_decompression_ordered_index-16.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-16.out
@@ -412,7 +412,7 @@ GROUP BY device_id;
  GroupAggregate (actual rows=1.00 loops=1)
    Group Key: mt.device_id
    ->  Nested Loop (actual rows=48.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1493
          ->  Merge Append (actual rows=1541.00 loops=1)
                Sort Key: mt.device_id
@@ -440,7 +440,7 @@ WHERE mt.time > nd.start_time
 ORDER BY time;
 --- QUERY PLAN ---
  Nested Loop (actual rows=48.00 loops=1)
-   Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+   Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
    Rows Removed by Join Filter: 1493
    ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1541.00 loops=1)
          Order: mt."time"
@@ -1127,7 +1127,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id
@@ -1172,7 +1172,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id

--- a/tsl/test/expected/transparent_decompression_ordered_index-17.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-17.out
@@ -412,7 +412,7 @@ GROUP BY device_id;
  GroupAggregate (actual rows=1.00 loops=1)
    Group Key: mt.device_id
    ->  Nested Loop (actual rows=48.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1493
          ->  Merge Append (actual rows=1541.00 loops=1)
                Sort Key: mt.device_id
@@ -440,7 +440,7 @@ WHERE mt.time > nd.start_time
 ORDER BY time;
 --- QUERY PLAN ---
  Nested Loop (actual rows=48.00 loops=1)
-   Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+   Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
    Rows Removed by Join Filter: 1493
    ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1541.00 loops=1)
          Order: mt."time"
@@ -1127,7 +1127,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id
@@ -1172,7 +1172,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id

--- a/tsl/test/expected/transparent_decompression_ordered_index-18.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-18.out
@@ -1136,7 +1136,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id
@@ -1181,7 +1181,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id

--- a/tsl/test/expected/transparent_decompression_ordered_index-19.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-19.out
@@ -1138,7 +1138,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id
@@ -1183,7 +1183,7 @@ ORDER BY "time", mt.device_id limit 5;
 --- QUERY PLAN ---
  Limit (actual rows=5.00 loops=1)
    ->  Nested Loop (actual rows=5.00 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (nd.node = mt.device_id))
          Rows Removed by Join Filter: 1488
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx mt (actual rows=1493.00 loops=1)
                Order: mt."time", mt.device_id

--- a/tsl/test/shared/expected/parameterized_chunkappend-19.out
+++ b/tsl/test/shared/expected/parameterized_chunkappend-19.out
@@ -30,7 +30,7 @@ ORDER BY devices.device_id, win.id
          Sort Key: devices.device_id, "*VALUES*".column1
          Sort Method: quicksort 
          ->  Nested Loop (actual rows=9.00 loops=1)
-               Join Filter: (devices.device_id = metrics.device_id)
+               Join Filter: (metrics.device_id = devices.device_id)
                Rows Removed by Join Filter: 36
                ->  Partial HashAggregate (actual rows=15.00 loops=1)
                      Group Key: "*VALUES*".column1, metrics.device_id


### PR DESCRIPTION
If a hypertable only appears on the nullable side of a LEFT/RIGHT/FULL
join, and none of its columns are used elsewhere in the query, Postgres
can normally drop the join entirely. This stopped working after
390d900ae (Run our hypertable expansion only from the
get_relation_info_hook, #9714)
