### PR TITLE
Set CCACHE_BASEDIR when using ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,9 @@ if((NOT DEFINED CMAKE_C_COMPILER) AND (NOT DEFINED ENV{CC}))
         STATUS
           "Using ${PG_CCACHE_FOUND} as C compiler launcher based on pg_config CC"
       )
-      set(CMAKE_C_COMPILER_LAUNCHER ${PG_CCACHE_FOUND})
+      set(CMAKE_C_COMPILER_LAUNCHER
+          ${CMAKE_COMMAND} -E env CCACHE_BASEDIR=${CMAKE_SOURCE_DIR}
+          ${PG_CCACHE_FOUND})
     endif()
     set(PG_CC ${PG_CC_LIST})
   else()


### PR DESCRIPTION
Set CCACHE_BASEDIR to the source root so ccache rewrites absolute paths
to be relative. This lets different checkouts/worktrees of the same commit
share cache entries.
