### PR TITLE
Fix overlap detection with running max

### DIFF
--- a/.unreleased/pr_10315
+++ b/.unreleased/pr_10315
@@ -1,0 +1,1 @@
+Fixes: #10315 Fix overlap detection with running max

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -77,10 +77,11 @@ typedef struct CompactChunkScanState
 	Datum *curr_last;
 	bool *curr_last_isnull;
 
-	/* Last-row orderby tuple of the batch processed just before the current
+	/* Max last-row orderby tuple from the batches processed before the current
 	 * one. Holds copies so it survives advancing the index scan. */
-	Datum *prev_last;
-	bool *prev_last_isnull;
+	Datum *max_last;
+	bool *max_last_isnull;
+	bool max_last_set; /* false until the first batch is recorded */
 } CompactChunkScanState;
 
 static CompactChunkScanState *
@@ -95,12 +96,13 @@ compact_chunk_scan_state_init(RecompressContext *recompress_ctx)
 	state->curr_first_isnull = palloc(sizeof(bool) * recompress_ctx->num_orderby);
 	state->curr_last = palloc(sizeof(Datum) * recompress_ctx->num_orderby);
 	state->curr_last_isnull = palloc(sizeof(bool) * recompress_ctx->num_orderby);
-	state->prev_last = palloc0(sizeof(Datum) * recompress_ctx->num_orderby);
-	state->prev_last_isnull = palloc(sizeof(bool) * recompress_ctx->num_orderby);
+	state->max_last = palloc0(sizeof(Datum) * recompress_ctx->num_orderby);
+	state->max_last_isnull = palloc(sizeof(bool) * recompress_ctx->num_orderby);
 	for (int i = 0; i < recompress_ctx->num_orderby; i++)
 	{
-		state->prev_last_isnull[i] = true;
+		state->max_last_isnull[i] = true;
 	}
+	state->max_last_set = false;
 	return state;
 }
 
