### PR TITLE
Add custom toaster for compression

### DIFF
--- a/.unreleased/pr_10388
+++ b/.unreleased/pr_10388
@@ -1,0 +1,1 @@
+Implements: #10388 Add custom toaster for compression

--- a/src/guc.c
+++ b/src/guc.c
@@ -85,6 +85,7 @@ TSDLLEXPORT bool ts_guc_enable_direct_compress_auto_segmentby = true;
 int ts_guc_direct_compress_insert_tuple_sort_limit = 30000;
 TSDLLEXPORT int ts_guc_direct_compress_segmentby_min_rows = 5000;
 TSDLLEXPORT int ts_guc_direct_compress_segmentby_batch_size_limit = 500;
+TSDLLEXPORT bool ts_guc_use_custom_toaster = false;
 bool ts_guc_enable_deprecation_warnings = true;
 TSDLLEXPORT bool ts_guc_enable_optimizations = true;
 bool ts_guc_restoring = false;
@@ -628,6 +629,18 @@ _guc_init(void)
 							 "an optimal segmentby column if none is configured.",
 							 &ts_guc_enable_direct_compress_auto_segmentby,
 							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable(MAKE_EXTOPTION("use_custom_toaster"),
+							 "Use a custom TOAST writer for compressed row inserts",
+							 "This setting is only used for compression. It has no effect on "
+							 "PostgreSQL 19 and above.",
+							 &ts_guc_use_custom_toaster,
+							 false,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -54,6 +54,7 @@ extern TSDLLEXPORT bool ts_guc_enable_direct_compress_auto_segmentby;
 extern int ts_guc_direct_compress_insert_tuple_sort_limit;
 extern TSDLLEXPORT int ts_guc_direct_compress_segmentby_min_rows;
 extern TSDLLEXPORT int ts_guc_direct_compress_segmentby_batch_size_limit;
+extern TSDLLEXPORT bool ts_guc_use_custom_toaster;
 extern TSDLLEXPORT bool ts_guc_enable_compressed_direct_batch_delete;
 extern TSDLLEXPORT int ts_guc_max_tuples_decompressed_per_dml;
 extern TSDLLEXPORT bool ts_guc_enable_compression_wal_markers;

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -7,9 +7,11 @@
 #include <access/attmap.h>
 #include <access/attnum.h>
 #include <access/detoast.h>
+#include <access/heapam.h>
 #include <access/htup_details.h>
 #include <access/skey.h>
 #include <access/tupdesc.h>
+#include <access/xlog.h>
 #include <catalog/heap.h>
 #include <catalog/indexing.h>
 #include <catalog/pg_am.h>
@@ -48,6 +50,7 @@
 #include "debug_assert.h"
 #include "debug_point.h"
 #include "guc.h"
+#include "import/compression_toast.h"
 #include "nodes/modify_hypertable.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/catalog.h"
@@ -1802,11 +1805,18 @@ row_compressor_flush(RowCompressor *row_compressor, BulkWriter *writer, bool cha
 	}
 
 	Assert(writer->bistate != NULL);
-	heap_insert(writer->out_rel,
-				compressed_tuple,
-				writer->mycid,
-				writer->insert_options /*=options*/,
-				writer->bistate);
+	if (writer->use_custom_toaster)
+	{
+		compression_heap_insert(writer, compressed_tuple);
+	}
+	else
+	{
+		heap_insert(writer->out_rel,
+					compressed_tuple,
+					writer->mycid,
+					writer->insert_options,
+					writer->bistate);
+	}
 	if (writer->indexstate->ri_NumIndices > 0)
 	{
 		ts_catalog_index_insert(writer->indexstate, compressed_tuple);
@@ -2013,6 +2023,13 @@ bulk_writer_build(Relation out_rel, int insert_options)
 		.mycid = GetCurrentCommandId(true),
 		.estate = CreateExecutorState(),
 		.insert_options = insert_options,
+		/*
+		 * The forked toast writer only works on the versions listed for
+		 * COMPRESSION_TOASTER_SUPPORTED, and without logical replication,
+		 * due to compatibility issues.
+		 */
+		.use_custom_toaster =
+			COMPRESSION_TOASTER_SUPPORTED && ts_guc_use_custom_toaster && !XLogLogicalInfoActive(),
 	};
 
 	MemoryContext oldcxt = MemoryContextSwitchTo(writer.estate->es_query_cxt);
@@ -2039,6 +2056,7 @@ bulk_writer_close(BulkWriter *writer)
 	{
 		CatalogCloseIndexes(writer->indexstate);
 	}
+	compression_toast_writer_close(writer);
 	FreeExecutorState(writer->estate);
 }
 

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -155,6 +155,20 @@ typedef struct BulkWriter
 	CommandId mycid;
 	BulkInsertState bistate;
 	int insert_options; /* heap insert options */
+	/*
+	 * Use custom toaster which uses bulk inserts for toasting values.
+	 */
+	bool use_custom_toaster;
+	/*
+	 * Toast relation/indexes for compression_toast_save_datum_multi(),
+	 * opened lazily on first use and closed by
+	 * compression_toast_writer_close(). NULL/0 if never toasted.
+	 */
+	Relation toast_rel;
+	Relation *toast_indexes;
+	int num_toast_indexes;
+	int toast_valid_index;
+	BulkInsertState toast_bistate;
 } BulkWriter;
 
 typedef struct RowDecompressor

--- a/tsl/src/import/CMakeLists.txt
+++ b/tsl/src/import/CMakeLists.txt
@@ -1,4 +1,19 @@
-set(SOURCES)
+# The forked toast writer copies core functions as they stand in PG 17.11 and
+# 18.6 and is only built there, so the copies need no version branches of their
+# own. This has to agree with COMPRESSION_TOASTER_SUPPORTED in
+# compression_toast.h, which supplies stand-ins everywhere else.
+set(SOURCES "")
+
+if((PG_VERSION_MAJOR EQUAL 17 AND PG_VERSION_MINOR GREATER_EQUAL 11)
+   OR (PG_VERSION_MAJOR EQUAL 18 AND PG_VERSION_MINOR GREATER_EQUAL 6))
+  list(
+    APPEND
+    SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/access/common/toast_internals.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/access/heap/heapam.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/access/heap/heaptoast.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/access/table/toast_helper.c)
+endif()
 
 if(USE_UMASH)
   list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/umash.c)

