### PR TITLE
Close a gap in tracking writer/flusher sync

### DIFF
--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -20,6 +20,7 @@
 #include "compat/compat.h"
 
 #include "continuous_aggs/insert.h"
+#include "debug_assert.h"
 #include "debug_point.h"
 #include "guc.h"
 #include "invalidation.h"
@@ -135,6 +136,16 @@ static HTAB *continuous_aggs_cache_hyper_inval_threshold_htab = NULL;
 /* Per-transaction tenant buffer (drained to shared memory at commit). */
 static HTAB *tenant_local_htab = NULL;
 static bool tenant_buffer_unencodable = false;
+
+/*
+ * Generation this backend currently pins, or NULL.  A flush will not drain a
+ * generation while its num_writers is non-zero, so a writer that fails between
+ * begin_batch and end_batch would stall every later flush.  The abort handler
+ * releases whatever this points at, which covers both an ERROR unwinding out of
+ * the drain and a FATAL exit (ShutdownPostgres, called during process cleanup,
+ * aborts the open transaction before shared memory is detached).
+ */
+static TenantGeneration *pinned_generation = NULL;
 
 /* Backend-lifetime resolved-tracker cache (see TenantTrackerCacheEntry). */
 static HTAB *tenant_tracker_resolved_htab = NULL;
@@ -694,8 +705,10 @@ tenant_local_htab_write(void)
 		/*
 		 * The tracker was resolved (and cached) in the DML path by
 		 * resolve_tenant_tracker, so the drain only reads the backend-local cache
-		 * here -- no attach, lookup, allocation, catalog scan, or PG_TRY, and thus
-		 * nothing that can throw at pre-commit.  A NULL entry means tracking is
+		 * here -- no attach, lookup, allocation or catalog scan.  Errors are still
+		 * possible (a debug build injects one below, and a cancel can arrive), so
+		 * the pin taken further down is released by the abort handler rather than
+		 * relying on this staying throw-free.  A NULL entry means tracking is
 		 * disabled for this hypertable; a missing entry means nothing was buffered
 		 * for it (shouldn't happen), both -> skip (untracked, seqnum 0).
 		 */
@@ -722,9 +735,18 @@ tenant_local_htab_write(void)
 		 * Reading it under the pin means every backend draining into this
 		 * generation gates on the same [window_start, window_end). */
 		generation = ts_tenant_tracker_begin_batch(tracking, &seqnum, &window_start, &window_end);
+
+		/* One pin at a time: this loop releases each before pinning the next. */
+		Ensure(pinned_generation == NULL,
+			   "tenant tracker generation pinned twice by the same backend");
+		pinned_generation = generation;
 		seq_entry->seqnum = seqnum;
 		seq_entry->late_threshold_start = window_start;
 		seq_entry->late_threshold_end = window_end;
+
+		/* Park while the generation is pinned, so a test can cancel or terminate
+		 * the writer before it reaches end_batch. */
+		DEBUG_WAITPOINT("tenant_tracker_in_pin");
 
 		hash_seq_init(&hash_seq, tenant_local_htab);
 		while ((entry = hash_seq_search(&hash_seq)) != NULL)
@@ -751,6 +773,7 @@ tenant_local_htab_write(void)
 			}
 		}
 		ts_tenant_tracker_end_batch(generation);
+		pinned_generation = NULL;
 	}
 
 	list_free(hypertable_ids);
