### PR TITLE
Fix crash when running pg_stat_plans and tsdb

### DIFF
--- a/src/nodes/modify_hypertable.c
+++ b/src/nodes/modify_hypertable.c
@@ -473,7 +473,7 @@ modify_hypertable_explain(CustomScanState *node, List *ancestors, ExplainState *
 	 * tuples from the ChunkTupleRouting state below the ModifyTable.
 	 */
 	if ((mtstate->operation == CMD_INSERT || mtstate->operation == CMD_MERGE) &&
-		outerPlanState(mtstate))
+		outerPlanState(mtstate) && state->ctr != NULL)
 	{
 		SharedCounters *counters = state->ctr->counters;
 


### PR DESCRIPTION
When inserting into a hypertable and having pg_stat_plans loaded as well it calls explain before the query has been executed. This means the ctr is NULL and dereferencing it crashes PostgreSQL.

Backtrace:
```
 #0  0x00007f8a5e8b1f93 in modify_hypertable_explain (node=0x55848c63f128, ancestors=<optimized out>, es=0x55848c5043b0) at tsdb/src/nodes/modify_hypertable.c:478
 #1  0x000055844c4e7444 in ExplainNode (planstate=0x55848c63f128, ancestors=0x0, relationship=0x0, plan_name=0x0, es=<optimized out>) at commands/explain.c:2155
 #2  0x000055844c4e9af6 in ExplainPrintPlan (es=es@entry=0x55848c5043b0, queryDesc=queryDesc@entry=0x55848c504328) at commands/explain.c:801
 #3  0x00007f8a92ee1c20 in pgsp_explain_plan (queryDesc=0x55848c504328) at pg_stat_plans-2.1.0/pg_stat_plans.c:284
 #4  pgstat_report_plan_stats (queryDesc=queryDesc@entry=0x55848c504328, exec_count=exec_count@entry=0, exec_time=exec_time@entry=0) at pg_stat_plans-2.1.0/pg_stat_plans.c:876
 #5  0x00007f8a92ee22f0 in pgsp_ExecutorStart (eflags=<optimized out>, queryDesc=0x55848c504328) at pg_stat_plans-2.1.0/pg_stat_plans.c:1236
 #6  pgsp_ExecutorStart (queryDesc=0x55848c504328, eflags=<optimized out>) at pg_stat_plans-2.1.0/pg_stat_plans.c:1205
 #7  0x000055844c79ff8c in ExecutorStart (queryDesc=0x55848c504328, eflags=0) at executor/execMain.c:135
 #8  ProcessQuery (plan=plan@entry=0x55848c649af0, sourceText=<optimized out>, params=<optimized out>, queryEnv=<optimized out>, dest=dest@entry=0x55848c47f1e0, qc=qc@entry=0x7ffdc2e96d70) at tcop/pquery.c:156
[...]
```

Reproducer:
```
CREATE EXTENSION pg_stat_plans;
CREATE EXTENSION timescaledb;
CREATE TABLE sensors (sensor_id pg_catalog.int4 PRIMARY KEY, name pg_catalog.text NOT NULL);
INSERT INTO sensors VALUES (1, 'Sensor A');
CREATE TABLE t1 (time pg_catalog.timestamptz NOT NULL, sensor_id pg_catalog.int4 REFERENCES sensors(sensor_id), c1 text);
SELECT create_hypertable('t1', 'time');
INSERT INTO t1(time, sensor_id, c1) VALUES ('2020-01-01T00:00:00', 1, 'Test');
-- we never reach this line
```