--- a/tsl/src/import/access/common/toast_internals.c
+++ b/tsl/src/import/access/common/toast_internals.c
@@ -1,0 +1,308 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ *
+ * This mirrors backend/access/common/toast_internals.c; see
+ * import/compression_toast.h for what the fork as a whole is for, and the
+ * comment above each function for which core function it copies and what
+ * was changed.
+ */
+
+#include <postgres.h>
+
+#include <access/detoast.h>
+#include <access/genam.h>
+#include <access/heapam.h>
+#include <access/heaptoast.h>
+#include <access/htup_details.h>
+#include <access/table.h>
+#include <access/toast_internals.h>
+#include <catalog/catalog.h>
+#include <catalog/index.h>
+#include <executor/tuptable.h>
+#include <miscadmin.h>
+#include <utils/rel.h>
+#include <varatt.h>
+
+#include "debug_assert.h"
+#include "import/compression_toast.h"
+
+/*
+ * This is a copy of toast_save_datum() in backend/access/common/toast_internals.c
+ * from PG 18.6, git commit sha 724edf9bde9d356724ad384a2e196edc3c9f80f7. It
+ * has three modifications:
+ *
+ * 1. The per-chunk "heap_form_tuple + heap_insert + index_insert" loop is
+ *    replaced by: form every chunk tuple up front, hand them all to a single
+ *    heap_multi_insert() call, then index each chunk using the tid it was
+ *    assigned.
+ * 2. The toast relation and its indexes are opened once per BulkWriter
+ *    (lazily, on first use here) and closed by compression_toast_writer_close(),
+ *    instead of being opened and closed on every call -- row_compressor_flush()
+ *    calls this once per toasted compresseddata column per batch, so a
+ *    compressed chunk with several batches and/or several toasted columns
+ *    would otherwise repeat that open/close needlessly.
+ * 3. The rewrite-preservation branch (reusing oldexternal's value id via
+ *    toastid_valueid_exists()) is replaced with an Ensure(): the
+ *    compressed-row insert path never runs under a toast-table-preserving
+ *    rewrite (CLUSTER/VACUUM FULL-style), so that branch is never reachable
+ *    here.
+ */
+Datum
+compression_toast_save_datum_multi(BulkWriter *writer, Datum value, struct varlena *oldexternal)
+{
+	Relation rel = writer->out_rel;
+	int options = writer->insert_options;
+	TupleDesc	toasttupDesc;
+	Datum		t_values[3];
+	bool		t_isnull[3];
+	CommandId	mycid = GetCurrentCommandId(true);
+	struct varlena *result;
+	struct varatt_external toast_pointer;
+	union
+	{
+		struct varlena hdr;
+		/* this is to make the union big enough for a chunk: */
+		char		data[TOAST_MAX_CHUNK_SIZE + VARHDRSZ];
+		/* ensure union is aligned well enough: */
+		int32		align_it;
+	}			chunk_data = {0};	/* silence compiler warning */
+	int32		chunk_size;
+	char	   *data_p;
+	int32		data_todo;
+	Pointer		dval = DatumGetPointer(value);
+	int nchunks;
+	int32 *chunk_seqs;
+	HeapTuple *toasttups;
+	TupleTableSlot **slots;
+	int i;
+
+	Assert(!VARATT_IS_EXTERNAL(dval));
+
+	if (writer->toast_rel == NULL)
+	{
+		/*
+		 * Allocated in the writer's query context, not the caller's current
+		 * context: row_compressor_flush() runs in row_compressor->per_row_ctx,
+		 * which is reset after every batch (row_compressor_clear_batch()), but
+		 * this handle must survive for the writer's whole lifetime.
+		 */
+		MemoryContext old_cxt = MemoryContextSwitchTo(writer->estate->es_query_cxt);
+
+		writer->toast_rel = table_open(rel->rd_rel->reltoastrelid, RowExclusiveLock);
+		writer->toast_valid_index = toast_open_indexes(writer->toast_rel,
+													   RowExclusiveLock,
+													   &writer->toast_indexes,
+													   &writer->num_toast_indexes);
+		writer->toast_bistate = GetBulkInsertState();
+
+		MemoryContextSwitchTo(old_cxt);
+	}
+	toasttupDesc = writer->toast_rel->rd_att;
+
+	/*
+	 * Get the data pointer and length, and compute va_rawsize and va_extinfo.
+	 *
+	 * va_rawsize is the size of the equivalent fully uncompressed datum, so
+	 * we have to adjust for short headers.
+	 *
+	 * va_extinfo stored the actual size of the data payload in the toast
+	 * records and the compression method in first 2 bits if data is
+	 * compressed.
+	 */
+	if (VARATT_IS_SHORT(dval))
+	{
+		data_p = VARDATA_SHORT(dval);
+		data_todo = VARSIZE_SHORT(dval) - VARHDRSZ_SHORT;
+		toast_pointer.va_rawsize = data_todo + VARHDRSZ;	/* as if not short */
+		toast_pointer.va_extinfo = data_todo;
+	}
+	else if (VARATT_IS_COMPRESSED(dval))
+	{
+		data_p = VARDATA(dval);
+		data_todo = VARSIZE(dval) - VARHDRSZ;
+		/* rawsize in a compressed datum is just the size of the payload */
+		toast_pointer.va_rawsize = VARDATA_COMPRESSED_GET_EXTSIZE(dval) + VARHDRSZ;
+
+		/* set external size and compression method */
+		VARATT_EXTERNAL_SET_SIZE_AND_COMPRESS_METHOD(toast_pointer, data_todo,
+													 VARDATA_COMPRESSED_GET_COMPRESS_METHOD(dval));
+		/*
+		 * VARATT_EXTERNAL_IS_COMPRESSED() compares va_extinfo (uint32)
+		 * against va_rawsize (int32), same as core's toast_save_datum() does
+		 * at this exact spot -- silence the sign-compare warning rather than
+		 * touch the core macro.
+		 */
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+		Assert(VARATT_EXTERNAL_IS_COMPRESSED(toast_pointer));
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+	}
+	else
+	{
+		data_p = VARDATA(dval);
+		data_todo = VARSIZE(dval) - VARHDRSZ;
+		toast_pointer.va_rawsize = VARSIZE(dval);
+		toast_pointer.va_extinfo = data_todo;
+	}
+
+	/*
+	 * Insert the correct table OID into the result TOAST pointer.
+	 *
+	 * Normally this is the actual OID of the target toast table, but during
+	 * table-rewriting operations such as CLUSTER, we have to insert the OID
+	 * of the table's real permanent toast table instead.  rd_toastoid is set
+	 * if we have to substitute such an OID.
+	 */
+	if (OidIsValid(rel->rd_toastoid))
+		toast_pointer.va_toastrelid = rel->rd_toastoid;
+	else
+		toast_pointer.va_toastrelid = RelationGetRelid(writer->toast_rel);
+
+	/*
+	 * The compressed-row insert path never runs under a toast-table-preserving
+	 * rewrite (CLUSTER/VACUUM FULL-style), so rd_toastoid should never be set
+	 * here. Core's rewrite-preservation branch (reusing oldexternal's value id
+	 * via toastid_valueid_exists()) isn't reachable and isn't replicated;
+	 * fail loudly rather than silently skip it if that assumption ever
+	 * changes.
+	 */
+	Ensure(!OidIsValid(rel->rd_toastoid), "unexpected toast relation missing during compression");
+	toast_pointer.va_valueid =
+		GetNewOidWithIndex(writer->toast_rel,
+						   RelationGetRelid(writer->toast_indexes[writer->toast_valid_index]),
+						   (AttrNumber) 1);
+	/*
+	 * Initialize constant parts of the tuple data
+	 */
+	t_values[0] = ObjectIdGetDatum(toast_pointer.va_valueid);
+	t_isnull[0] = false;
+	t_isnull[1] = false;
+	t_isnull[2] = false;
+
+	nchunks = data_todo > 0 ? (data_todo + TOAST_MAX_CHUNK_SIZE - 1) / TOAST_MAX_CHUNK_SIZE : 0;
+
+	toasttups = nchunks > 0 ? palloc(nchunks * sizeof(HeapTuple)) : NULL;
+	slots = nchunks > 0 ? palloc(nchunks * sizeof(TupleTableSlot *)) : NULL;
+	chunk_seqs = nchunks > 0 ? palloc(nchunks * sizeof(int32)) : NULL;
+
+	for (i = 0; data_todo > 0; i++)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * TOAST_MAX_CHUNK_SIZE is derived from several sizeof()s and so is
+		 * unsigned, compared here against int32 data_todo -- same
+		 * sign-compare core's toast_save_datum() has at this exact line.
+		 */
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+		chunk_size = Min(TOAST_MAX_CHUNK_SIZE, data_todo);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+		chunk_seqs[i] = i;
+
+		t_values[1] = Int32GetDatum(i);
+		SET_VARSIZE(&chunk_data, chunk_size + VARHDRSZ);
+		memcpy(VARDATA(&chunk_data), data_p, chunk_size);
+		t_values[2] = PointerGetDatum(&chunk_data);
+
+		toasttups[i] = heap_form_tuple(toasttupDesc, t_values, t_isnull);
+		slots[i] = MakeSingleTupleTableSlot(toasttupDesc, &TTSOpsHeapTuple);
+		/*
+		 * shouldFree = true: heap_multi_insert() fetches each slot's tuple
+		 * with materialize = true, and tts_heap_materialize() only skips its
+		 * copy when the slot already owns the tuple (TTS_SHOULDFREE). With
+		 * shouldFree = false here, it would silently substitute a copy, and
+		 * RelationPutHeapTuple()'s t_self update would land on that copy
+		 * instead of toasttups[i] -- leaving toasttups[i]->t_self invalid and
+		 * corrupting the index entries built from it below.
+		 */
+		ExecStoreHeapTuple(toasttups[i], slots[i], true);
+
+		data_todo -= chunk_size;
+		data_p += chunk_size;
+	}
+	Assert(i == nchunks);
+
+	if (nchunks > 0)
+	{
+		heap_multi_insert(writer->toast_rel, slots, nchunks, mycid, options, writer->toast_bistate);
+	}
+
+	/*
+	 * Insert all the chunks into the indexes.
+	 */
+	for (i = 0; i < nchunks; i++)
+	{
+		int j;
+
+		t_values[1] = Int32GetDatum(chunk_seqs[i]);
+		for (j = 0; j < writer->num_toast_indexes; j++)
+		{
+			Relation toastidx = writer->toast_indexes[j];
+
+			if (toastidx->rd_index->indisready)
+			{
+				index_insert(toastidx,
+							 t_values,
+							 t_isnull,
+							 &(toasttups[i]->t_self),
+							 writer->toast_rel,
+							 toastidx->rd_index->indisunique ? UNIQUE_CHECK_YES : UNIQUE_CHECK_NO,
+							 false,
+							 NULL);
+			}
+		}
+		/* Slot owns toasttups[i] (shouldFree = true above); dropping it frees
+		 * the tuple along with the slot. */
+		ExecDropSingleTupleTableSlot(slots[i]);
+	}
+
+	/*
+	 * Create the TOAST pointer value that we'll return
+	 */
+	result = (struct varlena *) palloc(TOAST_POINTER_SIZE);
+	SET_VARTAG_EXTERNAL(result, VARTAG_ONDISK);
+	memcpy(VARDATA_EXTERNAL(result), &toast_pointer, sizeof(toast_pointer));
+
+	return PointerGetDatum(result);
+}
+
+/*
+ * Close the toast relation/indexes lazily opened by
+ * compression_toast_save_datum_multi(), if any were. Mirrors core's own
+ * toast_save_datum() in keeping the lock until commit (NoLock here), so a
+ * concurrent reindex on the toast relation waits for this transaction rather
+ * than racing it.
+ *
+ * This is not a forked/mirrored function.
+ */
+void
+compression_toast_writer_close(BulkWriter *writer)
+{
+	if (writer->toast_rel == NULL)
+	{
+		return;
+	}
+
+	FreeBulkInsertState(writer->toast_bistate);
+	toast_close_indexes(writer->toast_indexes, writer->num_toast_indexes, NoLock);
+	table_close(writer->toast_rel, NoLock);
+	writer->toast_rel = NULL;
+}

