### PR TITLE
Validate max_batches in compact_chunk

### DIFF
--- a/.unreleased/pr_10340
+++ b/.unreleased/pr_10340
@@ -1,0 +1,1 @@
+Fixes: #10340 Validate max_batches in compact_chunk

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -289,7 +289,12 @@ tsl_compact_chunk(PG_FUNCTION_ARGS)
 	}
 
 	int max_batches = PG_GETARG_INT32(1);
-	Assert(max_batches >= 0);
+	if (max_batches < 0)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("max_batches must be greater than or equal to 0")));
+	}
 
 	uncompressed_relid = compact_chunk_impl(chunk, max_batches);
 

--- a/tsl/test/expected/compact_chunk.out
+++ b/tsl/test/expected/compact_chunk.out
@@ -115,6 +115,11 @@ SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks
 -------------------
  {COMPRESSED}
 
+-- compact_chunk with negative max_batches must fail
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.compact_chunk(chunk, -1) FROM show_chunks('metrics') chunk;
+ERROR:  max_batches must be greater than or equal to 0
+\set ON_ERROR_STOP 1
 -- compact an uncompressed chunk
 -- Create a new uncompressed chunk for a different time range by
 -- inserting with direct compress insert disabled.

--- a/tsl/test/sql/compact_chunk.sql
+++ b/tsl/test/sql/compact_chunk.sql
@@ -76,6 +76,11 @@ ORDER BY _ts_meta_min_1;
 -- Status should not contain UNORDERED flag
 SELECT DISTINCT _timescaledb_functions.chunk_status_text(chunk) FROM show_chunks('metrics') chunk;
 
+-- compact_chunk with negative max_batches must fail
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.compact_chunk(chunk, -1) FROM show_chunks('metrics') chunk;
+\set ON_ERROR_STOP 1
+
 -- compact an uncompressed chunk
 -- Create a new uncompressed chunk for a different time range by
 -- inserting with direct compress insert disabled.


### PR DESCRIPTION
Replace Assert with ereport for negative max_batches so callers get a proper error instead of a crash in debug builds.

Found by [LLM fuzzer](https://github.com/timescale/timescaledb/actions/runs/30298195399/job/90084815780?pr=10337)