### PR TITLE
Internalize snapshot in decompress_batches_scan

### DIFF
--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -60,7 +60,7 @@ typedef BatchQualSummary(BatchMatcher)(RowDecompressor *decompressor, ScanKeyDat
 									   bool check_full_match, bool *skip_current_tuple);
 
 static struct decompress_batches_stats
-decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
+decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 						bool *skip_current_tuple, bool delete_only, List *is_nulls,
 						InvalidationContext *invalidation_ctx, CachedDecompressionState *cdst,
 						TupleTableSlot *insert_slot, CmdType cmd_type);
@@ -516,16 +516,9 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 			 cdst->mem_scankeys.num_scankeys);
 	}
 
-	/*
-	 * Using latest snapshot to scan the heap since we are doing this to build
-	 * the index on the uncompressed chunks in order to do speculative insertion
-	 * which is always built from all tuples (even in higher levels of isolation).
-	 */
-	PushActiveSnapshot(GetLatestSnapshot());
 	stats = decompress_batches_scan(in_rel,
 									out_rel,
 									index_rel,
-									GetActiveSnapshot(),
 									&skip_current_tuple,
 									false,
 									NIL,
@@ -538,7 +531,6 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 	{
 		index_close(index_rel, AccessShareLock);
 	}
-	PopActiveSnapshot();
 
 	if (skip_current_tuple)
 	{
@@ -956,11 +948,9 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	temp_cdst.columns_with_null_check = null_columns;
 	temp_cdst.bloom_filters = bloom_filters;
 
-	PushActiveSnapshot(GetTransactionSnapshot());
 	stats = decompress_batches_scan(comp_chunk_rel,
 									chunk_rel,
 									matching_index_rel,
-									GetActiveSnapshot(),
 									NULL,
 									delete_only,
 									is_null,
@@ -974,8 +964,6 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	{
 		index_close(matching_index_rel, AccessShareLock);
 	}
-
-	PopActiveSnapshot();
 
 	/*
 	 * tuples from compressed chunk has been decompressed and moved
@@ -1100,7 +1088,7 @@ decompress_batch_endscan(DecompressBatchScanDesc scan)
  *
  */
 static struct decompress_batches_stats
-decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
+decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 						bool *skip_current_tuple, bool delete_only, List *is_nulls,
 						InvalidationContext *invalidation_ctx, CachedDecompressionState *cdst,
 						TupleTableSlot *insert_slot, CmdType cmd_type)
@@ -1136,6 +1124,12 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 								RelationGetRelid(in_rel),
 								RelationGetRelid(out_rel),
 								cmd_type);
+
+	/* CMD_INSERT uses GetLatestSnapshot to see all rows including from the
+	 * current transaction, needed for speculative insertion and index building.
+	 * All other commands use GetTransactionSnapshot for standard MVCC. */
+	Snapshot snapshot = (cmd_type == CMD_INSERT) ? RegisterSnapshot(GetLatestSnapshot()) :
+												   RegisterSnapshot(GetTransactionSnapshot());
 
 	/* TODO: Optimization by reusing the index scan while working on a single chunk */
 
@@ -1336,6 +1330,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			bulk_writer_close(&writer);
 			decompress_batch_endscan(scan);
 			ExecDropSingleTupleTableSlot(slot);
+			UnregisterSnapshot(snapshot);
 			return stats;
 		}
 
@@ -1371,6 +1366,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			row_decompressor_close(&decompressor);
 			bulk_writer_close(&writer);
 			decompress_batch_endscan(scan);
+			UnregisterSnapshot(snapshot);
 			report_error(result);
 			return stats;
 		}
@@ -1425,6 +1421,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 		 */
 		row_decompressor_flush_stats(&decompressor);
 	}
+
+	UnregisterSnapshot(snapshot);
 
 	if (ts_guc_debug_compression_path_info)
 	{


### PR DESCRIPTION
decompress_batches_scan now owns its snapshot lifecycle. It creates, registers, and unregisters the snapshot internally based on cmd_type, removing Push/Pop from callers and the snapshot parameter from the signature.


Needed for upcoming rescanning PR which will be for decompress_batches_scan. #10354 

Disable-check: force-changelog-file