### PR TITLE
Fix wrong results with IS NULL and minmax pushdown

### DIFF
--- a/.unreleased/fix_isnull_minmax_pushdown
+++ b/.unreleased/fix_isnull_minmax_pushdown
@@ -1,0 +1,1 @@
+Fixes: #9921 Fix wrong results with IS NULL and minmax sparse index pushdown

--- a/tsl/src/nodes/columnar_scan/qual_pushdown.c
+++ b/tsl/src/nodes/columnar_scan/qual_pushdown.c
@@ -1767,8 +1767,10 @@ qual_pushdown_mutator(Node *orig_node, QualPushdownContext *context)
 		}
 
 		/*
-		 * These nodes do not influence the pushdown by themselves, so we
-		 * recurse.
+		 * These nodes transform their child value, so we can only push them
+		 * down when every child pushes down exactly. A child that needs a
+		 * recheck is only approximate, and the transform could flip its result
+		 * (e.g. IS NULL), giving wrong results.
 		 */
 		case T_FuncExpr:
 		case T_CoerceViaIO:
@@ -1782,8 +1784,14 @@ qual_pushdown_mutator(Node *orig_node, QualPushdownContext *context)
 		case T_CaseWhen:
 		case T_ArrayExpr:
 		{
+			QualPushdownContext tmp_context = copy_context(context);
 			Node *pushed_down =
-				expression_tree_mutator((Node *) orig_node, qual_pushdown_mutator, context);
+				expression_tree_mutator((Node *) orig_node, qual_pushdown_mutator, &tmp_context);
+			if (!tmp_context.can_pushdown || tmp_context.needs_recheck)
+			{
+				context->can_pushdown = false;
+				return orig_node;
+			}
 			return pushed_down;
 		}
 

--- a/tsl/test/expected/compress_qualpushdown_complex.out
+++ b/tsl/test/expected/compress_qualpushdown_complex.out
@@ -406,3 +406,58 @@ blm1 = blm2 and segby in (1,2,3);
    ->  Index Scan using _hyper_1_1_chunk_compressed_segby__ts_meta_v2_first_ts__ts__idx on _hyper_1_1_chunk_compressed
          Index Cond: (segby = ANY ('{1,2,3}'::integer[]))
 
+-- NullTest over a minmax-pushdown column
+CREATE TABLE sparse_isnull(ts timestamptz NOT NULL, v int)
+WITH (
+    tsdb.hypertable,
+    tsdb.partition_column = 'ts',
+    tsdb.compress,
+    tsdb.orderby = 'ts, v'
+);
+INSERT INTO sparse_isnull VALUES ('2024-01-01', NULL), ('2024-01-02', 1);
+SELECT count(compress_chunk(c)) FROM show_chunks('sparse_isnull') c;
+ count 
+-------
+     1
+
+-- IS NULL is not pushed to the compressed scan
+explain (buffers off, costs off)
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NULL;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_2_2_chunk
+   Filter: ((v > 0) IS NULL)
+   ->  Seq Scan on _hyper_2_2_chunk_compressed
+
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NULL;
+              ts              | v 
+------------------------------+---
+ Mon Jan 01 00:00:00 2024 PST |  
+
+-- IS NOT NULL is not pushed to the compressed scan
+explain (buffers off, costs off)
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NOT NULL;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_2_2_chunk
+   Filter: ((v > 0) IS NOT NULL)
+   ->  Seq Scan on _hyper_2_2_chunk_compressed
+
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NOT NULL;
+              ts              | v 
+------------------------------+---
+ Tue Jan 02 00:00:00 2024 PST | 1
+
+-- plain minmax range pushdown
+explain (buffers off, costs off)
+SELECT * FROM sparse_isnull WHERE v > 0;
+--- QUERY PLAN ---
+ Custom Scan (ColumnarScan) on _hyper_2_2_chunk
+   Vectorized Filter: (v > 0)
+   ->  Seq Scan on _hyper_2_2_chunk_compressed
+         Filter: (_ts_meta_max_2 > 0)
+
+SELECT * FROM sparse_isnull WHERE v > 0;
+              ts              | v 
+------------------------------+---
+ Tue Jan 02 00:00:00 2024 PST | 1
+
+DROP TABLE sparse_isnull;

--- a/tsl/test/sql/compress_qualpushdown_complex.sql
+++ b/tsl/test/sql/compress_qualpushdown_complex.sql
@@ -234,3 +234,35 @@ explain (buffers off, costs off)
 SELECT * FROM complex_pushdown WHERE
 blm1 = blm2 and segby in (1,2,3);
 
+-- NullTest over a minmax-pushdown column
+CREATE TABLE sparse_isnull(ts timestamptz NOT NULL, v int)
+WITH (
+    tsdb.hypertable,
+    tsdb.partition_column = 'ts',
+    tsdb.compress,
+    tsdb.orderby = 'ts, v'
+);
+
+INSERT INTO sparse_isnull VALUES ('2024-01-01', NULL), ('2024-01-02', 1);
+SELECT count(compress_chunk(c)) FROM show_chunks('sparse_isnull') c;
+
+-- IS NULL is not pushed to the compressed scan
+explain (buffers off, costs off)
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NULL;
+
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NULL;
+
+-- IS NOT NULL is not pushed to the compressed scan
+explain (buffers off, costs off)
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NOT NULL;
+
+SELECT * FROM sparse_isnull WHERE (v > 0) IS NOT NULL;
+
+-- plain minmax range pushdown
+explain (buffers off, costs off)
+SELECT * FROM sparse_isnull WHERE v > 0;
+
+SELECT * FROM sparse_isnull WHERE v > 0;
+
+DROP TABLE sparse_isnull;
+


### PR DESCRIPTION
A qual like (v > 0) IS NULL wrapped an operator whose minmax pushdown is
a lossy, false-positive-only approximation. Wrapping that lossy result in
a NullTest could turn a false positive into a false negative and skip a
batch that actually holds matching rows, so the query returned wrong
results.

Only push down NullTest and the other transforming nodes when their child
is pushed down exactly, never when the child still needs a recheck.

Fixes #9921
