### PR TITLE
Handle TM_Updated in compressed DML scan

### DIFF
--- a/.unreleased/pr_10354
+++ b/.unreleased/pr_10354
@@ -1,0 +1,1 @@
+Implements: #10354 Handle TM_Updated in compressed DML scan

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -60,7 +60,7 @@ typedef BatchQualSummary(BatchMatcher)(RowDecompressor *decompressor, ScanKeyDat
 									   bool check_full_match, bool *skip_current_tuple);
 
 static struct decompress_batches_stats
-decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
+decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 						bool *skip_current_tuple, bool delete_only, List *is_nulls,
 						InvalidationContext *invalidation_ctx, CachedDecompressionState *cdst,
 						TupleTableSlot *insert_slot, CmdType cmd_type);
@@ -516,16 +516,9 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 			 cdst->mem_scankeys.num_scankeys);
 	}
 
-	/*
-	 * Using latest snapshot to scan the heap since we are doing this to build
-	 * the index on the uncompressed chunks in order to do speculative insertion
-	 * which is always built from all tuples (even in higher levels of isolation).
-	 */
-	PushActiveSnapshot(GetLatestSnapshot());
 	stats = decompress_batches_scan(in_rel,
 									out_rel,
 									index_rel,
-									GetActiveSnapshot(),
 									&skip_current_tuple,
 									false,
 									NIL,
@@ -538,7 +531,6 @@ decompress_batches_for_insert(ChunkInsertState *cis, TupleTableSlot *slot)
 	{
 		index_close(index_rel, AccessShareLock);
 	}
-	PopActiveSnapshot();
 
 	if (skip_current_tuple)
 	{
@@ -956,11 +948,9 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	temp_cdst.columns_with_null_check = null_columns;
 	temp_cdst.bloom_filters = bloom_filters;
 
-	PushActiveSnapshot(GetTransactionSnapshot());
 	stats = decompress_batches_scan(comp_chunk_rel,
 									chunk_rel,
 									matching_index_rel,
-									GetActiveSnapshot(),
 									NULL,
 									delete_only,
 									is_null,
@@ -974,8 +964,6 @@ decompress_batches_for_update_delete(ModifyHypertableState *ht_state, Chunk *chu
 	{
 		index_close(matching_index_rel, AccessShareLock);
 	}
-
-	PopActiveSnapshot();
 
 	/*
 	 * tuples from compressed chunk has been decompressed and moved
@@ -1100,7 +1088,7 @@ decompress_batch_endscan(DecompressBatchScanDesc scan)
  *
  */
 static struct decompress_batches_stats
-decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, Snapshot snapshot,
+decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 						bool *skip_current_tuple, bool delete_only, List *is_nulls,
 						InvalidationContext *invalidation_ctx, CachedDecompressionState *cdst,
 						TupleTableSlot *insert_slot, CmdType cmd_type)
@@ -1136,6 +1124,13 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 								RelationGetRelid(in_rel),
 								RelationGetRelid(out_rel),
 								cmd_type);
+
+	/* CMD_INSERT uses GetLatestSnapshot to see all rows including from the
+	 * current transaction, needed for speculative insertion and index building.
+	 * All other commands use GetTransactionSnapshot for standard MVCC. */
+	Snapshot snapshot = (cmd_type == CMD_INSERT) ?
+		RegisterSnapshot(GetLatestSnapshot()) :
+		RegisterSnapshot(GetTransactionSnapshot());
 
 	/* TODO: Optimization by reusing the index scan while working on a single chunk */
 
@@ -1336,6 +1331,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			bulk_writer_close(&writer);
 			decompress_batch_endscan(scan);
 			ExecDropSingleTupleTableSlot(slot);
+			UnregisterSnapshot(snapshot);
 			return stats;
 		}
 
@@ -1371,6 +1367,7 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 			row_decompressor_close(&decompressor);
 			bulk_writer_close(&writer);
 			decompress_batch_endscan(scan);
+			UnregisterSnapshot(snapshot);
 			report_error(result);
 			return stats;
 		}
@@ -1425,6 +1422,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel, S
 		 */
 		row_decompressor_flush_stats(&decompressor);
 	}
+
+	UnregisterSnapshot(snapshot);
 
 	if (ts_guc_debug_compression_path_info)
 	{

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -23,6 +23,7 @@
 #include <utils/typcache.h>
 
 #include <compat/compat.h>
+#include "debug_point.h"
 #include "foreach_ptr.h"
 #include "ts_stats/ts_stats_record.h"
 #include <chunk_insert_state.h>
@@ -1360,6 +1361,42 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 			stats.batches_decompressed++;
 			continue;
 		}
