### PR TITLE
Release 2.29.2

### DIFF
--- a/.unreleased/fix_10189
+++ b/.unreleased/fix_10189
@@ -1,1 +1,0 @@
-Fixes: #10189 Fix UDF named time_bucket causing XX000

--- a/.unreleased/fix_10363
+++ b/.unreleased/fix_10363
@@ -1,1 +1,0 @@
-Fixes: #10363 Fix gapfill with window agg of constant

--- a/.unreleased/fix_isnull_minmax_pushdown
+++ b/.unreleased/fix_isnull_minmax_pushdown
@@ -1,1 +1,0 @@
-Fixes: #9921 Fix wrong results with IS NULL and minmax sparse index pushdown

--- a/.unreleased/pr_10416
+++ b/.unreleased/pr_10416
@@ -1,1 +1,0 @@
-Fixes: #10416 Repair mismatched dimensional CHECK constraints

--- a/.unreleased/pr_10423
+++ b/.unreleased/pr_10423
@@ -1,2 +1,0 @@
-Fixes: #10423 Compressed SkipScan should not drop uncompressed part with sort keys unmatched to distint keys.
-Thanks: @borisborelly for reporting incorrect result with COUNT(DISTINCT) due to SkipScan dropping uncompressed part.

--- a/.unreleased/pr_10430
+++ b/.unreleased/pr_10430
@@ -1,1 +1,0 @@
-Fixes: #10430 Should not attach SkipScan to mismatched IndexScan under MergeAppend.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,18 @@
 
 ## 2.29.2 (2026-08-17)
 
-This release contains performance improvements and bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.
-
-**Highlighted features in TimescaleDB v2.29.2**
-* 
-
-**Backward-Incompatible Changes**
-
-**Features**
+This release contains bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.
 
 **Bugfixes**
-* [#10189](https://github.com/timescale/timescaledb/pull/10189) Fix UDF named time_bucket causing XX000
-* [#10363](https://github.com/timescale/timescaledb/pull/10363) Fix gapfill with window agg of constant
-* [#10416](https://github.com/timescale/timescaledb/pull/10416) Repair mismatched dimensional CHECK constraints
-* [#10423](https://github.com/timescale/timescaledb/pull/10423) Compressed SkipScan should not drop uncompressed part with sort keys unmatched to distint keys.
-* [#10430](https://github.com/timescale/timescaledb/pull/10430) Should not attach SkipScan to mismatched IndexScan under MergeAppend.
-* [#9921](https://github.com/timescale/timescaledb/pull/9921) Fix wrong results with IS NULL and minmax sparse index pushdown
-
-**New Settings**
-
-**GUCs**
+* [#10189](https://github.com/timescale/timescaledb/pull/10189) Fix user-defined functions named `time_bucket` causing SQLSTATE `XX000`
+* [#10363](https://github.com/timescale/timescaledb/pull/10363) Fix `time_bucket_gapfill()` with window aggregates over constants
+* [#10416](https://github.com/timescale/timescaledb/pull/10416) Repair mismatched dimensional `CHECK` constraints
+* [#10423](https://github.com/timescale/timescaledb/pull/10423) Fix compressed `SkipScan` dropping uncompressed rows when sort keys do not match distinct keys
+* [#10430](https://github.com/timescale/timescaledb/pull/10430) Do not attach `SkipScan` to mismatched `IndexScan` paths under `MergeAppend`
+* [#9921](https://github.com/timescale/timescaledb/pull/9921) Fix wrong results for `IS NULL` predicates with min/max sparse-index pushdown
 
 **Thanks**
-* @borisborelly for reporting incorrect result with COUNT(DISTINCT) due to SkipScan dropping uncompressed part.
+* @borisborelly for reporting incorrect results with `COUNT(DISTINCT)` due to `SkipScan` dropping uncompressed rows.
 
 ## 2.29.1 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
-## 2.29.2 (2026-08-17)
+## 2.29.2 (2026-08-18)
 
 This release contains bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.29.2 (2026-08-17)
+
+This release contains performance improvements and bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.29.2**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+
+**Bugfixes**
+* [#10189](https://github.com/timescale/timescaledb/pull/10189) Fix UDF named time_bucket causing XX000
+* [#10363](https://github.com/timescale/timescaledb/pull/10363) Fix gapfill with window agg of constant
+* [#10416](https://github.com/timescale/timescaledb/pull/10416) Repair mismatched dimensional CHECK constraints
+* [#10423](https://github.com/timescale/timescaledb/pull/10423) Compressed SkipScan should not drop uncompressed part with sort keys unmatched to distint keys.
+* [#10430](https://github.com/timescale/timescaledb/pull/10430) Should not attach SkipScan to mismatched IndexScan under MergeAppend.
+* [#9921](https://github.com/timescale/timescaledb/pull/9921) Fix wrong results with IS NULL and minmax sparse index pushdown
+
+**New Settings**
+
+**GUCs**
+
+**Thanks**
+* @borisborelly for reporting incorrect result with COUNT(DISTINCT) due to SkipScan dropping uncompressed part.
+
 ## 2.29.1 (2026-08-04)
 
 This release contains performance improvements and bug fixes since the 2.29.0 release and fixes for security vulnerabilities (#10360, #10379, #10386). You can check the [security advisory](https://github.com/timescale/timescaledb/security/advisories/GHSA-hcfx-29v5-2rcw) for more information on the vulnerability and the platforms that are affected. We recommend that you upgrade at the next available opportunity.


### PR DESCRIPTION
# TimescaleDB Changelog

**Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**

## 2.29.2 (2026-08-17)

This release contains bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* [#10189](https://github.com/timescale/timescaledb/pull/10189) Fix user-defined functions named `time_bucket` causing SQLSTATE `XX000`
* [#10363](https://github.com/timescale/timescaledb/pull/10363) Fix `time_bucket_gapfill()` with window aggregates over constants
* [#10416](https://github.com/timescale/timescaledb/pull/10416) Repair mismatched dimensional `CHECK` constraints
* [#10423](https://github.com/timescale/timescaledb/pull/10423) Fix compressed `SkipScan` dropping uncompressed rows when sort keys do not match distinct keys
* [#10430](https://github.com/timescale/timescaledb/pull/10430) Do not attach `SkipScan` to mismatched `IndexScan` paths under `MergeAppend`
* [#9921](https://github.com/timescale/timescaledb/pull/9921) Fix wrong results for `IS NULL` predicates with min/max sparse-index pushdown