### PR TITLE
Verify columns when attaching a compressed chunk

### DIFF
--- a/.unreleased/pr_10408
+++ b/.unreleased/pr_10408
@@ -1,0 +1,1 @@
+Fixes: #10408 Verify columns and their types in create_compressed_chunk

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -975,6 +975,48 @@ create_compress_chunk(Chunk *src_chunk, Oid table_id, bool skip_segmentby_defaul
 		List *column_defs = build_columndefs(settings, src_chunk->fd.relid);
 		table_id = compression_table_create(src_chunk, column_defs, tablespace_oid, settings);
 	}
+	else
+	{
+		/*
+		 * An existing table was supplied as the compressed chunk. Make sure it
+		 * has every column the settings require, otherwise a later query over
+		 * the chunk fails when a missing column is looked up.
+		 */
+		List *column_defs = build_columndefs(settings, src_chunk->fd.relid);
+		ListCell *lc;
+		foreach (lc, column_defs)
+		{
+			ColumnDef *coldef = lfirst_node(ColumnDef, lc);
+			AttrNumber attno = get_attnum(table_id, coldef->colname);
+			if (attno == InvalidAttrNumber)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_COLUMN),
+						 errmsg("relation \"%s\" is not a valid compressed chunk",
+								get_rel_name(table_id)),
+						 errdetail("Column \"%s\" is missing.", coldef->colname)));
+			}
+
+			/*
+			 * The expected type is encoded in the column definition: segmentby
+			 * columns keep their original type, the data columns are compressed
+			 * data, and the metadata columns have their fixed types.
+			 */
+			Oid expected_typid = typenameTypeId(NULL, coldef->typeName);
+			Oid actual_typid = get_atttype(table_id, attno);
+			if (actual_typid != expected_typid)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_DATATYPE_MISMATCH),
+						 errmsg("relation \"%s\" is not a valid compressed chunk",
+								get_rel_name(table_id)),
+						 errdetail("Column \"%s\" has type %s but %s was expected.",
+								   coldef->colname,
+								   format_type_be(actual_typid),
+								   format_type_be(expected_typid))));
+			}
+		}
+	}
 
 	if (!OidIsValid(table_id))
 	{

--- a/tsl/test/expected/compression_create_compressed_table.out
+++ b/tsl/test/expected/compression_create_compressed_table.out
@@ -80,3 +80,58 @@ SELECT _timescaledb_functions.create_compressed_chunk(
 );
 ERROR:  must be owner of hypertable "metrics"
 \set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- test create_compressed_chunk column/column type validation
+CREATE TABLE selfref(time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('selfref', 'time');
+  create_hypertable   
+----------------------
+ (2,public,selfref,t)
+
+ALTER TABLE selfref SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+INSERT INTO selfref VALUES ('2025-01-01', 'dev1', 1.0);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    ch, ch,
+    8192, 8192, 16384, 8192, 8192, 16384, 1, 1
+) FROM show_chunks('selfref') ch;
+ERROR:  relation "_hyper_2_2_chunk" is not a valid compressed chunk
+\set ON_ERROR_STOP 1
+-- create_compressed_chunk must reject a table where a segmentby column type does not match
+CREATE TABLE badtype(time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('badtype', 'time');
+  create_hypertable   
+----------------------
+ (3,public,badtype,t)
+
+ALTER TABLE badtype SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+INSERT INTO badtype VALUES ('2025-01-01', 'dev1', 1.0);
+SELECT ch AS "BADTYPE_CHUNK" FROM show_chunks('badtype') ch LIMIT 1 \gset
+-- segmentby column "device" has the wrong type (varchar instead of text)
+CREATE TABLE _timescaledb_internal.badtype_compressed(_ts_meta_count int4, device varchar(3));
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    :'BADTYPE_CHUNK'::regclass, '_timescaledb_internal.badtype_compressed'::regclass,
+    8192, 8192, 16384, 8192, 8192, 16384, 1, 1
+);
+ERROR:  relation "badtype_compressed" is not a valid compressed chunk
+\set ON_ERROR_STOP 1
+-- create_compressed_chunk must reject a table where a metadata column type does not match
+CREATE TABLE badcount(time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('badcount', 'time');
+   create_hypertable   
+-----------------------
+ (4,public,badcount,t)
+
+ALTER TABLE badcount SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+INSERT INTO badcount VALUES ('2025-01-01', 'dev1', 1.0);
+SELECT ch AS "BADCOUNT_CHUNK" FROM show_chunks('badcount') ch LIMIT 1 \gset
+-- metadata column "_ts_meta_count" has the wrong type (text instead of int4)
+CREATE TABLE _timescaledb_internal.badcount_compressed(_ts_meta_count text, device text);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    :'BADCOUNT_CHUNK'::regclass, '_timescaledb_internal.badcount_compressed'::regclass,
+    8192, 8192, 16384, 8192, 8192, 16384, 1, 1
+);
+ERROR:  relation "badcount_compressed" is not a valid compressed chunk
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/compression_create_compressed_table.sql
+++ b/tsl/test/sql/compression_create_compressed_table.sql
@@ -68,3 +68,47 @@ SELECT _timescaledb_functions.create_compressed_chunk(
 );
 \set ON_ERROR_STOP 1
 
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- test create_compressed_chunk column/column type validation
+CREATE TABLE selfref(time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('selfref', 'time');
+ALTER TABLE selfref SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+INSERT INTO selfref VALUES ('2025-01-01', 'dev1', 1.0);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    ch, ch,
+    8192, 8192, 16384, 8192, 8192, 16384, 1, 1
+) FROM show_chunks('selfref') ch;
+\set ON_ERROR_STOP 1
+
+-- create_compressed_chunk must reject a table where a segmentby column type does not match
+CREATE TABLE badtype(time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('badtype', 'time');
+ALTER TABLE badtype SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+INSERT INTO badtype VALUES ('2025-01-01', 'dev1', 1.0);
+SELECT ch AS "BADTYPE_CHUNK" FROM show_chunks('badtype') ch LIMIT 1 \gset
+-- segmentby column "device" has the wrong type (varchar instead of text)
+CREATE TABLE _timescaledb_internal.badtype_compressed(_ts_meta_count int4, device varchar(3));
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    :'BADTYPE_CHUNK'::regclass, '_timescaledb_internal.badtype_compressed'::regclass,
+    8192, 8192, 16384, 8192, 8192, 16384, 1, 1
+);
+\set ON_ERROR_STOP 1
+
+-- create_compressed_chunk must reject a table where a metadata column type does not match
+CREATE TABLE badcount(time timestamptz NOT NULL, device text, value float);
+SELECT create_hypertable('badcount', 'time');
+ALTER TABLE badcount SET (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+INSERT INTO badcount VALUES ('2025-01-01', 'dev1', 1.0);
+SELECT ch AS "BADCOUNT_CHUNK" FROM show_chunks('badcount') ch LIMIT 1 \gset
+-- metadata column "_ts_meta_count" has the wrong type (text instead of int4)
+CREATE TABLE _timescaledb_internal.badcount_compressed(_ts_meta_count text, device text);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_functions.create_compressed_chunk(
+    :'BADCOUNT_CHUNK'::regclass, '_timescaledb_internal.badcount_compressed'::regclass,
+    8192, 8192, 16384, 8192, 8192, 16384, 1, 1
+);
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
create_compressed_chunk accepted any table as a chunk's compressed
table without checking its columns. If the table was missing the
compressed data or metadata columns, a later query over the hypertable
crashed on an assertion in the columnar scan. Check that the supplied
table has all required columns with the expected types and raise a
clear error otherwise.
