### PR TITLE
Fix selecting MergeAppend subpaths with unmatched pathkeys for SkipScan

### DIFF
--- a/.unreleased/pr_10423
+++ b/.unreleased/pr_10423
@@ -1,0 +1,2 @@
+Fixes: #10423 Compressed SkipScan should not drop uncompressed part with sort keys unmatched to distint keys.
+Thanks: @borisborelly for reporting incorrect result with COUNT(DISTINCT) due to SkipScan dropping uncompressed part.

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -1203,17 +1203,15 @@ build_subpath(PlannerInfo *root, List *subpaths, DistinctPathInfo *dpinfo, List 
 		Path *child = lfirst(lc);
 		if (IsA(child, IndexPath) || ts_is_columnar_scan_path(child))
 		{
-			if (top_pathkeys && !pathkeys_contained_in(top_pathkeys, child->pathkeys))
+			if (!top_pathkeys || pathkeys_contained_in(top_pathkeys, child->pathkeys))
 			{
-				continue;
-			}
+				SkipScanPath *skip_path = skip_scan_path_create(root, child, dpinfo);
 
-			SkipScanPath *skip_path = skip_scan_path_create(root, child, dpinfo);
-
-			if (skip_path)
-			{
-				child = (Path *) skip_path;
-				has_skip_path = true;
+				if (skip_path)
+				{
+					child = (Path *) skip_path;
+					has_skip_path = true;
+				}
 			}
 		}
 

--- a/tsl/test/expected/skip_scan_bugs.out
+++ b/tsl/test/expected/skip_scan_bugs.out
@@ -1,0 +1,67 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+-- Fix for issue #10421: do not drop MergeAppend subpaths with pathkeys not matching distinct pathkeys
+-- when the compressed SkipScan plan is chosen.
+-- This table will have uncompressed index on (sale_day) and compressed index on(style, sale_day)
+CREATE TABLE t_10421 (
+    style    text,
+    sale_day date NOT NULL
+) WITH (tsdb.hypertable, tsdb.partition_column = 'sale_day',
+        tsdb.chunk_interval = '360 days', tsdb.segmentby = 'style');
+INSERT INTO t_10421
+SELECT 'S' || s, d
+FROM generate_series(1, 20) s,
+     generate_series('2026-01-02'::date, '2026-01-31'::date, '1 day') d;
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10421') c;
+ count 
+-------
+     1
+
+-- newer rows land in the same chunk, which is now partially compressed
+INSERT INTO t_10421
+SELECT 'S' || s, d
+FROM generate_series(1, 20) s,
+     generate_series('2026-02-01'::date, '2026-02-02'::date, '1 day') d;
+-- steer the planner to the index-based plan shape
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+-- Make sure SkipScan is used on compressed part
+-- and IndexScan with sort keys different from distinct keys but matching the predicate
+-- is used for uncompressed part
+:PREFIX
+SELECT count(DISTINCT style) FROM t_10421
+WHERE sale_day > '2026-01-31';
+--- QUERY PLAN ---
+ Aggregate
+   ->  Merge Append
+         Sort Key: t_10421.style
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (sale_day > '01-31-2026'::date)
+                     ->  Index Scan using _hyper_1_1_chunk_compressed_style__ts_meta_v2_first_sale_da_idx on _hyper_1_1_chunk_compressed
+                           Index Cond: (_ts_meta_v2_first_sale_day > '01-31-2026'::date)
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk.style
+               ->  Index Scan using _hyper_1_1_chunk_t_10421_sale_day_idx on _hyper_1_1_chunk
+                     Index Cond: (sale_day > '01-31-2026'::date)
+
+-- all 20 styles have sales after Jan 31, in the uncompressed part only
+SET timescaledb.enable_compressed_skipscan = off;
+SELECT count(DISTINCT style) FROM t_10421
+WHERE sale_day > '2026-01-31';  -- returns 20, correct
+ count 
+-------
+    20
+
+SET timescaledb.enable_compressed_skipscan = on;  -- default setting
+SELECT count(DISTINCT style) FROM t_10421
+WHERE sale_day > '2026-01-31';  -- returns 20, correct
+ count 
+-------
+    20
+
+drop table t_10421 cascade;
+RESET enable_seqscan;
+RESET enable_bitmapscan;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -217,7 +217,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "17"))
-  list(APPEND TEST_FILES privilege_maintain.sql)
+  list(APPEND TEST_FILES privilege_maintain.sql skip_scan_bugs.sql)
   list(APPEND TEST_TEMPLATES merge_append_partially_compressed.sql.in)
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     list(APPEND TEST_FILES vector_agg_expr_debug.sql)

--- a/tsl/test/sql/skip_scan_bugs.sql
+++ b/tsl/test/sql/skip_scan_bugs.sql
@@ -1,0 +1,52 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set PREFIX 'EXPLAIN (buffers off, costs off, timing off, summary off)'
+
+-- Fix for issue #10421: do not drop MergeAppend subpaths with pathkeys not matching distinct pathkeys
+-- when the compressed SkipScan plan is chosen.
+
+-- This table will have uncompressed index on (sale_day) and compressed index on(style, sale_day)
+CREATE TABLE t_10421 (
+    style    text,
+    sale_day date NOT NULL
+) WITH (tsdb.hypertable, tsdb.partition_column = 'sale_day',
+        tsdb.chunk_interval = '360 days', tsdb.segmentby = 'style');
+
+INSERT INTO t_10421
+SELECT 'S' || s, d
+FROM generate_series(1, 20) s,
+     generate_series('2026-01-02'::date, '2026-01-31'::date, '1 day') d;
+
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10421') c;
+
+-- newer rows land in the same chunk, which is now partially compressed
+INSERT INTO t_10421
+SELECT 'S' || s, d
+FROM generate_series(1, 20) s,
+     generate_series('2026-02-01'::date, '2026-02-02'::date, '1 day') d;
+
+-- steer the planner to the index-based plan shape
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+
+-- Make sure SkipScan is used on compressed part
+-- and IndexScan with sort keys different from distinct keys but matching the predicate
+-- is used for uncompressed part
+:PREFIX
+SELECT count(DISTINCT style) FROM t_10421
+WHERE sale_day > '2026-01-31';
+
+-- all 20 styles have sales after Jan 31, in the uncompressed part only
+SET timescaledb.enable_compressed_skipscan = off;
+SELECT count(DISTINCT style) FROM t_10421
+WHERE sale_day > '2026-01-31';  -- returns 20, correct
+
+SET timescaledb.enable_compressed_skipscan = on;  -- default setting
+SELECT count(DISTINCT style) FROM t_10421
+WHERE sale_day > '2026-01-31';  -- returns 20, correct
+
+drop table t_10421 cascade;
+RESET enable_seqscan;
+RESET enable_bitmapscan;


### PR DESCRIPTION
Fixes #10421.

We now add IndexPath child with no SkipScan due to unmatched pathkeys to Append/MergeAppend children, instead of dropping it. 