### PR TITLE
Add pg_depend entry for compressed relations

### DIFF
--- a/sql/compression.sql
+++ b/sql/compression.sql
@@ -17,3 +17,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_functions.decompress_batch(record)
    AS '@MODULE_PATHNAME@', 'ts_decompress_batch'
    LANGUAGE C STRICT;
 
+-- Record the pg_depend links between the compressed relations and their chunk.
+CREATE OR REPLACE FUNCTION _timescaledb_functions.restore_compressed_relation_dependencies()
+   RETURNS INTEGER
+   AS '@MODULE_PATHNAME@', 'ts_compressed_relation_restore_dependencies'
+   LANGUAGE C;

--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -41,6 +41,9 @@ BEGIN
     -- re-point foreign key check triggers recreated by restore at ours
     PERFORM _timescaledb_functions.restore_fk_check_triggers();
 
+    -- record the pg_depend links which are not part of a dump
+    PERFORM _timescaledb_functions.restore_compressed_relation_dependencies();
+
     RETURN true;
 END
 $BODY$

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -220,3 +220,20 @@ BEGIN
   END IF;
 END
 $$;
+
+-- Link the compressed relations to their chunk in pg_depend.
+INSERT INTO pg_catalog.pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT 'pg_catalog.pg_class'::regclass::oid, cs.compress_relid::oid, 0,
+       'pg_catalog.pg_class'::regclass::oid, cs.relid::oid, 0, 'i'
+FROM _timescaledb_catalog.compression_settings cs
+WHERE cs.compress_relid IS NOT NULL
+  AND NOT EXISTS (
+    SELECT FROM pg_catalog.pg_depend d
+    WHERE d.classid = 'pg_catalog.pg_class'::regclass::oid
+      AND d.objid = cs.compress_relid::oid
+      AND d.objsubid = 0
+      AND d.refclassid = 'pg_catalog.pg_class'::regclass::oid
+      AND d.refobjid = cs.relid::oid
+      AND d.refobjsubid = 0
+      AND d.deptype = 'i');
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -147,3 +147,16 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.tenant_tracking_map();
 
 ALTER TABLE _timescaledb_catalog.hypertable SET (user_catalog_table = true);
 ALTER TABLE _timescaledb_catalog.chunk SET (user_catalog_table = true);
+
+-- Remove the pg_depend link between the compressed relations and their chunk.
+DELETE FROM pg_catalog.pg_depend d
+USING _timescaledb_catalog.compression_settings cs
+WHERE d.classid = 'pg_catalog.pg_class'::regclass::oid
+  AND d.objid = cs.compress_relid::oid
+  AND d.objsubid = 0
+  AND d.refclassid = 'pg_catalog.pg_class'::regclass::oid
+  AND d.refobjid = cs.relid::oid
+  AND d.refobjsubid = 0
+  AND d.deptype = 'i';
+
+DROP FUNCTION IF EXISTS _timescaledb_functions.restore_compressed_relation_dependencies();

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3179,6 +3179,7 @@ chunk_tuple_delete(TupleInfo *ti, Oid relid, DropBehavior behavior, bool detach)
 		{
 			/* Plain drop without preserving catalog row because this is the compressed
 			 * chunk */
+			ts_compressed_relation_drop_dependency(compressed_relid);
 			ts_chunk_drop_by_relid(compressed_relid, behavior, DEBUG1);
 		}
 	}

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1654,6 +1654,8 @@ process_drop_table_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 		.objectId = chunk_relid,
 	};
 
+	/* Called for the compressed relation as well, which is linked to its chunk */
+	ts_compressed_relation_drop_dependency(chunk_relid);
 	ts_compression_settings_delete(chunk_relid);
 	ts_chunk_rewrite_delete(chunk_relid, false);
 	performDeletion(&objaddr, stmt->behavior, 0);
@@ -1715,6 +1717,7 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 				if (OidIsValid(compressed_relid))
 				{
 					LockRelationOid(compressed_relid, AccessExclusiveLock);
+					ts_compressed_relation_drop_dependency(compressed_relid);
 					ts_chunk_drop_by_relid(compressed_relid, stmt->behavior, DEBUG1);
 				}
 			}

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -4,12 +4,18 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
+#include <access/xact.h>
+#include <catalog/dependency.h>
+#include <catalog/objectaddress.h>
+#include <catalog/pg_class.h>
 #include <catalog/pg_inherits.h>
 #include <catalog/pg_type.h>
 #include <parser/parse_func.h>
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
+#include <utils/syscache.h>
 
