### PR TITLE
#10325 Allow Git commit tests for tarball builds

### DIFF
--- a/tsl/test/shared/expected/build_info_1.out
+++ b/tsl/test/shared/expected/build_info_1.out
@@ -1,0 +1,10 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Check what get_git_commit returns
+SELECT pg_typeof(commit_tag) AS commit_tag_type,
+       pg_typeof(commit_hash) AS commit_hash_type,
+       length(commit_hash) AS commit_hash_length,
+       pg_typeof(commit_time) AS commit_time_type
+  FROM _timescaledb_functions.get_git_commit();
+ERROR:  extension not built with any Git commit information

--- a/tsl/test/shared/expected/compat_1.out
+++ b/tsl/test/shared/expected/compat_1.out
@@ -1,0 +1,242 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET timezone TO PST8PDT;
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.alter_job_set_hypertable_id(0,0);
+WARNING:  function _timescaledb_internal.alter_job_set_hypertable_id(integer,regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  job 0 not found
+SELECT _timescaledb_internal.attach_osm_table_chunk(0,0);
+WARNING:  function _timescaledb_internal.attach_osm_table_chunk(regclass,regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.cagg_watermark(0);
+WARNING:  function _timescaledb_internal.cagg_watermark(integer) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid materialized hypertable ID: 0
+SELECT _timescaledb_internal.cagg_watermark_materialized(0);
+WARNING:  function _timescaledb_internal.cagg_watermark_materialized(integer) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid materialized hypertable ID: 0
+SELECT _timescaledb_internal.chunk_id_from_relid(0);
+WARNING:  function _timescaledb_internal.chunk_id_from_relid(oid) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ chunk_id_from_relid 
+---------------------
+                   0
+
+SELECT _timescaledb_internal.chunk_status(0);
+WARNING:  function _timescaledb_internal.chunk_status(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.chunks_local_size(NULL,NULL);
+WARNING:  function _timescaledb_internal.chunks_local_size(name,name) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ chunks_local_size 
+-------------------
+
+SELECT _timescaledb_internal.compressed_chunk_local_stats(NULL,NULL);
+WARNING:  function _timescaledb_internal.compressed_chunk_local_stats(name,name) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ compressed_chunk_local_stats 
+------------------------------
+
+SELECT _timescaledb_internal.create_chunk(0,NULL,NULL,NULL,0);
+WARNING:  function _timescaledb_internal.create_chunk(regclass,jsonb,name,name,regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.create_chunk_table(0,NULL,NULL,NULL);
+ERROR:  function _timescaledb_internal.create_chunk_table(integer, unknown, unknown, unknown) does not exist at character 8
+SELECT _timescaledb_internal.create_compressed_chunk(0,0,0,0,0,0,0,0,0,0);
+WARNING:  function _timescaledb_internal.create_compressed_chunk(regclass,regclass,bigint,bigint,bigint,bigint,bigint,bigint,bigint,bigint) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.drop_chunk(0);
+WARNING:  function _timescaledb_internal.drop_chunk(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  chunk not found
+SELECT _timescaledb_internal.freeze_chunk(0);
+WARNING:  function _timescaledb_internal.freeze_chunk(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT FROM _timescaledb_internal.generate_uuid();
+WARNING:  function _timescaledb_internal.generate_uuid() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+--
+
+SELECT _timescaledb_internal.get_approx_row_count(0);
+WARNING:  function _timescaledb_internal.get_approx_row_count(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ get_approx_row_count 
+----------------------
+                    0
+
+SELECT _timescaledb_internal.get_compressed_chunk_index_for_recompression(0);
+WARNING:  function _timescaledb_internal.get_compressed_chunk_index_for_recompression(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.get_create_command(NULL);
+WARNING:  function _timescaledb_internal.get_create_command(name) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  hypertable "<NULL>" not found
+SELECT pg_typeof(_timescaledb_internal.get_git_commit());
+WARNING:  function _timescaledb_internal.get_git_commit() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  extension not built with any Git commit information
+SELECT pg_typeof(_timescaledb_internal.get_os_info());
+WARNING:  function _timescaledb_internal.get_os_info() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ pg_typeof 
+-----------
+ record
+
+SELECT _timescaledb_internal.get_partition_for_key(NULL::text);
+WARNING:  function _timescaledb_internal.get_partition_for_key(anyelement) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ get_partition_for_key 
+-----------------------
+                      
+
+SELECT _timescaledb_internal.get_partition_hash(NULL::text);
+WARNING:  function _timescaledb_internal.get_partition_hash(anyelement) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ get_partition_hash 
+--------------------
+                   
+
+SELECT _timescaledb_internal.hypertable_local_size(NULL,NULL);
+WARNING:  function _timescaledb_internal.hypertable_local_size(name,name) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ hypertable_local_size 
+-----------------------
+
+SELECT _timescaledb_internal.interval_to_usec(NULL);
+WARNING:  function _timescaledb_internal.interval_to_usec(interval) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ interval_to_usec 
+------------------
+                 
+
+SELECT _timescaledb_internal.policy_compression_check(NULL);
+WARNING:  function _timescaledb_internal.policy_compression_check(jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  config must not be NULL
+SELECT _timescaledb_internal.policy_job_stat_history_retention(0,NULL);
+WARNING:  function _timescaledb_internal.policy_job_stat_history_retention(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  permission denied for table bgw_job_stat_history
+SELECT _timescaledb_internal.policy_job_stat_history_retention_check(NULL);
+WARNING:  function _timescaledb_internal.policy_job_stat_history_retention_check(jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  config cannot be NULL, and must contain drop_after
+SELECT _timescaledb_internal.policy_refresh_continuous_aggregate_check(NULL);
+WARNING:  function _timescaledb_internal.policy_refresh_continuous_aggregate_check(jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  config must not be NULL
+SELECT _timescaledb_internal.policy_reorder_check(NULL);
+WARNING:  function _timescaledb_internal.policy_reorder_check(jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  config must not be NULL
+SELECT _timescaledb_internal.policy_retention_check(NULL);
+WARNING:  function _timescaledb_internal.policy_retention_check(jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  config must not be NULL
+SELECT _timescaledb_internal.range_value_to_pretty(0,0);
+WARNING:  function _timescaledb_internal.range_value_to_pretty(bigint,regtype) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ range_value_to_pretty 
+-----------------------
+ 0
+
+SELECT _timescaledb_internal.recompress_chunk_segmentwise(0,true);
+WARNING:  function _timescaledb_internal.recompress_chunk_segmentwise(regclass,boolean) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.relation_size(0);
+WARNING:  function _timescaledb_internal.relation_size(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ relation_size 
+---------------
+ (,,,)
+
+SELECT _timescaledb_internal.restart_background_workers();
+WARNING:  function _timescaledb_internal.restart_background_workers() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  must be superuser to restart background workers
+SELECT _timescaledb_internal.show_chunk(0);
+WARNING:  function _timescaledb_internal.show_chunk(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.start_background_workers();
+WARNING:  function _timescaledb_internal.start_background_workers() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  must be superuser to start background workers
+SELECT _timescaledb_internal.stop_background_workers();
+WARNING:  function _timescaledb_internal.stop_background_workers() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  must be superuser to stop background workers
+SELECT _timescaledb_internal.subtract_integer_from_now(0,0);
+WARNING:  function _timescaledb_internal.subtract_integer_from_now(regclass,bigint) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+SELECT _timescaledb_internal.time_to_internal(NULL::timestamptz);
+WARNING:  function _timescaledb_internal.time_to_internal(anyelement) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ time_to_internal 
+------------------
+                 
+
+SELECT _timescaledb_internal.to_date(0);
+WARNING:  function _timescaledb_internal.to_date(bigint) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+  to_date   
+------------
+ 01-01-1970
+
+SELECT _timescaledb_internal.to_interval(0);
+WARNING:  function _timescaledb_internal.to_interval(bigint) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ to_interval 
+-------------
+ @ 0
+
+SELECT _timescaledb_internal.to_timestamp(0);
+WARNING:  function _timescaledb_internal.to_timestamp(bigint) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+         to_timestamp         
+------------------------------
+ Wed Dec 31 16:00:00 1969 PST
+
+SELECT _timescaledb_internal.to_timestamp_without_timezone(0);
+WARNING:  function _timescaledb_internal.to_timestamp_without_timezone(bigint) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ to_timestamp_without_timezone 
+-------------------------------
+ Thu Jan 01 00:00:00 1970
+
+SELECT _timescaledb_internal.to_unix_microseconds(NULL);
+WARNING:  function _timescaledb_internal.to_unix_microseconds(timestamp with time zone) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ to_unix_microseconds 
+----------------------
+                     
+
+SELECT _timescaledb_internal.tsl_loaded();
+WARNING:  function _timescaledb_internal.tsl_loaded() is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ tsl_loaded 
+------------
+ t
+
+SELECT _timescaledb_internal.unfreeze_chunk(0);
+WARNING:  function _timescaledb_internal.unfreeze_chunk(regclass) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+CALL _timescaledb_internal.policy_compression(0,NULL);
+WARNING:  procedure _timescaledb_internal.policy_compression(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+ERROR:  job 0 has null config
+CALL _timescaledb_internal.policy_recompression(0,NULL);
+WARNING:  procedure _timescaledb_internal.policy_recompression(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+CALL _timescaledb_internal.policy_refresh_continuous_aggregate(0,NULL);
+WARNING:  procedure _timescaledb_internal.policy_refresh_continuous_aggregate(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+CALL _timescaledb_internal.policy_reorder(0,NULL);
+WARNING:  procedure _timescaledb_internal.policy_reorder(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+CALL _timescaledb_internal.policy_retention(0,NULL);
+WARNING:  procedure _timescaledb_internal.policy_retention(integer,jsonb) is deprecated and has been moved to _timescaledb_functions schema. this compatibility function will be removed in a future version.
+CALL public.recompress_chunk(0);
+WARNING:  procedure public.recompress_chunk(regclass,boolean) is deprecated and the functionality is now included in public.compress_chunk. this compatibility function will be removed in a future version.
+ERROR:  invalid Oid
+\set ON_ERROR_STOP 1
+-- tests for the cagg invalidation trigger on the deprecated schema
+CREATE TABLE sensor_data (
+    time TIMESTAMPTZ NOT NULL,
+    temperature DOUBLE PRECISION NULL
+);
+SELECT hypertable_id FROM create_hypertable('sensor_data','time') \gset
+CREATE MATERIALIZED VIEW sensor_data_hourly WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
+SELECT time_bucket(INTERVAL '1 hour', time),
+       min(time),
+       max(time)
+FROM sensor_data
+GROUP BY 1
+WITH DATA;
+NOTICE:  continuous aggregate "sensor_data_hourly" is already up-to-date
+INSERT INTO sensor_data values('1980-01-01 00:00:00-00', 1);
+CALL refresh_continuous_aggregate('sensor_data_hourly', NULL, NULL);
+-- should not return rows because there's old invalid regions
+SELECT lowest_modified_value, greatest_modified_value
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :'hypertable_id';
+ lowest_modified_value | greatest_modified_value 
+-----------------------+-------------------------
+
+-- insert old data to create invalidation log
+INSERT INTO sensor_data values('1979-12-31 00:00:00-00', 1);
+-- should return the invalidation log generated by previous insert
+SELECT lowest_modified_value, greatest_modified_value
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :'hypertable_id';
+ lowest_modified_value | greatest_modified_value 
+-----------------------+-------------------------
+       315446400000000 |         315446400000000
+
+DROP MATERIALIZED VIEW sensor_data_hourly;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_X_X_chunk
+DROP TABLE sensor_data CASCADE;


### PR DESCRIPTION
This PR affects issue #10325  raised by @tureba 

Shared regression tests now handle builds made from source archives that do not contain git metadata.

When TimescaleDB is built without a `.git` directory, `get_git_commit()` intentionally raises:

    ERROR:  extension not built with any Git commit information

The existing `build_info.out` and `compat.out` files only describe the result from a Git checkout, where commit metadata is available. As a result, `build_info` and `compat` fail during regression testing of a tarball build even though the function is behaving as designed.

This uses PostgreSQL's numbered alternative expected-output mechanism. `pg_regress` now accepts either the existing metadata-present output or the new metadata-absent output. Each result is still compared as a complete exact match, so this does not ignore the error or weaken the tests. Unexpected errors and unrelated output differences will continue to fail.

## Implementation

- Added `tsl/test/shared/expected/build_info_1.out` for the archive-build result of `build_info.sql`.

  - It expects the intentional `get_git_commit()` error when Git metadata was not compiled into the extension.
  - The existing `build_info.out` remains unchanged and continues to validate the metadata-present result.

- Added `tsl/test/shared/expected/compat_1.out` for the archive-build result of `compat.sql`.

  - It continues to expect the deprecation warning from `_timescaledb_internal.get_git_commit()`.
  - It then expects the intentional missing-Git-metadata error.
  - The remainder of the compatibility test output is still checked normally.

- `compat_1.out` contains most of the same output as `compat.out` as alternative expected files should contain the complete test transcript. 

## Testing

- Built TimescaleDB in Debug mode with assertions enabled using PostgreSQL 18.

- Created and extracted a source archive outside any parent Git working tree, ensuring that no `.git` directory or Git metadata was available during the build.

- Ran the two affected tests against the archive build:

  - `build_info` passed using `build_info_1.out`.
  - `compat` passed using `compat_1.out`.
  - Result: all 2 tests passed.

- Ran the complete shared regression suite against the archive build.

  - Result: all 34 tests passed.

- Rebuilt with Git metadata available and ran the two affected tests again.

  - `build_info` passed using the existing `build_info.out`.
  - `compat` passed using the existing `compat.out`.
  - Result: all 2 tests passed.

- Compared both new expected files with the output captured from the archive build to confirm that they are exact matches.

This confirms that archive builds now accept the intentional missing-metadata result while Git checkout builds continue to validate the existing commit-information result.