### PR TITLE
Stabilize cancel/terminate isolation tests with sync steps

### DIFF
--- a/tsl/test/isolation/expected/cagg_cancel_kill_refresh.out
+++ b/tsl/test/isolation/expected/cagg_cancel_kill_refresh.out
@@ -1,6 +1,6 @@
 Parsed test spec with 14 sessions
 
-starting permutation: wp0_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel wp0_release s1_registered_ranges
+starting permutation: wp0_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel k1_noop wp0_release s1_registered_ranges
 step wp0_enable: 
     SELECT debug_waitpoint_enable('cagg_refresh_after_register');
 
@@ -29,6 +29,8 @@ step k1_cancel:
  <waiting ...>
 step r1_refresh: <... completed>
 ERROR:  canceling statement due to user request
+step k1_cancel: <... completed>
+step k1_noop: 
 step wp0_release: 
     SELECT debug_waitpoint_release('cagg_refresh_after_register');
 
@@ -36,7 +38,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step k1_cancel: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -47,7 +48,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp1_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel wp1_release s1_registered_ranges
+starting permutation: wp1_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel k1_noop wp1_release s1_registered_ranges
 step wp1_enable: 
     SELECT debug_waitpoint_enable('cagg_policy_batch_1_after_txn_1_wait');
 
@@ -76,6 +77,8 @@ step k1_cancel:
  <waiting ...>
 step r1_refresh: <... completed>
 ERROR:  canceling statement due to user request
+step k1_cancel: <... completed>
+step k1_noop: 
 step wp1_release: 
     SELECT debug_waitpoint_release('cagg_policy_batch_1_after_txn_1_wait');
 
@@ -83,7 +86,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step k1_cancel: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -94,7 +96,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp2_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel wp2_release s1_registered_ranges
+starting permutation: wp2_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel k1_noop wp2_release s1_registered_ranges
 step wp2_enable: 
     SELECT debug_waitpoint_enable('after_process_cagg_invalidations_for_refresh_lock');
 
@@ -123,6 +125,8 @@ step k1_cancel:
  <waiting ...>
 step r1_refresh: <... completed>
 ERROR:  canceling statement due to user request
+step k1_cancel: <... completed>
+step k1_noop: 
 step wp2_release: 
     SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock');
 
@@ -130,7 +134,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step k1_cancel: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -141,7 +144,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp3_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel wp3_release s1_registered_ranges
+starting permutation: wp3_enable r1_register_pid r1_refresh s1_registered_ranges k1_cancel k1_noop wp3_release s1_registered_ranges
 step wp3_enable: 
     SELECT debug_waitpoint_enable('after_process_cagg_materializations');
 
@@ -170,6 +173,8 @@ step k1_cancel:
  <waiting ...>
 step r1_refresh: <... completed>
 ERROR:  canceling statement due to user request
+step k1_cancel: <... completed>
+step k1_noop: 
 step wp3_release: 
     SELECT debug_waitpoint_release('after_process_cagg_materializations');
 
@@ -177,7 +182,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step k1_cancel: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -188,7 +192,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp0_enable tr1_register_pid tr1_refresh s1_registered_ranges t1_terminate wp0_release s1_registered_ranges r2_refresh s1_registered_ranges
+starting permutation: wp0_enable tr1_register_pid tr1_refresh s1_registered_ranges t1_terminate t1_noop wp0_release s1_registered_ranges r2_refresh s1_registered_ranges
 step wp0_enable: 
     SELECT debug_waitpoint_enable('cagg_refresh_after_register');
 
@@ -221,6 +225,8 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
+step t1_terminate: <... completed>
+step t1_noop: 
 step wp0_release: 
     SELECT debug_waitpoint_release('cagg_refresh_after_register');
 
@@ -228,7 +234,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step t1_terminate: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -252,7 +257,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp1_enable tr2_register_pid tr2_refresh s1_registered_ranges t1_terminate wp1_release s1_registered_ranges r2_refresh s1_registered_ranges
+starting permutation: wp1_enable tr2_register_pid tr2_refresh s1_registered_ranges t1_terminate t1_noop wp1_release s1_registered_ranges r2_refresh s1_registered_ranges
 step wp1_enable: 
     SELECT debug_waitpoint_enable('cagg_policy_batch_1_after_txn_1_wait');
 
