### PR TITLE
Fix crash on hypertable COPY when pgAudit is enabled by shielding ExecutorCheckPerms_hook

### DIFF
--- a/.unreleased/fix_7667
+++ b/.unreleased/fix_7667
@@ -1,0 +1,1 @@
+Fixes: #7667 Fix crash during COPY into hypertable when pgAudit is enabled

--- a/src/copy.c
+++ b/src/copy.c
@@ -1495,7 +1495,27 @@ copy_constraints_and_check(ParseState *pstate, Relation rel, List *attnums)
 		perminfo->insertedCols = bms_add_member(perminfo->insertedCols, attno);
 	}
 
-	ExecCheckPermissions(pstate->p_rtable, list_make1(perminfo), true);
+	/*
+	 * Check INSERT permissions directly on the hypertable root relation.
+	 * Temporarily clear ExecutorCheckPerms_hook so that third-party hooks
+	 * (e.g. pgaudit) are not invoked outside a normal executor context, where
+	 * their internal state is not initialized and they may crash (see #7667).
+	 * The standard ACL_INSERT checks performed by ExecCheckRTEPerms() are
+	 * unaffected, and the hook is restored afterwards, including on error.
+	 */
+	volatile ExecutorCheckPerms_hook_type prev_perms_hook = ExecutorCheckPerms_hook;
+	PG_TRY();
+	{
+		ExecutorCheckPerms_hook = NULL;
+		ExecCheckPermissions(pstate->p_rtable, list_make1(perminfo), true);
+		ExecutorCheckPerms_hook = prev_perms_hook;
+	}
+	PG_CATCH();
+	{
+		ExecutorCheckPerms_hook = prev_perms_hook;
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 
 	/*
 	 * Permission check for row security policies.


### PR DESCRIPTION
## Summary

TimescaleDB's hypertable `COPY FROM` path calls `ExecCheckPermissions()` in `copy_constraints_and_check()` solely to verify that the executing user has `ACL_INSERT` on the hypertable root relation. Because TimescaleDB handles that COPY itself and returns `DDL_DONE` without chaining the remaining `ProcessUtility` hooks, extensions such as pgAudit never see the statement. When pgAudit's `ExecutorCheckPerms_hook` is then invoked from this internal check, it runs outside a normal executor context with an uninitialized internal stack and segfaults the backend (pgaudit 17.0; `pgaudit stack is empty` on later builds).

This PR confines the fix to `src/copy.c`: `copy_constraints_and_check()` temporarily suppresses `ExecutorCheckPerms_hook` around its `ExecCheckPermissions()` call and restores the previous hook afterwards, including on the error path via `PG_TRY()`/`PG_CATCH()`.

```text
copy_constraints_and_check()
  save ExecutorCheckPerms_hook (volatile local)
  PG_TRY:
      ExecutorCheckPerms_hook = NULL
      ExecCheckPermissions()   -> ExecCheckRTEPerms() still enforces ACL_INSERT
      restore hook
  PG_CATCH:
      restore hook
      PG_RE_THROW()
```

- Standard PostgreSQL permission enforcement is fully preserved: `ExecCheckPermissions()` still runs `ExecCheckRTEPerms()`, so users without `ACL_INSERT` on the hypertable root still get `ERROR: permission denied for table ...`. Only third-party hook callbacks are skipped for this one internal check.
- The loader is untouched: it remains minimal and version-agnostic, with no new rendezvous variables, ABI surface, or API-version bump.
- No PostgreSQL restart is required on upgrade; `ALTER EXTENSION timescaledb UPDATE` applies cleanly.
- Behavior is identical regardless of `shared_preload_libraries` ordering (`timescaledb,pgaudit` or `pgaudit,timescaledb`).

Known trade-off: COPY into a hypertable remains invisible to pgAudit's audit log, since TimescaleDB routes that COPY through its own execution path and the statement never reaches pgAudit's `ProcessUtility` hook. That is pre-existing behavior for this custom command handling. This patch removes the crash without changing audit behavior.

Fixes #7667.

## Validation

- [x] PostgreSQL 17.4 build; `copy`, `copy_where`, `grant_hypertable-17`, `rowsecurity-17`, `triggers`, `cagg_permissions-17`, `compression_permissions-17` regression tests pass
- [x] Manual #7667 reproduction with pgaudit 17.0 and `shared_preload_libraries = 'timescaledb,pgaudit'`: unpatched `main` segfaults at the hypertable `COPY`; with this patch the COPY completes, a role without `INSERT` still gets a clean `permission denied` error, `GRANT INSERT` allows the COPY, and pgAudit continues auditing other statements
- [ ] Full `installcheck` / GitHub Actions
