### PR TITLE
Show per-chunk plans in EXPLAIN ANALYZE for DeferredChunkScan

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -180,6 +180,15 @@ table_tuple_update_compat(Relation rel, ItemPointer otid, TupleTableSlot *slot, 
 	pg_plan_query(querytree, query_string, cursorOptions, boundParams, es)
 #endif
 
+/* The 'execute_once' argument was removed in PG18, see 3eea7a0c97e. */
+#if PG18_GE
+#define ExecutorRun_compat(query_desc, direction, count, execute_once)                             \
+	ExecutorRun(query_desc, direction, count)
+#else
+#define ExecutorRun_compat(query_desc, direction, count, execute_once)                             \
+	ExecutorRun(query_desc, direction, count, execute_once)
+#endif
+
 /*
  * PG19 added a "flags" argument to MakeTupleTableSlot(). Provide a wrapper with
  * the new signature that drops the flags on earlier versions.

--- a/src/nodes/deferred_chunk_scan/deferred_chunk_scan.c
+++ b/src/nodes/deferred_chunk_scan/deferred_chunk_scan.c
@@ -20,6 +20,7 @@
 #include <catalog/pg_operator.h>
 #include <catalog/pg_type.h>
 #include <commands/explain.h>
+#include <executor/execdesc.h>
 #include <executor/executor.h>
 #include <executor/tuptable.h>
 #include <miscadmin.h>
@@ -34,13 +35,11 @@
 #include <rewrite/rewriteManip.h>
 #include <storage/lockdefs.h>
 #include <tcop/dest.h>
-#include <tcop/pquery.h>
 #include <tcop/tcopprot.h>
 #include <utils/builtins.h>
 #include <utils/fmgroids.h>
 #include <utils/guc.h>
 #include <utils/lsyscache.h>
-#include <utils/portal.h>
 #include <utils/rel.h>
 #include <utils/ruleutils.h>
 #include <utils/snapmgr.h>
@@ -62,7 +61,7 @@
 #include "ts_catalog/catalog.h"
 #include "utils.h"
 
-/* Rows fetched per PortalRunFetch when there is no pushed LIMIT to bound it. */
+/* Rows fetched per batch when there is no pushed LIMIT to bound it. */
 #define DCS_FETCH_MAX_BATCH_SIZE 1000
 
 /*
@@ -99,8 +98,10 @@ typedef struct DeferredChunkScanState
 	bool have_last;					/* whether the last_* resume key is set */
 	int chunks_scanned;				/* chunks opened so far (EXPLAIN counter) */
 
-	int batch_size;			  /* rows per PortalRunFetch */
-	Portal cur_portal;		  /* open portal for the current chunk, or NULL */
+	int batch_size;			  /* rows per ExecutorRun batch */
+	QueryDesc *cur_qd;		  /* executor for the current chunk, or NULL */
+	List *chunk_qds;		  /* under ANALYZE, every visited chunk's executor, kept
+							   * alive so EXPLAIN can print its actual plan */
 	DestReceiver *dest;		  /* receiver that copies fetched rows into chunk_mcxt */
 	MemoryContext chunk_mcxt; /* holds the current batch's tuples */
 	HeapTuple *cur_tuples;	  /* current batch (batch_size long), in chunk_mcxt */
@@ -743,15 +744,40 @@ compute_fetch_columns(DeferredChunkScanState *state, CustomScanState *node)
 	}
 }
 
+/* Shut down and free a per-chunk executor. */
+static void
+dcs_close_qd(QueryDesc *qd)
+{
+	if (!qd->estate->es_finished)
+	{
+		ExecutorFinish(qd);
+	}
+	ExecutorEnd(qd);
+	FreeQueryDesc(qd);
+}
+
+/* Shut down every executor still open (current chunk plus any kept for EXPLAIN). */
+static void
+dcs_close_all_qds(DeferredChunkScanState *state)
+{
+	if (state->cur_qd != NULL)
+	{
+		dcs_close_qd(state->cur_qd);
+		state->cur_qd = NULL;
+	}
+	ListCell *lc;
+	foreach (lc, state->chunk_qds)
+	{
+		dcs_close_qd((QueryDesc *) lfirst(lc));
+	}
+	state->chunk_qds = NIL;
+}
+
 /* Reset the scan position to the start */
 static void
 deferred_chunk_scan_reset(DeferredChunkScanState *state)
 {
-	if (state->cur_portal != NULL)
-	{
-		PortalDrop(state->cur_portal, false);
-		state->cur_portal = NULL;
-	}
+	dcs_close_all_qds(state);
 	state->cur_nrows = 0;
 	state->cur_row = 0;
 	state->have_last = false;
@@ -975,12 +1001,13 @@ next_chunk_reloid(DeferredChunkScanState *state)
 }
 
 /*
- * Open a Portal for the next chunk's per-chunk query. Returns false when there
- * are no more chunks.
+ * Start an executor for the next chunk's per-chunk query. Returns false when
+ * there are no more chunks.
  */
 static bool
 open_next_chunk(DeferredChunkScanState *state)
 {
+	EState *estate = state->css.ss.ps.state;
 	Oid reloid;
 
 	/*
@@ -1019,25 +1046,53 @@ open_next_chunk(DeferredChunkScanState *state)
 		pg_plan_query_compat(query, sql, CURSOR_OPT_FAST_PLAN | CURSOR_OPT_NO_SCROLL, NULL, NULL);
 	AtEOXact_GUC(false, save_nestlevel);
 
-	Portal portal = CreateNewPortal();
-	portal->visible = false;
-	PortalDefineQuery(portal, NULL, sql, CMDTAG_SELECT, list_make1(plan), NULL);
-	PortalStart(portal, NULL, 0, GetActiveSnapshot());
-	state->cur_portal = portal;
+	/* Use QueryDesc directly so we can control es_instrument. Allocate it in the
+	 * query context so it outlives the chunk. */
+	MemoryContext old = MemoryContextSwitchTo(estate->es_query_cxt);
+	QueryDesc *qd = CreateQueryDesc(plan,
+									sql,
+									GetActiveSnapshot(),
+									InvalidSnapshot,
+									state->dest,
+									NULL,
+									NULL,
+									estate->es_instrument);
+	ExecutorStart(qd, 0);
+	MemoryContextSwitchTo(old);
+	state->cur_qd = qd;
 
 	/* Per-chunk result row type is the same for every chunk; capture it once. */
 	if (state->cur_tupdesc == NULL)
 	{
-		MemoryContext old = MemoryContextSwitchTo(state->css.ss.ps.state->es_query_cxt);
-		state->cur_tupdesc = CreateTupleDescCopy(portal->tupDesc);
+		old = MemoryContextSwitchTo(estate->es_query_cxt);
+		state->cur_tupdesc = CreateTupleDescCopy(qd->tupDesc);
 		MemoryContextSwitchTo(old);
 	}
 
-	pfree(sql);
+	/* sql backs qd->sourceText for the executor's lifetime, so don't free it here. */
 	return true;
 }
 
