### PR TITLE
Do not skip chunks with invalidated ranges

### DIFF
--- a/.unreleased/fix_chunk_skipping_invalid_range
+++ b/.unreleased/fix_chunk_skipping_invalid_range
@@ -1,0 +1,1 @@
+Fixes: #10431 Do not exclude chunks with invalidated column ranges at execution time

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -581,7 +581,7 @@ create_col_stats_check_constraint(const Form_chunk_column_stats info, Oid main_t
 	List *compexprs = NIL;
 	Oid col_type;
 
-	if (info->range_start == PG_INT64_MIN && info->range_end == PG_INT64_MAX)
+	if (!info->valid || (info->range_start == PG_INT64_MIN && info->range_end == PG_INT64_MAX))
 	{
 		return NULL;
 	}

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -843,3 +843,78 @@ SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775805;
      2
 
 RESET timescaledb.enable_chunk_skipping;
+-- Test that a chunk whose range was invalidated is not excluded at execution time
+SET timescaledb.enable_chunk_skipping = on;
+CREATE TABLE chunk_skip_invalid(
+    ts     timestamptz NOT NULL,
+    ranged int
+);
+SELECT * FROM create_hypertable('chunk_skip_invalid', 'ts',
+                         chunk_time_interval => interval '1 day');
+ hypertable_id | schema_name |     table_name     | created 
+---------------+-------------+--------------------+---------
+             8 | public      | chunk_skip_invalid | t
+
+SELECT * FROM enable_chunk_skipping('chunk_skip_invalid', 'ranged');
+ column_stats_id | enabled 
+-----------------+---------
+              21 | t
+
+ALTER TABLE chunk_skip_invalid SET (timescaledb.compress);
+INSERT INTO chunk_skip_invalid VALUES ('2025-01-01', 20);
+INSERT INTO chunk_skip_invalid VALUES ('2025-01-02', 20);
+SELECT count(compress_chunk(c)) FROM show_chunks('chunk_skip_invalid') c;
+ count 
+-------
+     2
+
+-- DML on a compressed chunk makes it partial, which invalidates its ranges
+INSERT INTO chunk_skip_invalid VALUES ('2025-01-01', 9);
+SELECT chunk_id, range_start, range_end, valid FROM _timescaledb_catalog.chunk_column_stats
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'chunk_skip_invalid')
+  AND chunk_id IS NOT NULL ORDER BY 1;
+ chunk_id | range_start | range_end | valid 
+----------+-------------+-----------+-------
+       10 |          20 |        21 | f
+       11 |          20 |        21 | t
+
+-- The chunk with the invalidated range must survive executor startup exclusion
+:PREFIX SELECT * FROM chunk_skip_invalid WHERE ranged = length(substring(version(),1,9));
+--- QUERY PLAN ---
+ Custom Scan (ChunkAppend) on chunk_skip_invalid
+   Chunks excluded during startup: 1
+   ->  Custom Scan (ColumnarScan) on _hyper_8_10_chunk
+         Vectorized Filter: (ranged = length("substring"(version(), 1, 9)))
+         ->  Seq Scan on _hyper_8_10_chunk_compressed
+   ->  Seq Scan on _hyper_8_10_chunk
+         Filter: (ranged = length("substring"(version(), 1, 9)))
+
+:PREFIX UPDATE chunk_skip_invalid SET ranged = 0 WHERE ranged = length(substring(version(),1,9));
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Update on chunk_skip_invalid
+         Update on _hyper_8_10_chunk chunk_skip_invalid_1
+         Update on _hyper_8_11_chunk chunk_skip_invalid
+         ->  Result
+               ->  Custom Scan (ChunkAppend) on chunk_skip_invalid
+                     Chunks excluded during startup: 1
+                     ->  Seq Scan on _hyper_8_10_chunk chunk_skip_invalid_1
+                           Filter: (ranged = length("substring"(version(), 1, 9)))
+
+:PREFIX DELETE FROM chunk_skip_invalid WHERE ranged = length(substring(version(),1,9));
+--- QUERY PLAN ---
+ Custom Scan (ModifyHypertable)
+   ->  Delete on chunk_skip_invalid
+         Delete on _hyper_8_10_chunk chunk_skip_invalid_1
+         Delete on _hyper_8_11_chunk chunk_skip_invalid
+         ->  Custom Scan (ChunkAppend) on chunk_skip_invalid
+               Chunks excluded during startup: 1
+               ->  Seq Scan on _hyper_8_10_chunk chunk_skip_invalid_1
+                     Filter: (ranged = length("substring"(version(), 1, 9)))
+
+SELECT count(*) FROM chunk_skip_invalid WHERE ranged = length(substring(version(),1,9));
+ count 
+-------
+     1
+
+RESET timescaledb.enable_chunk_skipping;

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -382,3 +382,33 @@ SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775805;
 
 
 RESET timescaledb.enable_chunk_skipping;
+
+-- Test that a chunk whose range was invalidated is not excluded at execution time
+SET timescaledb.enable_chunk_skipping = on;
+
+CREATE TABLE chunk_skip_invalid(
+    ts     timestamptz NOT NULL,
+    ranged int
+);
+SELECT * FROM create_hypertable('chunk_skip_invalid', 'ts',
+                         chunk_time_interval => interval '1 day');
+SELECT * FROM enable_chunk_skipping('chunk_skip_invalid', 'ranged');
+ALTER TABLE chunk_skip_invalid SET (timescaledb.compress);
+
+INSERT INTO chunk_skip_invalid VALUES ('2025-01-01', 20);
+INSERT INTO chunk_skip_invalid VALUES ('2025-01-02', 20);
+SELECT count(compress_chunk(c)) FROM show_chunks('chunk_skip_invalid') c;
+
+-- DML on a compressed chunk makes it partial, which invalidates its ranges
+INSERT INTO chunk_skip_invalid VALUES ('2025-01-01', 9);
+SELECT chunk_id, range_start, range_end, valid FROM _timescaledb_catalog.chunk_column_stats
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'chunk_skip_invalid')
+  AND chunk_id IS NOT NULL ORDER BY 1;
+
+-- The chunk with the invalidated range must survive executor startup exclusion
+:PREFIX SELECT * FROM chunk_skip_invalid WHERE ranged = length(substring(version(),1,9));
+:PREFIX UPDATE chunk_skip_invalid SET ranged = 0 WHERE ranged = length(substring(version(),1,9));
+:PREFIX DELETE FROM chunk_skip_invalid WHERE ranged = length(substring(version(),1,9));
+SELECT count(*) FROM chunk_skip_invalid WHERE ranged = length(substring(version(),1,9));
+
+RESET timescaledb.enable_chunk_skipping;


### PR DESCRIPTION
Chunk skipping records a min/max range per chunk and marks it invalid when a compressed chunk becomes partial, meaning the range can no longer be relied on. The planning path honours the flag and keeps such a chunk, but the execution path built a check constraint from the range without looking at the flag, so a chunk holding matching rows was excluded: a query lost those rows and an UPDATE or DELETE left them untouched, both without an error.

The execution path runs for qualifiers not known at planning time, a stable function or a generic plan for instance.

Returning no constraint leaves the chunk unexcluded by this range, which is what the planning path already concludes for an invalidated range.