### PR TITLE
Add missing initialization to result variable in recompress.c

### DIFF
--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -685,7 +685,7 @@ recompress_chunk_segmentwise_impl(Chunk *uncompressed_chunk,
 
 		bool done_with_segment = false;
 		bool tuples_for_recompression = false;
-		enum Batch_match_result result;
+		enum Batch_match_result result = Tuple_match;
 
 		/* For full segmentwise decompress/compress we decompress all batches in
 		 * the current segment (i.e. treat each batch as a match) */


### PR DESCRIPTION
When building with -O1 or higher compiler would warn about uninitialized
variable:

tsl/src/compression/recompress.c:715:39: warning: ‘result’ may be used uninitialized [-Wmaybe-uninitialized]
  715 |                         while (result == Tuple_before)

Disable-check: force-changelog-file