### PR TITLE
Silence actionlint not recognizing parallel step annotations

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -73,7 +73,14 @@ jobs:
       - name: Run actionlint
         # The shellcheck integration is disabled for now because the existing
         # workflows have many unfixed shellcheck warnings.
-        run: ./actionlint -shellcheck=
+		# 
+  		# actionlint doesn't recognize parallel steps yet:
+		# https://github.com/rhysd/actionlint/issues/693
+        run: >-
+          ./actionlint -shellcheck=
+          -ignore 'unexpected key "background" for step'
+          -ignore 'step must run script with "run" section or run action with
+          "uses" section'
 
   spelling_checks:
     name: Check spelling

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -73,9 +73,9 @@ jobs:
       - name: Run actionlint
         # The shellcheck integration is disabled for now because the existing
         # workflows have many unfixed shellcheck warnings.
-		# 
-  		# actionlint doesn't recognize parallel steps yet:
-		# https://github.com/rhysd/actionlint/issues/693
+        # 
+        # actionlint doesn't recognize parallel steps yet:
+        # https://github.com/rhysd/actionlint/issues/693
         run: >-
           ./actionlint -shellcheck=
           -ignore 'unexpected key "background" for step'


### PR DESCRIPTION
It's not implemented yet: https://github.com/rhysd/actionlint/issues/693


Example failure: https://github.com/timescale/timescaledb/actions/runs/30250794233/job/89928091355