### PR TITLE
Revert "Temporarily disable commit count check for integration branch merge"

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -38,16 +38,14 @@ jobs:
         # Hard limit of 5 commits per pull request. This check cannot
         # be disabled via the Disable-check trailer or by using squash
         # merge.
-        # Temporarily disabled for PR #10427 (large stacked integration
-        # branch). Re-enable after that PR merges.
-        # if [[ "$count" -gt 5 ]]; then
-        #   echo "Found $count commits in pull request (there must be no more than 5):"
-        #   git log --format=format:'- %h %s' $base..$head
-        #   echo
-        #   echo "This limit cannot be overridden. Please rebase and reduce"
-        #   echo "the number of commits to 5 or fewer."
-        #   exit 1
-        # fi
+        if [[ "$count" -gt 5 ]]; then
+          echo "Found $count commits in pull request (there must be no more than 5):"
+          git log --format=format:'- %h %s' $base..$head
+          echo
+          echo "This limit cannot be overridden. Please rebase and reduce"
+          echo "the number of commits to 5 or fewer."
+          exit 1
+        fi
 
         if ! echo "$BODY" | grep -Eqsi '^disable-check:.*\<commit-count\>'
         then


### PR DESCRIPTION

- Re-enables the 5-commit-per-PR check in `.github/workflows/pr-validation.yaml`, which was temporarily disabled in d04002d39 for PR #10427 (large stacked integration branch merge).
- Reverts d04002d39819a9f6d7c78a096ed44d88de14ceae.

