### PR TITLE
Add concurrent DML compaction isolation test

### DIFF
--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -2615,7 +2615,20 @@ report_error(TM_Result result)
 		 */
 		case TM_Updated:
 		{
-			elog(ERROR, "tuple concurrently updated");
+			if (IsolationUsesXactSnapshot())
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+						 errmsg("could not serialize access due to concurrent update")));
+			}
+			/*
+			 * TODO: Gracefully handle these scenarios.
+			 * Can happen with compaction or recompress segmentwise.
+			 */
+			ereport(ERROR,
+					(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+					 errmsg("could not update/delete compressed data due to "
+							"concurrent modification")));
 		}
 		break;
 		case TM_Invisible:

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1254,6 +1254,8 @@ compact_chunk_recompress_overlapping_batches(
 		found_overlaps = true;
 		CommandCounterIncrement();
 
+		DEBUG_WAITPOINT("compact_chunk_after_batch_delete");
+
 		/* The overlapping batch becomes the predecessor for the scan loop. */
 		ItemPointerCopy(&state->first_overlap_tid, &state->previous_tid);
 		update_current_segment(recompress_ctx->current_segment,
@@ -1512,6 +1514,8 @@ compact_chunk_impl(Chunk *uncompressed_chunk, int max_batches)
 																 index_scan,
 																 recompress_ctx,
 																 state);
+
+	DEBUG_WAITPOINT("compact_chunk_after_find_overlaps");
 
 	if (found_overlaps)
 	{

--- a/tsl/test/isolation/expected/compact_chunk_concurrent.out
+++ b/tsl/test/isolation/expected/compact_chunk_concurrent.out
@@ -1,4 +1,4 @@
-Parsed test spec with 2 sessions
+Parsed test spec with 3 sessions
 
 starting permutation: s2_begin s2_select s1_compact s2_commit s1_show_status s1_count
 step s2_begin: 
@@ -243,4 +243,276 @@ step s1_count:
 count
 -----
  4100
+
+
+starting permutation: s3_wp_enable s1_compact s2_update s3_wp_release s1_show_status s1_count
+step s3_wp_enable: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_update: 
+    UPDATE metrics SET value = -1.0 WHERE value = 1.0;
+
+step s3_wp_release: 
+    SELECT debug_waitpoint_release('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+ERROR:  aborting compaction due to concurrent updates on compressed data, retrying with next policy run
+step s1_show_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics') chunk;
+
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
+
+
+starting permutation: s3_wp_enable s1_compact s2_delete s3_wp_release s1_show_status s1_count
+step s3_wp_enable: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_delete: 
+    DELETE FROM metrics WHERE value = 1.0;
+
+step s3_wp_release: 
+    SELECT debug_waitpoint_release('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+ERROR:  aborting compaction due to concurrent updates on compressed data, retrying with next policy run
+step s1_show_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics') chunk;
+
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 3999
+
+
+starting permutation: s3_wp_enable_after_delete s1_compact s2_update s3_wp_release_after_delete s1_show_status s1_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_update: 
+    UPDATE metrics SET value = -1.0 WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+compact
+-------
+      1
+
+step s2_update: <... completed>
+ERROR:  could not update/delete compressed data due to concurrent modification
+step s1_show_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics') chunk;
+
+status                
+----------------------
+{COMPRESSED,UNORDERED}
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
+
+
+starting permutation: s3_wp_enable_after_delete s1_compact s2_delete s3_wp_release_after_delete s1_show_status s1_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_delete: 
+    DELETE FROM metrics WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+compact
+-------
+      1
+
+step s2_delete: <... completed>
+ERROR:  could not update/delete compressed data due to concurrent modification
+step s1_show_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics') chunk;
+
+status                
+----------------------
+{COMPRESSED,UNORDERED}
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
+
+
+starting permutation: s3_wp_enable_after_delete s1_compact s2_begin_rr s2_update s3_wp_release_after_delete s2_commit s1_show_status s1_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_begin_rr: 
+    BEGIN ISOLATION LEVEL REPEATABLE READ;
+
+step s2_update: 
+    UPDATE metrics SET value = -1.0 WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+compact
+-------
+      1
+
+step s2_update: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step s2_commit: 
+    COMMIT;
+
+step s1_show_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics') chunk;
+
+status                
+----------------------
+{COMPRESSED,UNORDERED}
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
+
+
+starting permutation: s3_wp_enable_after_delete s1_compact s2_begin_rr s2_delete s3_wp_release_after_delete s2_commit s1_show_status s1_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_begin_rr: 
+    BEGIN ISOLATION LEVEL REPEATABLE READ;
+
+step s2_delete: 
+    DELETE FROM metrics WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+compact
+-------
+      1
+
+step s2_delete: <... completed>
+ERROR:  could not serialize access due to concurrent update
+step s2_commit: 
+    COMMIT;
+
+step s1_show_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics') chunk;
+
+status                
+----------------------
+{COMPRESSED,UNORDERED}
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
 

--- a/tsl/test/isolation/specs/compact_chunk_concurrent.spec
+++ b/tsl/test/isolation/specs/compact_chunk_concurrent.spec
@@ -46,6 +46,10 @@ step "s2_begin" {
     BEGIN;
 }
 
+step "s2_begin_rr" {
+    BEGIN ISOLATION LEVEL REPEATABLE READ;
+}
+
 step "s2_insert" {
     INSERT INTO metrics VALUES ('2025-01-02 12:00', 'd1', -1.0);
 }
@@ -77,6 +81,24 @@ step "s2_rollback" {
     ROLLBACK;
 }
 
+session "s3"
+step "s3_wp_enable" {
+    SELECT debug_waitpoint_enable('compact_chunk_after_find_overlaps');
+}
+
+step "s3_wp_release" {
+    SELECT debug_waitpoint_release('compact_chunk_after_find_overlaps');
+}
+
+step "s3_wp_enable_after_delete" {
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+}
+
+step "s3_wp_release_after_delete" {
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+}
+
+
 # compact_chunk should not block concurrent reads
 permutation "s2_begin" "s2_select" "s1_compact" "s2_commit" "s1_show_status" "s1_count"
 
@@ -97,3 +119,22 @@ permutation "s2_begin" "s2_insert" "s2_rollback" "s1_compact" "s1_show_status" "
 
 # compact_chunk should succeed after committed direct compress insert (chunk stays fully compressed)
 permutation "s2_begin" "s2_direct_insert" "s2_commit" "s1_compact" "s1_show_status" "s1_count"
+
+# concurrent update triggers serialization error:
+permutation "s3_wp_enable" "s1_compact" "s2_update" "s3_wp_release" "s1_show_status" "s1_count"
+
+# concurrent delete triggers serialization error
+permutation "s3_wp_enable" "s1_compact" "s2_delete" "s3_wp_release" "s1_show_status" "s1_count"
+
+# concurrent update after batch delete triggers serialization error
+permutation "s3_wp_enable_after_delete" "s1_compact" "s2_update" "s3_wp_release_after_delete" "s1_show_status" "s1_count"
+
+# concurrent delete after batch delete triggers serialization error
+permutation "s3_wp_enable_after_delete" "s1_compact" "s2_delete" "s3_wp_release_after_delete" "s1_show_status" "s1_count"
+
+# Repeatable Read DML: concurrent update after batch delete.
+# s2 runs in Repeatable Read and should get a serialization error.
+permutation "s3_wp_enable_after_delete" "s1_compact" "s2_begin_rr" "s2_update" "s3_wp_release_after_delete" "s2_commit" "s1_show_status" "s1_count"
+
+# Repeatable Read DML: concurrent delete after batch delete.
+permutation "s3_wp_enable_after_delete" "s1_compact" "s2_begin_rr" "s2_delete" "s3_wp_release_after_delete" "s2_commit" "s1_show_status" "s1_count"


### PR DESCRIPTION
Tests that UPDATE or DELETE on compressed data
during compaction triggers the serialization
error. Uses a debug waitpoint after the overlap
scan to allow DML before compaction proceeds.

Disable-check: force-changelog-file