+		/*
+		 * Handle TM_Updated from concurrent compaction or recompress.
+		 * Restart the scan with a fresh snapshot so the DML finds the rows
+		 * in the new recompressed batches.
+		 */
+		if (result == TM_Updated && !IsolationUsesXactSnapshot())
+		{
+			write_logical_replication_msg_decompression_end();
+			row_decompressor_reset(&decompressor);
+
+			/* Reset stats before restarting — only the final pass counts. */
+			memset(&stats, 0, sizeof(stats));
+
+			/* Restart scan with a fresh snapshot. */
+			decompress_batch_endscan(scan);
+			UnregisterSnapshot(snapshot);
+			snapshot = RegisterSnapshot(GetTransactionSnapshot());
+			if (index_rel)
+			{
+				scan = decompress_batch_beginscan(in_rel,
+												  index_rel,
+												  snapshot,
+												  num_index_scankeys,
+												  index_scankeys); // Poro: check what happens to
+																   // previously deleted batches
+			}
+			else
+			{
+				scan = decompress_batch_beginscan(in_rel,
+												  NULL,
+												  snapshot,
+												  num_heap_scankeys,
+												  heap_scankeys);
+			}
+			continue;
+		}
 		if (result != TM_Ok)
 		{
 			write_logical_replication_msg_decompression_end();
@@ -1402,6 +1439,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 				row_decompressor_decompress_row_to_table(&decompressor, &writer);
 			stats.batches_decompressed++;
 			write_logical_replication_msg_decompression_end();
+
+			DEBUG_WAITPOINT("decompress_batches_after_batch");
 		}
 	}
 	ExecDropSingleTupleTableSlot(slot);

--- a/tsl/src/compression/compression_dml.c
+++ b/tsl/src/compression/compression_dml.c
@@ -23,6 +23,7 @@
 #include <utils/typcache.h>
 
 #include <compat/compat.h>
+#include "debug_point.h"
 #include "foreach_ptr.h"
 #include "ts_stats/ts_stats_record.h"
 #include <chunk_insert_state.h>
@@ -1359,6 +1360,40 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 			stats.batches_decompressed++;
 			continue;
 		}
+		/*
+		 * Handle TM_Updated from concurrent compaction or recompress.
+		 * Restart the scan with a fresh snapshot and CID so the DML finds the rows
+		 * in the new recompressed batches.
+		 */
+		if (result == TM_Updated && !IsolationUsesXactSnapshot())
+		{
+			write_logical_replication_msg_decompression_end();
+			row_decompressor_reset(&decompressor);
+
+			/* Avoid TM_SelfModified */
+			CommandCounterIncrement();
+
+			decompress_batch_endscan(scan);
+			UnregisterSnapshot(snapshot);
+			snapshot = RegisterSnapshot(GetTransactionSnapshot());
+			if (index_rel)
+			{
+				scan = decompress_batch_beginscan(in_rel,
+												  index_rel,
+												  snapshot,
+												  num_index_scankeys,
+												  index_scankeys);
+			}
+			else
+			{
+				scan = decompress_batch_beginscan(in_rel,
+												  NULL,
+												  snapshot,
+												  num_heap_scankeys,
+												  heap_scankeys);
+			}
+			continue;
+		}
 		if (result != TM_Ok)
 		{
 			write_logical_replication_msg_decompression_end();
@@ -1414,6 +1449,8 @@ decompress_batches_scan(Relation in_rel, Relation out_rel, Relation index_rel,
 				row_decompressor_decompress_row_to_table(&decompressor, &writer);
 			stats.batches_decompressed++;
 			write_logical_replication_msg_decompression_end();
+
+			DEBUG_WAITPOINT("decompress_batches_after_batch");
 		}
 	}
 	ExecDropSingleTupleTableSlot(slot);

--- a/tsl/test/isolation/expected/compact_chunk_concurrent.out
+++ b/tsl/test/isolation/expected/compact_chunk_concurrent.out
@@ -353,14 +353,13 @@ compact
       1
 
 step s2_update: <... completed>
-ERROR:  could not update/delete compressed data due to concurrent modification
 step s1_show_status: 
     SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
     FROM show_chunks('metrics') chunk;
 
-status                
-----------------------
-{COMPRESSED,UNORDERED}
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
 
 step s1_count: 
     SELECT count(*) FROM metrics;
@@ -398,21 +397,20 @@ compact
       1
 
 step s2_delete: <... completed>
-ERROR:  could not update/delete compressed data due to concurrent modification
 step s1_show_status: 
     SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
     FROM show_chunks('metrics') chunk;
 