--- a/tsl/src/import/access/heap/heapam.c
+++ b/tsl/src/import/access/heap/heapam.c
@@ -1,0 +1,339 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ *
+ * This mirrors backend/access/heap/heapam.c; see
+ * import/compression_toast.h for what the fork as a whole is for, and the
+ * comment above each function for which core function it copies and what
+ * was changed.
+ */
+
+#include <postgres.h>
+
+#include <access/heapam.h>
+#include <access/heapam_xlog.h>
+#include <access/heaptoast.h>
+#include <access/hio.h>
+#include <access/htup_details.h>
+#include <access/visibilitymap.h>
+#include <access/xact.h>
+#include <access/xloginsert.h>
+#include <catalog/catalog.h>
+#include <miscadmin.h>
+#include <pgstat.h>
+#include <storage/bufmgr.h>
+#include <storage/predicate.h>
+#include <utils/inval.h>
+#include <utils/rel.h>
+#include <utils/snapmgr.h>
+
+#include "debug_assert.h"
+#include "import/compression_toast.h"
+
+static HeapTuple
+compression_heap_prepare_insert(BulkWriter *writer, HeapTuple tup, TransactionId xid);
+
+/*
+ * This is a copy of the static inline AssertHasSnapshotForToast() in
+ * backend/access/heap/heapam.c from PG 18.6, git commit sha
+ * 724edf9bde9d356724ad384a2e196edc3c9f80f7. It has one modification: it is
+ * renamed, since the original is static and can't be called from this file.
+ */
+static inline void
+compression_assert_has_snapshot_for_toast(Relation rel)
+{
+#ifdef USE_ASSERT_CHECKING
+
+	/* bootstrap mode in particular breaks this rule */
+	if (!IsNormalProcessingMode())
+		return;
+
+	/* if the relation doesn't have a TOAST table, we are good */
+	if (!OidIsValid(rel->rd_rel->reltoastrelid))
+		return;
+
+	Assert(HaveRegisteredOrActiveSnapshot());
+
+#endif							/* USE_ASSERT_CHECKING */
+}
+
+/*
+ * This is a copy of heap_insert() in backend/access/heap/heapam.c from PG
+ * 18.6, git commit sha 724edf9bde9d356724ad384a2e196edc3c9f80f7. It has a few
+ * modifications: it calls compression_heap_prepare_insert() instead of
+ * heap_prepare_insert(), so a compressed row whose compresseddata
+ * attribute(s) need toasting goes through the heap_multi_insert()-based
+ * toast writer instead of core's one-chunk-at-a-time path, change to the
+ * function signature to accommodate for the said writer and a change for
+ * dealing with catalog tables and logical decoding which is not applicable
+ * here. It also opens with an Ensure() that this path is supported on the
+ * running version, since callers are expected to keep it off where it is not.
+ */
+void
+compression_heap_insert(BulkWriter *writer, HeapTuple tup)
+{
+	Relation relation = writer->out_rel;
+	int options = writer->insert_options;
+	BulkInsertState bistate = writer->bistate;
+	TransactionId xid = GetCurrentTransactionId();
+	HeapTuple	heaptup;
+	Buffer		buffer;
+	Page		page;
+	Buffer		vmbuffer = InvalidBuffer;
+	bool		clear_all_visible = false;
+	bool		vmbuffer_modified = false;
+
+	/*
+	 * Callers are expected to keep this path off where it is not supported;
+	 * see COMPRESSION_TOASTER_SUPPORTED in the header for which versions
+	 * qualify and why.
+	 */
+	Ensure(COMPRESSION_TOASTER_SUPPORTED,
+		   "custom compression toaster is not supported on this PostgreSQL version");
+
+	/* Cheap, simplistic check that the tuple matches the rel's rowtype. */
+	Assert(HeapTupleHeaderGetNatts(tup->t_data) <=
+		   RelationGetNumberOfAttributes(relation));
+
+	compression_assert_has_snapshot_for_toast(relation);
+
+	/*
+	 * Fill in tuple header fields and toast the tuple if necessary.
+	 *
+	 * Note: below this point, heaptup is the data we actually intend to store
+	 * into the relation; tup is the caller's original untoasted data.
+	 */
+	heaptup = compression_heap_prepare_insert(writer, tup, xid);
+
+	/*
+	 * Find buffer to insert this tuple into.  If the page is all visible,
+	 * this will also pin the requisite visibility map page.
+	 */
+	buffer = RelationGetBufferForTuple(relation, heaptup->t_len,
+									   InvalidBuffer, options, bistate,
+									   &vmbuffer, NULL,
+									   0);
+	page = BufferGetPage(buffer);
+
+	/*
+	 * We're about to do the actual insert -- but check for conflict first, to
+	 * avoid possibly having to roll back work we've just done.
+	 *
+	 * This is safe without a recheck as long as there is no possibility of
+	 * another process scanning the page between this check and the insert
+	 * being visible to the scan (i.e., an exclusive buffer content lock is
+	 * continuously held from this point until the tuple insert is visible).
+	 *
+	 * For a heap insert, we only need to check for table-level SSI locks. Our
+	 * new tuple can't possibly conflict with existing tuple locks, and heap
+	 * page locks are only consolidated versions of tuple locks; they do not
+	 * lock "gaps" as index page locks do.  So we don't need to specify a
+	 * buffer when making the call, which makes for a faster check.
+	 */
+	CheckForSerializableConflictIn(relation, NULL, InvalidBlockNumber);
+
+	/* Lock the vmbuffer before the critical section */
+	if (PageIsAllVisible(page))
+	{
+		LockBuffer(vmbuffer, BUFFER_LOCK_EXCLUSIVE);
+		clear_all_visible = true;
+	}
+
+	/* NO EREPORT(ERROR) from here till changes are logged */
+	START_CRIT_SECTION();
+
+	RelationPutHeapTuple(relation, buffer, heaptup,
+						 (options & HEAP_INSERT_SPECULATIVE) != 0);
+
+	if (clear_all_visible)
+	{
+		/* It's possible the VM bits were already clear */
+		if (visibilitymap_clear_locked(relation,
+									   ItemPointerGetBlockNumber(&(heaptup->t_self)),
+									   vmbuffer, VISIBILITYMAP_VALID_BITS))
+			vmbuffer_modified = true;
+
+		PageClearAllVisible(page);
+	}
+
+	/*
+	 * XXX Should we set PageSetPrunable on this page ?
+	 *
+	 * The inserting transaction may eventually abort thus making this tuple
+	 * DEAD and hence available for pruning. Though we don't want to optimize
+	 * for aborts, if no other tuple in this page is UPDATEd/DELETEd, the
+	 * aborted tuple will never be pruned until next vacuum is triggered.
+	 *
+	 * If you do add PageSetPrunable here, add it in heap_xlog_insert too.
+	 */
+
+	MarkBufferDirty(buffer);
+
+	/* XLOG stuff */
+	if (RelationNeedsWAL(relation))
+	{
+		xl_heap_insert xlrec;
+		xl_heap_header xlhdr;
+		XLogRecPtr	recptr;
+		uint8		info = XLOG_HEAP_INSERT;
+		int			bufflags = 0;
+
+		/*
+		 * Core calls log_heap_new_cid() here, but it's static and can't be
+		 * called from this file. That's fine: it's only needed for catalog
+		 * tables, and this code never runs on a catalog table.
+		 */
+		Assert(!RelationIsAccessibleInLogicalDecoding(relation));
+
+		/*
+		 * If this is the single and first tuple on page, we can reinit the
+		 * page instead of restoring the whole thing.  Set flag, and hide
+		 * buffer references from XLogInsert.
+		 */
+		if (ItemPointerGetOffsetNumber(&(heaptup->t_self)) == FirstOffsetNumber &&
+			PageGetMaxOffsetNumber(page) == FirstOffsetNumber)
+		{
+			info |= XLOG_HEAP_INIT_PAGE;
+			bufflags |= REGBUF_WILL_INIT;
+		}
+
+		xlrec.offnum = ItemPointerGetOffsetNumber(&heaptup->t_self);
+		xlrec.flags = 0;
+		if (clear_all_visible)
+			xlrec.flags |= XLH_INSERT_ALL_VISIBLE_CLEARED;
+		if (options & HEAP_INSERT_SPECULATIVE)
+			xlrec.flags |= XLH_INSERT_IS_SPECULATIVE;
+		Assert(ItemPointerGetBlockNumber(&heaptup->t_self) == BufferGetBlockNumber(buffer));
+
+		/*
+		 * For logical decoding, we need the tuple even if we're doing a full
+		 * page write, so make sure it's included even if we take a full-page
+		 * image. (XXX We could alternatively store a pointer into the FPW).
+		 */
+		if (RelationIsLogicallyLogged(relation) &&
+			!(options & HEAP_INSERT_NO_LOGICAL))
+		{
+			xlrec.flags |= XLH_INSERT_CONTAINS_NEW_TUPLE;
+			bufflags |= REGBUF_KEEP_DATA;
+
+			if (IsToastRelation(relation))
+				xlrec.flags |= XLH_INSERT_ON_TOAST_RELATION;
+		}
+
+		XLogBeginInsert();
+		XLogRegisterData((char *)&xlrec, SizeOfHeapInsert);
+
+		xlhdr.t_infomask2 = heaptup->t_data->t_infomask2;
+		xlhdr.t_infomask = heaptup->t_data->t_infomask;
+		xlhdr.t_hoff = heaptup->t_data->t_hoff;
+
+		/*
+		 * note we mark xlhdr as belonging to buffer; if XLogInsert decides to
+		 * write the whole page to the xlog, we don't need to store
+		 * xl_heap_header in the xlog.
+		 */
+		XLogRegisterBuffer(HEAP_INSERT_BLKREF_HEAP, buffer,
+						   REGBUF_STANDARD | bufflags);
+		XLogRegisterBufData(HEAP_INSERT_BLKREF_HEAP, (char *) &xlhdr,
+							SizeOfHeapHeader);
+		/* PG73FORMAT: write bitmap [+ padding] [+ oid] + data */
+		XLogRegisterBufData(HEAP_INSERT_BLKREF_HEAP,
+							(char *) heaptup->t_data + SizeofHeapTupleHeader,
+							heaptup->t_len - SizeofHeapTupleHeader);
+
+		/* filtering by origin on a row level is much more efficient */
+		XLogSetRecordFlags(XLOG_INCLUDE_ORIGIN);
+
+		if (vmbuffer_modified)
+			XLogRegisterBuffer(HEAP_INSERT_BLKREF_VM, vmbuffer, 0);
+
+		recptr = XLogInsert(RM_HEAP_ID, info);
+
+		PageSetLSN(page, recptr);
+
+		if (vmbuffer_modified)
+			PageSetLSN(BufferGetPage(vmbuffer), recptr);
+	}
+
+	END_CRIT_SECTION();
+
+	UnlockReleaseBuffer(buffer);
+
+	/*
+	 * We locked vmbuffer if clear_all_visible was true regardless of whether
+	 * or not we ended up modifying the vmbuffer.
+	 */
+	if (clear_all_visible)
+		LockBuffer(vmbuffer, BUFFER_LOCK_UNLOCK);
+	if (BufferIsValid(vmbuffer))
+		ReleaseBuffer(vmbuffer);
+
+	/*
+	 * If tuple is cacheable, mark it for invalidation from the caches in case
+	 * we abort.  Note it is OK to do this after releasing the buffer, because
+	 * the heaptup data structure is all in local memory, not in the shared
+	 * buffer.
+	 */
+	CacheInvalidateHeapTuple(relation, heaptup, NULL);
+
+	/* Note: speculative insertions are counted too, even if aborted later */
+	pgstat_count_heap_insert(relation, 1);
+
+	/*
+	 * If heaptup is a private copy, release it.  Don't forget to copy t_self
+	 * back to the caller's image, too.
+	 */
+	if (heaptup != tup)
+	{
+		tup->t_self = heaptup->t_self;
+		heap_freetuple(heaptup);
+	}
+}
+
+/*
+ * This is a copy of the static heap_prepare_insert() in
+ * backend/access/heap/heapam.c from PG 18.6, git commit sha
+ * 724edf9bde9d356724ad384a2e196edc3c9f80f7. It has a few modifications:
+ *
+ * 1. It calls compression_toast_insert_or_update() instead of
+ *    heap_toast_insert_or_update() whenever toasting is needed.
+ * 2. Core's IsParallelWorker() error and its branch for relations that
+ *    aren't RELKIND_RELATION/RELKIND_MATVIEW (a table's own toast rel
+ *    recursing into itself) are replaced with Asserts, since neither can
+ *    happen for a compressed chunk table.
+ * 3. Change to function signature to accommodate for the writer.
+ */
+static HeapTuple
+compression_heap_prepare_insert(BulkWriter *writer, HeapTuple tup, TransactionId xid)
+{
+	CommandId cid = writer->mycid;
+	int options = writer->insert_options;
+
+	Assert(!IsParallelWorker());
+
+	tup->t_data->t_infomask &= ~(HEAP_XACT_MASK);
+	tup->t_data->t_infomask2 &= ~(HEAP2_XACT_MASK);
+	tup->t_data->t_infomask |= HEAP_XMAX_INVALID;
+	HeapTupleHeaderSetXmin(tup->t_data, xid);
+	if (options & HEAP_INSERT_FROZEN)
+		HeapTupleHeaderSetXminFrozen(tup->t_data);
+
+	HeapTupleHeaderSetCmin(tup->t_data, cid);
+	HeapTupleHeaderSetXmax(tup->t_data, 0); /* for cleanliness */
+	tup->t_tableOid = RelationGetRelid(writer->out_rel);
+
+	Assert(writer->out_rel->rd_rel->relkind == RELKIND_RELATION);
+
+	if (HeapTupleHasExternal(tup) || tup->t_len > TOAST_TUPLE_THRESHOLD)
+		return compression_toast_insert_or_update(writer, tup);
+	else
+		return tup;
+}