@@ -285,6 +290,8 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
+step t1_terminate: <... completed>
+step t1_noop: 
 step wp1_release: 
     SELECT debug_waitpoint_release('cagg_policy_batch_1_after_txn_1_wait');
 
@@ -292,7 +299,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step t1_terminate: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -316,7 +322,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp2_enable tr3_register_pid tr3_refresh s1_registered_ranges t1_terminate wp2_release s1_registered_ranges r2_refresh s1_registered_ranges
+starting permutation: wp2_enable tr3_register_pid tr3_refresh s1_registered_ranges t1_terminate t1_noop wp2_release s1_registered_ranges r2_refresh s1_registered_ranges
 step wp2_enable: 
     SELECT debug_waitpoint_enable('after_process_cagg_invalidations_for_refresh_lock');
 
@@ -349,6 +355,8 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
+step t1_terminate: <... completed>
+step t1_noop: 
 step wp2_release: 
     SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock');
 
@@ -356,7 +364,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step t1_terminate: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -380,7 +387,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp3_enable tr4_register_pid tr4_refresh s1_registered_ranges t1_terminate wp3_release s1_registered_ranges r2_refresh s1_registered_ranges
+starting permutation: wp3_enable tr4_register_pid tr4_refresh s1_registered_ranges t1_terminate t1_noop wp3_release s1_registered_ranges r2_refresh s1_registered_ranges
 step wp3_enable: 
     SELECT debug_waitpoint_enable('after_process_cagg_materializations');
 
@@ -413,6 +420,8 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
+step t1_terminate: <... completed>
+step t1_noop: 
 step wp3_release: 
     SELECT debug_waitpoint_release('after_process_cagg_materializations');
 
@@ -420,7 +429,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step t1_terminate: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r
@@ -444,7 +452,7 @@ cagg_name|start_range|end_range
 ---------+-----------+---------
 
 
-starting permutation: wp2_enable tr5_register_pid tr5_refresh s1_registered_ranges t1_terminate wp2_release s1_registered_ranges r2_refresh_nonoverlap s1_registered_ranges
+starting permutation: wp2_enable tr5_register_pid tr5_refresh s1_registered_ranges t1_terminate t1_noop wp2_release s1_registered_ranges r2_refresh_nonoverlap s1_registered_ranges
 step wp2_enable: 
     SELECT debug_waitpoint_enable('after_process_cagg_invalidations_for_refresh_lock');
 
@@ -477,6 +485,8 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
+step t1_terminate: <... completed>
+step t1_noop: 
 step wp2_release: 
     SELECT debug_waitpoint_release('after_process_cagg_invalidations_for_refresh_lock');
 
@@ -484,7 +494,6 @@ debug_waitpoint_release
 -----------------------
                        
 
-step t1_terminate: <... completed>
 step s1_registered_ranges: 
     SELECT ca.user_view_name AS cagg_name, r.start_range, r.end_range
     FROM _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges r

--- a/tsl/test/isolation/expected/cagg_granular_refresh_precommit_abort.out
+++ b/tsl/test/isolation/expected/cagg_granular_refresh_precommit_abort.out
@@ -1,6 +1,6 @@
 Parsed test spec with 4 sessions
 
-starting permutation: wp_pc_enable v_register_pid v_insert k_cancel wp_pc_release r_anchor_insert r_refresh r_check_conditions r_check_tracking r_refresh2 r_check_cagg r_check_tracking2 r_anchor_insert r_refresh2 r_refresh2 r_check_tracking2
+starting permutation: wp_pc_enable v_register_pid v_insert k_cancel k_noop wp_pc_release r_anchor_insert r_refresh r_check_conditions r_check_tracking r_refresh2 r_check_cagg r_check_tracking2 r_anchor_insert r_refresh2 r_refresh2 r_check_tracking2
 step wp_pc_enable: SELECT debug_waitpoint_enable('tenant_tracker_after_precommit_drain');
 debug_waitpoint_enable
 ----------------------
@@ -11,12 +11,13 @@ step v_insert: INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_vic
 step k_cancel: CALL cancelpids(); <waiting ...>
 step v_insert: <... completed>
 ERROR:  canceling statement due to user request