-/* Make the next row of the current chunk available in fetch_slot, refilling the
+/* Current chunk exhausted: under ANALYZE keep its executor (for EXPLAIN), else
+ * shut it down. */
+static void
+close_current_chunk(DeferredChunkScanState *state)
+{
+	QueryDesc *qd = state->cur_qd;
+	ExecutorFinish(qd);
+
+	if (qd->instrument_options != 0)
+	{
+		state->chunk_qds = lappend(state->chunk_qds, qd);
+	}
+	else
+	{
+		dcs_close_qd(qd);
+	}
+	state->cur_qd = NULL;
+}
+
+/* Make the next row of the current chunk available in cur_tuples, refilling the
  * batch and advancing to the next chunk as needed. False when fully exhausted. */
 static bool
 next_chunk_row(DeferredChunkScanState *state)
@@ -1048,7 +1103,7 @@ next_chunk_row(DeferredChunkScanState *state)
 		{
 			return true; /* buffered row available */
 		}
-		if (state->cur_portal == NULL && !open_next_chunk(state))
+		if (state->cur_qd == NULL && !open_next_chunk(state))
 		{
 			return false; /* no more chunks */
 		}
@@ -1058,12 +1113,11 @@ next_chunk_row(DeferredChunkScanState *state)
 			MemoryContextAlloc(state->chunk_mcxt, sizeof(HeapTuple) * state->batch_size);
 		state->cur_nrows = 0;
 		state->cur_row = 0;
-		PortalRunFetch(state->cur_portal, FETCH_FORWARD, state->batch_size, state->dest);
+		ExecutorRun_compat(state->cur_qd, ForwardScanDirection, state->batch_size, false);
 		if (state->cur_nrows == 0)
 		{
-			/* Chunk exhausted: drop the portal and move to the next chunk. */
-			PortalDrop(state->cur_portal, false);
-			state->cur_portal = NULL;
+			/* Chunk exhausted: close its executor and move to the next chunk. */
+			close_current_chunk(state);
 		}
 	}
 }