--- a/tsl/src/import/access/heap/heaptoast.c
+++ b/tsl/src/import/access/heap/heaptoast.c
@@ -1,0 +1,261 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ *
+ * This mirrors backend/access/heap/heaptoast.c; see
+ * import/compression_toast.h for what the fork as a whole is for, and the
+ * comment above each function for which core function it copies and what
+ * was changed.
+ */
+
+#include <postgres.h>
+
+#include <access/heaptoast.h>
+#include <access/htup_details.h>
+#include <access/toast_helper.h>
+#include <utils/rel.h>
+
+#include "import/compression_toast.h"
+
+/*
+ * This is a copy of heap_toast_insert_or_update() in backend/access/heap/heaptoast.c
+ * from PG 18.6, git commit sha 724edf9bde9d356724ad384a2e196edc3c9f80f7. It
+ * has a few modifications:
+ * 1. It calls compression_toast_tuple_externalize()
+ * instead of toast_tuple_externalize(), so externalized values go through
+ * the heap_multi_insert()-based writer.
+ * 2. Change to the function signature to accommodate for writer.
+ * 3. Remove ignoring speculative insertion since it doesn't apply to us.
+ * 4. Ignore toast value updates, does not apply.
+ * 5. Couple of OidIsValid uses to please Coccinelle and a Size cast.
+ */
+HeapTuple
+compression_toast_insert_or_update(BulkWriter *writer, HeapTuple newtup)
+{
+	Relation rel = writer->out_rel;
+	HeapTuple	result_tuple;
+	TupleDesc	tupleDesc;
+	int			numAttrs;
+
+	Size		maxDataLen;
+	Size		hoff;
+
+	bool		toast_isnull[MaxHeapAttributeNumber];
+	Datum		toast_values[MaxHeapAttributeNumber];
+	ToastAttrInfo toast_attr[MaxHeapAttributeNumber];
+	ToastTupleContext ttc;
+
+	/*
+	 * We should only ever be called for tuples of plain relations or
+	 * materialized views --- recursing on a toast rel is bad news.
+	 */
+	Assert(rel->rd_rel->relkind == RELKIND_RELATION ||
+		   rel->rd_rel->relkind == RELKIND_MATVIEW);
+
+	/*
+	 * Get the tuple descriptor and break down the tuple(s) into fields.
+	 */
+	tupleDesc = rel->rd_att;
+	numAttrs = tupleDesc->natts;
+
+	Assert(numAttrs <= MaxHeapAttributeNumber);
+	heap_deform_tuple(newtup, tupleDesc, toast_values, toast_isnull);
+
+	/* ----------
+	 * Prepare for toasting
+	 * ----------
+	 */
+	ttc.ttc_rel = rel;
+	ttc.ttc_values = toast_values;
+	ttc.ttc_isnull = toast_isnull;
+	ttc.ttc_oldvalues = NULL;
+	ttc.ttc_oldisnull = NULL;
+	ttc.ttc_attr = toast_attr;
+	toast_tuple_init(&ttc);
+
+	/* ----------
+	 * Compress and/or save external until data fits into target length
+	 *
+	 *	1: Inline compress attributes with attstorage EXTENDED, and store very
+	 *	   large attributes with attstorage EXTENDED or EXTERNAL external
+	 *	   immediately
+	 *	2: Store attributes with attstorage EXTENDED or EXTERNAL external
+	 *	3: Inline compress attributes with attstorage MAIN
+	 *	4: Store attributes with attstorage MAIN external
+	 * ----------
+	 */
+
+	/* compute header overhead --- this should match heap_form_tuple() */
+	hoff = SizeofHeapTupleHeader;
+	if ((ttc.ttc_flags & TOAST_HAS_NULLS) != 0)
+		hoff += BITMAPLEN(numAttrs);
+	hoff = MAXALIGN(hoff);
+	/* now convert to a limit on the tuple data size */
+	maxDataLen = RelationGetToastTupleTarget(rel, TOAST_TUPLE_TARGET) - hoff;
+
+	/*
+	 * Look for attributes with attstorage EXTENDED to compress.  Also find
+	 * large attributes with attstorage EXTENDED or EXTERNAL, and store them
+	 * external.
+	 */
+	while (heap_compute_data_size(tupleDesc,
+								  toast_values, toast_isnull) > maxDataLen)
+	{
+		int			biggest_attno;
+
+		biggest_attno = toast_tuple_find_biggest_attribute(&ttc, true, false);
+		if (biggest_attno < 0)
+			break;
+
+		/*
+		 * Attempt to compress it inline, if it has attstorage EXTENDED
+		 */
+		if (TupleDescAttr(tupleDesc, biggest_attno)->attstorage == TYPSTORAGE_EXTENDED)
+			toast_tuple_try_compression(&ttc, biggest_attno);
+		else
+		{
+			/*
+			 * has attstorage EXTERNAL, ignore on subsequent compression
+			 * passes
+			 */
+			toast_attr[biggest_attno].tai_colflags |= TOASTCOL_INCOMPRESSIBLE;
+		}
+
+		/*
+		 * If this value is by itself more than maxDataLen (after compression
+		 * if any), push it out to the toast table immediately, if possible.
+		 * This avoids uselessly compressing other fields in the common case
+		 * where we have one long field and several short ones.
+		 *
+		 * XXX maybe the threshold should be less than maxDataLen?
+		 */
+		if ((Size) toast_attr[biggest_attno].tai_size > maxDataLen &&
+			OidIsValid(rel->rd_rel->reltoastrelid))
+			compression_toast_tuple_externalize(writer, &ttc, biggest_attno);
+	}
+
+	/*
+	 * Second we look for attributes of attstorage EXTENDED or EXTERNAL that
+	 * are still inline, and make them external.  But skip this if there's no
+	 * toast table to push them to.
+	 */
+	while (heap_compute_data_size(tupleDesc,
+								  toast_values, toast_isnull) > maxDataLen &&
+		   OidIsValid(rel->rd_rel->reltoastrelid))
+	{
+		int			biggest_attno;
+
+		biggest_attno = toast_tuple_find_biggest_attribute(&ttc, false, false);
+		if (biggest_attno < 0)
+			break;
+		compression_toast_tuple_externalize(writer, &ttc, biggest_attno);
+	}
+
+	/*
+	 * Round 3 - this time we take attributes with storage MAIN into
+	 * compression
+	 */
+	while (heap_compute_data_size(tupleDesc,
+								  toast_values, toast_isnull) > maxDataLen)
+	{
+		int			biggest_attno;
+
+		biggest_attno = toast_tuple_find_biggest_attribute(&ttc, true, true);
+		if (biggest_attno < 0)
+			break;
+
+		toast_tuple_try_compression(&ttc, biggest_attno);
+	}
+
+	/*
+	 * Finally we store attributes of type MAIN externally.  At this point we
+	 * increase the target tuple size, so that MAIN attributes aren't stored
+	 * externally unless really necessary.
+	 */
+	maxDataLen = TOAST_TUPLE_TARGET_MAIN - hoff;
+
+	while (heap_compute_data_size(tupleDesc,
+								  toast_values, toast_isnull) > maxDataLen &&
+		   OidIsValid(rel->rd_rel->reltoastrelid))
+	{
+		int			biggest_attno;
+
+		biggest_attno = toast_tuple_find_biggest_attribute(&ttc, false, true);
+		if (biggest_attno < 0)
+			break;
+
+		compression_toast_tuple_externalize(writer, &ttc, biggest_attno);
+	}
+
+	/*
+	 * In the case we toasted any values, we need to build a new heap tuple
+	 * with the changed values.
+	 */
+	if ((ttc.ttc_flags & TOAST_NEEDS_CHANGE) != 0)
+	{
+		HeapTupleHeader olddata = newtup->t_data;
+		HeapTupleHeader new_data;
+		int32		new_header_len;
+		int32		new_data_len;
+		int32		new_tuple_len;
+
+		/*
+		 * Calculate the new size of the tuple.
+		 *
+		 * Note: we used to assume here that the old tuple's t_hoff must equal
+		 * the new_header_len value, but that was incorrect.  The old tuple
+		 * might have a smaller-than-current natts, if there's been an ALTER
+		 * TABLE ADD COLUMN since it was stored; and that would lead to a
+		 * different conclusion about the size of the null bitmap, or even
+		 * whether there needs to be one at all.
+		 */
+		new_header_len = SizeofHeapTupleHeader;
+		if ((ttc.ttc_flags & TOAST_HAS_NULLS) != 0)
+			new_header_len += BITMAPLEN(numAttrs);
+		new_header_len = MAXALIGN(new_header_len);
+		new_data_len = heap_compute_data_size(tupleDesc,
+											  toast_values, toast_isnull);
+		new_tuple_len = new_header_len + new_data_len;
+
+		/*
+		 * Allocate and zero the space needed, and fill HeapTupleData fields.
+		 */
+		result_tuple = (HeapTuple) palloc0(HEAPTUPLESIZE + new_tuple_len);
+		result_tuple->t_len = new_tuple_len;
+		result_tuple->t_self = newtup->t_self;
+		result_tuple->t_tableOid = newtup->t_tableOid;
+		new_data = (HeapTupleHeader) ((char *) result_tuple + HEAPTUPLESIZE);
+		result_tuple->t_data = new_data;
+
+		/*
+		 * Copy the existing tuple header, but adjust natts and t_hoff.
+		 */
+		memcpy(new_data, olddata, SizeofHeapTupleHeader);
+		HeapTupleHeaderSetNatts(new_data, numAttrs);
+		new_data->t_hoff = new_header_len;
+
+		/* Copy over the data, and fill the null bitmap if needed */
+		heap_fill_tuple(tupleDesc,
+						toast_values,
+						toast_isnull,
+						(char *) new_data + new_header_len,
+						new_data_len,
+						&(new_data->t_infomask),
+						((ttc.ttc_flags & TOAST_HAS_NULLS) != 0) ?
+						new_data->t_bits : NULL);
+	}
+	else
+		result_tuple = newtup;
+
+	toast_tuple_cleanup(&ttc);
+
+	return result_tuple;
+}

