### PR TITLE
[Bug]: Typo on executing MERGE command on compresses hypertable

### DIFF
--- a/docs/BuildSource.md
+++ b/docs/BuildSource.md
@@ -67,6 +67,6 @@ cmake --build ./build --config Release
 # To install
 cmake --build ./build --config Release --target install
 
-# Alternatively, build in Visual Studio via its built-in support for
+# Alternatively, build in Visual Studio via its built-in supported for
 # CMake or by opening the generated build/timescaledb.sln solution file.
 ```


### PR DESCRIPTION
Fixes #10367

This corrects `support` to `supported` in `docs/BuildSource.md`, as reported in #10367.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #10367