### PR TITLE
Release 2.29.1

### DIFF
--- a/.unreleased/fix-chunk-permission-checks
+++ b/.unreleased/fix-chunk-permission-checks
@@ -1,1 +1,0 @@
-Fixes: #10386 Add missing permission checks to internal chunk functions

--- a/.unreleased/fix_add_dimension_null_hypertable
+++ b/.unreleased/fix_add_dimension_null_hypertable
@@ -1,2 +1,0 @@
-Fixes: #10327 Assertion failure in add_dimension when the hypertable argument is NULL
-Thanks: @JoongHyuk-Shin for reporting and fixing NULL handling in add_dimension

--- a/.unreleased/fix_attach_chunk_attislocal
+++ b/.unreleased/fix_attach_chunk_attislocal
@@ -1,1 +1,0 @@
-Fixes: #10352 Reset inherited column and constraint flags on chunks during attach_chunk

--- a/.unreleased/pr_10339
+++ b/.unreleased/pr_10339
@@ -1,1 +1,0 @@
-Fixes: #10339 Fix crash when deleting from compressed cagg source

--- a/.unreleased/pr_10340
+++ b/.unreleased/pr_10340
@@ -1,1 +1,0 @@
-Fixes: #10340 Validate max_batches in compact_chunk

--- a/.unreleased/pr_10360
+++ b/.unreleased/pr_10360
@@ -1,2 +1,0 @@
-Fixes: #10360 Decompressor crashes with malformed compressed data
-Thanks: @mdisec for reporting the issues with the validation of the compressed data during decompression

--- a/.unreleased/pr_10369
+++ b/.unreleased/pr_10369
@@ -1,2 +1,0 @@
-Fixes: #10369 Fix typo in error message about MERGE support on compressed hypertables
-Thanks: @igor2x for reporting a typo in a MERGE support error message