--- a/tsl/src/import/access/table/toast_helper.c
+++ b/tsl/src/import/access/table/toast_helper.c
@@ -1,0 +1,44 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ *
+ * This mirrors backend/access/table/toast_helper.c; see
+ * import/compression_toast.h for what the fork as a whole is for, and the
+ * comment above each function for which core function it copies and what
+ * was changed.
+ */
+
+#include <postgres.h>
+
+#include <access/toast_helper.h>
+
+#include "import/compression_toast.h"
+
+/*
+ * This is a copy of toast_tuple_externalize() in backend/access/table/toast_helper.c
+ * from PG 18.6, git commit sha 724edf9bde9d356724ad384a2e196edc3c9f80f7. It
+ * has one modification: it calls compression_toast_save_datum_multi() instead
+ * of toast_save_datum().
+ */
+void
+compression_toast_tuple_externalize(BulkWriter *writer, ToastTupleContext *ttc, int attribute)
+{
+	Datum	   *value = &ttc->ttc_values[attribute];
+	Datum		old_value = *value;
+	ToastAttrInfo *attr = &ttc->ttc_attr[attribute];
+
+	attr->tai_colflags |= TOASTCOL_IGNORE;
+	*value = compression_toast_save_datum_multi(writer, old_value, attr->tai_oldexternal);
+	if ((attr->tai_colflags & TOASTCOL_NEEDS_FREE) != 0)
+		pfree(DatumGetPointer(old_value));
+	attr->tai_colflags |= TOASTCOL_NEEDS_FREE;
+	ttc->ttc_flags |= (TOAST_NEEDS_CHANGE | TOAST_NEEDS_FREE);
+}

