### PR TITLE
Fix UDF named time_bucket causing XX000

### DIFF
--- a/.unreleased/fix_10189
+++ b/.unreleased/fix_10189
@@ -1,0 +1,1 @@
+Fixes: #10189 Fix UDF named time_bucket causing XX000

--- a/src/utils.c
+++ b/src/utils.c
@@ -47,6 +47,7 @@
 #include "chunk.h"
 #include "cross_module_fn.h"
 #include "debug_point.h"
+#include "func_cache.h"
 #include "hypertable_cache.h"
 #include "jsonb_utils.h"
 #include "time_utils.h"
@@ -2186,10 +2187,13 @@ ts_find_aggrefs(Node *node)
 bool
 ts_is_time_bucket_function(Expr *node)
 {
-	if (IsA(node, FuncExpr) &&
-		strncmp(get_func_name(castNode(FuncExpr, node)->funcid), "time_bucket", NAMEDATALEN) == 0)
+	if (IsA(node, FuncExpr))
 	{
-		return true;
+		FuncInfo *finfo = ts_func_cache_get_bucketing_func(castNode(FuncExpr, node)->funcid);
+		if (finfo != NULL && strncmp(finfo->funcname, "time_bucket", NAMEDATALEN) == 0)
+		{
+			return true;
+		}
 	}
 
 	return false;

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -2263,6 +2263,15 @@ no transformation
          ->  Seq Scan on _hyper_1_15_chunk
                Filter: ((time_bucket(((10 + (floor(random()))::integer))::bigint, "time") > 10) AND (time_bucket(((10 + (floor(random()))::integer))::bigint, "time") < 100))
 
+\qecho user-defined function named time_bucket should not trigger internal error
+user-defined function named time_bucket should not trigger internal error
+CREATE FUNCTION time_bucket(int, text) RETURNS text AS $$ BEGIN RETURN left($2, $1); END $$ LANGUAGE plpgsql;
+SELECT count(*) FROM hyper WHERE time_bucket(1, 'foo') < 'z';
+ count 
+-------
+  1002
+
+DROP FUNCTION time_bucket(int, text);
 \qecho exclude chunks based on time column with partitioning function. This
 exclude chunks based on time column with partitioning function. This
 \qecho transparently applies the time partitioning function on the time

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -2263,6 +2263,15 @@ no transformation
          ->  Seq Scan on _hyper_1_15_chunk
                Filter: ((time_bucket(((10 + (floor(random()))::integer))::bigint, "time") > 10) AND (time_bucket(((10 + (floor(random()))::integer))::bigint, "time") < 100))
 
+\qecho user-defined function named time_bucket should not trigger internal error
+user-defined function named time_bucket should not trigger internal error
+CREATE FUNCTION time_bucket(int, text) RETURNS text AS $$ BEGIN RETURN left($2, $1); END $$ LANGUAGE plpgsql;
+SELECT count(*) FROM hyper WHERE time_bucket(1, 'foo') < 'z';
+ count 
+-------
+  1002
+
+DROP FUNCTION time_bucket(int, text);
 \qecho exclude chunks based on time column with partitioning function. This
 exclude chunks based on time column with partitioning function. This
 \qecho transparently applies the time partitioning function on the time

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -2263,6 +2263,15 @@ no transformation
          ->  Seq Scan on _hyper_1_15_chunk
                Filter: ((time_bucket(((10 + (floor(random()))::integer))::bigint, "time") > 10) AND (time_bucket(((10 + (floor(random()))::integer))::bigint, "time") < 100))
 
+\qecho user-defined function named time_bucket should not trigger internal error
+user-defined function named time_bucket should not trigger internal error
+CREATE FUNCTION time_bucket(int, text) RETURNS text AS $$ BEGIN RETURN left($2, $1); END $$ LANGUAGE plpgsql;
+SELECT count(*) FROM hyper WHERE time_bucket(1, 'foo') < 'z';
+ count 
+-------
+  1002
+
+DROP FUNCTION time_bucket(int, text);
 \qecho exclude chunks based on time column with partitioning function. This
 exclude chunks based on time column with partitioning function. This
 \qecho transparently applies the time partitioning function on the time

--- a/test/expected/plan_expand_hypertable-19.out
+++ b/test/expected/plan_expand_hypertable-19.out
@@ -2262,6 +2262,15 @@ no transformation
          ->  Seq Scan on _hyper_1_15_chunk
                Filter: ((time_bucket(((10 + (floor(random()))::integer))::bigint, "time") > 10) AND (time_bucket(((10 + (floor(random()))::integer))::bigint, "time") < 100))
 
+\qecho user-defined function named time_bucket should not trigger internal error
+user-defined function named time_bucket should not trigger internal error
+CREATE FUNCTION time_bucket(int, text) RETURNS text AS $$ BEGIN RETURN left($2, $1); END $$ LANGUAGE plpgsql;
+SELECT count(*) FROM hyper WHERE time_bucket(1, 'foo') < 'z';
+ count 
+-------
+  1002
+
+DROP FUNCTION time_bucket(int, text);
 \qecho exclude chunks based on time column with partitioning function. This
 exclude chunks based on time column with partitioning function. This
 \qecho transparently applies the time partitioning function on the time

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -328,6 +328,11 @@ DEALLOCATE P8;
 \qecho no transformation
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10 + floor(random())::int, time) > 10 AND time_bucket(10 + floor(random())::int, time) < 100 AND time < 150 ORDER BY time;
 
+\qecho user-defined function named time_bucket should not trigger internal error
+CREATE FUNCTION time_bucket(int, text) RETURNS text AS $$ BEGIN RETURN left($2, $1); END $$ LANGUAGE plpgsql;
+SELECT count(*) FROM hyper WHERE time_bucket(1, 'foo') < 'z';
+DROP FUNCTION time_bucket(int, text);
+
 \qecho exclude chunks based on time column with partitioning function. This
 \qecho transparently applies the time partitioning function on the time
 \qecho value to be able to exclude chunks (similar to a closed dimension).


### PR DESCRIPTION
ts_is_time_bucket_function() matched by name only,
causing user-defined functions called time_bucket
to be misidentified as TimescaleDB's own. Replace
strncmp() check with OID-based func_cache lookup.

Fixes #10189
