### PR TITLE
Cache install dir instead of build dir in Sanitizer workflow

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -332,14 +332,8 @@ jobs:
           show debug-file-directory
           printf "'"'"query = '%s'\n\n"'"'", debug_query_string
           bt full
-
-          # We try to find ExceptionalCondition frame to print the failed condition
-          # for searching in logs.
           frame function ExceptionalCondition
           printf "'"'"condition = '%s'\n"'"'", conditionName
-
-          # Hopefully now we should be around the failed assertion, print where
-          # we are.
           up 1
           list
           info args

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -118,9 +118,6 @@ jobs:
       if: runner.os == 'macOS'
       run: echo "CACHE_SUFFIX=-${ImageVersion}" >> $GITHUB_ENV
 
-    # we cache the build directory instead of the install directory here
-    # because extension installation will write files to install directory
-    # leading to a tainted cache
     - name: Restore PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }} Cache
       id: restore-postgresql-cache
       if: matrix.snapshot != 'snapshot'

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -241,14 +241,9 @@ jobs:
           printf "'"'"query = '%s'\n\n"'"'", debug_query_string
           bt full
 
-          # We try to find ExceptionalCondition frame to print the failed condition
-          # for searching in logs.
-          frame function ExceptionalCondition
-          printf "'"'"condition = '%s'\n"'"'", conditionName
+          frame function __sanitizer::Die
+          up 4
 
-          # Hopefully now we should be around the failed assertion, print where
-          # we are.
-          up 1
           list
           info args
           info locals

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -240,14 +240,12 @@ jobs:
           show debug-file-directory
           printf "'"'"query = '%s'\n\n"'"'", debug_query_string
           bt full
-
           frame function __sanitizer::Die
           up 4
-
           list
           info args
           info locals
-        " 2>&1 | tee stacktrace.log
+        " 2>&1 | tee -a stacktrace.log
         ./scripts/bundle_coredumps.sh
 
     - name: Show sanitizer logs

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -15,8 +15,6 @@ name: Sanitizer test
 
 env:
   name: "Sanitizer"
-  PG_SRC_DIR: "pgbuild"
-  PG_INSTALL_DIR: "postgresql"
   extra_packages: "clang-15 llvm-15 llvm-15-dev llvm-15-tools"
   llvm_config: "llvm-config-15"
   CLANG: "clang-15"
@@ -104,62 +102,78 @@ jobs:
       run: |
         mkdir ${{ github.workspace }}/sanitizer_logs
 
-    # we cache the build directory instead of the install directory here
-    # because extension installation will write files to install directory
-    # leading to a tainted cache
-    - name: Cache PostgreSQL ${{ matrix.pg }}
-      id: cache-postgresql
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Restore PostgreSQL ${{ matrix.pg }} Cache
+      id: restore-postgresql-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ~/${{ env.PG_SRC_DIR }}
-        key: "${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}\
-          -${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
+        path: |
+          install
+          pg
+        key: "${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
 
-    - name: Build PostgreSQL ${{ matrix.pg }} if not in cache
-      if: steps.cache-postgresql.outputs.cache-hit != 'true'
+    - name: Build PostgreSQL ${{ matrix.pg }}
+      if: steps.restore-postgresql-cache.outputs.cache-hit != 'true'
       run: |
+        set -xeu
+
         wget -q --tries=6 --waitretry=15 -O postgresql.tar.bz2 \
           https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
-        mkdir -p ~/$PG_SRC_DIR
-        tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
+        mkdir -p pg build-pg install
+        tar --extract --file postgresql.tar.bz2 --directory pg --strip-components 1
+
         # Add instrumentation to the Postgres memory contexts. For more details, see
         # https://github.com/timescale/eng-database/wiki/Using-Address-Sanitizer#adding-more-instrumentation
         PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
         if [ ${PG_MAJOR} -lt 18 ]; then
-          patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation.patch
+          patch -F5 -p1 -d pg < test/postgres-asan-instrumentation.patch
         else
-          patch -F5 -p1 -d ~/$PG_SRC_DIR < test/postgres-asan-instrumentation-PG18GE.patch
+          patch -F5 -p1 -d pg < test/postgres-asan-instrumentation-PG18GE.patch
         fi
-        cd ~/$PG_SRC_DIR
-        ./configure --prefix=$HOME/$PG_INSTALL_DIR --enable-debug --enable-cassert \
+
+        cd build-pg
+
+        ../pg/configure --prefix="$(readlink -f ../install)" --enable-debug --enable-cassert \
           --with-openssl --without-readline --without-zlib --without-libxml
