### PR TITLE
Add missing permission checks to internal chunk functions

### DIFF
--- a/.unreleased/fix-chunk-permission-checks
+++ b/.unreleased/fix-chunk-permission-checks
@@ -1,0 +1,1 @@
+Fixes: #10386 Add missing permission checks to internal chunk functions

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3994,6 +3994,10 @@ ts_chunk_drop_single_chunk(PG_FUNCTION_ARGS)
 															   CurrentMemoryContext,
 															   true);
 	Assert(ch != NULL);
+
+	/* Only the hypertable owner may drop a chunk */
+	ts_hypertable_permissions_check(ch->hypertable_relid, GetUserId());
+
 	ts_chunk_validate_chunk_status_for_operation(ch, CHUNK_DROP, true /*throw_error */);
 
 	/* do not drop any chunk dependencies */
@@ -5131,6 +5135,9 @@ ts_chunk_drop_osm_chunk(PG_FUNCTION_ARGS)
 	Hypertable *ht = ts_resolve_hypertable_from_table_or_cagg(hcache, hypertable_relid, true);
 	int32 osm_chunk_id = ts_chunk_get_osm_chunk_id(ht->fd.id);
 	Chunk *osm_chunk = ts_chunk_get_by_id(osm_chunk_id, true);
+
+	/* Only the hypertable owner may drop the OSM chunk */
+	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());
 
 	ts_chunk_validate_chunk_status_for_operation(osm_chunk, CHUNK_DROP, true);
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2544,6 +2544,9 @@ ts_hypertable_osm_range_update(PG_FUNCTION_ARGS)
 					   quote_identifier(NameStr(ht->fd.schema_name)),
 					   quote_identifier(NameStr(ht->fd.table_name))));
 	}