--- a/tsl/src/import/compression_toast.h
+++ b/tsl/src/import/compression_toast.h
@@ -1,0 +1,87 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This is the header for a narrow fork of a handful of Postgres core
+ * heap/toast insert functions. The compressed row written by the row
+ * compressor almost always carries a large compresseddata attribute that
+ * core's automatic toasting pushes out to the toast relation one ~2KB chunk
+ * at a time, each chunk getting its own heap_insert()+index_insert() call.
+ * compression_heap_insert() follows the same tuple decisions core would make,
+ * but writes the toast chunks for a value with a single heap_multi_insert()
+ * call instead, so the WAL and buffer-lock overhead is amortized across all
+ * chunks that fit on a page rather than paid once per chunk.
+ *
+ * Everything here is forked from (and should stay behaviorally identical to)
+ * the corresponding core function. The forked code lives under access/, in
+ * files named after the core file each function was copied from, so it can be
+ * diffed against a Postgres checkout when picking up core changes:
+ *
+ *   access/heap/heapam.c           compression_heap_insert()
+ *   access/heap/heaptoast.c        compression_toast_insert_or_update()
+ *   access/table/toast_helper.c    compression_toast_tuple_externalize()
+ *   access/common/toast_internals.c
+ *                                  compression_toast_save_datum_multi()
+ *
+ * The call chain runs top to bottom in that list, same as core's does. The
+ * comment above each function says which core function it copies and what was
+ * changed. Declarations for all of them live here rather than in per-file
+ * headers: they only exist so the forked files can call each other, and one
+ * header is one less thing to keep in sync.
+ */
+
+#pragma once
+
+#include <postgres.h>
+#include <access/heapam.h>
+#include <access/htup.h>
+#include <access/toast_helper.h>
+#include <storage/bufmgr.h>
+#include <utils/relcache.h>
+
+#include "compression/compression.h"
+
+/*
+ * Whether the forked toast writer may run. Only compatible with
+ * PG17.11+ and PG18.6+.
+ *
+ * The files under access/ are only compiled where this holds, so they stay
+ * verbatim copies of core with no version branches of their own. Keep this in
+ * step with CMakeLists.txt.
+ */
+#define COMPRESSION_TOASTER_SUPPORTED                                                              \
+	((PG_VERSION_NUM >= 170011 && PG_VERSION_NUM < 180000) ||                                      \
+	 (PG_VERSION_NUM >= 180006 && PG_VERSION_NUM < 190000))
+
+#if COMPRESSION_TOASTER_SUPPORTED
+
+extern void compression_heap_insert(BulkWriter *writer, HeapTuple tup);
+extern void compression_toast_writer_close(BulkWriter *writer);
+
+extern HeapTuple compression_toast_insert_or_update(BulkWriter *writer, HeapTuple newtup);
+extern void compression_toast_tuple_externalize(BulkWriter *writer, ToastTupleContext *ttc,
+												int attribute);
+extern Datum compression_toast_save_datum_multi(BulkWriter *writer, Datum value,
+												struct varlena *oldexternal);
+
+#else
+
+/*
+ * Stand-ins for the entry points compression.c calls, so it needs no version
+ * branches of its own.
+ */
+static inline void
+compression_heap_insert(BulkWriter *writer, HeapTuple tup)
+{
+	elog(ERROR, "custom compression toaster is not supported on this PostgreSQL version");
+}
+
+static inline void
+compression_toast_writer_close(BulkWriter *writer)
+{
+}
+
+#endif

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -348,7 +348,10 @@ COMMIT;
 -- Test that newly created chunks are automatically added to publications
 SET ROLE :ROLE_SUPERUSER;
 SET timescaledb.enable_chunk_auto_publication = true;
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_chunk_pub FOR TABLE chunkapi;
+RESET client_min_messages;
 -- Verify existing chunks are in the publication
 SELECT COUNT(*) as initial_chunk_count
 FROM pg_publication_tables