-status                
-----------------------
-{COMPRESSED,UNORDERED}
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
 
 step s1_count: 
     SELECT count(*) FROM metrics;
 
 count
 -----
- 4000
+ 3999
 
 
 starting permutation: s3_wp_enable_after_delete s1_compact s2_begin_rr s2_update s3_wp_release_after_delete s2_commit s1_show_status s1_count
@@ -515,4 +513,72 @@ step s1_count:
 count
 -----
  4000
+
+
+starting permutation: s3_wp_enable_after_delete s3_wp_enable_dml_batch s1_compact_rescan s2_update_rescan s3_wp_release_dml_batch s3_wp_release_after_delete s2_check_rescan_update s1_rescan_status s1_rescan_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s3_wp_enable_dml_batch: 
+    SELECT debug_waitpoint_enable('decompress_batches_after_batch');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact_rescan: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics_dml_rescan') chunk;
+ <waiting ...>
+step s2_update_rescan: 
+    UPDATE metrics_dml_rescan SET value = value + 0.001 WHERE device = 'd1';
+ <waiting ...>
+step s3_wp_release_dml_batch: 
+    SELECT debug_waitpoint_release('decompress_batches_after_batch');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact_rescan: <... completed>
+compact
+-------
+      1
+
+step s2_update_rescan: <... completed>
+step s2_check_rescan_update: 
+    SELECT count(*) AS total,
+           count(*) FILTER (WHERE value != round(value::numeric, 0)
+                             AND value != round(value::numeric, 1)) AS updated
+    FROM metrics_dml_rescan;
+
+total|updated
+-----+-------
+ 4500|   4500
+
+step s1_rescan_status: 
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics_dml_rescan') chunk;
+
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
+
+step s1_rescan_count: 
+    SELECT count(*) FROM metrics_dml_rescan;
+
+count
+-----
+ 4500
 

--- a/tsl/test/isolation/expected/compact_chunk_concurrent.out
+++ b/tsl/test/isolation/expected/compact_chunk_concurrent.out
@@ -353,14 +353,13 @@ compact
       1
 
 step s2_update: <... completed>
-ERROR:  could not update/delete compressed data due to concurrent modification
 step s1_show_status: 
     SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
     FROM show_chunks('metrics') chunk;
 
-status                
-----------------------
-{COMPRESSED,UNORDERED}
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
 
 step s1_count: 
     SELECT count(*) FROM metrics;
@@ -398,21 +397,20 @@ compact
       1
 
 step s2_delete: <... completed>
-ERROR:  could not update/delete compressed data due to concurrent modification
 step s1_show_status: 
     SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
     FROM show_chunks('metrics') chunk;
 
-status                
-----------------------
-{COMPRESSED,UNORDERED}
+status                        
+------------------------------
+{COMPRESSED,UNORDERED,PARTIAL}
 
 step s1_count: 
     SELECT count(*) FROM metrics;
 
 count
 -----
- 4000
+ 3999
 
 
 starting permutation: s3_wp_enable_after_delete s1_compact s2_begin_rr s2_update s3_wp_release_after_delete s2_commit s1_show_status s1_count
@@ -515,4 +513,198 @@ step s1_count:
 count
 -----
  4000