+step k_cancel: <... completed>
+step k_noop: 
 step wp_pc_release: SELECT debug_waitpoint_release('tenant_tracker_after_precommit_drain');
 debug_waitpoint_release
 -----------------------
                        
 
-step k_cancel: <... completed>
 step r_anchor_insert: INSERT INTO conditions VALUES ('2026-07-15 00:00+00', 'sensor_anchor', 0);
 step r_refresh: CALL refresh_continuous_aggregate('cond_daily', '2026-07-15 00:00+00', NULL);
 step r_check_conditions: 

--- a/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
+++ b/tsl/test/isolation/expected/cagg_refresh_cleanup_register.out
@@ -345,7 +345,7 @@ debug_waitpoint_release
 
 step P1_run_policy: <... completed>
 
-starting permutation: WP_before_txn2_commit_enable R1_refresh check_jobs K1_terminate WP_before_txn2_commit_disable L1_lock R2_refresh R3_refresh L1_unlock check_jobs
+starting permutation: WP_before_txn2_commit_enable R1_refresh check_jobs K1_terminate K1_noop WP_before_txn2_commit_disable L1_lock R2_refresh R3_refresh L1_unlock check_jobs
 step WP_before_txn2_commit_enable: SELECT debug_waitpoint_enable('before_process_cagg_invalidations_for_refresh_lock');
 debug_waitpoint_enable
 ----------------------
@@ -376,12 +376,13 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
+step K1_terminate: <... completed>
+step K1_noop: 
 step WP_before_txn2_commit_disable: SELECT debug_waitpoint_release('before_process_cagg_invalidations_for_refresh_lock');
 debug_waitpoint_release
 -----------------------
                        
 
-step K1_terminate: <... completed>
 step L1_lock: 
     BEGIN;
     LOCK TABLE _timescaledb_catalog.continuous_aggs_jobs_refresh_ranges

--- a/tsl/test/isolation/specs/cagg_cancel_kill_refresh.spec
+++ b/tsl/test/isolation/specs/cagg_cancel_kill_refresh.spec
@@ -45,9 +45,12 @@ setup
         pid INTEGER NOT NULL PRIMARY KEY
     );
 
-    -- Signal cancel to registered backends. The isolation tester's
-    -- (blocked_step) annotation synchronizes step completion, so no polling
-    -- on pg_stat_activity is required here.
+    -- Signal cancel to registered backends. No polling on pg_stat_activity is
+    -- required here: the (blocked_step) marker holds this step's completion
+    -- report until the signalled refresh is reported done, and the k1_noop
+    -- step that follows it in every permutation keeps the next step from being
+    -- launched until then. See the "empty step" idiom in the PostgreSQL
+    -- src/test/isolation/README, "Dealing with race conditions".
     CREATE OR REPLACE PROCEDURE cancelpids() AS
     $$
     BEGIN
@@ -204,6 +207,12 @@ step "k1_cancel"
 {
     CALL cancelpids();
 }
+# Empty synchronization step. Markers only delay the *reporting* of a step's
+# completion, never the *launch* of the next one, so without this the
+# waitpoint-release step races the cancelled backend's unwind. Since k1_noop
+# runs in the same session as k1_cancel, it cannot be launched until k1_cancel
+# is reported complete, which in turn waits on the cancelled refresh.
+step "k1_noop" { }
 
 # Session for killing via pg_terminate_backend
 session "T1"
@@ -211,6 +220,8 @@ step "t1_terminate"
 {
     CALL terminatepids();
 }
+# Same rationale as k1_noop.
+step "t1_noop" { }
 
 # Session to view registered ranges
 session "S1"
@@ -244,33 +255,33 @@ step "r2_refresh_nonoverlap"
 #
 
 # Cancel after registration
