### PR TITLE
fix: make ts_bmslist_free NULL-safe to prevent pfree(NULL) segfault (#10414)

### DIFF
--- a/src/bmslist_utils.c
+++ b/src/bmslist_utils.c
@@ -99,5 +99,13 @@ ts_bmslist_contains_set(TsBmsList bmslist, Bitmapset *set)
 void
 ts_bmslist_free(TsBmsList bmslist)
 {
-	list_free_deep(bmslist);
+	ListCell *lc;
+
+	foreach (lc, bmslist)
+	{
+		Bitmapset *bms = (Bitmapset *) lfirst(lc);
+		if (bms != NULL)
+			bms_free(bms);
+	}
+	list_free(bmslist);
 }


### PR DESCRIPTION
## What type of bug is this?

Crash fix

## What subsystems and features are affected?

Compression

## What happened?

Setting `timescaledb.sparse_index = ''` on a hypertable and converting a chunk to columnstore produces a chunk whose sparse index configuration contains a degenerate `{"source": "config"}` descriptor with no columns. Three statement classes against that chunk then crash the backend with SIGSEGV (`pfree(NULL)`), taking down the whole instance:

- `DELETE`/`UPDATE` with at least one equality predicate
- `SELECT` with equality predicates on two or more columns
- `INSERT ... ON CONFLICT` when the table has a unique index

Affects 2.27.0 through 2.29.1 (regression shipped with the DML bloom-filter pass #9399).

## Root cause

`ts_resolve_columns_to_attnos_from_parsed_settings()` resolves the sentinel entry (no columns) to an empty `Bitmapset`, which PostgreSQL represents as a **NULL pointer** in the `List`. Every consumer skips the sentinel safely inside its loop, but they all free the list with `ts_bmslist_free()`, implemented as `list_free_deep()` (`src/bmslist_utils.c:100`), which calls `pfree()` on every element unconditionally → `pfree(NULL)` → SIGSEGV.

Three call sites match the three crashing statement classes:

| Crash | Call site |
|---|---|
| UPDATE/DELETE w/ equality predicate | `process_predicates()`, `tsl/src/compression/compression_dml.c:2437` |
| INSERT ... ON CONFLICT w/ unique index | `init_upsert_bloom_state()`, `tsl/src/compression/compression_dml.c:315` |
| SELECT w/ ≥2 equality predicates | `pushdown_composite_blooms()`, `tsl/src/nodes/columnar_scan/qual_pushdown.c:1270,1358` |

## Fix

Make `ts_bmslist_free()` NULL-tolerant: iterate the list, free each non-NULL `Bitmapset` with `bms_free()`, then `list_free()` the list — instead of `list_free_deep()`, which unconditionally `pfree()`s NULL elements.

```c
void
ts_bmslist_free(TsBmsList bmslist)
{
	ListCell *lc;
	foreach (lc, bmslist)
	{
		Bitmapset *bms = (Bitmapset *) lfirst(lc);
		if (bms != NULL)
			bms_free(bms);
	}
	list_free(bmslist);
}
```

This single-point fix covers all three crash sites, since they all free through `ts_bmslist_free()`.

## How to reproduce

```sql
CREATE TABLE t (day date NOT NULL);
SELECT create_hypertable('t', 'day', chunk_time_interval => interval '30 days');
INSERT INTO t SELECT '2025-01-01'::date + i FROM generate_series(0, 9) i;

ALTER TABLE t SET (
    timescaledb.enable_columnstore,
    timescaledb.orderby      = 'day DESC',
    timescaledb.sparse_index = ''
);

SELECT show_chunks('t') AS c LIMIT 1 \gset
CALL convert_to_columnstore(:'c');

-- Crashes the backend with SIGSEGV before the fix:
DELETE FROM t WHERE day = '2025-01-05';
```

Fixes #10414