+#include "export.h"
 #include "foreach_ptr.h"
 #include "jsonb_utils.h"
 #include "scan_iterator.h"
@@ -496,6 +502,94 @@ ts_relation_is_compressed_chunk_relation(Oid compress_relid)
 	ts_scan_iterator_close(&iterator);
 
 	return found;
+}
+
+/*
+ * Link the compressed relation to its chunk in pg_depend. Replaces any
+ * previous link.
+ */
+TSDLLEXPORT void
+ts_compressed_relation_record_dependency(Oid relid, Oid compress_relid)
+{
+	ObjectAddress compressed, chunk;
+
+	Assert(OidIsValid(relid) && OidIsValid(compress_relid));
+
+	ts_compressed_relation_drop_dependency(compress_relid);
+
+	ObjectAddressSet(compressed, RelationRelationId, compress_relid);
+	ObjectAddressSet(chunk, RelationRelationId, relid);
+	recordDependencyOn(&compressed, &chunk, DEPENDENCY_INTERNAL);
+}
+
+/*
+ * Record the links for all compressed relations in the catalog. Returns the
+ * number of links recorded.
+ */
+TS_FUNCTION_INFO_V1(ts_compressed_relation_restore_dependencies);
+
+Datum
+ts_compressed_relation_restore_dependencies(PG_FUNCTION_ARGS)
+{
+	List *relids = NIL;
+	List *compress_relids = NIL;
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_SETTINGS, AccessShareLock, CurrentMemoryContext);
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		bool isnull;
+		Datum compress_relid =
+			slot_getattr(ti->slot, Anum_compression_settings_compress_relid, &isnull);
+
+		/* Settings of a hypertable have no compressed relation */
+		if (isnull)
+		{
+			continue;
+		}
+
+		Datum relid = slot_getattr(ti->slot, Anum_compression_settings_relid, &isnull);
+		Assert(!isnull);
+
+		/* Skip settings left behind by a relation that is already gone */
+		if (!SearchSysCacheExists1(RELOID, relid) || !SearchSysCacheExists1(RELOID, compress_relid))
+		{
+			continue;
+		}
+
+		relids = lappend_oid(relids, DatumGetObjectId(relid));
+		compress_relids = lappend_oid(compress_relids, DatumGetObjectId(compress_relid));
+	}
+
+	/* Record the links after the scan so we don't modify catalogs mid-scan */
+	ListCell *lc1, *lc2;
+	forboth (lc1, relids, lc2, compress_relids)
+	{
+		ts_compressed_relation_record_dependency(lfirst_oid(lc1), lfirst_oid(lc2));
+	}
+
+	PG_RETURN_INT32(list_length(relids));
+}
+
+/*
+ * Remove the link so the compressed relation can be dropped on its own.
+ */
+TSDLLEXPORT void
+ts_compressed_relation_drop_dependency(Oid compress_relid)
+{
+	Assert(OidIsValid(compress_relid));
+
+	long deleted = deleteDependencyRecordsForClass(RelationRelationId,
+												   compress_relid,
+												   RelationRelationId,
+												   DEPENDENCY_INTERNAL);
+
+	/* Make the delete visible to the drop that follows */
+	if (deleted > 0)
+	{
+		CommandCounterIncrement();
+	}
 }
 
 /*

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -147,6 +147,8 @@ TSDLLEXPORT void ts_compression_settings_free(CompressionSettings *settings);
 TSDLLEXPORT bool ts_relation_is_compressed_chunk_relation(Oid relid);
 TSDLLEXPORT Oid ts_relation_get_uncompressed_relid(Oid compress_relid);
 TSDLLEXPORT Oid ts_relation_get_compressed_relid(Oid relid);
+TSDLLEXPORT void ts_compressed_relation_record_dependency(Oid relid, Oid compress_relid);
+TSDLLEXPORT void ts_compressed_relation_drop_dependency(Oid compress_relid);
 
 TSDLLEXPORT CompressionSettings *ts_compression_settings_materialize(const CompressionSettings *src,
 																	 Oid relid, Oid compress_relid);

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -692,6 +692,7 @@ decompress_chunk_impl(Chunk *uncompressed_chunk, bool if_compressed)
 	 */
 	LockRelationOid(uncompressed_chunk->fd.relid, AccessExclusiveLock);
 	LockRelationOid(compressed_relid, AccessExclusiveLock);
