### PR TITLE
Block compaction in Repeatable Read

### DIFF
--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -255,6 +255,15 @@ tsl_compact_chunk(PG_FUNCTION_ARGS)
 
 	ts_feature_flag_check(FEATURE_HYPERTABLE_COMPRESSION);
 	TS_PREVENT_FUNC_IF_READ_ONLY();
+
+	if (IsolationUsesXactSnapshot())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("compact_chunk is not supported in REPEATABLE READ or SERIALIZABLE "
+						"isolation level")));
+	}
+
 	Chunk *chunk = ts_chunk_get_by_relid(uncompressed_relid, true);
 
 	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());

--- a/tsl/test/expected/compact_chunk.out
+++ b/tsl/test/expected/compact_chunk.out
@@ -178,6 +178,13 @@ SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics') c
 ERROR:  cannot execute compact_chunk() in a read-only transaction
 \set ON_ERROR_STOP 1
 SET default_transaction_read_only TO off;
+-- compact_chunk in REPEATABLE READ must fail
+\set ON_ERROR_STOP 0
+BEGIN ISOLATION LEVEL REPEATABLE READ;
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics') chunk;
+ERROR:  compact_chunk is not supported in REPEATABLE READ or SERIALIZABLE isolation level
+COMMIT;
+\set ON_ERROR_STOP 1
 -- Create a hypertable with a segmentby column.
 -- Each segment ('d1', 'd2') will have its own set of batches, and
 -- compact_chunk should handle overlaps per segment independently.

--- a/tsl/test/sql/compact_chunk.sql
+++ b/tsl/test/sql/compact_chunk.sql
@@ -136,6 +136,13 @@ SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics') c
 
 SET default_transaction_read_only TO off;
 
+-- compact_chunk in REPEATABLE READ must fail
+\set ON_ERROR_STOP 0
+BEGIN ISOLATION LEVEL REPEATABLE READ;
+SELECT _timescaledb_functions.compact_chunk(chunk) FROM show_chunks('metrics') chunk;
+COMMIT;
+\set ON_ERROR_STOP 1
+
 -- Create a hypertable with a segmentby column.
 -- Each segment ('d1', 'd2') will have its own set of batches, and
 -- compact_chunk should handle overlaps per segment independently.


### PR DESCRIPTION
Compaction cannot safely verify results in
Repeatable Read due to stale snapshots. Error
early with ERRCODE_FEATURE_NOT_SUPPORTED.

Disable-check: force-changelog-file
Disable-check: approval-count