-        make -j$(getconf _NPROCESSORS_ONLN)
+        make -j $(getconf _NPROCESSORS_ONLN)
         for ext in ${EXTENSIONS}; do
-          make -j$(getconf _NPROCESSORS_ONLN) -C contrib/${ext}
+          make -j $(getconf _NPROCESSORS_ONLN) -C contrib/${ext}
         done
 
-    - name: Upload config.log
-      if: always() && steps.cache-postgresql.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: config.log for PostgreSQL ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
-        path: ~/${{ env.PG_SRC_DIR }}/config.log
-
-    - name: Install PostgreSQL ${{ matrix.pg }}
-      run: |
-        cd ~/$PG_SRC_DIR
         make install
         for ext in ${EXTENSIONS}; do
           make -C contrib/${ext} install
         done
-        ~/$PG_INSTALL_DIR/bin/pg_config --version
+        make install-tests
+
+    - name: Save PostgreSQL ${{ matrix.pg }} Cache
+      if: steps.restore-postgresql-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          install
+          pg
+        key: "${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}"
+
+    - name: Upload config.log
+      if: always() && steps.restore-postgresql-cache.outputs.cache-hit != 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: config.log for PostgreSQL ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
+        path: build-pg/config.log
+
+    - name: Set up PATH
+      run: |
+        set -xeu
+
+        echo "$(readlink -f install/bin)" >> "${GITHUB_PATH}"
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=Debug -DPG_SOURCE_DIR=~/$PG_SRC_DIR \
-          -DPG_PATH=~/$PG_INSTALL_DIR -DCODECOVERAGE=OFF -DREQUIRE_ALL_TESTS=ON \
+        ./bootstrap -DCMAKE_BUILD_TYPE=Debug \
+          -DPG_SOURCE_DIR=$(readlink -f pg) \
+          -DCODECOVERAGE=OFF -DREQUIRE_ALL_TESTS=ON \
           -DTEST_GROUP_SIZE=5 -DTEST_PG_LOG_DIRECTORY="$(readlink -f .)" -DTEST_TIMEOUT=240
-        make -j$(getconf _NPROCESSORS_ONLN) -C build
+        make -j $(getconf _NPROCESSORS_ONLN) -C build
         make -C build install
 
     - name: make installcheck
@@ -167,13 +181,14 @@ jobs:
         set -o pipefail
         # IGNORE some test since they fail under ASAN.
         make -k -C build installcheck IGNORES="${IGNORES}" \
-          PSQL="${HOME}/${PG_INSTALL_DIR}/bin/psql" | tee installcheck.log
+          | tee installcheck.log
 
     - name: Show regression diffs
       if: always()
       id: collectlogs
       run: |
         find . -name regression.diffs -exec cat {} + > regression.log
+
         # TAP tests do not produce regression.diffs. Append prove's failure
         # summary from installcheck.log plus, for each failing test, the failed
         # assertions
@@ -188,6 +203,7 @@ jobs:
             blk { print }
           ' {} + >> regression.log || true
         done
+
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           # wait in case there are in-progress coredumps
           sleep 10
@@ -195,7 +211,7 @@ jobs:
           # print OOM killer information
           sudo journalctl --system -q --facility=kern --grep "Killed process" || true
         fi
-        if [[ -s regression.log ]]; then echo "regression_diff=true" >>$GITHUB_OUTPUT; fi
+        if [[ -s regression.log ]]; then echo "regression_diff=true" >> $GITHUB_OUTPUT; fi
         grep -e 'FAILED' -e 'failed (ignored)' -e 'not ok' installcheck.log || true
         cat regression.log
 
@@ -218,18 +234,24 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        sudo coredumpctl gdb <<<"
+        sudo coredumpctl debug --debugger=gdb --debugger-arguments='' <<<"
           set verbose on
           set trace-commands on
           show debug-file-directory
           printf "'"'"query = '%s'\n\n"'"'", debug_query_string
+          bt full
+
+          # We try to find ExceptionalCondition frame to print the failed condition
+          # for searching in logs.
           frame function ExceptionalCondition
           printf "'"'"condition = '%s'\n"'"'", conditionName
+
+          # Hopefully now we should be around the failed assertion, print where
+          # we are.
           up 1
-          l
+          list
           info args
           info locals
-          bt full
         " 2>&1 | tee stacktrace.log
         ./scripts/bundle_coredumps.sh
 


### PR DESCRIPTION
We made the same change recently for Linux regression tests.

Also make small cosmetic tweaks to make textual diff between these workflows smaller.

Previous change: https://github.com/timescale/timescaledb/pull/10285