+
+	/* Only the hypertable owner may update the OSM chunk range */
+	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());
 	/*
 	 * range_start, range_end arguments must be converted to internal representation
 	 * a NULL start value is interpreted as INT64_MAX - 1 and a NULL end value is
@@ -2707,6 +2710,9 @@ ts_lock_osm_chunk_dimension_slice(PG_FUNCTION_ARGS)
 					   quote_identifier(NameStr(ht->fd.schema_name)),
 					   quote_identifier(NameStr(ht->fd.table_name))));
 	}
+
+	/* Only the hypertable owner may lock the OSM chunk dimension slice */
+	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());
 
 	/*
 	 * Lock the OSM chunk's dimension slice tuple FOR UPDATE. The row lock is

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1569,3 +1569,19 @@ SELECT pg_typeof(_timescaledb_functions.hypertable_status_text(0));
 -----------
  text[]
 
+-- A non-owner must not be able to drop a chunk via the internal drop_chunk API
+\c  :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE drop_chunk_perm(time timestamptz NOT NULL);
+SELECT create_hypertable('drop_chunk_perm', 'time');
+       create_hypertable       
+-------------------------------
+ (20,public,drop_chunk_perm,t)
+
+INSERT INTO drop_chunk_perm VALUES ('2025-01-01');
+SELECT ch AS "PERMCHUNK" FROM show_chunks('drop_chunk_perm') ch \gset
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.drop_chunk(:'PERMCHUNK');
+ERROR:  must be owner of hypertable "drop_chunk_perm"
+\set ON_ERROR_STOP 1
+RESET ROLE;

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -699,3 +699,15 @@ SELECT _timescaledb_functions.hypertable_status('pg_class'::regclass);
 -- Test that function exists and returns an array type
 SELECT pg_typeof(_timescaledb_functions.hypertable_status_text(0));
 
+-- A non-owner must not be able to drop a chunk via the internal drop_chunk API
+\c  :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE drop_chunk_perm(time timestamptz NOT NULL);
+SELECT create_hypertable('drop_chunk_perm', 'time');
+INSERT INTO drop_chunk_perm VALUES ('2025-01-01');
+SELECT ch AS "PERMCHUNK" FROM show_chunks('drop_chunk_perm') ch \gset
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.drop_chunk(:'PERMCHUNK');
+\set ON_ERROR_STOP 1
+RESET ROLE;
+

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -49,6 +49,7 @@ chunk_freeze_chunk(PG_FUNCTION_ARGS)
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
 	Assert(chunk != NULL);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
 	{
 		ereport(ERROR,
@@ -77,6 +78,7 @@ chunk_unfreeze_chunk(PG_FUNCTION_ARGS)
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
 	Assert(chunk != NULL);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
 	{
 		ereport(ERROR,

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -842,6 +842,7 @@ tsl_create_compressed_chunk(PG_FUNCTION_ARGS)
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	ts_hypertable_permissions_check(chunk->hypertable_relid, GetUserId());
 	hcache = ts_hypertable_cache_pin();
 	compresschunkcxt_init(&cxt, hcache, chunk->hypertable_relid, chunk_relid);
 

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -868,6 +868,15 @@ ERROR:  must be owner of hypertable "ht_try"
 CREATE TABLE non_ht (time bigint, temp float);
 SELECT _timescaledb_functions.attach_osm_table_chunk('non_ht', 'child_fdw_table');
 ERROR:  "non_ht" is not a hypertable
+-- TEST error have to be hypertable owner to drop the OSM chunk
+SELECT _timescaledb_functions.drop_osm_chunk('ht_try');
+ERROR:  must be owner of hypertable "ht_try"
+-- TEST error have to be hypertable owner to update the OSM chunk range
+SELECT _timescaledb_functions.hypertable_osm_range_update('ht_try', NULL::timestamptz, NULL::timestamptz);
+ERROR:  must be owner of hypertable "ht_try"
+-- TEST error have to be hypertable owner to lock the OSM chunk dimension slice
+SELECT _timescaledb_functions.lock_osm_chunk_dimension_slice('ht_try');
+ERROR:  must be owner of hypertable "ht_try"
 -- TEST drop OSM chunk
 \c :TEST_DBNAME :ROLE_4
 -- We need the OSM chunk for other tests so we run the test in a single
@@ -1886,3 +1895,22 @@ SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
 ERROR:  chunk "_timescaledb_internal._hyper_25_43_chunk" is frozen, skipping compression
 ROLLBACK;
 \set ON_ERROR_STOP 1
+-- A non-owner must not be able to freeze or unfreeze a chunk
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE freeze_perm(time timestamptz NOT NULL);
+SELECT create_hypertable('freeze_perm', 'time');
+     create_hypertable     
+---------------------------
+ (26,public,freeze_perm,t)
+
+INSERT INTO freeze_perm VALUES ('2025-01-01');
+SELECT ch AS "FREEZECHUNK" FROM show_chunks('freeze_perm') ch \gset
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.freeze_chunk(:'FREEZECHUNK');
+ERROR:  must be owner of hypertable "freeze_perm"
+SELECT _timescaledb_functions.unfreeze_chunk(:'FREEZECHUNK');
+ERROR:  must be owner of hypertable "freeze_perm"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP TABLE freeze_perm;

--- a/tsl/test/expected/compression_create_compressed_table.out
+++ b/tsl/test/expected/compression_create_compressed_table.out
@@ -63,3 +63,20 @@ SELECT count(*) FROM "_timescaledb_internal"."_hyper_1_1_chunk";
 -------
      2
 
+-- A non-owner must not be able to attach a compressed chunk
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    '"_timescaledb_internal"."_hyper_1_1_chunk"'::TEXT::REGCLASS,
+    '"_timescaledb_internal"."custom_compressed_chunk"'::TEXT::REGCLASS,
+    8192,
+    8192,
+    16384,
+    8192,
+    8192,
+    16384,
+    1,
+    1
+);
+ERROR:  must be owner of hypertable "metrics"
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -535,6 +535,15 @@ SELECT _timescaledb_functions.attach_osm_table_chunk('ht_try', 'child_fdw_table'
 CREATE TABLE non_ht (time bigint, temp float);
 SELECT _timescaledb_functions.attach_osm_table_chunk('non_ht', 'child_fdw_table');
 
+-- TEST error have to be hypertable owner to drop the OSM chunk
+SELECT _timescaledb_functions.drop_osm_chunk('ht_try');
+
+-- TEST error have to be hypertable owner to update the OSM chunk range
+SELECT _timescaledb_functions.hypertable_osm_range_update('ht_try', NULL::timestamptz, NULL::timestamptz);
+
+-- TEST error have to be hypertable owner to lock the OSM chunk dimension slice
+SELECT _timescaledb_functions.lock_osm_chunk_dimension_slice('ht_try');
+
 -- TEST drop OSM chunk
 \c :TEST_DBNAME :ROLE_4
 -- We need the OSM chunk for other tests so we run the test in a single
@@ -1037,3 +1046,17 @@ SELECT _timescaledb_functions.freeze_chunk(chunk) FROM show_chunks('metrics') ch
 SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
 ROLLBACK;
 \set ON_ERROR_STOP 1
+
+-- A non-owner must not be able to freeze or unfreeze a chunk
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE freeze_perm(time timestamptz NOT NULL);
+SELECT create_hypertable('freeze_perm', 'time');
+INSERT INTO freeze_perm VALUES ('2025-01-01');
+SELECT ch AS "FREEZECHUNK" FROM show_chunks('freeze_perm') ch \gset
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.freeze_chunk(:'FREEZECHUNK');
+SELECT _timescaledb_functions.unfreeze_chunk(:'FREEZECHUNK');
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP TABLE freeze_perm;

--- a/tsl/test/sql/compression_create_compressed_table.sql
+++ b/tsl/test/sql/compression_create_compressed_table.sql
@@ -51,3 +51,20 @@ SELECT _timescaledb_functions.create_compressed_chunk(
 -- select total rows in chunk (should be 2)
 SELECT count(*) FROM "_timescaledb_internal"."_hyper_1_1_chunk";
 
+-- A non-owner must not be able to attach a compressed chunk
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    '"_timescaledb_internal"."_hyper_1_1_chunk"'::TEXT::REGCLASS,
+    '"_timescaledb_internal"."custom_compressed_chunk"'::TEXT::REGCLASS,
+    8192,
+    8192,
+    16384,
+    8192,
+    8192,
+    16384,
+    1,
+    1
+);
+\set ON_ERROR_STOP 1
+


### PR DESCRIPTION
Several internal chunk functions were missing permission checks:
- drop_chunk
- drop_osm_chunk
- create_compressed_chunk
- freeze_chunk, unfreeze_chunk
- hypertable_osm_range_update
- lock_osm_chunk_dimension_slice