--- a/tsl/test/expected/chunk_publication_compression.out
+++ b/tsl/test/expected/chunk_publication_compression.out
@@ -21,7 +21,10 @@ INSERT INTO test_hypertable VALUES ('2024-01-01 00:00:00+00', 1, 1.0, 'data1');
 INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
 INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
 -- Create publication and add hypertable
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_pub FOR TABLE test_hypertable;
+RESET client_min_messages;
 -- Verify initial state (3 uncompressed chunks)
 SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;
       schemaname       |    tablename     |           attnames           | rowfilter 

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -1800,7 +1800,10 @@ INSERT INTO ht_pub_test VALUES ('2023-01-01 01:00', 1, 10.5);
 -- Create publication
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET timescaledb.enable_chunk_auto_publication = true;
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_pub_osm FOR TABLE ht_pub_test;
+RESET client_min_messages;
 -- Verify: 1 normal chunk in publication
 SELECT schemaname, tablename
 FROM pg_publication_tables
@@ -1883,7 +1886,10 @@ ORDER BY relid::text COLLATE "C";
  _timescaledb_internal._hyper_24_42_chunk | f
  osm_chunk_pub_test                       | t
 
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_pub_osm FOR TABLES IN SCHEMA pub_osm_schema;
+RESET client_min_messages;
 -- Only normal chunks should appear; OSM chunk is skipped.
 SELECT schemaname, tablename
 FROM pg_publication_tables

--- a/tsl/test/expected/merge_chunks.out
+++ b/tsl/test/expected/merge_chunks.out
@@ -917,7 +917,10 @@ INSERT INTO pub_merge_test VALUES
     ('2024-01-01 01:00', 1, 1.0),
     ('2024-01-02 01:00', 2, 2.0);
 -- Create publication
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_merge_pub FOR TABLE pub_merge_test;
+RESET client_min_messages;
 -- Verify chunks before merge
 SELECT schemaname, tablename
 FROM pg_publication_tables