@@ -927,6 +950,21 @@ cache_inval_htab_write(List *hypertable_seqnums)
 static void
 continuous_agg_xact_invalidation_callback(XactEvent event, void *arg)
 {
+	/* A writer that did not reach end_batch still holds its generation pinned;
+	 * (i.e., it increased num_writers but never decreased it). Release it
+	 * in the Abort events before the transaction ends.
+	 *
+	 * Note that we release the generation pin here instead of in the
+	 * switch below, so it wouldn't be missed in the early return
+	 * when continuous_aggs_cache_inval_htab is NULL
+	 */
+	if (pinned_generation != NULL &&
+		(event == XACT_EVENT_ABORT || event == XACT_EVENT_PARALLEL_ABORT))
+	{
+		ts_tenant_tracker_end_batch(pinned_generation);
+		pinned_generation = NULL;
+	}
+
 	/* Return quickly if we never initialize the hashtable */
 	if (!continuous_aggs_cache_inval_htab)
 	{
@@ -964,11 +1002,19 @@ continuous_agg_xact_invalidation_callback(XactEvent event, void *arg)
 			DEBUG_WAITPOINT("tenant_tracker_after_precommit_drain");
 			break;
 		}
+		case XACT_EVENT_ABORT:
+		case XACT_EVENT_PARALLEL_ABORT:
+			/* The pin, if any, should have been released above. */
+			Ensure(pinned_generation == NULL,
+				   "tenant tracker generation still pinned by this backend at abort");
+			cache_inval_cleanup();
+			break;
 		case XACT_EVENT_PREPARE:
 		case XACT_EVENT_COMMIT:
 		case XACT_EVENT_PARALLEL_COMMIT:
-		case XACT_EVENT_ABORT:
-		case XACT_EVENT_PARALLEL_ABORT:
+			/* The pin should have been released before reaching commit. */
+			Ensure(pinned_generation == NULL,
+				   "tenant tracker generation still pinned by this backend at commit");
 			cache_inval_cleanup();
 			break;
 		default:

--- a/tsl/src/continuous_aggs/tenant_tracker.c
+++ b/tsl/src/continuous_aggs/tenant_tracker.c
@@ -179,6 +179,7 @@
 #include <utils/memutils.h>
 #include <utils/timestamp.h>
 
+#include "debug_assert.h"
 #include "debug_point.h"
 #include "loader/tenant_tracker_shmem.h"
 #include "tenant_tracker.h"
@@ -441,7 +442,13 @@ ts_tenant_tracker_apply_one(TenantGeneration *generation, const char *key, uint1
 void
 ts_tenant_tracker_end_batch(TenantGeneration *generation)
 {
-	pg_atomic_fetch_sub_u32(&generation->num_writers, 1);
+	uint32 prev = pg_atomic_fetch_sub_u32(&generation->num_writers, 1);
+
+	/* num_writers is only ever decremented by a backend that incremented it, so
+	 * a count of 0 here means an unmatched release: the counter would wrap to
+	 * UINT32_MAX and this generation's flush would spin forever.
+	 */
+	Ensure(prev > 0, "tenant tracker generation released without a matching pin");
 }
 
 void

--- a/tsl/test/isolation/expected/cagg_granular_refresh_precommit_abort.out
+++ b/tsl/test/isolation/expected/cagg_granular_refresh_precommit_abort.out
@@ -1,6 +1,6 @@
-Parsed test spec with 4 sessions
+Parsed test spec with 6 sessions
 
-starting permutation: wp_pc_enable v_register_pid v_insert k_cancel wp_pc_release r_anchor_insert r_refresh r_check_conditions r_check_tracking r_refresh2 r_check_cagg r_check_tracking2 r_anchor_insert r_refresh2 r_refresh2 r_check_tracking2
+starting permutation: wp_pc_enable v_register_pid v_insert k_cancel k_noop wp_pc_release r_anchor_insert r_refresh r_check_conditions r_check_tracking r_refresh2 r_check_cagg r_check_tracking2 r_anchor_insert r_refresh2 r_refresh2 r_check_tracking2
 step wp_pc_enable: SELECT debug_waitpoint_enable('tenant_tracker_after_precommit_drain');
 debug_waitpoint_enable
 ----------------------
@@ -11,12 +11,13 @@ step v_insert: INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_vic
 step k_cancel: CALL cancelpids(); <waiting ...>
 step v_insert: <... completed>
 ERROR:  canceling statement due to user request
+step k_cancel: <... completed>
+step k_noop: 
 step wp_pc_release: SELECT debug_waitpoint_release('tenant_tracker_after_precommit_drain');
 debug_waitpoint_release
 -----------------------
                        
 
-step k_cancel: <... completed>
 step r_anchor_insert: INSERT INTO conditions VALUES ('2026-07-15 00:00+00', 'sensor_anchor', 0);
 step r_refresh: CALL refresh_continuous_aggregate('cond_daily', '2026-07-15 00:00+00', NULL);
 step r_check_conditions: 
@@ -77,4 +78,108 @@ step r_check_tracking2:
 tenant_id    |seqnum
 -------------+------
 sensor_anchor|     4
+
+
+starting permutation: wp_pin_enable v_register_pid v_insert k_cancel k_noop wp_pin_release r_anchor_insert r_refresh r_check_conditions r_check_tracking r_refresh2 r_check_cagg
+step wp_pin_enable: SELECT debug_waitpoint_enable('tenant_tracker_in_pin');
+debug_waitpoint_enable
+----------------------
+                      
+
+step v_register_pid: INSERT INTO cancelpid VALUES (pg_backend_pid()) ON CONFLICT (pid) DO NOTHING;
+step v_insert: INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_victim', 1); <waiting ...>
+step k_cancel: CALL cancelpids(); <waiting ...>
+step v_insert: <... completed>
+ERROR:  canceling statement due to user request
+step k_cancel: <... completed>
+step k_noop: 
+step wp_pin_release: SELECT debug_waitpoint_release('tenant_tracker_in_pin');
+debug_waitpoint_release
+-----------------------
+                       
+
+step r_anchor_insert: INSERT INTO conditions VALUES ('2026-07-15 00:00+00', 'sensor_anchor', 0);
+step r_refresh: CALL refresh_continuous_aggregate('cond_daily', '2026-07-15 00:00+00', NULL);
+step r_check_conditions: 
+    SELECT count(*) AS victim_rows_in_hypertable
+    FROM conditions
+    WHERE sensor_id = 'sensor_victim';
+
+victim_rows_in_hypertable
+-------------------------
+                        0
+
+step r_check_tracking: 
+    SELECT tenant_id, seqnum
+    FROM _timescaledb_catalog.continuous_aggs_tenant_tracking
+    WHERE hypertable_id = (
+        SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+        WHERE user_view_name = 'cond_daily')
+    ORDER BY tenant_id, seqnum;
+
+tenant_id    |seqnum
+-------------+------
+sensor_1     |     1
+sensor_anchor|     1
+
+step r_refresh2: CALL refresh_continuous_aggregate('cond_daily', '2026-06-15 00:00+00', NULL) ;
+step r_check_cagg: SELECT * FROM cond_daily ORDER BY 1, 2;
+bucket                      |sensor_id    |avg
+----------------------------+-------------+---
+Sat Jun 20 00:00:00 2026 UTC|sensor_1     |  1
+Wed Jul 15 00:00:00 2026 UTC|sensor_anchor|  0
+
+
+starting permutation: wp_pin_enable vk_register_pid vk_insert t_terminate t_noop wp_pin_release r_anchor_insert r_refresh r_check_conditions r_check_tracking r_refresh2 r_check_cagg
+step wp_pin_enable: SELECT debug_waitpoint_enable('tenant_tracker_in_pin');
+debug_waitpoint_enable
+----------------------
+                      
+
+step vk_register_pid: INSERT INTO cancelpid VALUES (pg_backend_pid()) ON CONFLICT (pid) DO NOTHING;
+step vk_insert: INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_victim', 1); <waiting ...>
+step t_terminate: CALL terminatepids(); <waiting ...>
+step vk_insert: <... completed>
+FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+
+step t_terminate: <... completed>
+step t_noop: 
+step wp_pin_release: SELECT debug_waitpoint_release('tenant_tracker_in_pin');
+debug_waitpoint_release
+-----------------------
+                       
+
+step r_anchor_insert: INSERT INTO conditions VALUES ('2026-07-15 00:00+00', 'sensor_anchor', 0);
+step r_refresh: CALL refresh_continuous_aggregate('cond_daily', '2026-07-15 00:00+00', NULL);
+step r_check_conditions: 
+    SELECT count(*) AS victim_rows_in_hypertable
+    FROM conditions
+    WHERE sensor_id = 'sensor_victim';
+
+victim_rows_in_hypertable
+-------------------------
+                        0
+
+step r_check_tracking: 
+    SELECT tenant_id, seqnum
+    FROM _timescaledb_catalog.continuous_aggs_tenant_tracking
+    WHERE hypertable_id = (
+        SELECT raw_hypertable_id FROM _timescaledb_catalog.continuous_agg
+        WHERE user_view_name = 'cond_daily')
+    ORDER BY tenant_id, seqnum;
+
+tenant_id    |seqnum
+-------------+------
+sensor_1     |     1
+sensor_anchor|     1
+
+step r_refresh2: CALL refresh_continuous_aggregate('cond_daily', '2026-06-15 00:00+00', NULL) ;
+step r_check_cagg: SELECT * FROM cond_daily ORDER BY 1, 2;
+bucket                      |sensor_id    |avg
+----------------------------+-------------+---
+Sat Jun 20 00:00:00 2026 UTC|sensor_1     |  1
+Wed Jul 15 00:00:00 2026 UTC|sensor_anchor|  0
 

--- a/tsl/test/isolation/specs/cagg_granular_refresh_precommit_abort.spec
+++ b/tsl/test/isolation/specs/cagg_granular_refresh_precommit_abort.spec
@@ -39,6 +39,15 @@ setup
         DELETE FROM cancelpid;
     END;
     $$ LANGUAGE plpgsql;
+
+    -- Signal terminate to registered backends.
+    CREATE OR REPLACE PROCEDURE terminatepids() AS
+    $$
+    BEGIN
+        PERFORM pg_terminate_backend(pid) FROM cancelpid;
+        DELETE FROM cancelpid;
+    END;
+    $$ LANGUAGE plpgsql;
 }
 
 teardown
@@ -53,6 +62,11 @@ teardown
 session "WP"
 step "wp_pc_enable"  { SELECT debug_waitpoint_enable('tenant_tracker_after_precommit_drain'); }
 step "wp_pc_release" { SELECT debug_waitpoint_release('tenant_tracker_after_precommit_drain'); }
+# Park a writer inside the generation pin instead: begin_batch has incremented
+# num_writers and end_batch has not run yet, so a flush of that generation
+# cannot proceed until the pin is given up.
+step "wp_pin_enable"  { SELECT debug_waitpoint_enable('tenant_tracker_in_pin'); }
+step "wp_pin_release" { SELECT debug_waitpoint_release('tenant_tracker_in_pin'); }
 
 # victim that will be cancelled: its INSERT will publish a tenant, park at PRE_COMMIT, then
 # get cancelled -- aborting the transaction AFTER the tenant was published.
@@ -64,12 +78,37 @@ step "v_insert" { INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_
 # Cancels while it is parked at the waitpoint.
 session "K"
 step "k_cancel" { CALL cancelpids(); }
+# Empty synchronization step. Markers only delay the *reporting* of a step's
+# completion, never the *launch* of the next one, so without this the waitpoint
+# release and the checks after it start while the victim is still unwinding.
+# k_noop is in the same session as k_cancel, which cannot launch until k_cancel
+# is reported complete, and that in turn waits on the cancelled step.
+step "k_noop" { }
+
+# Terminated victim: parks in the pin like V, but the backend exits rather than
+# unwinding through ERROR.  pg_terminate_backend kills the session connection,
+# which cannot be reconnected between permutations, so this session is used by
+# the last permutation only.
+session "VK"
+setup { SET client_min_messages TO warning; }
+step "vk_register_pid" { INSERT INTO cancelpid VALUES (pg_backend_pid()) ON CONFLICT (pid) DO NOTHING; }
+step "vk_insert" { INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_victim', 1); }
+
+session "T"
+step "t_terminate" { CALL terminatepids(); }
+step "t_noop" { }
 
 # An unrelated writer + refresh flushes all tenant tracking entries
 # The refresh window excludes the cancelled backend's  
 # data, so the flushed tenant is not consumed and stays inspectable.
+# The timeout is a ceiling so that a refresh stuck on a pin the victim never
+# gave up fails here instead of hanging the tester; it is not the assertion, so
+# it is set well above anything a loaded runner needs.
 session "R"
-setup { SET timezone TO 'UTC'; SET client_min_messages TO warning; }
+setup {
+    SET timezone TO 'UTC'; SET client_min_messages TO warning;
+    SET statement_timeout = '60s';
+}
 step "r_anchor_insert" { INSERT INTO conditions VALUES ('2026-07-15 00:00+00', 'sensor_anchor', 0); }
 step "r_refresh" { CALL refresh_continuous_aggregate('cond_daily', '2026-07-15 00:00+00', NULL); }
 
@@ -81,7 +120,7 @@ step "r_check_conditions"
     FROM conditions
     WHERE sensor_id = 'sensor_victim';
 }
-#the victim's tenant is present in tenant tracker
+#the tenant trackings currently in the table
 step "r_check_tracking"
 {
     SELECT tenant_id, seqnum
@@ -107,4 +146,18 @@ step "r_check_tracking2"
     ORDER BY tenant_id, seqnum;
 }
 
-permutation "wp_pc_enable" "v_register_pid" "v_insert"("wp_pc_enable") "k_cancel"("v_insert") "wp_pc_release" "r_anchor_insert"("wp_pc_release") "r_refresh" "r_check_conditions" "r_check_tracking" "r_refresh2" "r_check_cagg" "r_check_tracking2" "r_anchor_insert" "r_refresh2" "r_refresh2" "r_check_tracking2"
+# Cancelled after the drain: the tenant was already published to the generation,
+# so the victim's own tenant shows up in the tracking table as an orphan.
+permutation "wp_pc_enable" "v_register_pid" "v_insert"("wp_pc_enable") "k_cancel"("v_insert") "k_noop" "wp_pc_release" "r_anchor_insert"("wp_pc_release") "r_refresh" "r_check_conditions" "r_check_tracking" "r_refresh2" "r_check_cagg" "r_check_tracking2" "r_anchor_insert" "r_refresh2" "r_refresh2" "r_check_tracking2"
+
+# Cancelled inside the pin: the writer unwinds via ERROR still holding it, and
+# the refresh only drains because the abort handler released it.  The park is
+# ahead of the loop that applies tenants to the generation, so unlike the
+# permutation above the victim's own tenant never reaches the tracking table.
+permutation "wp_pin_enable" "v_register_pid" "v_insert"("wp_pin_enable") "k_cancel"("v_insert") "k_noop" "wp_pin_release" "r_anchor_insert"("wp_pin_release") "r_refresh" "r_check_conditions" "r_check_tracking" "r_refresh2" "r_check_cagg"
+
+# Terminated inside the pin: the writer exits without unwinding, and the pin is
+# released because ShutdownPostgres aborts the open transaction first.  Same
+# park as above, so the victim's tenant is absent here too.  Must be last --
+# session VK's connection does not survive it.
+permutation "wp_pin_enable" "vk_register_pid" "vk_insert"("wp_pin_enable") "t_terminate"("vk_insert") "t_noop" "wp_pin_release" "r_anchor_insert"("wp_pin_release") "r_refresh" "r_check_conditions" "r_check_tracking" "r_refresh2" "r_check_cagg"


### PR DESCRIPTION
 Close a gap in tracking writer/flusher sync

    There used to be a small window where a tracking writer (DML)
    failed to decrease num_writers on failure exit. This commit fixes
    the issue by making sure ts_tenant_tracker_end_batch is called
    during transaction abort events.

I will merge into one commit before merging. Separating reproducers from the fix now so it's easier to review. 
Disable-check: force-changelog-file