### PR TITLE
Report user error disabling continuous aggregate

### DIFF
--- a/.unreleased/fix_cagg_disable_errcode
+++ b/.unreleased/fix_cagg_disable_errcode
@@ -1,0 +1,1 @@
+Fixes: #10384 Use a user-visible error code when attempting to disable a continuous aggregate

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -190,7 +190,9 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 {
 	if (!with_clause_options[CreateMaterializedViewFlagContinuous].is_default)
 	{
-		elog(ERROR, "cannot disable continuous aggregates");
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot disable continuous aggregates")));
 	}
 
 	if (!with_clause_options[CreateMaterializedViewFlagMaterializedOnly].is_default)

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -317,6 +317,10 @@ ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'fa
 ERROR:  cannot alter create_group_indexes option for continuous aggregates
 ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
 ERROR:  cannot alter create_group_indexes option for continuous aggregates
+\set VERBOSITY sqlstate
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.continuous = false);
+ERROR:  0A000
+\set VERBOSITY default
 ALTER MATERIALIZED VIEW mat_with_test ALTER timec DROP default;
 ERROR:  cannot alter only SET options of a continuous aggregate
 \set ON_ERROR_STOP 1

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -289,6 +289,9 @@ FOR EACH ROW EXECUTE FUNCTION not_allowed();
 
 ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
 ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
+\set VERBOSITY sqlstate
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.continuous = false);
+\set VERBOSITY default
 ALTER MATERIALIZED VIEW mat_with_test ALTER timec DROP default;
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse


### PR DESCRIPTION
Changing the timescaledb.continuous flag of a continuous aggregate was rejected with elog(), 
which reports SQLSTATE XX000 (internal error) for an ordinary user-facing condition. 
Use ereport() with ERRCODE_FEATURE_NOT_SUPPORTED, matching the other option checks in the same file.