### PR TITLE
Fix add_dimension assertion on NULL hypertable

### DIFF
--- a/.unreleased/fix_add_dimension_null_hypertable
+++ b/.unreleased/fix_add_dimension_null_hypertable
@@ -1,1 +1,2 @@
 Fixes: #10327 Assertion failure in add_dimension when the hypertable argument is NULL
+Thanks: @JoongHyuk-Shin for reporting and fixing NULL handling in add_dimension

--- a/.unreleased/fix_add_dimension_null_hypertable
+++ b/.unreleased/fix_add_dimension_null_hypertable
@@ -1,0 +1,1 @@
+Fixes: #10327 Assertion failure in add_dimension when the hypertable argument is NULL

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1948,7 +1948,7 @@ ts_dimension_add_general(PG_FUNCTION_ARGS)
 {
 	DimensionInfo *info = NULL;
 	GETARG_NOTNULL_POINTER(info, 1, "dimension", DimensionInfo);
-	info->table_relid = PG_GETARG_OID(0);
+	GETARG_NOTNULL_OID(info->table_relid, 0, "hypertable");
 	if (PG_GETARG_BOOL(2))
 	{
 		info->if_not_exists = true;

--- a/tsl/test/expected/hypertable_generalization.out
+++ b/tsl/test/expected/hypertable_generalization.out
@@ -18,6 +18,8 @@ SELECT create_hypertable('n',NULL::_timescaledb_internal.dimension_info);
 ERROR:  dimension cannot be NULL
 SELECT add_dimension('n',NULL::_timescaledb_internal.dimension_info);
 ERROR:  dimension cannot be NULL
+SELECT add_dimension(NULL, by_range('id'));
+ERROR:  hypertable cannot be NULL
 \set ON_ERROR_STOP 1
 -- test int types
 SELECT by_range('id',2::int2);

--- a/tsl/test/sql/hypertable_generalization.sql
+++ b/tsl/test/sql/hypertable_generalization.sql
@@ -18,6 +18,7 @@ $BODY$;
 CREATE TABLE n();
 SELECT create_hypertable('n',NULL::_timescaledb_internal.dimension_info);
 SELECT add_dimension('n',NULL::_timescaledb_internal.dimension_info);
+SELECT add_dimension(NULL, by_range('id'));
 \set ON_ERROR_STOP 1
 
 -- test int types


### PR DESCRIPTION
ts_dimension_add_general read the hypertable argument with a bare PG_GETARG_OID(0), 
so a NULL argument left table_relid as InvalidOid and tripped an assertion in ts_dimension_add_internal. 
Guard it with GETARG_NOTNULL_OID to reject NULL with a clear error, 
matching the dimension argument guard on the line above.

Disable-check: commit-count