### PR TITLE
Swap relallfrozen when swapping relation files

### DIFF
--- a/src/import/heapswap.c
+++ b/src/import/heapswap.c
@@ -258,6 +258,14 @@ ts_swap_relation_files(Oid r1, Oid r2, bool target_is_pg_class, bool swap_toast_
 		swap_allvisible = relform1->relallvisible;
 		relform1->relallvisible = relform2->relallvisible;
 		relform2->relallvisible = swap_allvisible;
+
+#if PG18_GE
+		int32 swap_allfrozen;
+
+		swap_allfrozen = relform1->relallfrozen;
+		relform1->relallfrozen = relform2->relallfrozen;
+		relform2->relallfrozen = swap_allfrozen;
+#endif
 	}
 
 	/*


### PR DESCRIPTION
When swapping the physical files of two relations we copy the size
statistics from one relation to the other, but we missed the count of
all-frozen pages that was added in PostgreSQL 18. Swap it too so the
statistics stay correct after the swap.

Disable-check: force-changelog-file
Disable-check: commit-count
Disable-check: approval-count
