### PR TITLE
Fix wrong step name in linux build Github Action

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -171,7 +171,7 @@ jobs:
         key: "${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}${{ env.CACHE_SUFFIX }}"
 
     - name: Upload config.log
-      if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'
+      if: always() && steps.restore-postgresql-cache.outputs.cache-hit != 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: config.log for PostgreSQL ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}


### PR DESCRIPTION
I forgot to rename a step in the condition for some other step.

Fixes this actionlint complaint: https://github.com/timescale/timescaledb/actions/runs/30530896372/job/90832723387