### PR TITLE
Adapt tests for COPY end marker change in PG snapshot

### DIFF
--- a/test/runner_cleanup_output.sh
+++ b/test/runner_cleanup_output.sh
@@ -26,6 +26,8 @@ sed  -E -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
      -e '/Index Searches: [0-9]+/d' \
      -e '/Storage: Memory  Maximum Storage: [0-9]+kB/d' \
      -e '/Window: /d' \
+     -e '/\\\.$/d' \
+     -e '/invalid command \\\.$/d'\
      -e '/Batches: [0-9]+/d' \
      -e '/found [0-9]+ removable, [0-9]+ nonremovable row versions in [0-9]+ pages/d' | \
 grep -av 'DEBUG:  rehashing catalog cache id' | \

--- a/test/sql/rowsecurity.sql.in
+++ b/test/sql/rowsecurity.sql.in
@@ -1340,8 +1340,10 @@ COPY copy_t FROM STDIN; --ok
 SET SESSION AUTHORIZATION regress_rls_bob;
 SET row_security TO OFF;
 COPY copy_t FROM STDIN; --fail - would be affected by RLS.
+\.
 SET row_security TO ON;
 COPY copy_t FROM STDIN; --fail - COPY FROM not supported by RLS.
+\.
 
 -- Check COPY FROM as user with permissions and BYPASSRLS
 SET SESSION AUTHORIZATION regress_rls_exempt_user;
@@ -1357,8 +1359,10 @@ COPY copy_t FROM STDIN; --ok
 SET SESSION AUTHORIZATION regress_rls_carol;
 SET row_security TO OFF;
 COPY copy_t FROM STDIN; --fail - permission denied.
+\.
 SET row_security TO ON;
 COPY copy_t FROM STDIN; --fail - permission denied.
+\.
 
 RESET SESSION AUTHORIZATION;
 DROP TABLE copy_t;

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -967,6 +967,7 @@ INSERT INTO :COMPRESSED_CHUNK SELECT;
 UPDATE :COMPRESSED_CHUNK SET device = 'dev3' WHERE device = 'dev1';
 DELETE FROM :COMPRESSED_CHUNK WHERE device = 'dev1';
 COPY :COMPRESSED_CHUNK FROM STDIN;
+\.
 \set ON_ERROR_STOP 1
 
 -- TEST: OSM chunks should NOT be added to publications

--- a/tsl/test/sql/read_only.sql
+++ b/tsl/test/sql/read_only.sql
@@ -183,6 +183,7 @@ CLUSTER test_table USING test_table_time_idx;
 --
 \set ON_ERROR_STOP 0
 COPY test_table (time, device) FROM STDIN DELIMITER ',';
+\.
 \set ON_ERROR_STOP 1
 
 -- COPY TO (expect to be working in read-only mode)


### PR DESCRIPTION
They added a requirement for the `\.` terminator to be present even if the COPY command fails. Add the terminator. On the current releases, it leads to psql error message instead, so filter it out.

Reference: https://github.com/postgres/postgres/commit/46fa1f6f373865fae7553043790cd17944893ac3#diff-fd57ecde9f67cd174c33dda1de40859ad9ebdc520c1af7a987e867e785661fee