### PR TITLE
Reject non-constant secondary window args

### DIFF
--- a/.unreleased/pr_10446
+++ b/.unreleased/pr_10446
@@ -1,0 +1,1 @@
+Fixes: #10446 Reject non-constant secondary window args

--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -542,18 +542,19 @@ gapfill_build_pathtarget(PathTarget *pt_upper, PathTarget *pt_path, PathTarget *
 
 				/*
 				 * check arguments past first argument dont have Vars
+				 * or aggregates
 				 */
 				for (lc_arg =
 						 lnext(context.call.window->args, list_head(context.call.window->args));
 					 lc_arg != NULL;
 					 lc_arg = lnext(context.call.window->args, lc_arg))
 				{
-					if (contain_var_clause(lfirst(lc_arg)))
+					if (contain_var_clause(lfirst(lc_arg)) || contain_agg_clause(lfirst(lc_arg)))
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("window functions with multiple column "
-										"references not supported")));
+								 errmsg("window function arguments after the first must be "
+										"constants")));
 					}
 				}
 
@@ -892,22 +893,25 @@ gapfill_adjust_window_targetlist(PlannerInfo *root, RelOptInfo *input_rel, RelOp
 						else if (context.call.window->args != NIL)
 						{
 							ListCell *lc_arg;
+
 							if (list_length(context.call.window->args) > 1)
 							{
 								/*
-								 * check arguments past first argument dont have Vars
+								 * check arguments past first argument dont
+								 * have Vars or Aggregates
 								 */
 								for (lc_arg = lnext(context.call.window->args,
 													list_head(context.call.window->args));
 									 lc_arg != NULL;
 									 lc_arg = lnext(context.call.window->args, lc_arg))
 								{
-									if (contain_var_clause(lfirst(lc_arg)))
+									if (contain_var_clause(lfirst(lc_arg)) ||
+										contain_agg_clause(lfirst(lc_arg)))
 									{
 										ereport(ERROR,
 												(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-												 errmsg("window functions with multiple column "
-														"references not supported")));
+												 errmsg("window function arguments after the first "
+														"must be constants")));
 									}
 								}
 							}

--- a/tsl/test/shared/expected/gapfill-16.out
+++ b/tsl/test/shared/expected/gapfill-16.out
@@ -316,7 +316,7 @@ SELECT
   first(min(time),min(time)) OVER ()
 FROM :METRICS
 GROUP BY 1;
-ERROR:  window functions with multiple column references not supported
+ERROR:  window function arguments after the first must be constants
 -- test with unsupported operator
 SELECT
   time_bucket_gapfill(1,time)
@@ -2064,6 +2064,39 @@ GROUP BY 1;
                    4 |         1.0
                    5 |         1.0
 
+-- test window function with aggregate of constant across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value | first_value 
+---------------------+-------------+-------------
+                   0 |           0 |         1.0
+                   1 |           0 |         1.0
+                   2 |           0 |         1.0
+                   3 |           0 |         1.0
+                   4 |           0 |         1.0
+                   5 |           0 |         1.0
+
+\set ON_ERROR_STOP 0
+-- test window function with aggregate in secondary arg
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+-- test window function with aggregate in secondary arg across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+\set ON_ERROR_STOP 1
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/expected/gapfill-17.out
+++ b/tsl/test/shared/expected/gapfill-17.out
@@ -316,7 +316,7 @@ SELECT
   first(min(time),min(time)) OVER ()
 FROM :METRICS
 GROUP BY 1;
-ERROR:  window functions with multiple column references not supported
+ERROR:  window function arguments after the first must be constants
 -- test with unsupported operator
 SELECT
   time_bucket_gapfill(1,time)
@@ -2064,6 +2064,39 @@ GROUP BY 1;
                    4 |         1.0
                    5 |         1.0
 
+-- test window function with aggregate of constant across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value | first_value 
+---------------------+-------------+-------------
+                   0 |           0 |         1.0
+                   1 |           0 |         1.0
+                   2 |           0 |         1.0
+                   3 |           0 |         1.0
+                   4 |           0 |         1.0
+                   5 |           0 |         1.0
+
+\set ON_ERROR_STOP 0
+-- test window function with aggregate in secondary arg
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+-- test window function with aggregate in secondary arg across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+\set ON_ERROR_STOP 1
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/expected/gapfill-18.out
+++ b/tsl/test/shared/expected/gapfill-18.out
@@ -316,7 +316,7 @@ SELECT
   first(min(time),min(time)) OVER ()
 FROM :METRICS
 GROUP BY 1;
-ERROR:  window functions with multiple column references not supported
+ERROR:  window function arguments after the first must be constants
 -- test with unsupported operator
 SELECT
   time_bucket_gapfill(1,time)
@@ -2064,6 +2064,39 @@ GROUP BY 1;
                    4 |         1.0
                    5 |         1.0
 
+-- test window function with aggregate of constant across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value | first_value 
+---------------------+-------------+-------------
+                   0 |           0 |         1.0
+                   1 |           0 |         1.0
+                   2 |           0 |         1.0
+                   3 |           0 |         1.0
+                   4 |           0 |         1.0
+                   5 |           0 |         1.0
+
+\set ON_ERROR_STOP 0
+-- test window function with aggregate in secondary arg
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+-- test window function with aggregate in secondary arg across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+\set ON_ERROR_STOP 1
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/expected/gapfill-19.out
+++ b/tsl/test/shared/expected/gapfill-19.out
@@ -316,7 +316,7 @@ SELECT
   first(min(time),min(time)) OVER ()
 FROM :METRICS
 GROUP BY 1;
-ERROR:  window functions with multiple column references not supported
+ERROR:  window function arguments after the first must be constants
 -- test with unsupported operator
 SELECT
   time_bucket_gapfill(1,time)
@@ -2067,6 +2067,39 @@ GROUP BY 1;
                    4 |         1.0
                    5 |         1.0
 
+-- test window function with aggregate of constant across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ time_bucket_gapfill | first_value | first_value 
+---------------------+-------------+-------------
+                   0 |           0 |         1.0
+                   1 |           0 |         1.0
+                   2 |           0 |         1.0
+                   3 |           0 |         1.0
+                   4 |           0 |         1.0
+                   5 |           0 |         1.0
+
+\set ON_ERROR_STOP 0
+-- test window function with aggregate in secondary arg
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+-- test window function with aggregate in secondary arg across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+ERROR:  window function arguments after the first must be constants
+\set ON_ERROR_STOP 1
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -928,6 +928,31 @@ SELECT
 FROM (VALUES (0),(2),(5)) v(time)
 GROUP BY 1;
 
+-- test window function with aggregate of constant across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  first_value(min(1.0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+
+\set ON_ERROR_STOP 0
+-- test window function with aggregate in secondary arg
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+
+-- test window function with aggregate in secondary arg across multiple windows
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  first_value(min(time)) OVER (ORDER BY time_bucket_gapfill(1,time,0,5)),
+  lag(min(time), 1, min(0)) OVER ()
+FROM (VALUES (0),(2),(5)) v(time)
+GROUP BY 1;
+\set ON_ERROR_STOP 1
+
 -- test window functions with PARTITION BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,


### PR DESCRIPTION
Previously, non-constant secondary arguments like
min(0) in lag(min(time), 1, min(0)) caused an
internal error. Now they are rejected with a clear
ERRCODE_FEATURE_NOT_SUPPORTED error instead.
