### PR TITLE
fix(compression): use resolved settings for sort order during in-memory recompression

### DIFF
--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1854,8 +1854,15 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 	}
 
 	Relation index_rel = index_open(index_oid, lockmode);
+	/* Sort info (in particular each orderby column's ASC/DESC operator) must
+	 * come from new_settings: it is the only one of the two settings objects
+	 * guaranteed to reflect the orderby the caller just resolved (e.g. after
+	 * an ALTER TABLE ... SET (timescaledb.compress_orderby = ...) changed
+	 * direction). recompress_ctx's segmentby scankeys and firstlast index
+	 * attnos are unused on this path (perform_recompression() never reads
+	 * them), so passing new_settings here does not affect them. */
 	RecompressContext *recompress_ctx =
-		compress_chunk_populate_recompress_ctx(settings,
+		compress_chunk_populate_recompress_ctx(new_settings,
 											   uncompressed_chunk_rel,
 											   compressed_chunk_rel,
 											   index_rel,

--- a/tsl/test/expected/recompression_integrity_tests.out
+++ b/tsl/test/expected/recompression_integrity_tests.out
@@ -575,3 +575,45 @@ SELECT * FROM recomp_guc_test ORDER BY time, device;
 
 RESET timescaledb.enable_in_memory_recompression;
 DROP TABLE recomp_guc_test CASCADE;
+-- Test Case 7: In-memory recompression after an orderby direction change (#10058)
+-- Changing compress_orderby's direction between compress_chunk() and
+-- compress_chunk(recompress := true) must re-sort the data, not just relabel
+-- it: an ordered scan with LIMIT trusts the compressed batches' min/max
+-- metadata to skip a full sort, so stale physical ordering surfaces directly
+-- in query results, not only in internal metadata.
+DROP TABLE IF EXISTS recomp_orderby_change_test CASCADE;
+NOTICE:  table "recomp_orderby_change_test" does not exist, skipping
+CREATE TABLE recomp_orderby_change_test(started_at int NOT NULL, vehicle_id int NOT NULL);
+SELECT create_hypertable('recomp_orderby_change_test', 'started_at');
+            create_hypertable            
+-----------------------------------------
+ (7,public,recomp_orderby_change_test,t)
+
+INSERT INTO recomp_orderby_change_test SELECT i, 0 FROM generate_series(0, 9) i;
+ALTER TABLE recomp_orderby_change_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'started_at',
+    timescaledb.compress_segmentby = 'vehicle_id'
+);
+SELECT compress_chunk(ch) FROM show_chunks('recomp_orderby_change_test') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_10_chunk
+
+-- Reverse the orderby direction, then recompress in-memory.
+ALTER TABLE recomp_orderby_change_test SET (timescaledb.compress_orderby = 'started_at DESC');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(ch, recompress => true) FROM show_chunks('recomp_orderby_change_test') ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_10_chunk
+
+-- Must reflect the new DESC orderby, not the stale ASC physical order.
+SELECT started_at FROM recomp_orderby_change_test ORDER BY started_at DESC LIMIT 3;
+ started_at 
+------------
+          9
+          8
+          7
+
+DROP TABLE recomp_orderby_change_test CASCADE;

--- a/tsl/test/sql/recompression_integrity_tests.sql
+++ b/tsl/test/sql/recompression_integrity_tests.sql
@@ -221,5 +221,34 @@ SELECT * FROM recomp_guc_test ORDER BY time, device;
 RESET timescaledb.enable_in_memory_recompression;
 DROP TABLE recomp_guc_test CASCADE;
 
+-- Test Case 7: In-memory recompression after an orderby direction change (#10058)
+-- Changing compress_orderby's direction between compress_chunk() and
+-- compress_chunk(recompress := true) must re-sort the data, not just relabel
+-- it: an ordered scan with LIMIT trusts the compressed batches' min/max
+-- metadata to skip a full sort, so stale physical ordering surfaces directly
+-- in query results, not only in internal metadata.
+DROP TABLE IF EXISTS recomp_orderby_change_test CASCADE;
+CREATE TABLE recomp_orderby_change_test(started_at int NOT NULL, vehicle_id int NOT NULL);
+SELECT create_hypertable('recomp_orderby_change_test', 'started_at');
+
+INSERT INTO recomp_orderby_change_test SELECT i, 0 FROM generate_series(0, 9) i;
+
+ALTER TABLE recomp_orderby_change_test SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'started_at',
+    timescaledb.compress_segmentby = 'vehicle_id'
+);
+
+SELECT compress_chunk(ch) FROM show_chunks('recomp_orderby_change_test') ch;
+
+-- Reverse the orderby direction, then recompress in-memory.
+ALTER TABLE recomp_orderby_change_test SET (timescaledb.compress_orderby = 'started_at DESC');
+SELECT compress_chunk(ch, recompress => true) FROM show_chunks('recomp_orderby_change_test') ch;
+
+-- Must reflect the new DESC orderby, not the stale ASC physical order.
+SELECT started_at FROM recomp_orderby_change_test ORDER BY started_at DESC LIMIT 3;
+
+DROP TABLE recomp_orderby_change_test CASCADE;
+
 
 


### PR DESCRIPTION
## Fixes #10058

`compress_chunk(chunk, recompress => true)` silently keeps the old physical row order after `compress_orderby`'s direction was changed, even though the recompressed chunk's catalog metadata claims the new direction.

## Root cause

`recompress_chunk_in_memory_impl()` (`tsl/src/compression/recompress.c`) already resolves `new_settings` via `resolve_recompression_settings()` to reflect the hypertable's *current* compression settings (including any `ALTER TABLE ... SET (timescaledb.compress_orderby = ...)` that happened since the chunk was last compressed), and correctly passes `new_settings` to `row_compressor_init()` and `create_compress_chunk()`.

But it builds the `RecompressContext` — via `compress_chunk_populate_recompress_ctx()` — from the chunk's stale, pre-ALTER `settings` object instead. `compress_chunk_populate_sort_info_for_column()` picks the sort operator (`lt_opr` for ASC, `gt_opr` for DESC) straight from `settings->fd.orderby_desc`, so `recompress_ctx->sort_operators` reflects the *old* direction. Those are exactly the operators `perform_recompression()` uses to build the `tuplesortstate` that physically re-sorts every decompressed row before recompressing — so the real re-sort still runs in the old direction, while the new chunk's compression metadata (built from `new_settings`) says otherwise.

An ordered scan with `LIMIT` trusts that (now-wrong) metadata to skip a full sort, so the mismatch surfaces directly in query results, not just in internal state:

```sql
CREATE TABLE rideshare_trips(started_at int NOT NULL, vehicle_id int NOT NULL);
SELECT create_hypertable('rideshare_trips', 'started_at');
INSERT INTO rideshare_trips SELECT i, 0 FROM generate_series(0, 9) i;
ALTER TABLE rideshare_trips SET (timescaledb.compress,
                                 timescaledb.compress_orderby = 'started_at',
                                 timescaledb.compress_segmentby = 'vehicle_id');
SELECT compress_chunk(c) FROM show_chunks('rideshare_trips') c;
ALTER TABLE rideshare_trips SET (timescaledb.compress_orderby = 'started_at DESC');
SELECT compress_chunk(c, recompress => true) FROM show_chunks('rideshare_trips') c;

SELECT started_at FROM rideshare_trips ORDER BY started_at DESC LIMIT 3;
-- before: 0, 1, 2   (stale ASC order)
-- after:  9, 8, 7    (correct)
```

## Fix

Pass `new_settings` instead of `settings` to `compress_chunk_populate_recompress_ctx()` in `recompress_chunk_in_memory_impl()`, so the sort keys/operators driving the actual re-sort match what the rest of the function already treats as current. The other fields that call populates from its `settings` argument (segmentby scankeys, firstlast index attnos) are read only by the separate `compact_chunk` code path, not by `perform_recompression()`, so this doesn't change behavior for them.

## Testing

- Added Test Case 7 to `tsl/test/sql/recompression_integrity_tests.sql`, mirroring the issue's own repro: compress with `compress_orderby = 'started_at'`, change it to `'started_at DESC'`, recompress in-memory, and assert `ORDER BY started_at DESC LIMIT 3` returns `9, 8, 7`.
- Verified red-before-green locally: reverting just this fix and rebuilding reproduces the reported `0, 1, 2` output; restoring the fix and rebuilding gives `9, 8, 7`.
- Ran the full `recompression_integrity_tests` file (all 7 cases) via the project's own `runner.sh`/`runner_cleanup_output.sh` pipeline against a local Postgres 18 build — output matches the expected file exactly aside from a `psql:<file>:<line>:` prefix on NOTICE lines that appears identically across *all* test cases (including the untouched ones), which looks like a psql-version-specific formatting difference between PG18 and whatever version generates CI's expected output, not a behavioral difference.
- Also ran `compression_settings.sql` (an existing test that already exercises several `compress_orderby` changes) end-to-end against the fix — clean, with only the same environment-only NOTICE-prefix artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)