### PR TITLE
Change container shm limit for i386 workflow

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
     needs: [config, check_paths]
     container:
       image: i386/debian:bookworm-slim@sha256:4d0f3abf8160f14d07208ff72dc4c46882bc5f0a259a8bb8652702c0ee2cc67a
-      options: --privileged --ulimit core=-1:-1 --ulimit fsize=-1:-1
+      options: --privileged --shm-size=512m --ulimit core=-1:-1 --ulimit fsize=-1:-1
       env:
         PG_SRC_DIR: pgbuild
         PG_INSTALL_DIR: postgresql


### PR DESCRIPTION
Change container shm limit for i386 workflow
    
    We use a container for i386 workflow with defaul Linux container
    /dev/shm setting of 64MB. The new granular refresh tests allocate
    shared memory to track changes on each granular-enabled hypertable,
    but don't reclaim the memory when the hypertable is dropped. The
    accumulated DSM reached the limit of /dev/shm and fail subsequent
    requests by parallel query executions.
    
    This commit is a workaround, by increasing /dev/shm to 512MB.
    Real fix would be to deallocate the shared memory used by a
    hypertable when the hypertable is dropped.