-permutation "wp0_enable" "r1_register_pid" "r1_refresh"("wp0_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "wp0_release" "s1_registered_ranges"
+permutation "wp0_enable" "r1_register_pid" "r1_refresh"("wp0_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "k1_noop" "wp0_release" "s1_registered_ranges"
 
 # Cancel after txn 1
-permutation "wp1_enable" "r1_register_pid" "r1_refresh"("wp1_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "wp1_release" "s1_registered_ranges"
+permutation "wp1_enable" "r1_register_pid" "r1_refresh"("wp1_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "k1_noop" "wp1_release" "s1_registered_ranges"
 
 # Cancel after txn 2
-permutation "wp2_enable" "r1_register_pid" "r1_refresh"("wp2_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "wp2_release" "s1_registered_ranges"
+permutation "wp2_enable" "r1_register_pid" "r1_refresh"("wp2_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "k1_noop" "wp2_release" "s1_registered_ranges"
 
 # Cancel after txn 3
-permutation "wp3_enable" "r1_register_pid" "r1_refresh"("wp3_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "wp3_release" "s1_registered_ranges"
+permutation "wp3_enable" "r1_register_pid" "r1_refresh"("wp3_enable") "s1_registered_ranges" "k1_cancel"("r1_refresh") "k1_noop" "wp3_release" "s1_registered_ranges"
 
 #
 # pg_terminate_backend — ranges are NOT cleared since the PID is immediately killed. A follow-up refresh should detect and clean up orphaned entries.
 #
 
 # Terminate after registration (txn 0). Follow-up refresh cleans registered ranges
-permutation "wp0_enable" "tr1_register_pid" "tr1_refresh"("wp0_enable") "s1_registered_ranges" "t1_terminate"("tr1_refresh") "wp0_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
+permutation "wp0_enable" "tr1_register_pid" "tr1_refresh"("wp0_enable") "s1_registered_ranges" "t1_terminate"("tr1_refresh") "t1_noop" "wp0_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
 
 # Terminate after txn 1. Follow-up refresh cleans registered ranges
-permutation "wp1_enable" "tr2_register_pid" "tr2_refresh"("wp1_enable") "s1_registered_ranges" "t1_terminate"("tr2_refresh") "wp1_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
+permutation "wp1_enable" "tr2_register_pid" "tr2_refresh"("wp1_enable") "s1_registered_ranges" "t1_terminate"("tr2_refresh") "t1_noop" "wp1_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
 
 # Terminate after txn 2. Follow-up refresh cleans registered ranges
-permutation "wp2_enable" "tr3_register_pid" "tr3_refresh"("wp2_enable") "s1_registered_ranges" "t1_terminate"("tr3_refresh") "wp2_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
+permutation "wp2_enable" "tr3_register_pid" "tr3_refresh"("wp2_enable") "s1_registered_ranges" "t1_terminate"("tr3_refresh") "t1_noop" "wp2_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
 
 # Terminate after txn 3. Follow-up refresh cleans registered ranges
-permutation "wp3_enable" "tr4_register_pid" "tr4_refresh"("wp3_enable") "s1_registered_ranges" "t1_terminate"("tr4_refresh") "wp3_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
+permutation "wp3_enable" "tr4_register_pid" "tr4_refresh"("wp3_enable") "s1_registered_ranges" "t1_terminate"("tr4_refresh") "t1_noop" "wp3_release" "s1_registered_ranges" "r2_refresh" "s1_registered_ranges"
 
 # A non-overlapping follow-up refresh should also clean up orphaned registered ranges
 #
-permutation "wp2_enable" "tr5_register_pid" "tr5_refresh"("wp2_enable") "s1_registered_ranges" "t1_terminate"("tr5_refresh") "wp2_release" "s1_registered_ranges" "r2_refresh_nonoverlap" "s1_registered_ranges"
+permutation "wp2_enable" "tr5_register_pid" "tr5_refresh"("wp2_enable") "s1_registered_ranges" "t1_terminate"("tr5_refresh") "t1_noop" "wp2_release" "s1_registered_ranges" "r2_refresh_nonoverlap" "s1_registered_ranges"

--- a/tsl/test/isolation/specs/cagg_granular_refresh_precommit_abort.spec
+++ b/tsl/test/isolation/specs/cagg_granular_refresh_precommit_abort.spec
@@ -64,6 +64,13 @@ step "v_insert" { INSERT INTO conditions VALUES ('2026-07-01 00:00+00', 'sensor_
 # Cancels while it is parked at the waitpoint.
 session "K"
 step "k_cancel" { CALL cancelpids(); }
+# Empty synchronization step. The ("v_insert") marker only delays the
+# *reporting* of k_cancel's completion, never the *launch* of the next
+# permutation step, so without this wp_pc_release races V's unwind. k_noop is
+# in the same session, so it cannot be launched until k_cancel is reported
+# complete. See PostgreSQL src/test/isolation/README, "Dealing with race
+# conditions".
+step "k_noop" { }
 
 # An unrelated writer + refresh flushes all tenant tracking entries
 # The refresh window excludes the cancelled backend's  
@@ -107,4 +114,4 @@ step "r_check_tracking2"
     ORDER BY tenant_id, seqnum;
 }
 
-permutation "wp_pc_enable" "v_register_pid" "v_insert"("wp_pc_enable") "k_cancel"("v_insert") "wp_pc_release" "r_anchor_insert"("wp_pc_release") "r_refresh" "r_check_conditions" "r_check_tracking" "r_refresh2" "r_check_cagg" "r_check_tracking2" "r_anchor_insert" "r_refresh2" "r_refresh2" "r_check_tracking2"
+permutation "wp_pc_enable" "v_register_pid" "v_insert"("wp_pc_enable") "k_cancel"("v_insert") "k_noop" "wp_pc_release" "r_anchor_insert"("wp_pc_release") "r_refresh" "r_check_conditions" "r_check_tracking" "r_refresh2" "r_check_cagg" "r_check_tracking2" "r_anchor_insert" "r_refresh2" "r_refresh2" "r_check_tracking2"

--- a/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
+++ b/tsl/test/isolation/specs/cagg_refresh_cleanup_register.spec
@@ -93,6 +93,13 @@ session "K1"
 step "K1_terminate" {
     CALL terminate_r1();
 }
+# Empty synchronization step. The ("R1_refresh") marker only delays the
+# *reporting* of K1_terminate's completion, never the *launch* of the next
+# permutation step, so without this the following steps race R1's unwind.
+# K1_noop is in the same session, so it cannot be launched until K1_terminate
+# is reported complete. See PostgreSQL src/test/isolation/README,
+# "Dealing with race conditions".
+step "K1_noop" { }
 
 # Refresh sessions
 session "R2"
@@ -240,4 +247,4 @@ permutation "P1_add_policy" "WP_after_register_enable" "P1_run_policy" "check_jo
 # Stale registration cleanup by concurrent refreshes.
 # Kill a backend during refresh to end up with a pid left behind. Later two concurrent refreshes run, only one removes the stale pid.
 # backend R1 is killed, we can no longer use this for later permutations
-permutation "WP_before_txn2_commit_enable" "R1_refresh" "check_jobs" "K1_terminate"("R1_refresh") "WP_before_txn2_commit_disable" "L1_lock" "R2_refresh"("L1_lock") "R3_refresh"("R2_refresh") "L1_unlock"(R2_refresh, R3_refresh) "check_jobs"
+permutation "WP_before_txn2_commit_enable" "R1_refresh" "check_jobs" "K1_terminate"("R1_refresh") "K1_noop" "WP_before_txn2_commit_disable" "L1_lock" "R2_refresh"("L1_lock") "R3_refresh"("R2_refresh") "L1_unlock"(R2_refresh, R3_refresh) "check_jobs"


### PR DESCRIPTION
cagg_cancel_kill_refresh flaked on PG19beta2: the terminated backend's "step tr3_refresh: <... completed>" was reported after wp2_release instead of before it. Same lines, different position.

isolationtester's (blocked_step) marker only delays the *reporting* of a step's completion, never the *launch* of the next step. A step launches as soon as the preceding one is done or deemed blocked, and a marker-delayed step counts as deemed blocked. So the waitpoint-release step was launched and reported while the signalled backend was still unwinding, and which of the two got reported first came down to timing.

Fix it the way src/test/isolation/README prescribes: add an empty step in the signalling session right after the signal step. Rule (A) -- all prior steps of a session must be done before the next one launches -- then transitively holds the release step until the cancelled or terminated refresh has been fully reported. This also closes a visibility race in the cancel permutations, where s1_registered_ranges could read the catalog before R1's PG_CATCH cleanup committed.
(https://github.com/postgres/postgres/blob/ac5cea86e8a474e13d7dcd22a4a7fabf722c5514/src/test/isolation/README#L207)

Applied to the two sibling specs carrying the same latent race.