### PR TITLE
Do not attach SkipScan to mismatched IndexScan under MergeAppend

### DIFF
--- a/.unreleased/pr_10430
+++ b/.unreleased/pr_10430
@@ -1,0 +1,1 @@
+Fixes: #10430 Should not attach SkipScan to mismatched IndexScan under MergeAppend.

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -615,10 +615,13 @@ tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *ou
 			{
 				continue;
 			}
-			/* Need to check sortedness for inputs of Distinct aggs, so we'll keep track of the
-			 * input pathkeys  */
-			top_pathkeys = subpath->pathkeys;
 		}
+		/* Need to check that subpath pathkeys match pathkeys of subpath children:
+		 * relevant for MergeAppend/ChunkAppend as we don't add SortPath over mismatched IndexPath
+		 * but will add Sort node later, and we don't want SkipScan to go over mismatched IndexScan.
+		 * Also relevant for distinct aggregate AggPath pathkeys matching its input pathkeys.
+		 */
+		top_pathkeys = subpath->pathkeys;
 
 		/* If path is a ProjectionPath we strip it off for processing
 		 * but also add a ProjectionPath on top of the SKipScanPaths

--- a/tsl/test/expected/skip_scan_bugs.out
+++ b/tsl/test/expected/skip_scan_bugs.out
@@ -63,5 +63,170 @@ WHERE sale_day > '2026-01-31';  -- returns 20, correct
     20
 
 drop table t_10421 cascade;
+-- Fix for issue #10429: don't use SkipScan over unmatched IndexScan with sort on top.
+-- Set up table with multikeys indexes on compressed and uncompressed data
+CREATE TABLE t_10429(
+	run_datetime              timestamp without time zone NOT NULL,
+	runno                     integer                     NOT NULL,
+	interval_datetime         timestamp without time zone NOT NULL,
+	constraintid              text                        NOT NULL,
+	versionno                 integer                     NOT NULL,
+	bidtype                   text                        NOT NULL,
+	relevant_regions          text                        NOT NULL
+);
+CREATE INDEX fpp_fcas_summary_run_datetime_idx ON t_10429
+	USING btree (run_datetime, runno, interval_datetime, constraintid, versionno);
+SELECT table_name FROM public.create_hypertable(
+	relation => 't_10429',
+	time_column_name => 'run_datetime',
+	chunk_time_interval => interval '6 months',
+	create_default_indexes => false
+);
+WARNING:  column type "timestamp without time zone" used for "run_datetime" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "interval_datetime" does not follow best practices
+ table_name 
+------------
+ t_10429
+
+ALTER TABLE t_10429 SET (
+	timescaledb.compress,
+	timescaledb.compress_segmentby = 'runno, constraintid, versionno',
+	timescaledb.compress_orderby='interval_datetime DESC, run_datetime DESC'
+);
+-- Fill in and compress some data
+WITH base AS (
+    SELECT
+        gs AS run_datetime,
+        gs - interval '5 minutes' AS interval_datetime,
+        c.constraintid,
+        b.bidtype,
+        r.region AS relevant_regions,
+        row_number() OVER (
+            PARTITION BY gs, c.constraintid
+            ORDER BY b.bidtype, r.region
+        )::integer AS runno
+    FROM generate_series(
+        '2026-01-01 00:00:00'::timestamp,
+        '2026-08-04 23:55:00'::timestamp,
+        interval '1 day'
+    ) AS gs
+    CROSS JOIN (
+        VALUES  ('CONSTRAINT_001'), ('CONSTRAINT_002'), ('CONSTRAINT_003')
+    ) AS c(constraintid)
+    CROSS JOIN (
+        VALUES  ('RAISE6SEC'), ('RAISE60SEC')
+    ) AS b(bidtype)
+    CROSS JOIN (
+        VALUES  ('NSW1'), ('QLD1')
+    ) AS r(region)
+)
+INSERT INTO t_10429 (
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    versionno,
+    bidtype,
+    relevant_regions
+)
+SELECT
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    1 AS versionno,
+    bidtype,
+    relevant_regions
+FROM base;
+SELECT count(compress_chunk(ch)) FROM show_chunks('t_10429') ch;
+ count 
+-------
+     2
+
+-- Add uncompressed data so that we have partial chunk with different sort order
+-- on compressed vs. uncompressed data
+WITH base AS (
+    SELECT
+        gs AS run_datetime,
+        gs - interval '5 minutes' AS interval_datetime,
+        c.constraintid,
+        b.bidtype,
+        r.region AS relevant_regions,
+        row_number() OVER (
+            PARTITION BY gs, c.constraintid
+            ORDER BY b.bidtype, r.region
+        )::integer AS runno
+    FROM generate_series(
+        '2026-01-01 00:00:00'::timestamp,
+        '2026-08-04 23:55:00'::timestamp,
+        interval '1 day'
+    ) AS gs
+    CROSS JOIN (
+        VALUES  ('CONSTRAINT_001'), ('CONSTRAINT_002'), ('CONSTRAINT_003')
+    ) AS c(constraintid)
+    CROSS JOIN (
+        VALUES  ('RAISE6SEC'), ('RAISE60SEC')
+    ) AS b(bidtype)
+    CROSS JOIN (
+        VALUES  ('NSW1'), ('QLD1')
+    ) AS r(region)
+)
+INSERT INTO t_10429 (
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    versionno,
+    bidtype,
+    relevant_regions
+)
+SELECT
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    1 AS versionno,
+    bidtype,
+    relevant_regions
+FROM base;
+ANALYZE t_10429;
+SET datestyle = 'iso, mdy';
+SET timezone = 'UTC';
+-- In this query we should not use SkipScan over uncompressed IndexScan
+-- as IndexScan pathkey on (interval_datetime) is not matching distinct pathkeys for the query.
+-- It should return result without error.
+SET timescaledb.debug_skip_scan_info  TO true;
+SELECT DISTINCT
+ON (interval_datetime, run_datetime, runno, constraintid) *
+FROM
+t_10429
+WHERE
+interval_datetime > '2026-08-01'
+AND interval_datetime <= '2026-08-02'
+ORDER BY
+interval_datetime,
+run_datetime DESC,
+runno DESC,
+constraintid,
+versionno DESC;
+    run_datetime     | runno |  interval_datetime  |  constraintid  | versionno |  bidtype   | relevant_regions 
+---------------------+-------+---------------------+----------------+-----------+------------+------------------
+ 2026-08-02 00:00:00 |     4 | 2026-08-01 23:55:00 | CONSTRAINT_001 |         1 | RAISE6SEC  | QLD1
+ 2026-08-02 00:00:00 |     4 | 2026-08-01 23:55:00 | CONSTRAINT_002 |         1 | RAISE6SEC  | QLD1
+ 2026-08-02 00:00:00 |     4 | 2026-08-01 23:55:00 | CONSTRAINT_003 |         1 | RAISE6SEC  | QLD1
+ 2026-08-02 00:00:00 |     3 | 2026-08-01 23:55:00 | CONSTRAINT_001 |         1 | RAISE6SEC  | NSW1
+ 2026-08-02 00:00:00 |     3 | 2026-08-01 23:55:00 | CONSTRAINT_002 |         1 | RAISE6SEC  | NSW1
+ 2026-08-02 00:00:00 |     3 | 2026-08-01 23:55:00 | CONSTRAINT_003 |         1 | RAISE6SEC  | NSW1
+ 2026-08-02 00:00:00 |     2 | 2026-08-01 23:55:00 | CONSTRAINT_001 |         1 | RAISE60SEC | QLD1
+ 2026-08-02 00:00:00 |     2 | 2026-08-01 23:55:00 | CONSTRAINT_002 |         1 | RAISE60SEC | QLD1
+ 2026-08-02 00:00:00 |     2 | 2026-08-01 23:55:00 | CONSTRAINT_003 |         1 | RAISE60SEC | QLD1
+ 2026-08-02 00:00:00 |     1 | 2026-08-01 23:55:00 | CONSTRAINT_001 |         1 | RAISE60SEC | NSW1
+ 2026-08-02 00:00:00 |     1 | 2026-08-01 23:55:00 | CONSTRAINT_002 |         1 | RAISE60SEC | NSW1
+ 2026-08-02 00:00:00 |     1 | 2026-08-01 23:55:00 | CONSTRAINT_003 |         1 | RAISE60SEC | NSW1
+
+RESET timescaledb.debug_skip_scan_info;
+drop table t_10429 cascade;
+RESET datestyle;
+RESET timezone;
 RESET enable_seqscan;
 RESET enable_bitmapscan;

--- a/tsl/test/sql/skip_scan_bugs.sql
+++ b/tsl/test/sql/skip_scan_bugs.sql
@@ -48,5 +48,156 @@ SELECT count(DISTINCT style) FROM t_10421
 WHERE sale_day > '2026-01-31';  -- returns 20, correct
 
 drop table t_10421 cascade;
+
+-- Fix for issue #10429: don't use SkipScan over unmatched IndexScan with sort on top.
+
+-- Set up table with multikeys indexes on compressed and uncompressed data
+CREATE TABLE t_10429(
+	run_datetime              timestamp without time zone NOT NULL,
+	runno                     integer                     NOT NULL,
+	interval_datetime         timestamp without time zone NOT NULL,
+	constraintid              text                        NOT NULL,
+	versionno                 integer                     NOT NULL,
+	bidtype                   text                        NOT NULL,
+	relevant_regions          text                        NOT NULL
+);
+CREATE INDEX fpp_fcas_summary_run_datetime_idx ON t_10429
+	USING btree (run_datetime, runno, interval_datetime, constraintid, versionno);
+SELECT table_name FROM public.create_hypertable(
+	relation => 't_10429',
+	time_column_name => 'run_datetime',
+	chunk_time_interval => interval '6 months',
+	create_default_indexes => false
+);
+ALTER TABLE t_10429 SET (
+	timescaledb.compress,
+	timescaledb.compress_segmentby = 'runno, constraintid, versionno',
+	timescaledb.compress_orderby='interval_datetime DESC, run_datetime DESC'
+);
+
+-- Fill in and compress some data
+WITH base AS (
+    SELECT
+        gs AS run_datetime,
+        gs - interval '5 minutes' AS interval_datetime,
+        c.constraintid,
+        b.bidtype,
+        r.region AS relevant_regions,
+        row_number() OVER (
+            PARTITION BY gs, c.constraintid
+            ORDER BY b.bidtype, r.region
+        )::integer AS runno
+    FROM generate_series(
+        '2026-01-01 00:00:00'::timestamp,
+        '2026-08-04 23:55:00'::timestamp,
+        interval '1 day'
+    ) AS gs
+    CROSS JOIN (
+        VALUES  ('CONSTRAINT_001'), ('CONSTRAINT_002'), ('CONSTRAINT_003')
+    ) AS c(constraintid)
+    CROSS JOIN (
+        VALUES  ('RAISE6SEC'), ('RAISE60SEC')
+    ) AS b(bidtype)
+    CROSS JOIN (
+        VALUES  ('NSW1'), ('QLD1')
+    ) AS r(region)
+)
+INSERT INTO t_10429 (
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    versionno,
+    bidtype,
+    relevant_regions
+)
+SELECT
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    1 AS versionno,
+    bidtype,
+    relevant_regions
+FROM base;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('t_10429') ch;
+
+-- Add uncompressed data so that we have partial chunk with different sort order
+-- on compressed vs. uncompressed data
+WITH base AS (
+    SELECT
+        gs AS run_datetime,
+        gs - interval '5 minutes' AS interval_datetime,
+        c.constraintid,
+        b.bidtype,
+        r.region AS relevant_regions,
+        row_number() OVER (
+            PARTITION BY gs, c.constraintid
+            ORDER BY b.bidtype, r.region
+        )::integer AS runno
+    FROM generate_series(
+        '2026-01-01 00:00:00'::timestamp,
+        '2026-08-04 23:55:00'::timestamp,
+        interval '1 day'
+    ) AS gs
+    CROSS JOIN (
+        VALUES  ('CONSTRAINT_001'), ('CONSTRAINT_002'), ('CONSTRAINT_003')
+    ) AS c(constraintid)
+    CROSS JOIN (
+        VALUES  ('RAISE6SEC'), ('RAISE60SEC')
+    ) AS b(bidtype)
+    CROSS JOIN (
+        VALUES  ('NSW1'), ('QLD1')
+    ) AS r(region)
+)
+INSERT INTO t_10429 (
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    versionno,
+    bidtype,
+    relevant_regions
+)
+SELECT
+    run_datetime,
+    runno,
+    interval_datetime,
+    constraintid,
+    1 AS versionno,
+    bidtype,
+    relevant_regions
+FROM base;
+
+ANALYZE t_10429;
+
+SET datestyle = 'iso, mdy';
+SET timezone = 'UTC';
+
+-- In this query we should not use SkipScan over uncompressed IndexScan
+-- as IndexScan pathkey on (interval_datetime) is not matching distinct pathkeys for the query.
+-- It should return result without error.
+SET timescaledb.debug_skip_scan_info  TO true;
+SELECT DISTINCT
+ON (interval_datetime, run_datetime, runno, constraintid) *
+FROM
+t_10429
+WHERE
+interval_datetime > '2026-08-01'
+AND interval_datetime <= '2026-08-02'
+ORDER BY
+interval_datetime,
+run_datetime DESC,
+runno DESC,
+constraintid,
+versionno DESC;
+RESET timescaledb.debug_skip_scan_info;
+
+drop table t_10429 cascade;
+
+RESET datestyle;
+RESET timezone;
+
 RESET enable_seqscan;
 RESET enable_bitmapscan;


### PR DESCRIPTION
Fixes #10429.

Pathkeys for Unique subpath should match pathkeys of subpath child and the child should be IndexPath or ColumnarScan path for SkipScan to be applied to the subpath child.

For MergeAppend children we do not add SortPath at planning time (but rather add Sort node for execution), so it appeared that IndexPath with mismatched pathkeys was directly under MergeAppendPath, fooling SkipScan that it's a valid IndexPath to be attached to. 

We now check that pathkeys for MergeAppend shoud match pathkeys of its IndexPath child before allowing SkipScan to be attached to this IndexPath. 
We used to do similar check for AggPath and its children for distinct aggregates, and now we extended this check for the general case.