@@ -112,14 +114,15 @@ compact_chunk_scan_state_reset(CompactChunkScanState *state, RecompressContext *
 	for (int i = 0; i < recompress_ctx->num_orderby; i++)
 	{
 		int key = recompress_ctx->num_segmentby + i;
-		if (!state->prev_last_isnull[i] && !recompress_ctx->key_byval[key] &&
-			PointerIsValid(DatumGetPointer(state->prev_last[i])))
+		if (!state->max_last_isnull[i] && !recompress_ctx->key_byval[key] &&
+			PointerIsValid(DatumGetPointer(state->max_last[i])))
 		{
-			pfree(DatumGetPointer(state->prev_last[i]));
+			pfree(DatumGetPointer(state->max_last[i]));
 		}
-		state->prev_last[i] = (Datum) 0;
-		state->prev_last_isnull[i] = true;
+		state->max_last[i] = (Datum) 0;
+		state->max_last_isnull[i] = true;
 	}
+	state->max_last_set = false;
 }
 
 static bool fetch_uncompressed_chunk_into_tuplesort(Tuplesortstate *tuplesortstate,
@@ -148,7 +151,7 @@ static IndexScanDesc compact_chunk_begin_index_scan(Relation compressed_chunk_re
 													Relation index_rel, Snapshot snapshot);
 static void read_batch_firstlast(IndexScanDesc index_scan, RecompressContext *recompress_ctx,
 								 CompactChunkScanState *state);
-static void save_prev_last(CompactChunkScanState *state, RecompressContext *recompress_ctx);
+static void save_new_last(CompactChunkScanState *state, RecompressContext *recompress_ctx);
 static bool batches_overlap_firstlast(RecompressContext *recompress_ctx, Datum *prev_last,
 									  bool *prev_last_isnull, Datum *curr_first,
 									  bool *curr_first_isnull);
@@ -990,28 +993,41 @@ read_batch_firstlast(IndexScanDesc index_scan, RecompressContext *recompress_ctx
 
 /*
  * Remember the current batch's last-row orderby tuple as the predecessor for
- * the next batch. The index tuple is only valid for the current scan position,
+ * the next batch only if it is greater than the saved last-row orderby value.
+ * The index tuple is only valid for the current scan position,
  * so pass-by-reference values are deep-copied to survive advancing the scan.
  */
 static void
-save_prev_last(CompactChunkScanState *state, RecompressContext *recompress_ctx)
+save_new_last(CompactChunkScanState *state, RecompressContext *recompress_ctx)
 {
+	/* Skip if max_last is already set and curr_last does not exceed its value. */
+	if (state->max_last_set && !batches_overlap_firstlast(recompress_ctx,
+														  state->curr_last,
+														  state->curr_last_isnull,
+														  state->max_last,
+														  state->max_last_isnull))
+	{
+		return;
+	}
+
+	state->max_last_set = true;
+
 	for (int i = 0; i < recompress_ctx->num_orderby; i++)
 	{
 		int key = recompress_ctx->num_segmentby + i;
 
-		if (!state->prev_last_isnull[i] && !recompress_ctx->key_byval[key] &&
-			PointerIsValid(DatumGetPointer(state->prev_last[i])))
+		if (!state->max_last_isnull[i] && !recompress_ctx->key_byval[key] &&
+			PointerIsValid(DatumGetPointer(state->max_last[i])))
 		{
-			pfree(DatumGetPointer(state->prev_last[i]));
+			pfree(DatumGetPointer(state->max_last[i]));
 		}
 
-		state->prev_last_isnull[i] = state->curr_last_isnull[i];
-		state->prev_last[i] = state->curr_last_isnull[i] ?
-								  (Datum) 0 :
-								  datumCopy(state->curr_last[i],
-											recompress_ctx->key_byval[key],
-											recompress_ctx->key_typlen[key]);
+		state->max_last_isnull[i] = state->curr_last_isnull[i];
+		state->max_last[i] = state->curr_last_isnull[i] ?
+								 (Datum) 0 :
+								 datumCopy(state->curr_last[i],
+										   recompress_ctx->key_byval[key],
+										   recompress_ctx->key_typlen[key]);
 	}
 }
 
@@ -1137,13 +1153,15 @@ compact_chunk_find_overlapping_batches(Relation compressed_chunk_rel, IndexScanD
 								   state->seg_values,
 								   state->seg_isnull,
 								   recompress_ctx->num_segmentby);
-			save_prev_last(state, recompress_ctx);
+			/* Reset running max for the new segment group. */
+			state->max_last_set = false;
+			save_new_last(state, recompress_ctx);
 			continue;
 		}
 
 		if (batches_overlap_firstlast(recompress_ctx,
-									  state->prev_last,
-									  state->prev_last_isnull,
+									  state->max_last,
+									  state->max_last_isnull,
 									  state->curr_first,
 									  state->curr_first_isnull))
 		{
@@ -1154,7 +1172,7 @@ compact_chunk_find_overlapping_batches(Relation compressed_chunk_rel, IndexScanD
 
 		/* No overlap: this batch becomes the predecessor for the next one. */
 		ItemPointerCopy(&index_scan->xs_heaptid, &state->previous_tid);
-		save_prev_last(state, recompress_ctx);
+		save_new_last(state, recompress_ctx);
 	}
 
 	ExecDropSingleTupleTableSlot(compressed_slot);
@@ -1242,7 +1260,7 @@ compact_chunk_recompress_overlapping_batches(
 							   state->seg_values,
 							   state->seg_isnull,
 							   recompress_ctx->num_segmentby);
-		save_prev_last(state, recompress_ctx);
+		save_new_last(state, recompress_ctx);
 	}
 
 	while (index_getnext_slot(index_scan, ForwardScanDirection, compressed_slot))
@@ -1277,15 +1295,17 @@ compact_chunk_recompress_overlapping_batches(
 								   state->seg_values,
 								   state->seg_isnull,
 								   recompress_ctx->num_segmentby);
-			save_prev_last(state, recompress_ctx);
+			/* Reset running max for the new segment group. */
+			state->max_last_set = false;
+			save_new_last(state, recompress_ctx);
 			continue;
 		}
 
 		/* A batch joins the current group when it overlaps its predecessor; the
 		 * first batch that no longer overlaps closes the group. */
 		bool batch_overlaps = batches_overlap_firstlast(recompress_ctx,
-														state->prev_last,
-														state->prev_last_isnull,
+														state->max_last,
+														state->max_last_isnull,
 														state->curr_first,
 														state->curr_first_isnull);
 
