### PR TITLE
tsl/compression: fix stale sparse-index entries after rebuild_sparse_index

### DIFF
--- a/.unreleased/pr_10324
+++ b/.unreleased/pr_10324
@@ -1,0 +1,2 @@
+Fixes: #10324 Fix stale index entries after rebuild_sparse_index() on compressed chunks
+Thanks: @tureba for reporting and fixing stale sparse-index entries after rebuild

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -7,6 +7,7 @@
 #include <postgres.h>
 #include "debug_point.h"
 #include <access/tableam.h>
+#include <catalog/indexing.h>
 #include <miscadmin.h>
 #include <parser/parse_coerce.h>
 #include <parser/parse_relation.h>
@@ -36,6 +37,7 @@
 #include "recompress.h"
 #include "sparse_index_bloom1.h"
 #include "ts_catalog/array_utils.h"
+#include "ts_catalog/catalog.h"
 #include "ts_catalog/chunk_column_stats.h"
 #include "ts_catalog/compression_chunk_size.h"
 #include "ts_catalog/compression_settings.h"
@@ -2561,7 +2563,7 @@ populate_sparse_index_columns(Relation compressed_rel, RowDecompressor *decompre
 	TupleDesc compressed_desc = RelationGetDescr(compressed_rel);
 	TableScanDesc scan = table_beginscan_compat(compressed_rel, GetActiveSnapshot(), 0, NULL, 0);
 	TupleTableSlot *scan_slot = table_slot_create(compressed_rel, NULL);
-	TupleTableSlot *update_slot = MakeSingleTupleTableSlot(compressed_desc, &TTSOpsHeapTuple);
+	CatalogIndexState indstate = CatalogOpenIndexes(compressed_rel);
 
 	while (table_scan_getnextslot(scan, ForwardScanDirection, scan_slot))
 	{
@@ -2601,20 +2603,22 @@ populate_sparse_index_columns(Relation compressed_rel, RowDecompressor *decompre
 												decompressor->compressed_datums,
 												decompressor->compressed_is_nulls,
 												repl);
-		ExecStoreHeapTuple(new_tuple, update_slot, false);
 
 		/*
-		 * Sparse index metadata columns are not covered by any index.
-		 * If indexes on metadata columns are added in the future,
-		 * this will need to handle index updates via update_indexes.
+		 * Sparse index metadata columns are covered by a btree index
+		 * (segmentby, first/last time, and any minmax/bloom columns). If
+		 * this update isn't HOT-eligible, the old index entries are left
+		 * pointing at the superseded tuple, so we must insert new entries
+		 * ourselves -- mirroring what CatalogTupleUpdate() does for
+		 * catalog tuples. We use simple_heap_update() rather than
+		 * simple_table_tuple_update() so that heap_update() writes the new
+		 * tuple's location and HOT status directly into new_tuple, which
+		 * ts_catalog_index_insert() (a no-op when the update was HOT)
+		 * relies on below.
 		 */
 		TU_UpdateIndexes update_indexes;
-		simple_table_tuple_update(compressed_rel,
-								  &tid,
-								  update_slot,
-								  GetActiveSnapshot(),
-								  &update_indexes);
-		ExecClearTuple(update_slot);
+		simple_heap_update(compressed_rel, &tid, new_tuple, &update_indexes);
+		ts_catalog_index_insert(indstate, new_tuple);
 
 		/* Reset */
 		foreach_ptr(BatchMetadataBuilder, builder, builders)
@@ -2632,9 +2636,9 @@ populate_sparse_index_columns(Relation compressed_rel, RowDecompressor *decompre
 		}
 	}
 
-	ExecDropSingleTupleTableSlot(update_slot);
 	ExecDropSingleTupleTableSlot(scan_slot);
 	table_endscan(scan);
+	CatalogCloseIndexes(indstate);
 }
 
 void

--- a/tsl/test/expected/rebuild_sparse_index.out
+++ b/tsl/test/expected/rebuild_sparse_index.out
@@ -518,6 +518,35 @@ FROM :ic_schema1.:ic_table1 WHERE device = 'd2' LIMIT 1;
 -------+-------+-------
  f     | f     | f
 
+-- Sparse index integrity: the (device, first_time, last_time) btree must be
+-- able to find every batch for every device after rebuild_sparse_index, not
+-- just the ones whose metadata rewrite happened to be a HOT update. Forced
+-- index/bitmap scans must return the same per-device batch counts as an
+-- unindexed scan.
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT device, count(*) FROM :ic_schema1.:ic_table1 GROUP BY device ORDER BY device;
+ device | count 
+--------+-------
+ d1     |     2
+ d2     |     2
+ d3     |     2
+ d4     |     2
+ d5     |     2
+
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+SET enable_seqscan = off;
+SELECT device, count(*) FROM :ic_schema1.:ic_table1 GROUP BY device ORDER BY device;
+ device | count 
+--------+-------
+ d1     |     2
+ d2     |     2
+ d3     |     2
+ d4     |     2
+ d5     |     2
+
+RESET enable_seqscan;
 SELECT decompress_chunk(:'ichunk1');
             decompress_chunk            
 ----------------------------------------