+	ts_compressed_relation_drop_dependency(compressed_relid);
 	ts_chunk_drop_by_relid(compressed_relid, DROP_RESTRICT, -1);
 	ts_cache_release(&hcache);
 	write_logical_replication_msg_decompression_end();

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1260,6 +1260,7 @@ compressor_apply_segmentby_and_rebuild(RowCompressor *old_compressor, BulkWriter
 
 	tsl_compressor_close(old_compressor, old_bulk_writer);
 
+	ts_compressed_relation_drop_dependency(old_compressed_relid);
 	ts_chunk_drop_by_relid(old_compressed_relid, DROP_RESTRICT, -1);
 
 	tuplesort_performsort(new_compressor.sort_state);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1034,6 +1034,8 @@ create_compress_chunk(Chunk *src_chunk, Oid table_id, bool skip_segmentby_defaul
 		ts_compression_settings_update(settings);
 	}
 
+	ts_compressed_relation_record_dependency(src_chunk->fd.relid, table_id);
+
 	ts_chunk_set_compressed(src_chunk);
 
 	return table_id;

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1878,6 +1878,7 @@ recompress_chunk_in_memory_impl(Chunk *uncompressed_chunk)
 
 	LockRelationOid(uncompressed_chunk->fd.relid, AccessExclusiveLock);
 	LockRelationOid(compressed_relid, AccessExclusiveLock);
+	ts_compressed_relation_drop_dependency(compressed_relid);
 	ts_chunk_drop_by_relid(compressed_relid, DROP_RESTRICT, -1);
 	if (ts_chunk_clear_status(uncompressed_chunk, CHUNK_STATUS_COMPRESSED_UNORDERED))
 	{

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -345,7 +345,7 @@ CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
 \set ON_ERROR_STOP 0
 --errors due to dependent objects
 DROP TABLE :UNCOMPRESSED_CHUNK_NAME;
-ERROR:  cannot drop table _timescaledb_internal._hyper_1_9_chunk_compressed because other objects depend on it
+ERROR:  cannot drop table _timescaledb_internal._hyper_1_9_chunk because other objects depend on it
 \set ON_ERROR_STOP 1
 DROP TABLE :UNCOMPRESSED_CHUNK_NAME CASCADE;
 NOTICE:  drop cascades to view dependent_1
@@ -2668,3 +2668,72 @@ ALTER TABLE alter_col_type_test ALTER COLUMN device_id TYPE text;
 ERROR:  operation not supported on hypertables with compressed chunks
 \set ON_ERROR_STOP 1
 DROP TABLE alter_col_type_test;
+-- the compressed relation is linked to its chunk in pg_depend
+CREATE TABLE dep_test(time timestamptz NOT NULL, device int, value float);
+SELECT create_hypertable('dep_test', 'time', chunk_time_interval => interval '1 day');
+   create_hypertable    
+------------------------
+ (27,public,dep_test,t)
+
+ALTER TABLE dep_test SET (timescaledb.compress);
+INSERT INTO dep_test VALUES ('2026-01-01', 1, 1.0), ('2026-01-02', 2, 2.0);
+CREATE VIEW dep_test_deps AS
+SELECT d.deptype, count(*) AS links
+FROM pg_depend d
+  JOIN _timescaledb_catalog.compression_settings cs
+    ON d.objid = cs.compress_relid::oid AND d.refobjid = cs.relid::oid
+  JOIN _timescaledb_catalog.chunk ch ON ch.relid = cs.relid
+  JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id
+WHERE d.classid = 'pg_class'::regclass::oid
+  AND d.refclassid = 'pg_class'::regclass::oid
+  AND d.objsubid = 0
+  AND ht.table_name = 'dep_test'
+GROUP BY d.deptype;
+SELECT count(compress_chunk(ch)) FROM show_chunks('dep_test') ch;
+ count 
+-------
+     2
+
+SELECT * FROM dep_test_deps;
+ deptype | links 
+---------+-------
+ i       |     2
+
+-- restoring the links is idempotent
+SELECT _timescaledb_functions.restore_compressed_relation_dependencies() > 0 AS restored;
+ restored 
+----------
+ t
+
+SELECT * FROM dep_test_deps;
+ deptype | links 
+---------+-------
+ i       |     2
+
+-- decompressing removes the link again
+SELECT count(decompress_chunk(ch)) FROM show_chunks('dep_test') ch;
+ count 
+-------
+     2
+
+SELECT * FROM dep_test_deps;
+ deptype | links 
+---------+-------
+
+-- dropping the chunks takes the compressed relations with them
+SELECT count(compress_chunk(ch)) FROM show_chunks('dep_test') ch;
+ count 
+-------
+     2
+
+SELECT count(*) FROM (SELECT drop_chunks('dep_test', older_than => '2026-01-03'::timestamptz)) c;
+ count 
+-------
+     2
+
+SELECT * FROM dep_test_deps;
+ deptype | links 
+---------+-------
+
+DROP TABLE dep_test;
+DROP VIEW dep_test_deps;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -134,6 +134,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_functions.relation_size(regclass)
  _timescaledb_functions.remove_dropped_chunk_metadata(integer)
  _timescaledb_functions.restart_background_workers()
+ _timescaledb_functions.restore_compressed_relation_dependencies()
  _timescaledb_functions.restore_fk_check_triggers()
  _timescaledb_functions.show_chunk(regclass)
  _timescaledb_functions.start_background_workers()

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -1297,3 +1297,41 @@ ALTER TABLE alter_col_type_test ALTER COLUMN device_id TYPE text;
 
 DROP TABLE alter_col_type_test;
 
+
+-- the compressed relation is linked to its chunk in pg_depend
+CREATE TABLE dep_test(time timestamptz NOT NULL, device int, value float);
+SELECT create_hypertable('dep_test', 'time', chunk_time_interval => interval '1 day');
+ALTER TABLE dep_test SET (timescaledb.compress);
+INSERT INTO dep_test VALUES ('2026-01-01', 1, 1.0), ('2026-01-02', 2, 2.0);
+
+CREATE VIEW dep_test_deps AS
+SELECT d.deptype, count(*) AS links
+FROM pg_depend d
+  JOIN _timescaledb_catalog.compression_settings cs
+    ON d.objid = cs.compress_relid::oid AND d.refobjid = cs.relid::oid
+  JOIN _timescaledb_catalog.chunk ch ON ch.relid = cs.relid
+  JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id
+WHERE d.classid = 'pg_class'::regclass::oid
+  AND d.refclassid = 'pg_class'::regclass::oid
+  AND d.objsubid = 0
+  AND ht.table_name = 'dep_test'
+GROUP BY d.deptype;
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('dep_test') ch;
+SELECT * FROM dep_test_deps;
+
+-- restoring the links is idempotent
+SELECT _timescaledb_functions.restore_compressed_relation_dependencies() > 0 AS restored;
+SELECT * FROM dep_test_deps;
+
+-- decompressing removes the link again
+SELECT count(decompress_chunk(ch)) FROM show_chunks('dep_test') ch;
+SELECT * FROM dep_test_deps;
+
+-- dropping the chunks takes the compressed relations with them
+SELECT count(compress_chunk(ch)) FROM show_chunks('dep_test') ch;
+SELECT count(*) FROM (SELECT drop_chunks('dep_test', older_than => '2026-01-03'::timestamptz)) c;
+SELECT * FROM dep_test_deps;
+
+DROP TABLE dep_test;
+DROP VIEW dep_test_deps;


### PR DESCRIPTION
The link between a chunk and its compressed relation is only stored in
our own catalog. To allow resolving this dependency without relying on
internals of timescaledb catalog we record the compressed relation as
internal dependency of its chunk in pg_depend so the link is also
available to readers that only look at system catalogs.

pg_depend is not part of a dump, so the links are gone after a restore or
a pg_upgrade. The new function
_timescaledb_functions.restore_compressed_relation_dependencies() records
them again for all compressed relations in the catalog. It is called by
timescaledb_post_restore() and can be called by any user afterwards.