@@ -1340,7 +1360,7 @@ compact_chunk_recompress_overlapping_batches(
 		}
 
 		ItemPointerCopy(&index_scan->xs_heaptid, &state->previous_tid);
-		save_prev_last(state, recompress_ctx);
+		save_new_last(state, recompress_ctx);
 	}
 
 	if (overlapping)
@@ -1350,6 +1370,11 @@ compact_chunk_recompress_overlapping_batches(
 
 	ExecDropSingleTupleTableSlot(previous_compressed_slot);
 	ExecDropSingleTupleTableSlot(compressed_slot);
+
+	ereport(DEBUG1,
+			(errmsg("compaction processed %d batches (max_batches %d)",
+					processed_batches,
+					max_batches)));
 
 	return found_overlaps;
 }

--- a/tsl/test/expected/compact_chunk.out
+++ b/tsl/test/expected/compact_chunk.out
@@ -1621,3 +1621,151 @@ SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('
  _timescaledb_internal._hyper_14_16_chunk | {COMPRESSED}
 
 DROP TABLE metrics_max_batches;
+-- Test Small intermediate batches must not hide overlaps with later batches.
+CREATE TABLE metrics_running_max (time TIMESTAMPTZ NOT NULL, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,1000) i;
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(500,1500) i;
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1000,2000) i;
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1500,2500) i;
+-- Should resolve all overlaps in one pass.
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_running_max') chunk;
+              compact_chunk               
+------------------------------------------
+ _timescaledb_internal._hyper_15_17_chunk
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_running_max') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+DROP TABLE metrics_running_max;
+-- Test NULL last with NULLS LAST must stay as the running max.
+CREATE TABLE metrics_null_boundary (time TIMESTAMPTZ NOT NULL, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='value NULLS LAST');
+NOTICE:  using column "time" as partitioning column
+-- insert in a pattern to trigger NULL value overlap
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval,
+       CASE WHEN i = 1000 THEN NULL ELSE i::float END
+FROM generate_series(1,1000) i;
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + ((999 + i) || ' minute')::interval, (499 + i)::float
+FROM generate_series(1,11) i;
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + ((1010 + i) || ' minute')::interval, (799 + i)::float
+FROM generate_series(1,101) i;
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + ((1200 + i) || ' minute')::interval, (950 + i)::float
+FROM generate_series(1,50) i;
+SELECT cs.compress_relid::regclass::text AS "MIXED_NULLS_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = ch.relid
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_null_boundary'
+ORDER BY ch.id LIMIT 1 \gset
+SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
+FROM :MIXED_NULLS_CHUNK
+ORDER BY _ts_meta_min_1;
+ ctid  | _ts_meta_count | _ts_meta_min_1 | _ts_meta_max_1 | _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------+----------------+----------------+----------------+-------------------------+------------------------
+ (0,1) |           1000 |              1 |            999 |                       1 |                       
+ (0,2) |             11 |            500 |            510 |                     500 |                    510
+ (0,3) |            101 |            800 |            900 |                     800 |                    900
+ (0,4) |             50 |            951 |           1000 |                     951 |                   1000
+
+-- Should resolve all overlaps in one pass.
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_null_boundary') chunk;
+              compact_chunk               
+------------------------------------------
+ _timescaledb_internal._hyper_16_18_chunk
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_null_boundary') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
+FROM :MIXED_NULLS_CHUNK
+ORDER BY _ts_meta_min_1;
+ ctid  | _ts_meta_count | _ts_meta_min_1 | _ts_meta_max_1 | _ts_meta_v2_first_value | _ts_meta_v2_last_value 
+-------+----------------+----------------+----------------+-------------------------+------------------------
+ (0,5) |           1000 |              1 |            894 |                       1 |                    894
+ (0,6) |            162 |            895 |           1000 |                     895 |                       
+
+DROP TABLE metrics_null_boundary;
+-- Test with orderby DESC
+CREATE TABLE metrics_rm_desc (time TIMESTAMPTZ NOT NULL, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time DESC');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,1000) i;
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(500,1500) i;
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1000,2000) i;
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1500,2500) i;
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_rm_desc') chunk;
+              compact_chunk               
+------------------------------------------
+ _timescaledb_internal._hyper_17_19_chunk
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_rm_desc') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+SELECT count(*) FROM metrics_rm_desc;
+ count 
+-------
+  4003
+
+DROP TABLE metrics_rm_desc;
+-- Running max with multi-column orderby and mixed directions.
+CREATE TABLE metrics_rm_multi (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time ASC, value DESC');
+NOTICE:  using column "time" as partitioning column
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(1,1000) i;
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(500,1500) i;
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(1000,2000) i;
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(1500,2500) i;
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_rm_multi') chunk;
+              compact_chunk               
+------------------------------------------
+ _timescaledb_internal._hyper_18_20_chunk
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_rm_multi') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+SELECT count(*) FROM metrics_rm_multi;
+ count 
+-------
+  4003
+
+DROP TABLE metrics_rm_multi;
+-- Running max with segmentby: each segment tracked independently.
+CREATE TABLE metrics_rm_seg (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+NOTICE:  using column "time" as partitioning column
+-- Same overlapping pattern for two devices.
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(1,1000) i, (VALUES ('d1'), ('d2')) AS v(d);
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(500,1500) i, (VALUES ('d1'), ('d2')) AS v(d);
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(1000,2000) i, (VALUES ('d1'), ('d2')) AS v(d);
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(1500,2500) i, (VALUES ('d1'), ('d2')) AS v(d);
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_rm_seg') chunk;
+              compact_chunk               
+------------------------------------------
+ _timescaledb_internal._hyper_19_21_chunk
+
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_rm_seg') chunk;
+ chunk_status_text 
+-------------------
+ {COMPRESSED}
+
+SELECT count(*) FROM metrics_rm_seg;
+ count 
+-------
+  8006
+
+DROP TABLE metrics_rm_seg;

--- a/tsl/test/sql/compact_chunk.sql
+++ b/tsl/test/sql/compact_chunk.sql
@@ -1136,3 +1136,103 @@ SELECT _ts_meta_count, device, _ts_meta_min_1, _ts_meta_max_1 FROM :MB_CHUNK ORD
 SELECT chunk, _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_max_batches') chunk;
 
 DROP TABLE metrics_max_batches;
+
+-- Test Small intermediate batches must not hide overlaps with later batches.
+CREATE TABLE metrics_running_max (time TIMESTAMPTZ NOT NULL, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time');
+
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,1000) i;
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(500,1500) i;
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1000,2000) i;
+INSERT INTO metrics_running_max SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1500,2500) i;
+
+-- Should resolve all overlaps in one pass.
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_running_max') chunk;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_running_max') chunk;
+DROP TABLE metrics_running_max;
+
+-- Test NULL last with NULLS LAST must stay as the running max.
+CREATE TABLE metrics_null_boundary (time TIMESTAMPTZ NOT NULL, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='value NULLS LAST');
+
+-- insert in a pattern to trigger NULL value overlap
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval,
+       CASE WHEN i = 1000 THEN NULL ELSE i::float END
+FROM generate_series(1,1000) i;
+
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + ((999 + i) || ' minute')::interval, (499 + i)::float
+FROM generate_series(1,11) i;
+
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + ((1010 + i) || ' minute')::interval, (799 + i)::float
+FROM generate_series(1,101) i;
+
+INSERT INTO metrics_null_boundary
+SELECT '2025-01-02'::timestamptz + ((1200 + i) || ' minute')::interval, (950 + i)::float
+FROM generate_series(1,50) i;
+
+SELECT cs.compress_relid::regclass::text AS "MIXED_NULLS_CHUNK"
+FROM _timescaledb_catalog.chunk ch
+    JOIN _timescaledb_catalog.compression_settings cs
+        ON cs.relid = ch.relid
+    JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_null_boundary'
+ORDER BY ch.id LIMIT 1 \gset
+
+SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
+FROM :MIXED_NULLS_CHUNK
+ORDER BY _ts_meta_min_1;
+
+-- Should resolve all overlaps in one pass.
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_null_boundary') chunk;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_null_boundary') chunk;
+
+SELECT ctid, _ts_meta_count, _ts_meta_min_1, _ts_meta_max_1, _ts_meta_v2_first_value, _ts_meta_v2_last_value
+FROM :MIXED_NULLS_CHUNK
+ORDER BY _ts_meta_min_1;
+DROP TABLE metrics_null_boundary;
+
+-- Test with orderby DESC
+CREATE TABLE metrics_rm_desc (time TIMESTAMPTZ NOT NULL, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time DESC');
+
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1,1000) i;
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(500,1500) i;
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1000,2000) i;
+INSERT INTO metrics_rm_desc SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, i FROM generate_series(1500,2500) i;
+
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_rm_desc') chunk;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_rm_desc') chunk;
+SELECT count(*) FROM metrics_rm_desc;
+DROP TABLE metrics_rm_desc;
+
+-- Running max with multi-column orderby and mixed directions.
+CREATE TABLE metrics_rm_multi (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time ASC, value DESC');
+
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(1,1000) i;
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(500,1500) i;
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(1000,2000) i;
+INSERT INTO metrics_rm_multi SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, 'd1', i FROM generate_series(1500,2500) i;
+
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_rm_multi') chunk;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_rm_multi') chunk;
+SELECT count(*) FROM metrics_rm_multi;
+DROP TABLE metrics_rm_multi;
+
+-- Running max with segmentby: each segment tracked independently.
+CREATE TABLE metrics_rm_seg (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+  WITH (tsdb.hypertable, tsdb.orderby='time', tsdb.segmentby='device');
+
+-- Same overlapping pattern for two devices.
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(1,1000) i, (VALUES ('d1'), ('d2')) AS v(d);
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(500,1500) i, (VALUES ('d1'), ('d2')) AS v(d);
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(1000,2000) i, (VALUES ('d1'), ('d2')) AS v(d);
+INSERT INTO metrics_rm_seg SELECT '2025-07-07'::timestamptz + (i || ' minute')::interval, d, i FROM generate_series(1500,2500) i, (VALUES ('d1'), ('d2')) AS v(d);
+
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics_rm_seg') chunk;
+SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics_rm_seg') chunk;
+SELECT count(*) FROM metrics_rm_seg;
+DROP TABLE metrics_rm_seg;


### PR DESCRIPTION
Overlap detection compared only against the immediately previous batch's last value. A small intermediate batch (e.g. a 1-row boundary batch) could reset the comparison point and hide overlaps with later batches, requiring multiple compaction passes to converge.

Track the running maximum of last values instead, so all overlaps within a segment are detected in a single pass. Uses full-tuple comparison to avoid mixing column values from different batches in multi-column orderby.