### PR TITLE
fix: abandon SkipScan when an append child cannot satisfy required pathkeys

### DIFF
--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -1205,7 +1205,14 @@ build_subpath(PlannerInfo *root, List *subpaths, DistinctPathInfo *dpinfo, List 
 		{
 			if (top_pathkeys && !pathkeys_contained_in(top_pathkeys, child->pathkeys))
 			{
-				continue;
+				/* A child that cannot satisfy the required pathkeys must not be
+				 * silently dropped, as that would lose the rows it produces on a
+				 * partially compressed chunk where the heap and compressed
+				 * branches have different pathkeys. Abandon the SkipScan attempt
+				 * entirely so the unmodified paths are used instead. */
+				if (new_paths)
+					pfree(new_paths);
+				return NIL;
 			}
 
 			SkipScanPath *skip_path = skip_scan_path_create(root, child, dpinfo);


### PR DESCRIPTION
Fixes #10421

## Problem

On a **partially compressed chunk** (compressed, but still holding rows in its uncompressed heap), `SELECT COUNT(DISTINCT ...)` with a **runtime** date predicate silently returns a wrong result (typically `0`) instead of the correct count.

The planner produces a `ConstraintAwareAppend → Merge Append` that carries **only the compressed branch** of the chunk. The uncompressed heap, where the matching rows live, is not scanned at all.

## Root cause

In `build_subpath()` (`tsl/src/nodes/skip_scan/planner.c`), when an append child cannot satisfy the required `top_pathkeys`, the child is silently dropped with `continue`:

```c
if (top_pathkeys && !pathkeys_contained_in(top_pathkeys, child->pathkeys))
{
    continue;   /* child dropped, never appended to new_paths */
}
```

On a partially compressed chunk the heap and compressed branches have different pathkeys, so the heap branch is dropped while the compressed branch survives — the result set loses exactly those rows.

## Fix

Abandon the SkipScan attempt entirely when any child fails the pathkey test, instead of dropping the child. This makes the planner fall back to the unmodified paths, which scan both branches and return the correct result.

## Verification

The reproduction script returns `800` (correct) for query A (`COUNT(DISTINCT ticker)` with a runtime predicate) after this fix, matching the literal-bound control query.

## Notes

- `build_subpath()` is byte-identical across 2.27.0 → 2.29.1; the root defect is unchanged.
- This is a planning-time correctness fix that preserves the SkipScan optimization when all children can satisfy the pathkeys.