@@ -1121,11 +1175,7 @@ deferred_chunk_scan_end(CustomScanState *node)
 {
 	DeferredChunkScanState *state = (DeferredChunkScanState *) node;
 
-	if (state->cur_portal != NULL)
-	{
-		PortalDrop(state->cur_portal, false);
-		state->cur_portal = NULL;
-	}
+	dcs_close_all_qds(state);
 	if (state->scan_slot != NULL)
 	{
 		ExecDropSingleTupleTableSlot(state->scan_slot);
@@ -1144,8 +1194,8 @@ deferred_chunk_scan_rescan(CustomScanState *node)
 	deferred_chunk_scan_reset((DeferredChunkScanState *) node);
 }
 
-/* Show the ORDER BY key (ordered mode) and, under ANALYZE, how many chunks the
- * LIMIT visited. */
+/* Show the ORDER BY key (ordered mode) and, under ANALYZE, the number of chunks
+ * the LIMIT visited followed by each chunk's actual per-chunk plan. */
 static void
 deferred_chunk_scan_explain(CustomScanState *node, List *ancestors, ExplainState *es)
 {
@@ -1159,10 +1209,27 @@ deferred_chunk_scan_explain(CustomScanState *node, List *ancestors, ExplainState
 	{
 		ExplainPropertyText("Filter", state->where_clause, es);
 	}
-	/* Under ANALYZE, how many chunks the LIMIT actually made us visit. */
-	if (es->analyze)
+	if (!es->analyze)
 	{
-		ExplainPropertyInteger("Chunks Visited", NULL, state->chunks_scanned, es);
+		return;
+	}
+
+	ExplainPropertyInteger("Chunks Visited", NULL, state->chunks_scanned, es);
+
+	/*
+	 * ExplainPrintPlan overwrites the range table and deparse state on es.
+	 * Use a copy of es so we don't clobber the caller's state.
+	 */
+	ExplainState chunk_es = *es;
+
+	ListCell *lc;
+	foreach (lc, state->chunk_qds)
+	{
+		ExplainPrintPlan(&chunk_es, (QueryDesc *) lfirst(lc));
+	}
+	if (state->cur_qd != NULL)
+	{
+		ExplainPrintPlan(&chunk_es, state->cur_qd);
 	}
 }
 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1940,6 +1940,18 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 3
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: "time", sensor_id, cpu, temperature
+               ->  Index Scan using _hyper_26_64_chunk_sensor_data_compressed_time_idx on _timescaledb_internal._hyper_26_64_chunk (actual rows=2.00 loops=1)
+                     Output: "time", sensor_id, cpu, temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: "time", sensor_id, cpu, temperature
+               ->  Index Scan using _hyper_26_63_chunk_sensor_data_compressed_time_idx on _timescaledb_internal._hyper_26_63_chunk (actual rows=2.00 loops=1)
+                     Output: "time", sensor_id, cpu, temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: "time", sensor_id, cpu, temperature
+               ->  Index Scan using _hyper_26_62_chunk_sensor_data_compressed_time_idx on _timescaledb_internal._hyper_26_62_chunk (actual rows=2.00 loops=1)
+                     Output: "time", sensor_id, cpu, temperature
 
 -- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
@@ -1952,6 +1964,18 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 3
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: "time", sensor_id, cpu, temperature
+               ->  Index Scan using _hyper_26_64_chunk_sensor_data_compressed_time_idx on _timescaledb_internal._hyper_26_64_chunk (actual rows=2.00 loops=1)
+                     Output: "time", sensor_id, cpu, temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: "time", sensor_id, cpu, temperature
+               ->  Index Scan using _hyper_26_63_chunk_sensor_data_compressed_time_idx on _timescaledb_internal._hyper_26_63_chunk (actual rows=2.00 loops=1)
+                     Output: "time", sensor_id, cpu, temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: "time", sensor_id, cpu, temperature
+               ->  Index Scan using _hyper_26_62_chunk_sensor_data_compressed_time_idx on _timescaledb_internal._hyper_26_62_chunk (actual rows=2.00 loops=1)
+                     Output: "time", sensor_id, cpu, temperature
 
 RESET timescaledb.enable_decompression_sorted_merge;
 -- Compress the remaining chunks
@@ -1989,6 +2013,42 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 3
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_64_chunk (actual rows=2.00 loops=1)
+                     Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_26_64_chunk_compressed._ts_meta_count, _hyper_26_64_chunk_compressed.sensor_id, _hyper_26_64_chunk_compressed._ts_meta_min_1, _hyper_26_64_chunk_compressed._ts_meta_max_1, _hyper_26_64_chunk_compressed._ts_meta_v2_first_time, _hyper_26_64_chunk_compressed._ts_meta_v2_last_time, _hyper_26_64_chunk_compressed."time", _hyper_26_64_chunk_compressed.cpu, _hyper_26_64_chunk_compressed.temperature
+                           Sort Key: _hyper_26_64_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_64_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_64_chunk_compressed._ts_meta_count, _hyper_26_64_chunk_compressed.sensor_id, _hyper_26_64_chunk_compressed._ts_meta_min_1, _hyper_26_64_chunk_compressed._ts_meta_max_1, _hyper_26_64_chunk_compressed._ts_meta_v2_first_time, _hyper_26_64_chunk_compressed._ts_meta_v2_last_time, _hyper_26_64_chunk_compressed."time", _hyper_26_64_chunk_compressed.cpu, _hyper_26_64_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_63_chunk (actual rows=2.00 loops=1)
+                     Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_26_63_chunk_compressed._ts_meta_count, _hyper_26_63_chunk_compressed.sensor_id, _hyper_26_63_chunk_compressed._ts_meta_min_1, _hyper_26_63_chunk_compressed._ts_meta_max_1, _hyper_26_63_chunk_compressed._ts_meta_v2_first_time, _hyper_26_63_chunk_compressed._ts_meta_v2_last_time, _hyper_26_63_chunk_compressed."time", _hyper_26_63_chunk_compressed.cpu, _hyper_26_63_chunk_compressed.temperature
+                           Sort Key: _hyper_26_63_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_63_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_63_chunk_compressed._ts_meta_count, _hyper_26_63_chunk_compressed.sensor_id, _hyper_26_63_chunk_compressed._ts_meta_min_1, _hyper_26_63_chunk_compressed._ts_meta_max_1, _hyper_26_63_chunk_compressed._ts_meta_v2_first_time, _hyper_26_63_chunk_compressed._ts_meta_v2_last_time, _hyper_26_63_chunk_compressed."time", _hyper_26_63_chunk_compressed.cpu, _hyper_26_63_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_62_chunk (actual rows=2.00 loops=1)
+                     Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_26_62_chunk_compressed._ts_meta_count, _hyper_26_62_chunk_compressed.sensor_id, _hyper_26_62_chunk_compressed._ts_meta_min_1, _hyper_26_62_chunk_compressed._ts_meta_max_1, _hyper_26_62_chunk_compressed._ts_meta_v2_first_time, _hyper_26_62_chunk_compressed._ts_meta_v2_last_time, _hyper_26_62_chunk_compressed."time", _hyper_26_62_chunk_compressed.cpu, _hyper_26_62_chunk_compressed.temperature
+                           Sort Key: _hyper_26_62_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_62_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_62_chunk_compressed._ts_meta_count, _hyper_26_62_chunk_compressed.sensor_id, _hyper_26_62_chunk_compressed._ts_meta_min_1, _hyper_26_62_chunk_compressed._ts_meta_max_1, _hyper_26_62_chunk_compressed._ts_meta_v2_first_time, _hyper_26_62_chunk_compressed._ts_meta_v2_last_time, _hyper_26_62_chunk_compressed."time", _hyper_26_62_chunk_compressed.cpu, _hyper_26_62_chunk_compressed.temperature
 
 -- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
@@ -2001,6 +2061,39 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 3
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+               ->  Sort (actual rows=2.00 loops=1)
+                     Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+                     Sort Key: _hyper_26_64_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_64_chunk (actual rows=2.00 loops=1)
+                           Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_64_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_64_chunk_compressed._ts_meta_count, _hyper_26_64_chunk_compressed.sensor_id, _hyper_26_64_chunk_compressed._ts_meta_min_1, _hyper_26_64_chunk_compressed._ts_meta_max_1, _hyper_26_64_chunk_compressed._ts_meta_v2_first_time, _hyper_26_64_chunk_compressed._ts_meta_v2_last_time, _hyper_26_64_chunk_compressed."time", _hyper_26_64_chunk_compressed.cpu, _hyper_26_64_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+               ->  Sort (actual rows=2.00 loops=1)
+                     Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+                     Sort Key: _hyper_26_63_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_63_chunk (actual rows=2.00 loops=1)
+                           Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_63_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_63_chunk_compressed._ts_meta_count, _hyper_26_63_chunk_compressed.sensor_id, _hyper_26_63_chunk_compressed._ts_meta_min_1, _hyper_26_63_chunk_compressed._ts_meta_max_1, _hyper_26_63_chunk_compressed._ts_meta_v2_first_time, _hyper_26_63_chunk_compressed._ts_meta_v2_last_time, _hyper_26_63_chunk_compressed."time", _hyper_26_63_chunk_compressed.cpu, _hyper_26_63_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+               ->  Sort (actual rows=2.00 loops=1)
+                     Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+                     Sort Key: _hyper_26_62_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_62_chunk (actual rows=2.00 loops=1)
+                           Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_62_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_62_chunk_compressed._ts_meta_count, _hyper_26_62_chunk_compressed.sensor_id, _hyper_26_62_chunk_compressed._ts_meta_min_1, _hyper_26_62_chunk_compressed._ts_meta_max_1, _hyper_26_62_chunk_compressed._ts_meta_v2_first_time, _hyper_26_62_chunk_compressed._ts_meta_v2_last_time, _hyper_26_62_chunk_compressed."time", _hyper_26_62_chunk_compressed.cpu, _hyper_26_62_chunk_compressed.temperature
 
 RESET timescaledb.enable_decompression_sorted_merge;
 -- Convert the last chunk into a partially compressed chunk
@@ -2017,6 +2110,42 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 3
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_64_chunk (actual rows=2.00 loops=1)
+                     Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_26_64_chunk_compressed._ts_meta_count, _hyper_26_64_chunk_compressed.sensor_id, _hyper_26_64_chunk_compressed._ts_meta_min_1, _hyper_26_64_chunk_compressed._ts_meta_max_1, _hyper_26_64_chunk_compressed._ts_meta_v2_first_time, _hyper_26_64_chunk_compressed._ts_meta_v2_last_time, _hyper_26_64_chunk_compressed."time", _hyper_26_64_chunk_compressed.cpu, _hyper_26_64_chunk_compressed.temperature
+                           Sort Key: _hyper_26_64_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_64_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_64_chunk_compressed._ts_meta_count, _hyper_26_64_chunk_compressed.sensor_id, _hyper_26_64_chunk_compressed._ts_meta_min_1, _hyper_26_64_chunk_compressed._ts_meta_max_1, _hyper_26_64_chunk_compressed._ts_meta_v2_first_time, _hyper_26_64_chunk_compressed._ts_meta_v2_last_time, _hyper_26_64_chunk_compressed."time", _hyper_26_64_chunk_compressed.cpu, _hyper_26_64_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_63_chunk (actual rows=2.00 loops=1)
+                     Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_26_63_chunk_compressed._ts_meta_count, _hyper_26_63_chunk_compressed.sensor_id, _hyper_26_63_chunk_compressed._ts_meta_min_1, _hyper_26_63_chunk_compressed._ts_meta_max_1, _hyper_26_63_chunk_compressed._ts_meta_v2_first_time, _hyper_26_63_chunk_compressed._ts_meta_v2_last_time, _hyper_26_63_chunk_compressed."time", _hyper_26_63_chunk_compressed.cpu, _hyper_26_63_chunk_compressed.temperature
+                           Sort Key: _hyper_26_63_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_63_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_63_chunk_compressed._ts_meta_count, _hyper_26_63_chunk_compressed.sensor_id, _hyper_26_63_chunk_compressed._ts_meta_min_1, _hyper_26_63_chunk_compressed._ts_meta_max_1, _hyper_26_63_chunk_compressed._ts_meta_v2_first_time, _hyper_26_63_chunk_compressed._ts_meta_v2_last_time, _hyper_26_63_chunk_compressed."time", _hyper_26_63_chunk_compressed.cpu, _hyper_26_63_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_62_chunk (actual rows=2.00 loops=1)
+                     Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_26_62_chunk_compressed._ts_meta_count, _hyper_26_62_chunk_compressed.sensor_id, _hyper_26_62_chunk_compressed._ts_meta_min_1, _hyper_26_62_chunk_compressed._ts_meta_max_1, _hyper_26_62_chunk_compressed._ts_meta_v2_first_time, _hyper_26_62_chunk_compressed._ts_meta_v2_last_time, _hyper_26_62_chunk_compressed."time", _hyper_26_62_chunk_compressed.cpu, _hyper_26_62_chunk_compressed.temperature
+                           Sort Key: _hyper_26_62_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_62_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_62_chunk_compressed._ts_meta_count, _hyper_26_62_chunk_compressed.sensor_id, _hyper_26_62_chunk_compressed._ts_meta_min_1, _hyper_26_62_chunk_compressed._ts_meta_max_1, _hyper_26_62_chunk_compressed._ts_meta_v2_first_time, _hyper_26_62_chunk_compressed._ts_meta_v2_last_time, _hyper_26_62_chunk_compressed."time", _hyper_26_62_chunk_compressed.cpu, _hyper_26_62_chunk_compressed.temperature
 
 -- Only the first chunks should be accessed (batch sorted merge is disabled)
 SET timescaledb.enable_decompression_sorted_merge = FALSE;
@@ -2029,6 +2158,39 @@ SELECT * FROM sensor_data_compressed ORDER BY time DESC LIMIT 5;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 3
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+               ->  Sort (actual rows=2.00 loops=1)
+                     Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+                     Sort Key: _hyper_26_64_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_64_chunk (actual rows=2.00 loops=1)
+                           Output: _hyper_26_64_chunk."time", _hyper_26_64_chunk.sensor_id, _hyper_26_64_chunk.cpu, _hyper_26_64_chunk.temperature
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_64_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_64_chunk_compressed._ts_meta_count, _hyper_26_64_chunk_compressed.sensor_id, _hyper_26_64_chunk_compressed._ts_meta_min_1, _hyper_26_64_chunk_compressed._ts_meta_max_1, _hyper_26_64_chunk_compressed._ts_meta_v2_first_time, _hyper_26_64_chunk_compressed._ts_meta_v2_last_time, _hyper_26_64_chunk_compressed."time", _hyper_26_64_chunk_compressed.cpu, _hyper_26_64_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+               ->  Sort (actual rows=2.00 loops=1)
+                     Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+                     Sort Key: _hyper_26_63_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_63_chunk (actual rows=2.00 loops=1)
+                           Output: _hyper_26_63_chunk."time", _hyper_26_63_chunk.sensor_id, _hyper_26_63_chunk.cpu, _hyper_26_63_chunk.temperature
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_63_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_63_chunk_compressed._ts_meta_count, _hyper_26_63_chunk_compressed.sensor_id, _hyper_26_63_chunk_compressed._ts_meta_min_1, _hyper_26_63_chunk_compressed._ts_meta_max_1, _hyper_26_63_chunk_compressed._ts_meta_v2_first_time, _hyper_26_63_chunk_compressed._ts_meta_v2_last_time, _hyper_26_63_chunk_compressed."time", _hyper_26_63_chunk_compressed.cpu, _hyper_26_63_chunk_compressed.temperature
+         ->  Limit (actual rows=2.00 loops=1)
+               Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+               ->  Sort (actual rows=2.00 loops=1)
+                     Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+                     Sort Key: _hyper_26_62_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_26_62_chunk (actual rows=2.00 loops=1)
+                           Output: _hyper_26_62_chunk."time", _hyper_26_62_chunk.sensor_id, _hyper_26_62_chunk.cpu, _hyper_26_62_chunk.temperature
+                           Bulk Decompression: true
+                           ->  Seq Scan on _timescaledb_internal._hyper_26_62_chunk_compressed (actual rows=2.00 loops=1)
+                                 Output: _hyper_26_62_chunk_compressed._ts_meta_count, _hyper_26_62_chunk_compressed.sensor_id, _hyper_26_62_chunk_compressed._ts_meta_min_1, _hyper_26_62_chunk_compressed._ts_meta_max_1, _hyper_26_62_chunk_compressed._ts_meta_v2_first_time, _hyper_26_62_chunk_compressed._ts_meta_v2_last_time, _hyper_26_62_chunk_compressed."time", _hyper_26_62_chunk_compressed.cpu, _hyper_26_62_chunk_compressed.temperature
 
 RESET timescaledb.enable_decompression_sorted_merge;
 -- create another chunk

--- a/tsl/test/expected/compression_sorted_merge.out
+++ b/tsl/test/expected/compression_sorted_merge.out
@@ -1086,6 +1086,18 @@ SELECT * FROM sensor_data ORDER BY time DESC LIMIT 1;
          Output: "time", sensor_id, cpu, temperature
          Order: "time" DESC
          Chunks Visited: 1
+         ->  Limit (actual rows=1.00 loops=1)
+               Output: _hyper_4_9_chunk."time", _hyper_4_9_chunk.sensor_id, _hyper_4_9_chunk.cpu, _hyper_4_9_chunk.temperature
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_4_9_chunk (actual rows=1.00 loops=1)
+                     Output: _hyper_4_9_chunk."time", _hyper_4_9_chunk.sensor_id, _hyper_4_9_chunk.cpu, _hyper_4_9_chunk.temperature
+                     Batch Sorted Merge: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Output: _hyper_4_9_chunk_compressed._ts_meta_count, _hyper_4_9_chunk_compressed.sensor_id, _hyper_4_9_chunk_compressed._ts_meta_min_1, _hyper_4_9_chunk_compressed._ts_meta_max_1, _hyper_4_9_chunk_compressed._ts_meta_v2_first_time, _hyper_4_9_chunk_compressed._ts_meta_v2_last_time, _hyper_4_9_chunk_compressed."time", _hyper_4_9_chunk_compressed.cpu, _hyper_4_9_chunk_compressed.temperature
+                           Sort Key: _hyper_4_9_chunk_compressed._ts_meta_v2_first_time DESC
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_4_9_chunk_compressed (actual rows=100.00 loops=1)
+                                 Output: _hyper_4_9_chunk_compressed._ts_meta_count, _hyper_4_9_chunk_compressed.sensor_id, _hyper_4_9_chunk_compressed._ts_meta_min_1, _hyper_4_9_chunk_compressed._ts_meta_max_1, _hyper_4_9_chunk_compressed._ts_meta_v2_first_time, _hyper_4_9_chunk_compressed._ts_meta_v2_last_time, _hyper_4_9_chunk_compressed."time", _hyper_4_9_chunk_compressed.cpu, _hyper_4_9_chunk_compressed.temperature
 
 -- Verify that we produce the same order without and with the optimization
 CREATE PROCEDURE order_test(query text) LANGUAGE plpgsql AS $$
@@ -1466,6 +1478,19 @@ SELECT t.dttm FROM test t ORDER BY t.dttm LIMIT 1;
          Output: dttm
          Order: dttm
          Chunks Visited: 1
+         ->  Limit (actual rows=1.00 loops=1)
+               Output: _hyper_7_12_chunk.dttm
+               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_7_12_chunk (actual rows=1.00 loops=1)
+                     Output: _hyper_7_12_chunk.dttm
+                     Batch Sorted Merge: true
+                     Reverse: true
+                     Bulk Decompression: false
+                     ->  Sort (actual rows=5.00 loops=1)
+                           Output: _hyper_7_12_chunk_compressed._ts_meta_count, _hyper_7_12_chunk_compressed.otherid, _hyper_7_12_chunk_compressed.valuefk, _hyper_7_12_chunk_compressed.otherfk, _hyper_7_12_chunk_compressed.id, _hyper_7_12_chunk_compressed._ts_meta_min_1, _hyper_7_12_chunk_compressed._ts_meta_max_1, _hyper_7_12_chunk_compressed._ts_meta_v2_first_dttm, _hyper_7_12_chunk_compressed._ts_meta_v2_last_dttm, _hyper_7_12_chunk_compressed.dttm, _hyper_7_12_chunk_compressed.measure
+                           Sort Key: _hyper_7_12_chunk_compressed._ts_meta_v2_last_dttm
+                           Sort Method: quicksort 
+                           ->  Seq Scan on _timescaledb_internal._hyper_7_12_chunk_compressed (actual rows=32.00 loops=1)
+                                 Output: _hyper_7_12_chunk_compressed._ts_meta_count, _hyper_7_12_chunk_compressed.otherid, _hyper_7_12_chunk_compressed.valuefk, _hyper_7_12_chunk_compressed.otherfk, _hyper_7_12_chunk_compressed.id, _hyper_7_12_chunk_compressed._ts_meta_min_1, _hyper_7_12_chunk_compressed._ts_meta_max_1, _hyper_7_12_chunk_compressed._ts_meta_v2_first_dttm, _hyper_7_12_chunk_compressed._ts_meta_v2_last_dttm, _hyper_7_12_chunk_compressed.dttm, _hyper_7_12_chunk_compressed.measure
 
 RESET enable_sort;
 drop table test cascade;

--- a/tsl/test/expected/deferredchunkscan-16.out
+++ b/tsl/test/expected/deferredchunkscan-16.out
@@ -1127,3 +1127,112 @@ SELECT g, l.gg, l.value FROM generate_series(1, 3) g, LATERAL (SELECT g AS gg, v
 \o
 SET timescaledb.enable_deferred_chunk_scan TO on;
 :DIFF_CMD
+-- EXPLAIN ANALYZE prints the actual per-chunk plan for every chunk the LIMIT visited.
+SET timescaledb.debug_require_deferred_chunk_scan TO 'require';
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 3;  -- stops in the first non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Chunks Visited: 3
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 6;  -- spills into a second non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=6.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=6.00 loops=1)
+         Chunks Visited: 4
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=4.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=4.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics ORDER BY time DESC LIMIT 3;  -- ordered: per-chunk plan carries the ORDER BY
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 2
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Index Scan using _hyper_1_7_chunk_metrics_time_idx on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Index Scan using _hyper_1_5_chunk_metrics_time_idx on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 3;  -- compressed chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=3.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- compressed + ordered: per-chunk Sort
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Sort (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+
+-- make the first-visited chunk partially compressed, then scan it
+INSERT INTO metrics_compressed (time, device, value) VALUES ('2020-01-05 06:00', 9, 99);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 4;  -- partial chunk: compressed and uncompressed parts
+--- QUERY PLAN ---
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=4.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Append (actual rows=4.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (never executed)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- partial chunk + ordered: per-chunk Merge Append
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Merge Append (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Sort Key: _hyper_2_12_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Index Scan using _hyper_2_12_chunk_metrics_compressed_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+
+-- a correlated target-list subplan is explained after the per-chunk plans and must resolve against the outer range table
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT value, (SELECT count(*) FROM metrics_regular r WHERE r.time < m.time) FROM metrics m ORDER BY time LIMIT 3;
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Result (actual rows=3.00 loops=1)
+         ->  Custom Scan (DeferredChunkScan) on metrics m (actual rows=3.00 loops=1)
+               Order: "time"
+               Chunks Visited: 2
+               ->  Limit (actual rows=0.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_6_chunk_metrics_time_idx on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+               ->  Limit (actual rows=3.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk (actual rows=3.00 loops=1)
+         SubPlan 1
+           ->  Aggregate (actual rows=1.00 loops=3)
+                 ->  Seq Scan on metrics_regular r (actual rows=0.00 loops=3)
+                       Filter: ("time" < m."time")
+                       Rows Removed by Filter: 1
+
+RESET timescaledb.debug_require_deferred_chunk_scan;

--- a/tsl/test/expected/deferredchunkscan-17.out
+++ b/tsl/test/expected/deferredchunkscan-17.out
@@ -1127,3 +1127,112 @@ SELECT g, l.gg, l.value FROM generate_series(1, 3) g, LATERAL (SELECT g AS gg, v
 \o
 SET timescaledb.enable_deferred_chunk_scan TO on;
 :DIFF_CMD
+-- EXPLAIN ANALYZE prints the actual per-chunk plan for every chunk the LIMIT visited.
+SET timescaledb.debug_require_deferred_chunk_scan TO 'require';
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 3;  -- stops in the first non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Chunks Visited: 3
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 6;  -- spills into a second non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=6.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=6.00 loops=1)
+         Chunks Visited: 4
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=4.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=4.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics ORDER BY time DESC LIMIT 3;  -- ordered: per-chunk plan carries the ORDER BY
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 2
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Index Scan using _hyper_1_7_chunk_metrics_time_idx on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Index Scan using _hyper_1_5_chunk_metrics_time_idx on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 3;  -- compressed chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=3.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- compressed + ordered: per-chunk Sort
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Sort (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+
+-- make the first-visited chunk partially compressed, then scan it
+INSERT INTO metrics_compressed (time, device, value) VALUES ('2020-01-05 06:00', 9, 99);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 4;  -- partial chunk: compressed and uncompressed parts
+--- QUERY PLAN ---
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=4.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Append (actual rows=4.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (never executed)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- partial chunk + ordered: per-chunk Merge Append
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Merge Append (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Sort Key: _hyper_2_12_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Index Scan using _hyper_2_12_chunk_metrics_compressed_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+
+-- a correlated target-list subplan is explained after the per-chunk plans and must resolve against the outer range table
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT value, (SELECT count(*) FROM metrics_regular r WHERE r.time < m.time) FROM metrics m ORDER BY time LIMIT 3;
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Result (actual rows=3.00 loops=1)
+         ->  Custom Scan (DeferredChunkScan) on metrics m (actual rows=3.00 loops=1)
+               Order: "time"
+               Chunks Visited: 2
+               ->  Limit (actual rows=0.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_6_chunk_metrics_time_idx on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+               ->  Limit (actual rows=3.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk (actual rows=3.00 loops=1)
+         SubPlan 1
+           ->  Aggregate (actual rows=1.00 loops=3)
+                 ->  Seq Scan on metrics_regular r (actual rows=0.00 loops=3)
+                       Filter: ("time" < m."time")
+                       Rows Removed by Filter: 1
+
+RESET timescaledb.debug_require_deferred_chunk_scan;

--- a/tsl/test/expected/deferredchunkscan-18.out
+++ b/tsl/test/expected/deferredchunkscan-18.out
@@ -1127,3 +1127,112 @@ SELECT g, l.gg, l.value FROM generate_series(1, 3) g, LATERAL (SELECT g AS gg, v
 \o
 SET timescaledb.enable_deferred_chunk_scan TO on;
 :DIFF_CMD
+-- EXPLAIN ANALYZE prints the actual per-chunk plan for every chunk the LIMIT visited.
+SET timescaledb.debug_require_deferred_chunk_scan TO 'require';
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 3;  -- stops in the first non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Chunks Visited: 3
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 6;  -- spills into a second non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=6.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=6.00 loops=1)
+         Chunks Visited: 4
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=4.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=4.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics ORDER BY time DESC LIMIT 3;  -- ordered: per-chunk plan carries the ORDER BY
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 2
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Index Scan using _hyper_1_7_chunk_metrics_time_idx on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Index Scan using _hyper_1_5_chunk_metrics_time_idx on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 3;  -- compressed chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=3.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- compressed + ordered: per-chunk Sort
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Sort (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+
+-- make the first-visited chunk partially compressed, then scan it
+INSERT INTO metrics_compressed (time, device, value) VALUES ('2020-01-05 06:00', 9, 99);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 4;  -- partial chunk: compressed and uncompressed parts
+--- QUERY PLAN ---
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=4.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Append (actual rows=4.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (never executed)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- partial chunk + ordered: per-chunk Merge Append
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Merge Append (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Sort Key: _hyper_2_12_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Index Scan using _hyper_2_12_chunk_metrics_compressed_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+
+-- a correlated target-list subplan is explained after the per-chunk plans and must resolve against the outer range table
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT value, (SELECT count(*) FROM metrics_regular r WHERE r.time < m.time) FROM metrics m ORDER BY time LIMIT 3;
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Result (actual rows=3.00 loops=1)
+         ->  Custom Scan (DeferredChunkScan) on metrics m (actual rows=3.00 loops=1)
+               Order: "time"
+               Chunks Visited: 2
+               ->  Limit (actual rows=0.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_6_chunk_metrics_time_idx on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+               ->  Limit (actual rows=3.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk (actual rows=3.00 loops=1)
+         SubPlan 1
+           ->  Aggregate (actual rows=1.00 loops=3)
+                 ->  Seq Scan on metrics_regular r (actual rows=0.00 loops=3)
+                       Filter: ("time" < m."time")
+                       Rows Removed by Filter: 1
+
+RESET timescaledb.debug_require_deferred_chunk_scan;

--- a/tsl/test/expected/deferredchunkscan-19.out
+++ b/tsl/test/expected/deferredchunkscan-19.out
@@ -1127,3 +1127,112 @@ SELECT g, l.gg, l.value FROM generate_series(1, 3) g, LATERAL (SELECT g AS gg, v
 \o
 SET timescaledb.enable_deferred_chunk_scan TO on;
 :DIFF_CMD
+-- EXPLAIN ANALYZE prints the actual per-chunk plan for every chunk the LIMIT visited.
+SET timescaledb.debug_require_deferred_chunk_scan TO 'require';
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 3;  -- stops in the first non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Chunks Visited: 3
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 6;  -- spills into a second non-empty chunk
+--- QUERY PLAN ---
+ Limit (actual rows=6.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=6.00 loops=1)
+         Chunks Visited: 4
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Seq Scan on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_5_chunk (actual rows=4.00 loops=1)
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=4.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics ORDER BY time DESC LIMIT 3;  -- ordered: per-chunk plan carries the ORDER BY
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 2
+         ->  Limit (actual rows=0.00 loops=1)
+               ->  Index Scan using _hyper_1_7_chunk_metrics_time_idx on _hyper_1_7_chunk (actual rows=0.00 loops=1)
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Index Scan using _hyper_1_5_chunk_metrics_time_idx on _hyper_1_5_chunk (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 3;  -- compressed chunk
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=3.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=3.00 loops=1)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- compressed + ordered: per-chunk Sort
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Sort (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+
+-- make the first-visited chunk partially compressed, then scan it
+INSERT INTO metrics_compressed (time, device, value) VALUES ('2020-01-05 06:00', 9, 99);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 4;  -- partial chunk: compressed and uncompressed parts
+--- QUERY PLAN ---
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=4.00 loops=1)
+         Chunks Visited: 1
+         ->  Limit (actual rows=4.00 loops=1)
+               ->  Append (actual rows=4.00 loops=1)
+                     ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (never executed)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- partial chunk + ordered: per-chunk Merge Append
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Custom Scan (DeferredChunkScan) on metrics_compressed (actual rows=3.00 loops=1)
+         Order: "time" DESC
+         Chunks Visited: 1
+         ->  Limit (actual rows=3.00 loops=1)
+               ->  Merge Append (actual rows=3.00 loops=1)
+                     Sort Key: _hyper_2_12_chunk."time" DESC
+                     ->  Sort (actual rows=2.00 loops=1)
+                           Sort Key: _hyper_2_12_chunk."time" DESC
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ColumnarScan) on _hyper_2_12_chunk (actual rows=4.00 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk_compressed (actual rows=4.00 loops=1)
+                     ->  Index Scan using _hyper_2_12_chunk_metrics_compressed_time_idx on _hyper_2_12_chunk (actual rows=1.00 loops=1)
+
+-- a correlated target-list subplan is explained after the per-chunk plans and must resolve against the outer range table
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT value, (SELECT count(*) FROM metrics_regular r WHERE r.time < m.time) FROM metrics m ORDER BY time LIMIT 3;
+--- QUERY PLAN ---
+ Limit (actual rows=3.00 loops=1)
+   ->  Result (actual rows=3.00 loops=1)
+         ->  Custom Scan (DeferredChunkScan) on metrics m (actual rows=3.00 loops=1)
+               Order: "time"
+               Chunks Visited: 2
+               ->  Limit (actual rows=0.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_6_chunk_metrics_time_idx on _hyper_1_6_chunk (actual rows=0.00 loops=1)
+               ->  Limit (actual rows=3.00 loops=1)
+                     ->  Index Scan Backward using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk (actual rows=3.00 loops=1)
+         SubPlan expr_1
+           ->  Aggregate (actual rows=1.00 loops=3)
+                 ->  Seq Scan on metrics_regular r (actual rows=0.00 loops=3)
+                       Filter: ("time" < m."time")
+                       Rows Removed by Filter: 1
+
+RESET timescaledb.debug_require_deferred_chunk_scan;

--- a/tsl/test/sql/deferredchunkscan.sql.in
+++ b/tsl/test/sql/deferredchunkscan.sql.in
@@ -289,3 +289,18 @@ SET timescaledb.enable_deferred_chunk_scan TO off;
 SET timescaledb.enable_deferred_chunk_scan TO on;
 :DIFF_CMD
 
+-- EXPLAIN ANALYZE prints the actual per-chunk plan for every chunk the LIMIT visited.
+SET timescaledb.debug_require_deferred_chunk_scan TO 'require';
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 3;  -- stops in the first non-empty chunk
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics LIMIT 6;  -- spills into a second non-empty chunk
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics ORDER BY time DESC LIMIT 3;  -- ordered: per-chunk plan carries the ORDER BY
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 3;  -- compressed chunk
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- compressed + ordered: per-chunk Sort
+-- make the first-visited chunk partially compressed, then scan it
+INSERT INTO metrics_compressed (time, device, value) VALUES ('2020-01-05 06:00', 9, 99);
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed LIMIT 4;  -- partial chunk: compressed and uncompressed parts
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT * FROM metrics_compressed ORDER BY time DESC LIMIT 3;  -- partial chunk + ordered: per-chunk Merge Append
+-- a correlated target-list subplan is explained after the per-chunk plans and must resolve against the outer range table
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF, BUFFERS OFF) SELECT value, (SELECT count(*) FROM metrics_regular r WHERE r.time < m.time) FROM metrics m ORDER BY time LIMIT 3;
+RESET timescaledb.debug_require_deferred_chunk_scan;
+


### PR DESCRIPTION
EXPLAIN ANALYZE now prints the plan of each chunk a query visited under the
DeferredChunkScan node, with the rows and loops each chunk produced, so you can
see how every chunk was scanned.

To allow this the node runs each per-chunk query through its own executor so the
scan can be measured when the query is analyzed.

Disable-check: force-changelog-file
