### PR TITLE
Fix gapfill with window agg of constant

### DIFF
--- a/.unreleased/fix_10363
+++ b/.unreleased/fix_10363
@@ -1,0 +1,1 @@
+Fixes: #10363 Fix gapfill with window agg of constant

--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -557,7 +557,8 @@ gapfill_build_pathtarget(PathTarget *pt_upper, PathTarget *pt_path, PathTarget *
 					}
 				}
 
-				if (contain_var_clause(linitial(context.call.window->args)))
+				if (contain_var_clause(linitial(context.call.window->args)) ||
+					contain_agg_clause(linitial(context.call.window->args)))
 				{
 					add_column_to_pathtarget(pt_path,
 											 linitial(context.call.window->args),
@@ -911,7 +912,8 @@ gapfill_adjust_window_targetlist(PlannerInfo *root, RelOptInfo *input_rel, RelOp
 								}
 							}
 
-							if (contain_var_clause(linitial(context.call.window->args)))
+							if (contain_var_clause(linitial(context.call.window->args)) ||
+								contain_agg_clause(linitial(context.call.window->args)))
 							{
 								add_column_to_pathtarget(pt,
 														 linitial(context.call.window->args),

--- a/tsl/test/shared/expected/gapfill-16.out
+++ b/tsl/test/shared/expected/gapfill-16.out
@@ -2049,6 +2049,21 @@ GROUP BY 1;
                    4 |           0 |         2 |          5
                    5 |           0 |         2 |          5
 
+-- test window function with aggregate of constant
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value 
+---------------------+-------------
+                   0 |         1.0
+                   1 |         1.0
+                   2 |         1.0
+                   3 |         1.0
+                   4 |         1.0
+                   5 |         1.0
+
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/expected/gapfill-17.out
+++ b/tsl/test/shared/expected/gapfill-17.out
@@ -2049,6 +2049,21 @@ GROUP BY 1;
                    4 |           0 |         2 |          5
                    5 |           0 |         2 |          5
 
+-- test window function with aggregate of constant
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value 
+---------------------+-------------
+                   0 |         1.0
+                   1 |         1.0
+                   2 |         1.0
+                   3 |         1.0
+                   4 |         1.0
+                   5 |         1.0
+
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/expected/gapfill-18.out
+++ b/tsl/test/shared/expected/gapfill-18.out
@@ -2049,6 +2049,21 @@ GROUP BY 1;
                    4 |           0 |         2 |          5
                    5 |           0 |         2 |          5
 
+-- test window function with aggregate of constant
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value 
+---------------------+-------------
+                   0 |         1.0
+                   1 |         1.0
+                   2 |         1.0
+                   3 |         1.0
+                   4 |         1.0
+                   5 |         1.0
+
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/expected/gapfill-19.out
+++ b/tsl/test/shared/expected/gapfill-19.out
@@ -2052,6 +2052,21 @@ GROUP BY 1;
                    4 |           0 |         2 |          5
                    5 |           0 |         2 |          5
 
+-- test window function with aggregate of constant
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value 
+---------------------+-------------
+                   0 |         1.0
+                   1 |         1.0
+                   2 |         1.0
+                   3 |         1.0
+                   4 |         1.0
+                   5 |         1.0
+
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -921,6 +921,13 @@ SELECT
 FROM (VALUES (0),(2),(5)) v(time)
 GROUP BY 1;
 
+-- test window function with aggregate of constant
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,


### PR DESCRIPTION
gapfill_build_pathtarget() used contain_var_clause()
to decide if a window function arg needs the subpath.
Aggregates of constants like min(1.0) have no Vars,
so the expression was dropped, leaving an orphaned
Aggref. Add contain_agg_clause() check alongside.

Fixes #10363