--- a/tsl/test/expected/split_chunk.out
+++ b/tsl/test/expected/split_chunk.out
@@ -1144,7 +1144,10 @@ SELECT create_hypertable('pub_split_test', 'time', chunk_time_interval => interv
  (5,public,pub_split_test,t)
 
 -- Create publication
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_split_pub FOR TABLE pub_split_test;
+RESET client_min_messages;
 -- Insert data to create a single chunk
 INSERT INTO pub_split_test VALUES
     ('2024-01-03 01:00', 1, 1.0),

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -31,9 +31,14 @@ log_min_messages='INFO'
 # This breaks isolation tests, not sure why the statements end in
 # the isolation tester output.
 log_statement='all'
+# Include custom toaster in our tests
+# remove this once we switch the GUC to ON by default
+timescaledb.use_custom_toaster=true
 
-# Some tests use logical entries in WAL
-wal_level = logical
+# The custom toaster above only runs below wal_level = logical, so keep this at
+# replica to get it covered. Tests that need logical decoding set wal_level
+# themselves.
+wal_level = replica
 
 # It is necessary to have at least 2 more workers than `max_worker_processes`
 # in order to test failures starting bgworkers.

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -244,7 +244,10 @@ COMMIT;
 -- Test that newly created chunks are automatically added to publications
 SET ROLE :ROLE_SUPERUSER;
 SET timescaledb.enable_chunk_auto_publication = true;
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_chunk_pub FOR TABLE chunkapi;
+RESET client_min_messages;
 
 -- Verify existing chunks are in the publication
 SELECT COUNT(*) as initial_chunk_count

--- a/tsl/test/sql/chunk_publication_compression.sql
+++ b/tsl/test/sql/chunk_publication_compression.sql
@@ -23,7 +23,10 @@ INSERT INTO test_hypertable VALUES ('2024-01-02 00:00:00+00', 2, 2.0, 'data2');
 INSERT INTO test_hypertable VALUES ('2024-01-03 00:00:00+00', 3, 3.0, 'data3');
 
 -- Create publication and add hypertable
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_pub FOR TABLE test_hypertable;
+RESET client_min_messages;
 
 -- Verify initial state (3 uncompressed chunks)
 SELECT schemaname, tablename, attnames, rowfilter FROM pg_publication_tables WHERE pubname = 'test_pub' ORDER BY schemaname, tablename;

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -982,7 +982,10 @@ INSERT INTO ht_pub_test VALUES ('2023-01-01 01:00', 1, 10.5);
 -- Create publication
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET timescaledb.enable_chunk_auto_publication = true;
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_pub_osm FOR TABLE ht_pub_test;
+RESET client_min_messages;
 
 -- Verify: 1 normal chunk in publication
 SELECT schemaname, tablename
@@ -1040,7 +1043,10 @@ WHERE hypertable_id IN (SELECT id FROM _timescaledb_catalog.hypertable
                         WHERE table_name = 'ht_pub_test')
 ORDER BY relid::text COLLATE "C";
 
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_pub_osm FOR TABLES IN SCHEMA pub_osm_schema;
+RESET client_min_messages;
 
 -- Only normal chunks should appear; OSM chunk is skipped.
 SELECT schemaname, tablename

--- a/tsl/test/sql/merge_chunks.sql
+++ b/tsl/test/sql/merge_chunks.sql
@@ -481,7 +481,10 @@ INSERT INTO pub_merge_test VALUES
     ('2024-01-02 01:00', 2, 2.0);
 
 -- Create publication
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_merge_pub FOR TABLE pub_merge_test;
+RESET client_min_messages;
 
 -- Verify chunks before merge
 SELECT schemaname, tablename

--- a/tsl/test/sql/split_chunk.sql
+++ b/tsl/test/sql/split_chunk.sql
@@ -723,7 +723,10 @@ CREATE TABLE pub_split_test(time timestamptz not null, device int, temp float);
 SELECT create_hypertable('pub_split_test', 'time', chunk_time_interval => interval '1 month');
 
 -- Create publication
+-- This suite runs at wal_level = replica, so hide the warning about that
+SET client_min_messages TO error;
 CREATE PUBLICATION test_split_pub FOR TABLE pub_split_test;
+RESET client_min_messages;
 
 -- Insert data to create a single chunk
 INSERT INTO pub_split_test VALUES

--- a/tsl/test/t/002_logrepl_decomp_marker.pl
+++ b/tsl/test/t/002_logrepl_decomp_marker.pl
@@ -14,8 +14,11 @@ use Test::More;
 # Publishing node - create with manual initialization to set max_worker_processes=0
 my $db = TimescaleNode->new('publisher');
 $db->init(allows_streaming => 'logical');
-# Set max_process_workers to 0 before starting the node
-$db->append_conf('postgresql.conf', 'max_worker_processes=0');
+# Set max_process_workers to 0 before starting the node. wal_level has to be
+# set here too: init() appends the shared test config, which puts wal_level
+# back to replica, after what allows_streaming asked for.
+$db->append_conf('postgresql.conf',
+	"max_worker_processes=0\nwal_level=logical\n");
 $db->start();
 $db->safe_psql('postgres', 'CREATE EXTENSION timescaledb');
 

--- a/tsl/test/t/007_custom_toaster.pl
+++ b/tsl/test/t/007_custom_toaster.pl
@@ -1,0 +1,183 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+use strict;
+use warnings;
+use TimescaleNode;
+use Test::More;
+
+# Two things about the custom compression toaster are checked here, by looking
+# at what compression actually wrote to WAL:
+#
+# 1. It stays off when wal_level is logical. It writes a value's toast chunks
+#    with one heap_multi_insert() call, and only heap_insert() marks a toast
+#    chunk insert as such in the WAL -- the mark logical decoding needs to
+#    collect the chunks and stitch the value back together.
+#
+# 2. Where it does run, the WAL it writes replays correctly: compress a chunk,
+#    crash the server before a checkpoint can flush the new pages to disk, and
+#    the compressed chunk still decompresses to the same data afterwards.
+
+my $node = TimescaleNode->create('custom_toaster');
+
+if ($node->safe_psql('postgres',
+		q[SELECT count(*) FROM pg_available_extensions WHERE name = 'pg_walinspect']
+	) ne '1')
+{
+	plan skip_all => 'pg_walinspect is not available';
+}
+
+$node->safe_psql('postgres', 'CREATE EXTENSION pg_walinspect');
+
+# Push the checkpointer's own schedule well past how long this test takes, so a
+# timed checkpoint can't sneak in and flush the compressed chunk's pages before
+# the crash at the end -- we verify below (via pg_control_checkpoint()) that
+# none completed, but this makes that outcome the expected one rather than a
+# race.
+#
+# The shared test config runs at wal_level = replica so that the custom toaster
+# gets exercised, so ask for logical explicitly for the first part below.
+$node->append_conf('postgresql.conf',
+	"checkpoint_timeout = '1h'\nmax_wal_size = '10GB'\ntimescaledb.use_custom_toaster = true\nwal_level = logical\n"
+);
+$node->restart();
+
+# Compress a hypertable whose payload column is wide enough that every
+# compressed batch has to be toasted, and return how many WAL records of each
+# kind landed in the compressed chunk's toast relation.
+sub compress_and_count_toast_wal
+{
+	my ($name) = @_;
+
+	my $start_lsn =
+	  $node->safe_psql('postgres', 'SELECT pg_current_wal_flush_lsn()');
+
+	$node->safe_psql(
+		'postgres', qq[
+		CREATE TABLE $name(time timestamptz, device_id int, val double precision, payload text);
+		SELECT create_hypertable('$name', 'time');
+		ALTER TABLE $name SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id', timescaledb.compress_orderby = 'time');
+		INSERT INTO $name
+		SELECT t, (extract(epoch from t)::int % 4), random(), repeat(md5(t::text), 10)
+		FROM generate_series('2024-01-01'::timestamptz, '2024-01-01 01:00:00'::timestamptz, interval '1 sec') t;
+		SELECT compress_chunk(c) FROM show_chunks('$name') c;
+		]);
+
+	my $end_lsn =
+	  $node->safe_psql('postgres', 'SELECT pg_current_wal_flush_lsn()');
+
+	my $toast_filenodes = $node->safe_psql(
+		'postgres', qq[
+		SELECT string_agg(toast.relfilenode::text, ',')
+		FROM _timescaledb_catalog.compression_settings cs
+		JOIN pg_class c ON c.oid = cs.compress_relid
+		JOIN pg_class toast ON toast.oid = c.reltoastrelid
+		WHERE cs.relid IN (SELECT show_chunks('$name'))
+		]);
+
+	isnt($toast_filenodes, '',
+		"$name: compressed chunk has a toast relation");
+
+	my %counts;
+	foreach my $line (
+		split(
+			/\n/,
+			$node->safe_psql(
+				'postgres', qq[
+		SELECT record_type, count(*)
+		FROM pg_get_wal_block_info('$start_lsn', '$end_lsn', false)
+		WHERE relfilenode IN ($toast_filenodes)
+		GROUP BY record_type
+		])))
+	{
+		my ($record_type, $count) = split(/\|/, $line);
+		$counts{$record_type} = $count;
+	}
+
+	return \%counts;
+}
+
+# The val column is random, so compare the whole table against itself over the
+# crash rather than against fixed values.
+sub checksum
+{
+	my ($name) = @_;
+
+	return $node->safe_psql(
+		'postgres', qq[
+		SELECT count(*), md5(string_agg(format('%s|%s|%s|%s', time, device_id, val, payload), ',' ORDER BY device_id, time))
+		FROM $name]);
+}
+
+# The payload is derived from the time, so this checks the data is right and not
+# just unchanged.
+sub payload_intact
+{
+	my ($name) = @_;
+
+	return $node->safe_psql(
+		'postgres', qq[
+		SELECT count(*) = 3601 AND count(*) = count(payload)
+		FROM $name WHERE payload = repeat(md5(time::text), 10)]);
+}
+
+is($node->safe_psql('postgres', 'SHOW wal_level'),
+	'logical', 'wal_level is logical after restart');
+is($node->safe_psql('postgres', 'SHOW timescaledb.use_custom_toaster'),
+	'on', 'custom toaster is enabled');
+
+my $logical_counts = compress_and_count_toast_wal('metrics_logical');
+
+is($logical_counts->{MULTI_INSERT},
+	undef,
+	'wal_level = logical: no toast chunk written by the custom toaster');
+cmp_ok($logical_counts->{INSERT} // 0,
+	'>', 0, 'wal_level = logical: toast chunks written by core instead');
+
+# Drop to wal_level = replica, where nothing can be decoding, and the custom
+# toaster takes over. This is also the control for the check above -- without
+# it, a broken query in the helper would look like a passing test.
+$node->append_conf('postgresql.conf', "wal_level = replica\n");
+$node->restart();
+
+is($node->safe_psql('postgres', 'SHOW wal_level'),
+	'replica', 'wal_level is back to replica');
+
+# redo_lsn only advances when a checkpoint completes, and pg_control_checkpoint()
+# has the same column names on every supported PG version, unlike
+# pg_stat_checkpointer (whose columns differ between PG17 and PG18). Read it
+# after the restart above, whose shutdown checkpoint advances it.
+my $redo_lsn_query    = q[SELECT redo_lsn FROM pg_control_checkpoint()];
+my $redo_lsn_at_start = $node->safe_psql('postgres', $redo_lsn_query);
+
+my $replica_counts = compress_and_count_toast_wal('metrics_replica');
+
+cmp_ok($replica_counts->{MULTI_INSERT} // 0,
+	'>', 0,
+	'wal_level = replica: toast chunks written by the custom toaster');
+
+my %checksum_before =
+  map { $_ => checksum($_) } ('metrics_logical', 'metrics_replica');
+
+is($node->safe_psql('postgres', $redo_lsn_query),
+	$redo_lsn_at_start,
+	'no checkpoint completed between server start and the crash below');
+
+# "immediate" shutdown skips the checkpoint a clean stop does, so recovery has
+# to replay the WAL from the compression above -- the same WAL the custom
+# toaster generated -- to reconstruct the compressed chunk's pages.
+$node->stop('immediate');
+$node->start();
+
+is($node->safe_psql('postgres', 'SELECT 1'),
+	'1', 'server recovered after crash');
+
+foreach my $name ('metrics_logical', 'metrics_replica')
+{
+	is(checksum($name), $checksum_before{$name},
+		"$name: decompressed data unchanged after crash recovery");
+	is(payload_intact($name), 't', "$name: decompressed data is correct");
+}
+
+done_testing();

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(PROVE_TEST_FILES 001_job_crash_log.pl 002_logrepl_decomp_marker.pl
                      004_truncate_or_delete_spin_lock.pl)
 
+# The custom toaster only runs on PG 17.11+ and 18.6+, which is what
+# COMPRESSION_TOASTER_SUPPORTED in tsl/src/import/compression_toast.h allows.
+# Everywhere else this test has nothing to look at.
+if((PG_VERSION_MAJOR EQUAL 17 AND PG_VERSION_MINOR GREATER_EQUAL 11)
+   OR (PG_VERSION_MAJOR EQUAL 18 AND PG_VERSION_MINOR GREATER_EQUAL 6))
+  list(APPEND PROVE_TEST_FILES 007_custom_toaster.pl)
+endif()
+
 set(PROVE_DEBUG_TEST_FILES 003_mvcc_cagg.pl 005_recompression_spin_lock_test.pl)
 if(TMP_ENABLE_GRANULAR_REFRESH_TESTS)
   list(APPEND PROVE_DEBUG_TEST_FILES 006_granular_refresh_restart.pl)


### PR DESCRIPTION
Compressed rows are often large and get pushed to the toast relation in
~2KB chunks. Core writes each chunk with its own heap_insert() and
index_insert() call. This change adds a custom toasting mechanism using
relevant core function forks: chunks of a value are batched into a
single heap_multi_insert() call instead, cutting the WAL and
buffer-lock overhead.

The forked functions live under tsl/src/import/, the existing home for
code copied from PostgreSQL core, since compression_toast.c is exactly
that.

The new path is gated behind timescaledb.use_custom_toaster, off by
default. Also add a TAP test confirming the WAL this change
generates is correct.

Based on local benchmarking this can reduce up to 38% of write overhead 
when toasting a lot of compressed data.