@@ -594,6 +623,7 @@ SELECT * FROM rsi_integrity WHERE device = 'd1' AND humidity = 42 AND label = 'l
          ->  Index Scan using _hyper_2_3_chunk_compressed_device__ts_meta_v2_first_time___idx on _hyper_2_3_chunk_compressed (actual rows=0.00 loops=1)
                Index Cond: (device = 'd1'::text)
                Filter: _timescaledb_functions.bloom1_contains_any_hashes(regress-test-bloom_577c_humidity_label, TEST-HASHES::bigint[])
+               Rows Removed by Filter: 2
    ->  Seq Scan on _hyper_2_4_chunk (actual rows=0.00 loops=1)
          Filter: ((device = 'd1'::text) AND (humidity = 42) AND (label = 'label_0'::text))
          Rows Removed by Filter: 8640

--- a/tsl/test/sql/rebuild_sparse_index.sql
+++ b/tsl/test/sql/rebuild_sparse_index.sql
@@ -355,6 +355,21 @@ SELECT _timescaledb_functions.bloom1_contains(:"bloom_label", 'nonexistent'::tex
        _timescaledb_functions.bloom1_contains(:"bloom_label", 'NOPE'::text) AS nope3
 FROM :ic_schema1.:ic_table1 WHERE device = 'd2' LIMIT 1;
 
+-- Sparse index integrity: the (device, first_time, last_time) btree must be
+-- able to find every batch for every device after rebuild_sparse_index, not
+-- just the ones whose metadata rewrite happened to be a HOT update. Forced
+-- index/bitmap scans must return the same per-device batch counts as an
+-- unindexed scan.
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT device, count(*) FROM :ic_schema1.:ic_table1 GROUP BY device ORDER BY device;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
+SET enable_seqscan = off;
+SELECT device, count(*) FROM :ic_schema1.:ic_table1 GROUP BY device ORDER BY device;
+RESET enable_seqscan;
+
 SELECT decompress_chunk(:'ichunk1');
 
 -- Test 11: composite bloom integrity (drop, rebuild, verify via explain)


### PR DESCRIPTION
## What type of bug is this?

Data corruption / wrong query results

## What subsystems and features are affected?

Compression (sparse indexes / columnstore), `rebuild_sparse_index()`

## What happened?

After changing a hypertable's `compress_index` setting and calling `rebuild_sparse_index()` (or recompressing) on an already-compressed chunk, the btree index that TimescaleDB maintains on the compressed table's sparse index metadata columns (segmentby column plus `_ts_meta_v2_first_time`/`_ts_meta_v2_last_time`, and any configured minmax/bloom columns) can end up pointing at superseded, dead tuples instead of the row's new location.

Once that happens, any query plan that uses an index scan or bitmap scan against the compressed table (chosen by the planner, or forced via `enable_seqscan = off`) silently returns **fewer rows than exist**, or the wrong rows, for the affected compressed batch — while a sequential scan over the same table returns the correct data. This is a genuine data-correctness bug: two scan strategies over the same committed data return different results.

The bug does not always surface immediately after the metadata rewrite, which is why it can look intermittent: PostgreSQL's HOT-chain "redirect" mechanism transparently follows a stale index entry to the tuple's current location, as long as the whole update chain stays on the *same heap page*. The wrong results only become visible once that redirect chain is broken — either by ordinary autovacuum/pruning activity, or immediately, whenever the metadata rewrite doesn't fit back onto its original page and the tuple must relocate.

### Root cause

`populate_sparse_index_columns()` in `tsl/src/compression/recompress.c` rewrites each compressed batch's sparse-index metadata columns in place:

```c
HeapTuple new_tuple = heap_modify_tuple(compressed_tuple, ...);
ExecStoreHeapTuple(new_tuple, update_slot, false);

/*
 * Sparse index metadata columns are not covered by any index.
 * If indexes on metadata columns are added in the future,
 * this will need to handle index updates via update_indexes.
 */
TU_UpdateIndexes update_indexes;
simple_table_tuple_update(compressed_rel, &tid, update_slot,
                          GetActiveSnapshot(), &update_indexes);
ExecClearTuple(update_slot);
```

The comment's premise is stale: the sparse index metadata columns *are* covered by a btree index (`<chunk>_compressed_<segmentby>__ts_meta_v2_first_time___idx`, covering the segmentby column, `_ts_meta_v2_first_time`, `_ts_meta_v2_last_time`, plus any minmax/bloom columns configured via `compress_index`). `update_indexes` is computed correctly by `simple_table_tuple_update()`/`heap_update()` on every call, but the result is discarded — no new index entry is ever inserted for a non-HOT update, leaving the old entry (now pointing at a dead tuple) as the only index entry for that row.

## How can we reproduce the bug?

This reproduces deterministically on stock PostgreSQL — no special extension or vendor build required, and confirmed on PostgreSQL 16, 17, and 18. The key is to make each compressed row wide enough that the sparse-index metadata rewrite can't fit back onto its original heap page, forcing a non-HOT update:

```sql
CREATE EXTENSION IF NOT EXISTS timescaledb;

CREATE TABLE rsi_bug(
    ts timestamptz NOT NULL,
    device text NOT NULL,
    val int,
    filler text DEFAULT repeat('x', 500)  -- pads rows so pages fill up
);
SELECT create_hypertable('rsi_bug', 'ts');

INSERT INTO rsi_bug(ts, device, val)
SELECT '2024-01-01'::timestamptz + (i * interval '1 second'), 'd' || (i % 20), i
FROM generate_series(1, 4000) i;

SELECT format('%I.%I', chunk_schema, chunk_name)::regclass AS chunk1
FROM timescaledb_information.chunks
WHERE hypertable_name = 'rsi_bug' ORDER BY range_start LIMIT 1 \gset

ALTER TABLE rsi_bug SET (
    timescaledb.compress,
    timescaledb.compress_segmentby = 'device',
    timescaledb.compress_orderby = 'ts',
    timescaledb.compress_index = 'bloom("val")'
);
SELECT compress_chunk(:'chunk1');

-- Drop and restore the sparse index config, rebuilding it each time --
-- this is a supported, documented workflow, not an edge case.
ALTER TABLE rsi_bug SET (
    timescaledb.compress,
    timescaledb.compress_segmentby = 'device',
    timescaledb.compress_orderby = 'ts',
    timescaledb.compress_index = ''
);
SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);

ALTER TABLE rsi_bug SET (
    timescaledb.compress,
    timescaledb.compress_segmentby = 'device',
    timescaledb.compress_orderby = 'ts',
    timescaledb.compress_index = 'bloom("val")'
);
SELECT _timescaledb_functions.rebuild_sparse_index(:'chunk1'::regclass);

-- Ground truth: sequential scan, one row per device
SET enable_indexscan = off;
SET enable_bitmapscan = off;
SELECT device, count(*) FROM <compressed_table> WHERE device = 'd5';
RESET enable_indexscan;
RESET enable_bitmapscan;
-- -> 1 row

-- Forced index/bitmap scan over the SAME committed data
SET enable_seqscan = off;
EXPLAIN (analyze, costs off)
SELECT device FROM <compressed_table> WHERE device = 'd5';
SELECT device FROM <compressed_table> WHERE device = 'd5';
RESET enable_seqscan;
-- -> 0 rows (WRONG: should match the seq scan above)
```

(`<compressed_table>` is the chunk's internal compressed relation, found via `_timescaledb_catalog.compression_settings.compress_relid` for the chunk.)

Actual output observed on a clean vanilla PostgreSQL 17.9 build:

```
Bitmap Heap Scan on _hyper_3_5_chunk_compressed (actual time=0.011..0.012 rows=0 loops=1)
  Recheck Cond: (device = 'd5'::text)
  Heap Blocks: exact=1
  ->  Bitmap Index Scan on _hyper_3_5_chunk_compressed_device__ts_meta_v2_first_ts__ts_idx (actual time=0.007..0.008 rows=3 loops=1)
        Index Cond: (device = 'd5'::text)

 device
--------
(0 rows)
```

vs. the sequential-scan ground truth, which correctly returns `d5`.

Root-cause confirmation (via `pageinspect`): the btree index still contains entries pointing at the row's *pre-rebuild* ctid; the row's actual current location (after the metadata rewrite forced it onto a different heap page) has no corresponding index entry at all.

## The fix

`populate_sparse_index_columns()` now opens the compressed table's indexes once (`CatalogOpenIndexes`) and inserts a new index entry after each update whenever it wasn't HOT-eligible, using the `TU_UpdateIndexes` result the code already computed but previously discarded (`ts_catalog_index_insert()`, TimescaleDB's own vendored copy of PostgreSQL's static `CatalogIndexInsert()`) — mirroring the same open-index/update/insert-index-entry sequence PostgreSQL's own `CatalogTupleUpdate()` uses for catalog tuples.

This also required switching from `simple_table_tuple_update()` to `simple_heap_update()`: the former funnels the update through a `TupleTableSlot` and materializes a throwaway copy of the tuple inside `heapam_tuple_update()`, so the caller's own `HeapTuple` is never updated with the tuple's real post-update location or HOT status — using it to drive `ts_catalog_index_insert()` silently inserted nothing. `simple_heap_update()` operates directly on the passed `HeapTuple`, exactly as `CatalogTupleUpdate()` relies on, and is consistent with the rest of this function, which already assumes a plain heap-backed relation (`heap_modify_tuple`, `heap_deform_tuple`).

Added a regression check in `rebuild_sparse_index.sql` that forces an index/bitmap scan after the `compress_index` drop-and-restore dance in Test 10 and asserts the per-device batch counts match a sequential scan; this fails against unpatched `main` and passes with the fix.

Verified against clean source builds of vanilla PostgreSQL 16.14, 17.9, and 18.4: compiles warning-free, and the full `compress*`/`recompress*`/`*sparse*` TSL regression suite (51 tests) passes on all three.