+
+
+starting permutation: s3_wp_enable_after_delete s1_compact s2_update s3_wp_release_after_delete s2_check_update s1_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_update: 
+    UPDATE metrics SET value = -1.0 WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+compact
+-------
+      1
+
+step s2_update: <... completed>
+step s2_check_update: 
+    SELECT count(*) AS updated_rows FROM metrics WHERE value = -1.0;
+
+updated_rows
+------------
+           1
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
+
+
+starting permutation: s3_wp_enable_after_delete s1_compact s2_delete s3_wp_release_after_delete s2_check_delete s1_count
+step s3_wp_enable_after_delete: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_batch_delete');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_delete: 
+    DELETE FROM metrics WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release_after_delete: 
+    SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+compact
+-------
+      1
+
+step s2_delete: <... completed>
+step s2_check_delete: 
+    SELECT count(*) AS remaining FROM metrics WHERE value = 1.0;
+
+remaining
+---------
+        0
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 3999
+
+
+starting permutation: s3_wp_enable s3_wp_enable_dml_batch s1_compact s2_update s3_wp_release s3_wp_release_dml_batch s2_check_update s1_count
+step s3_wp_enable: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s3_wp_enable_dml_batch: 
+    SELECT debug_waitpoint_enable('decompress_batches_after_batch');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_update: 
+    UPDATE metrics SET value = -1.0 WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release: 
+    SELECT debug_waitpoint_release('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s3_wp_release_dml_batch: 
+    SELECT debug_waitpoint_release('decompress_batches_after_batch');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+ERROR:  aborting compaction due to concurrent updates on compressed data, retrying with next policy run
+step s2_update: <... completed>
+step s2_check_update: 
+    SELECT count(*) AS updated_rows FROM metrics WHERE value = -1.0;
+
+updated_rows
+------------
+           1
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 4000
+
+
+starting permutation: s3_wp_enable s3_wp_enable_dml_batch s1_compact s2_delete s3_wp_release s3_wp_release_dml_batch s2_check_delete s1_count
+step s3_wp_enable: 
+    SELECT debug_waitpoint_enable('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s3_wp_enable_dml_batch: 
+    SELECT debug_waitpoint_enable('decompress_batches_after_batch');
+
+debug_waitpoint_enable
+----------------------
+                      
+
+step s1_compact: 
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics') chunk;
+ <waiting ...>
+step s2_delete: 
+    DELETE FROM metrics WHERE value = 1.0;
+ <waiting ...>
+step s3_wp_release: 
+    SELECT debug_waitpoint_release('compact_chunk_after_find_overlaps');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s3_wp_release_dml_batch: 
+    SELECT debug_waitpoint_release('decompress_batches_after_batch');
+
+debug_waitpoint_release
+-----------------------
+                       
+
+step s1_compact: <... completed>
+ERROR:  aborting compaction due to concurrent updates on compressed data, retrying with next policy run
+step s2_delete: <... completed>
+step s2_check_delete: 
+    SELECT count(*) AS remaining FROM metrics WHERE value = 1.0;
+
+remaining
+---------
+        0
+
+step s1_count: 
+    SELECT count(*) FROM metrics;
+
+count
+-----
+ 3999
 

--- a/tsl/test/isolation/specs/compact_chunk_concurrent.spec
+++ b/tsl/test/isolation/specs/compact_chunk_concurrent.spec
@@ -69,6 +69,14 @@ step "s2_delete" {
     DELETE FROM metrics WHERE value = 1.0;
 }
 
+step "s2_check_update" {
+    SELECT count(*) AS updated_rows FROM metrics WHERE value = -1.0;
+}
+
+step "s2_check_delete" {
+    SELECT count(*) AS remaining FROM metrics WHERE value = 1.0;
+}
+
 step "s2_select" {
     SELECT count(*) FROM metrics;
 }
@@ -96,6 +104,14 @@ step "s3_wp_enable_after_delete" {
 
 step "s3_wp_release_after_delete" {
     SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+}
+
+step "s3_wp_enable_dml_batch" {
+    SELECT debug_waitpoint_enable('decompress_batches_after_batch');
+}
+
+step "s3_wp_release_dml_batch" {
+    SELECT debug_waitpoint_release('decompress_batches_after_batch');
 }
 
 
@@ -138,3 +154,21 @@ permutation "s3_wp_enable_after_delete" "s1_compact" "s2_begin_rr" "s2_update" "
 
 # Repeatable Read DML: concurrent delete after batch delete.
 permutation "s3_wp_enable_after_delete" "s1_compact" "s2_begin_rr" "s2_delete" "s3_wp_release_after_delete" "s2_commit" "s1_show_status" "s1_count"
+
+# DML scan restart safety: concurrent update completes correctly after
+# compaction modifies batches mid-scan. The update should actually take
+# effect (value=1.0 changed to -1.0) even though the scan restarted.
+permutation "s3_wp_enable_after_delete" "s1_compact" "s2_update" "s3_wp_release_after_delete" "s2_check_update" "s1_count"
+
+# DML scan restart safety: concurrent delete completes correctly after
+# compaction modifies batches mid-scan. The row with value=1.0 should
+# actually be deleted.
+permutation "s3_wp_enable_after_delete" "s1_compact" "s2_delete" "s3_wp_release_after_delete" "s2_check_delete" "s1_count"
+
+# DML mid-scan restart: s1 starts compaction first (passes lock check),
+# pauses after finding overlaps. s2 starts DML, processes one batch,
+# pauses. s1 resumes and modifies batches. s2 resumes, hits TM_Updated
+# on a compacted batch, restarts scan. Data should be correct.
+permutation "s3_wp_enable" "s3_wp_enable_dml_batch" "s1_compact" "s2_update" "s3_wp_release" "s3_wp_release_dml_batch" "s2_check_update" "s1_count"
+
+permutation "s3_wp_enable" "s3_wp_enable_dml_batch" "s1_compact" "s2_delete" "s3_wp_release" "s3_wp_release_dml_batch" "s2_check_delete" "s1_count"

--- a/tsl/test/isolation/specs/compact_chunk_concurrent.spec
+++ b/tsl/test/isolation/specs/compact_chunk_concurrent.spec
@@ -20,10 +20,27 @@ setup {
     INSERT INTO metrics
     SELECT '2025-01-02'::timestamptz + (i || ' minute')::interval, 'd1', (i + 0.5)::float
     FROM generate_series(1,2000) i;
+
+    -- Second table for concurrent DML rescan test:
+    CREATE TABLE metrics_dml_rescan (time TIMESTAMPTZ NOT NULL, device TEXT, value float)
+    WITH (tsdb.hypertable, tsdb.orderby='time');
+
+    INSERT INTO metrics_dml_rescan
+    SELECT '2025-01-02 00:01'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+    FROM generate_series(1,500) i;
+
+    INSERT INTO metrics_dml_rescan
+    SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd1', i::float
+    FROM generate_series(1,2000) i;
+
+    INSERT INTO metrics_dml_rescan
+    SELECT '2025-01-03'::timestamptz + (i || ' minute')::interval, 'd1', (i + 0.5)::float
+    FROM generate_series(1,2000) i;
 }
 
 teardown {
     DROP TABLE metrics;
+    DROP TABLE metrics_dml_rescan;
 }
 
 session "s1"
@@ -39,6 +56,20 @@ step "s1_show_status" {
 
 step "s1_count" {
     SELECT count(*) FROM metrics;
+}
+
+step "s1_compact_rescan" {
+    SELECT count(_timescaledb_functions.compact_chunk(chunk)) AS compact
+    FROM show_chunks('metrics_dml_rescan') chunk;
+}
+
+step "s1_rescan_status" {
+    SELECT _timescaledb_functions.chunk_status_text(chunk) AS status
+    FROM show_chunks('metrics_dml_rescan') chunk;
+}
+
+step "s1_rescan_count" {
+    SELECT count(*) FROM metrics_dml_rescan;
 }
 
 session "s2"
@@ -73,6 +104,17 @@ step "s2_select" {
     SELECT count(*) FROM metrics;
 }
 
+step "s2_update_rescan" {
+    UPDATE metrics_dml_rescan SET value = value + 0.001 WHERE device = 'd1';
+}
+
+step "s2_check_rescan_update" {
+    SELECT count(*) AS total,
+           count(*) FILTER (WHERE value != round(value::numeric, 0)
+                             AND value != round(value::numeric, 1)) AS updated
+    FROM metrics_dml_rescan;
+}
+
 step "s2_commit" {
     COMMIT;
 }
@@ -96,6 +138,14 @@ step "s3_wp_enable_after_delete" {
 
 step "s3_wp_release_after_delete" {
     SELECT debug_waitpoint_release('compact_chunk_after_batch_delete');
+}
+
+step "s3_wp_enable_dml_batch" {
+    SELECT debug_waitpoint_enable('decompress_batches_after_batch');
+}
+
+step "s3_wp_release_dml_batch" {
+    SELECT debug_waitpoint_release('decompress_batches_after_batch');
 }
 
 
@@ -138,3 +188,11 @@ permutation "s3_wp_enable_after_delete" "s1_compact" "s2_begin_rr" "s2_update" "
 
 # Repeatable Read DML: concurrent delete after batch delete.
 permutation "s3_wp_enable_after_delete" "s1_compact" "s2_begin_rr" "s2_delete" "s3_wp_release_after_delete" "s2_commit" "s1_show_status" "s1_count"
+
+# DML mid-scan restart with batch already processed:
+# s1 compaction pauses after deleting overlapping batches. s2 UPDATE starts,
+# processes the non-overlapping batch (early times), then pauses at DML
+# waitpoint. s2 resumes, hits compaction's row lock on the overlapping batch,
+# waits. s1 resumes and commits. s2 gets TM_Updated, restarts scan.
+# The UPDATE should take effect on all rows, chunk should be PARTIAL.
+permutation "s3_wp_enable_after_delete" "s3_wp_enable_dml_batch" "s1_compact_rescan" "s2_update_rescan" "s3_wp_release_dml_batch" "s3_wp_release_after_delete" "s2_check_rescan_update" "s1_rescan_status" "s1_rescan_count"


### PR DESCRIPTION
On TM_Updated in Read Committed, restart the scan
with a fresh snapshot after CommandCounterIncrement
so the DML finds rows in recompressed batches. In
Repeatable Read, raise a serialization error. Adds
isolation test for concurrent compaction and DML.