### PR TITLE
Fix off-by-one in split_chunk upper bound

### DIFF
--- a/.unreleased/fix_split_chunk_upper_bound
+++ b/.unreleased/fix_split_chunk_upper_bound
@@ -1,0 +1,1 @@
+Fixes: #10342 split_chunk() rejected a valid split point at the end of a chunk's range

--- a/tsl/src/chunk_split.c
+++ b/tsl/src/chunk_split.c
@@ -1125,7 +1125,7 @@ chunk_split_chunk(PG_FUNCTION_ARGS)
 		 * split_at value needs to produce partition ranges of at least length
 		 * 1.
 		 */
-		if (split_at < (slice->fd.range_start + 1) || split_at > (slice->fd.range_end - 2))
+		if (split_at < (slice->fd.range_start + 1) || split_at > (slice->fd.range_end - 1))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -1175,3 +1175,19 @@ ORDER BY schemaname, tablename;
 -- Cleanup
 DROP PUBLICATION test_split_pub CASCADE;
 DROP TABLE pub_split_test CASCADE;
+-- Split at range_end - 1 (last valid split point)
+create table splitme_edge (time int not null, v int);
+select create_hypertable('splitme_edge', 'time', chunk_time_interval => 10::int);
+     create_hypertable     
+---------------------------
+ (6,public,splitme_edge,t)
+
+insert into splitme_edge values (1, 1);
+select ch as edge_chunk from show_chunks('splitme_edge') ch order by ch limit 1 \gset
+call split_chunk(:'edge_chunk', split_at => 9);
+select * from chunk_slices where hypertable_name = 'splitme_edge';
+ hypertable_name |               chunk_name                |             range_start             |              range_end              
+-----------------+-----------------------------------------+-------------------------------------+-------------------------------------
+ splitme_edge    | _timescaledb_internal._hyper_6_24_chunk | Wed Dec 31 16:00:00 1969 PST        | Wed Dec 31 16:00:00.000009 1969 PST
+ splitme_edge    | _timescaledb_internal._hyper_6_25_chunk | Wed Dec 31 16:00:00.000009 1969 PST | Wed Dec 31 16:00:00.00001 1969 PST
+

--- a/tsl/test/sql/split_chunk.sql
+++ b/tsl/test/sql/split_chunk.sql
@@ -748,3 +748,11 @@ ORDER BY schemaname, tablename;
 -- Cleanup
 DROP PUBLICATION test_split_pub CASCADE;
 DROP TABLE pub_split_test CASCADE;
+
+-- Split at range_end - 1 (last valid split point)
+create table splitme_edge (time int not null, v int);
+select create_hypertable('splitme_edge', 'time', chunk_time_interval => 10::int);
+insert into splitme_edge values (1, 1);
+select ch as edge_chunk from show_chunks('splitme_edge') ch order by ch limit 1 \gset
+call split_chunk(:'edge_chunk', split_at => 9);
+select * from chunk_slices where hypertable_name = 'splitme_edge';


### PR DESCRIPTION
split_chunk() splits a chunk [start, end) into [start, split_at) and [split_at, end). Per the invariant documented in the code, both resulting ranges must have length at least 1, so the valid split points are [start + 1, end - 1].

The lower bound was correct, but the upper bound required the right range to have length at least 2. This rejected split_at = end - 1 (a valid length-1 right range) and made a chunk of width 2 unsplittable via an explicit split_at, even though the default midpoint path picks and accepts that same point for a width-2 chunk.

Allow split points up to end - 1 so the bounds are symmetric and match the documented invariant. Empty-range splits remain rejected.