### PR TITLE
Remove wrong assertion in interpolate lookup

### DIFF
--- a/.unreleased/fix_gapfill_interpolate_composite
+++ b/.unreleased/fix_gapfill_interpolate_composite
@@ -1,0 +1,1 @@
+Fixes: #10399 Assertion failure in interpolate when the lookup argument is a named composite type

--- a/tsl/src/nodes/gapfill/interpolate.c
+++ b/tsl/src/nodes/gapfill/interpolate.c
@@ -114,7 +114,6 @@ gapfill_fetch_sample(GapFillState *state, GapFillInterpolateColumnState *column,
 	}
 
 	/* Extract type information from the tuple itself */
-	Assert(RECORDOID == HeapTupleHeaderGetTypeId(th));
 	tupdesc = lookup_rowtype_tupdesc(HeapTupleHeaderGetTypeId(th), HeapTupleHeaderGetTypMod(th));
 
 	/* Build a temporary HeapTuple control structure */

--- a/tsl/test/shared/expected/gapfill_bug.out
+++ b/tsl/test/shared/expected/gapfill_bug.out
@@ -585,3 +585,30 @@ DROP FUNCTION gf_userfn.time_bucket_gapfill(int, text);
 DROP FUNCTION gf_userfn.locf(int);
 DROP FUNCTION gf_userfn.interpolate(int);
 DROP SCHEMA gf_userfn;
+-- interpolate lookup queries may return a named composite type, not only an anonymous record
+CREATE TYPE gf_interp_sample AS (time int, value int);
+SELECT
+  time_bucket_gapfill(1,time,1,5),
+  interpolate(min(time),prev=>(SELECT ROW(0,0)::gf_interp_sample))
+FROM (VALUES (3),(4)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | interpolate 
+---------------------+-------------
+                   1 |           1
+                   2 |           2
+                   3 |           3
+                   4 |           4
+
+SELECT
+  time_bucket_gapfill(1,time,1,5),
+  interpolate(min(time),next=>(SELECT ROW(9,9)::gf_interp_sample))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | interpolate 
+---------------------+-------------
+                   1 |           1
+                   2 |           2
+                   3 |           3
+                   4 |           4
+
+DROP TYPE gf_interp_sample;

--- a/tsl/test/shared/sql/gapfill_bug.sql
+++ b/tsl/test/shared/sql/gapfill_bug.sql
@@ -342,3 +342,20 @@ DROP FUNCTION gf_userfn.time_bucket_gapfill(int, text);
 DROP FUNCTION gf_userfn.locf(int);
 DROP FUNCTION gf_userfn.interpolate(int);
 DROP SCHEMA gf_userfn;
+
+-- interpolate lookup queries may return a named composite type, not only an anonymous record
+CREATE TYPE gf_interp_sample AS (time int, value int);
+
+SELECT
+  time_bucket_gapfill(1,time,1,5),
+  interpolate(min(time),prev=>(SELECT ROW(0,0)::gf_interp_sample))
+FROM (VALUES (3),(4)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill(1,time,1,5),
+  interpolate(min(time),next=>(SELECT ROW(9,9)::gf_interp_sample))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+DROP TYPE gf_interp_sample;


### PR DESCRIPTION
interpolate() declares its prev and next parameters as RECORD, which accepts any composite value, including one of a named composite type. The lookup path asserted that the fetched sample always carries the anonymous RECORD type id, so passing a named composite aborts the backend in assertion-enabled builds.

The assertion contradicts the call it precedes: the type id and typmod are passed to lookup_rowtype_tupdesc(), which resolves named composite types as well, and the element types are validated right afterwards. The same pattern is used without an assertion in compression.c.