--- a/.unreleased/pr_10379
+++ b/.unreleased/pr_10379
@@ -1,1 +1,0 @@
-Fixes: #10379 Read hypertable max time value with an ordered scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.29.1 (2026-08-03)
+
+This release contains performance improvements and bug fixes since the 2.29.0 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.29.1**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* [#10327](https://github.com/timescale/timescaledb/pull/10327) Assertion failure in add_dimension when the hypertable argument is NULL
+* [#10339](https://github.com/timescale/timescaledb/pull/10339) Fix crash when deleting from compressed cagg source
+* [#10369](https://github.com/timescale/timescaledb/pull/10369) Fix typo in error message about MERGE support on compressed hypertables
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* @JoongHyuk-Shin for reporting and fixing NULL handling in add_dimension
+* @igor2x for reporting a typo in a MERGE support error message
+
 ## 2.29.0 (2026-07-28)
 
 This release contains performance improvements and bug fixes since the 2.28.3 release. We recommend that you upgrade at the next available opportunity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.29.1 (2026-08-03)
+## 2.29.1 (2026-08-04)
 
 This release contains performance improvements and bug fixes since the 2.29.0 release and fixes for security vulnerabilities (#10360, #10379, #10386). You can check the [security advisory](https://github.com/timescale/timescaledb/security/advisories/GHSA-hcfx-29v5-2rcw) for more information on the vulnerability and the platforms that are affected. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ This release contains performance improvements and bug fixes since the 2.29.0 re
 **Bugfixes**
 * [#10327](https://github.com/timescale/timescaledb/pull/10327) Assertion failure in `add_dimension()` when the hypertable argument is `NULL`
 * [#10339](https://github.com/timescale/timescaledb/pull/10339) Fix crash when deleting from a compressed continuous aggregate source
+* [#10340](https://github.com/timescale/timescaledb/pull/10340) Validate `max_batches` in `compact_chunk()`
+* [#10352](https://github.com/timescale/timescaledb/pull/10352) Reset inherited column and constraint flags on chunks during `attach_chunk()`
+* [#10360](https://github.com/timescale/timescaledb/pull/10360) Fix decompressor crashes with malformed compressed data
 * [#10369](https://github.com/timescale/timescaledb/pull/10369) Fix typo in error message about `MERGE` support on compressed hypertables
+* [#10379](https://github.com/timescale/timescaledb/pull/10379) Read hypertable max time value with an ordered scan
+* [#10386](https://github.com/timescale/timescaledb/pull/10386) Add missing permission checks to internal chunk functions
 
 **Thanks**
 * @JoongHyuk-Shin for reporting and fixing `NULL` handling in `add_dimension()`
 * @igor2x for reporting a typo in a `MERGE` support error message
+* @mdisec for reporting issues with compressed data validation during decompression
 
 ## 2.29.0 (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,14 @@
 
 This release contains performance improvements and bug fixes since the 2.29.0 release. We recommend that you upgrade at the next available opportunity.
 
-**Highlighted features in TimescaleDB v2.29.1**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
-
 **Bugfixes**
-* [#10327](https://github.com/timescale/timescaledb/pull/10327) Assertion failure in add_dimension when the hypertable argument is NULL
-* [#10339](https://github.com/timescale/timescaledb/pull/10339) Fix crash when deleting from compressed cagg source
-* [#10369](https://github.com/timescale/timescaledb/pull/10369) Fix typo in error message about MERGE support on compressed hypertables
-
-**New Settings**
-
-**GUCs**
+* [#10327](https://github.com/timescale/timescaledb/pull/10327) Assertion failure in `add_dimension()` when the hypertable argument is `NULL`
+* [#10339](https://github.com/timescale/timescaledb/pull/10339) Fix crash when deleting from a compressed continuous aggregate source
+* [#10369](https://github.com/timescale/timescaledb/pull/10369) Fix typo in error message about `MERGE` support on compressed hypertables
 
 **Thanks**
-* @JoongHyuk-Shin for reporting and fixing NULL handling in add_dimension
-* @igor2x for reporting a typo in a MERGE support error message
+* @JoongHyuk-Shin for reporting and fixing `NULL` handling in `add_dimension()`
+* @igor2x for reporting a typo in a `MERGE` support error message
 
 ## 2.29.0 (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.29.1 (2026-08-03)
 
-This release contains performance improvements and bug fixes since the 2.29.0 release. We recommend that you upgrade at the next available opportunity.
+This release contains performance improvements and bug fixes since the 2.29.0 release and fixes for security vulnerabilities (#10360, #10379, #10386). You can check the [security advisory](https://github.com/timescale/timescaledb/security/advisories/GHSA-hcfx-29v5-2rcw) for more information on the vulnerability and the platforms that are affected. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
 * [#10327](https://github.com/timescale/timescaledb/pull/10327) Assertion failure in `add_dimension()` when the hypertable argument is `NULL`


### PR DESCRIPTION
# TimescaleDB Changelog

**Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**

## 2.29.1 (2026-08-04)

This release contains performance improvements and bug fixes since the 2.29.0 release and fixes for security vulnerabilities (#10360, #10379, #10386). You can check the [security advisory](https://github.com/timescale/timescaledb/security/advisories/GHSA-hcfx-29v5-2rcw) for more information on the vulnerability and the platforms that are affected. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#10327](https://github.com/timescale/timescaledb/pull/10327) Assertion failure in `add_dimension()` when the hypertable argument is `NULL`
* [#10339](https://github.com/timescale/timescaledb/pull/10339) Fix crash when deleting from a compressed continuous aggregate source
* [#10340](https://github.com/timescale/timescaledb/pull/10340) Validate `max_batches` in `compact_chunk()`
* [#10352](https://github.com/timescale/timescaledb/pull/10352) Reset inherited column and constraint flags on chunks during `attach_chunk()`
* [#10360](https://github.com/timescale/timescaledb/pull/10360) Fix decompressor crashes with malformed compressed data
* [#10369](https://github.com/timescale/timescaledb/pull/10369) Fix typo in error message about `MERGE` support on compressed hypertables
* [#10379](https://github.com/timescale/timescaledb/pull/10379) Read hypertable max time value with an ordered scan
* [#10386](https://github.com/timescale/timescaledb/pull/10386) Add missing permission checks to internal chunk functions

**Thanks**
* @JoongHyuk-Shin for reporting and fixing `NULL` handling in `add_dimension()`
* @igor2x for reporting a typo in a `MERGE` support error message
* @mdisec for reporting issues with compressed data validation during decompression