### PR TITLE
Use ColumnarIndexScan for ORDER BY LIMIT 1 queries

### DIFF
--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.c
@@ -21,21 +21,134 @@
 #include "expression_utils.h"
 #include "func_cache.h"
 #include "guc.h"
+#include "import/setrefs.h"
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/columnar_scan/planner.h"
 #include "ts_catalog/array_utils.h"
 #include "ts_catalog/compression_settings.h"
 #include "utils.h"
 
+static AttrNumber find_resno_by_varattno(ts_indexed_tlist *tlist_index, Index varno,
+										 AttrNumber attno);
+static Plan *columnar_index_scan_plan_path(PlannerInfo *root, RelOptInfo *rel,
+										   CustomPath *best_path, List *tlist, List *clauses,
+										   List *custom_plans);
+
 static CustomScanMethods columnar_index_scan_plan_methods = {
 	.CustomName = COLUMNAR_INDEX_SCAN_NAME,
 	.CreateCustomScanState = columnar_index_scan_state_create,
+};
+
+static CustomPathMethods columnar_index_scan_path_methods = {
+	.CustomName = COLUMNAR_INDEX_SCAN_NAME,
+	.PlanCustomPath = columnar_index_scan_plan_path,
 };
 
 void
 _columnar_index_scan_init(void)
 {
 	TryRegisterCustomScanMethods(&columnar_index_scan_plan_methods);
+}
+
+Path *
+columnar_index_scan_path_create(Path *compressed_path, RelOptInfo *chunk_rel, List *pathkeys,
+								List *metadata_output_map, double limit_tuples)
+{
+	Assert(limit_tuples > 0);
+
+	CustomPath *path = (CustomPath *) newNode(sizeof(CustomPath), T_CustomPath);
+
+	path->path.pathtype = T_CustomScan;
+	path->path.parent = chunk_rel;
+	path->path.pathtarget = chunk_rel->reltarget;
+	path->path.param_info = NULL;
+	path->path.pathkeys = pathkeys;
+	path->path.rows = Min(compressed_path->rows, limit_tuples);
+	path->path.startup_cost = compressed_path->startup_cost;
+
+	double run_cost = compressed_path->total_cost - compressed_path->startup_cost;
+	if (compressed_path->rows > 0 && limit_tuples < compressed_path->rows)
+	{
+		run_cost *= limit_tuples / compressed_path->rows;
+	}
+	path->path.total_cost = compressed_path->startup_cost + run_cost;
+
+#if PG18_GE
+	path->path.disabled_nodes = compressed_path->disabled_nodes;
+#endif
+	path->path.parallel_aware = false;
+	path->path.parallel_safe = compressed_path->parallel_safe;
+	path->path.parallel_workers = compressed_path->parallel_workers;
+
+	path->flags = CUSTOMPATH_SUPPORT_PROJECTION;
+	path->custom_paths = list_make1(compressed_path);
+	path->custom_private = metadata_output_map;
+	path->methods = &columnar_index_scan_path_methods;
+
+	return &path->path;
+}
+
+CustomScan *
+columnar_index_scan_make_plan(List *custom_plans, Index scanrelid, List *targetlist,
+							  List *custom_scan_tlist, List *exec_output_map, int flags)
+{
+	Assert(list_length(custom_plans) == 1);
+	Assert(list_length(exec_output_map) % 2 == 0);
+
+	CustomScan *columnar_index_scan = (CustomScan *) makeNode(CustomScan);
+	columnar_index_scan->flags = flags;
+	columnar_index_scan->methods = &columnar_index_scan_plan_methods;
+	columnar_index_scan->custom_plans = custom_plans;
+	columnar_index_scan->custom_private = exec_output_map;
+	columnar_index_scan->scan.scanrelid = scanrelid;
+	columnar_index_scan->scan.plan.targetlist = targetlist;
+	columnar_index_scan->custom_scan_tlist = custom_scan_tlist;
+
+	return columnar_index_scan;
+}
+
+static Plan *
+columnar_index_scan_plan_path(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_path,
+							  List *tlist, List *clauses, List *custom_plans)
+{
+	(void) root;
+	(void) clauses;
+
+	Assert(list_length(custom_plans) == 1);
+	Plan *compressed_plan = linitial(custom_plans);
+	Path *compressed_path = linitial(best_path->custom_paths);
+	ts_indexed_tlist *compressed_tlist_index = ts_build_tlist_index(compressed_plan->targetlist);
+	List *path_output_map = best_path->custom_private;
+	List *exec_output_map = NIL;
+
+	int map_len = list_length(path_output_map);
+	Assert(map_len % 2 == 0);
+	for (int i = 0; i < map_len; i += 2)
+	{
+		AttrNumber result_attno = list_nth_int(path_output_map, i);
+		AttrNumber compressed_attno = list_nth_int(path_output_map, i + 1);
+		AttrNumber child_resno = find_resno_by_varattno(compressed_tlist_index,
+														compressed_path->parent->relid,
+														compressed_attno);
+		if (child_resno == InvalidAttrNumber)
+		{
+			elog(ERROR,
+				 "could not find compressed attribute %d in ColumnarIndexScan child plan",
+				 compressed_attno);
+		}
+
+		exec_output_map = lappend_int(exec_output_map, result_attno);
+		exec_output_map = lappend_int(exec_output_map, child_resno);
+	}
+
+	CustomScan *columnar_index_scan = columnar_index_scan_make_plan(custom_plans,
+																	rel->relid,
+																	tlist,
+																	NIL,
+																	exec_output_map,
+																	best_path->flags);
+
+	return &columnar_index_scan->scan.plan;
 }
 
 /*
@@ -202,26 +315,17 @@ columnar_scan_has_no_vector_quals(CustomScan *cscan)
 	return false;
 }
 
-/*
- * Find the resno in the leaf plan's targetlist that corresponds to a given
- * compressed chunk attribute number.
- */
 static AttrNumber
-find_resno_by_compressed_attno(Plan *leaf_plan, AttrNumber compressed_attno)
+find_resno_by_varattno(ts_indexed_tlist *tlist_index, Index varno, AttrNumber attno)
 {
-	ListCell *lc;
-	foreach (lc, leaf_plan->targetlist)
+	for (int i = 0; i < tlist_index->num_vars; i++)
 	{
-		TargetEntry *tle = lfirst_node(TargetEntry, lc);
-		if (IsA(tle->expr, Var))
+		if ((Index) tlist_index->vars[i].varno == varno && tlist_index->vars[i].varattno == attno)
 		{
-			Var *var = castNode(Var, tle->expr);
-			if (var->varattno == compressed_attno)
-			{
-				return tle->resno;
-			}
+			return tlist_index->vars[i].resno;
 		}
 	}
+
 	return InvalidAttrNumber;
 }
 
@@ -235,7 +339,7 @@ typedef struct ValidateContext
 	Index uncompressed_scanrelid;
 	Index compressed_scanrelid;
 	CompressionSettings *settings;
-	Plan *leaf_plan;
+	ts_indexed_tlist *leaf_tlist_index;
 	List *custom_scan_tlist;
 	List *output_map;
 	AttrNumber next_resno;
@@ -246,10 +350,12 @@ add_scan_output(ValidateContext *ctx, AttrNumber child_resno, Index tlist_varno,
 				AttrNumber tlist_attno, Oid col_type, int32 col_typmod, Oid col_collid)
 {
 	Var *tlist_var = makeVar(tlist_varno, tlist_attno, col_type, col_typmod, col_collid, 0);
+	AttrNumber result_resno = ctx->next_resno++;
 	ctx->custom_scan_tlist =
 		lappend(ctx->custom_scan_tlist,
-				makeTargetEntry((Expr *) tlist_var, ctx->next_resno++, NULL, false));
-	ctx->output_map = lappend(ctx->output_map, makeInteger(child_resno));
+				makeTargetEntry((Expr *) tlist_var, result_resno, NULL, false));
+	ctx->output_map = lappend_int(ctx->output_map, result_resno);
+	ctx->output_map = lappend_int(ctx->output_map, child_resno);
 }
 
 /*
@@ -304,7 +410,9 @@ validate_entries_walker(Node *node, void *context)
 			return true;
 		}
 
-		AttrNumber child_resno = find_resno_by_compressed_attno(ctx->leaf_plan, compressed_attno);
+		AttrNumber child_resno = find_resno_by_varattno(ctx->leaf_tlist_index,
+														ctx->compressed_scanrelid,
+														compressed_attno);
 		if (child_resno == InvalidAttrNumber)
 		{
 			return true;
@@ -339,8 +447,9 @@ validate_entries_walker(Node *node, void *context)
 				return true;
 			}
 
-			AttrNumber child_resno =
-				find_resno_by_compressed_attno(ctx->leaf_plan, meta_count_attno);
+			AttrNumber child_resno = find_resno_by_varattno(ctx->leaf_tlist_index,
+															ctx->compressed_scanrelid,
+															meta_count_attno);
 			if (child_resno == InvalidAttrNumber)
 			{
 				return true;
@@ -423,8 +532,9 @@ validate_entries_walker(Node *node, void *context)
 					return true;
 				}
 
-				AttrNumber value_child_resno =
-					find_resno_by_compressed_attno(ctx->leaf_plan, value_meta_attno);
+				AttrNumber value_child_resno = find_resno_by_varattno(ctx->leaf_tlist_index,
+																	  ctx->compressed_scanrelid,
+																	  value_meta_attno);
 				if (value_child_resno == InvalidAttrNumber)
 				{
 					return true;
@@ -442,8 +552,9 @@ validate_entries_walker(Node *node, void *context)
 					return true;
 				}
 
-				AttrNumber orderby_child_resno =
-					find_resno_by_compressed_attno(ctx->leaf_plan, orderby_meta_attno);
+				AttrNumber orderby_child_resno = find_resno_by_varattno(ctx->leaf_tlist_index,
+																		ctx->compressed_scanrelid,
+																		orderby_meta_attno);
 				if (orderby_child_resno == InvalidAttrNumber)
 				{
 					return true;
@@ -494,7 +605,9 @@ validate_entries_walker(Node *node, void *context)
 					return true;
 				}
 
-				AttrNumber child_resno = find_resno_by_compressed_attno(ctx->leaf_plan, meta_attno);
+				AttrNumber child_resno = find_resno_by_varattno(ctx->leaf_tlist_index,
+																ctx->compressed_scanrelid,
+																meta_attno);
 				if (child_resno == InvalidAttrNumber)
 				{
 					return true;
@@ -725,7 +838,7 @@ columnar_index_scan_plan_create(Agg *agg, CustomScan *cscan, List *rtable)
 		.uncompressed_scanrelid = cscan->scan.scanrelid,
 		.compressed_scanrelid = compressed_scan->scanrelid,
 		.settings = settings,
-		.leaf_plan = leaf_plan,
+		.leaf_tlist_index = ts_build_tlist_index(leaf_plan->targetlist),
 		.custom_scan_tlist = NIL,
 		.output_map = NIL,
 		.next_resno = 1,
@@ -784,15 +897,13 @@ columnar_index_scan_plan_create(Agg *agg, CustomScan *cscan, List *rtable)
 	}
 
 	/* Build ColumnarIndexScan CustomScan */
-	CustomScan *columnar_index_scan = (CustomScan *) makeNode(CustomScan);
-	columnar_index_scan->custom_plans = list_make1(compressed_scan_subtree);
-	columnar_index_scan->methods = &columnar_index_scan_plan_methods;
-
-	columnar_index_scan->scan.scanrelid = cscan->scan.scanrelid;
-
-	columnar_index_scan->custom_scan_tlist = custom_scan_tlist;
-	columnar_index_scan->scan.plan.targetlist =
-		ts_build_trivial_custom_output_targetlist(custom_scan_tlist);
+	CustomScan *columnar_index_scan =
+		columnar_index_scan_make_plan(list_make1(compressed_scan_subtree),
+									  cscan->scan.scanrelid,
+									  ts_build_trivial_custom_output_targetlist(custom_scan_tlist),
+									  custom_scan_tlist,
+									  output_map,
+									  0);
 
 	/* Copy cost/parallel/param fields from the ColumnarScan */
 	columnar_index_scan->scan.plan.plan_rows = cscan->scan.plan.plan_rows;
@@ -809,8 +920,6 @@ columnar_index_scan_plan_create(Agg *agg, CustomScan *cscan, List *rtable)
 	columnar_index_scan->scan.plan.initPlan = cscan->scan.plan.initPlan;
 	columnar_index_scan->scan.plan.extParam = bms_copy(cscan->scan.plan.extParam);
 	columnar_index_scan->scan.plan.allParam = bms_copy(cscan->scan.plan.allParam);
-
-	columnar_index_scan->custom_private = list_make1(output_map);
 
 	/* Set ColumnarIndexScan as the Agg's child */
 	agg->plan.lefttree = (Plan *) columnar_index_scan;

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan.h
@@ -5,11 +5,19 @@
  */
 #pragma once
 
-#define COLUMNAR_INDEX_SCAN_NAME "ColumnarIndexScan"
-
 #include <postgres.h>
+#include <nodes/extensible.h>
+#include <nodes/pathnodes.h>
 #include <nodes/plannodes.h>
 
+#define COLUMNAR_INDEX_SCAN_NAME "ColumnarIndexScan"
+
 extern void _columnar_index_scan_init(void);
-extern Plan *try_insert_columnar_index_scan_node(Plan *plan, List *rtable);
+extern Path *columnar_index_scan_path_create(Path *compressed_path, RelOptInfo *chunk_rel,
+											 List *pathkeys, List *metadata_output_map,
+											 double limit_tuples);
+extern CustomScan *columnar_index_scan_make_plan(List *custom_plans, Index scanrelid,
+												 List *targetlist, List *custom_scan_tlist,
+												 List *exec_output_map, int flags);
 extern Node *columnar_index_scan_state_create(CustomScan *cscan);
+extern Plan *try_insert_columnar_index_scan_node(Plan *plan, List *rtable);

--- a/tsl/src/nodes/columnar_index_scan/columnar_index_scan_exec.c
+++ b/tsl/src/nodes/columnar_index_scan/columnar_index_scan_exec.c
@@ -7,6 +7,7 @@
 
 #include <access/sysattr.h>
 #include <executor/executor.h>
+#include <executor/tuptable.h>
 #include <nodes/extensible.h>
 #include <nodes/plannodes.h>
 #include <utils/rel.h>
@@ -17,7 +18,8 @@ typedef struct ColumnarIndexScanState
 {
 	CustomScanState custom;
 	int num_outputs;
-	AttrNumber *child_resnos; /* one per output column */
+	AttrNumber *result_attnos;
+	AttrNumber *child_resnos;
 } ColumnarIndexScanState;
 
 static void
@@ -25,21 +27,18 @@ columnar_index_scan_begin(CustomScanState *node, EState *estate, int eflags)
 {
 	ColumnarIndexScanState *state = (ColumnarIndexScanState *) node;
 	CustomScan *cscan = castNode(CustomScan, node->ss.ps.plan);
+	List *output_map = cscan->custom_private;
 
-	/*
-	 * Parse output_map from custom_private: a flat list of Integer values,
-	 * one child_resno per output column.
-	 */
-	List *output_map = linitial(cscan->custom_private);
-	int num_outputs = list_length(output_map);
+	Assert(list_length(output_map) % 2 == 0);
+	int num_outputs = list_length(output_map) / 2;
 	state->num_outputs = num_outputs;
+	state->result_attnos = palloc(sizeof(AttrNumber) * num_outputs);
 	state->child_resnos = palloc(sizeof(AttrNumber) * num_outputs);
 
-	ListCell *lc;
-	int i = 0;
-	foreach (lc, output_map)
+	for (int i = 0; i < num_outputs; i++)
 	{
-		state->child_resnos[i++] = intVal(lfirst(lc));
+		state->result_attnos[i] = list_nth_int(output_map, i * 2);
+		state->child_resnos[i] = list_nth_int(output_map, i * 2 + 1);
 	}
 
 	Assert(list_length(cscan->custom_plans) == 1);
@@ -47,40 +46,52 @@ columnar_index_scan_begin(CustomScanState *node, EState *estate, int eflags)
 }
 
 static TupleTableSlot *
-columnar_index_scan_exec(CustomScanState *node)
+columnar_index_scan_next(ScanState *node)
 {
 	ColumnarIndexScanState *state = (ColumnarIndexScanState *) node;
-	PlanState *child_ps = linitial(node->custom_ps);
-	TupleTableSlot *result_slot = node->ss.ps.ps_ResultTupleSlot;
-	ExecClearTuple(result_slot);
-
+	PlanState *child_ps = linitial(state->custom.custom_ps);
 	TupleTableSlot *child_slot = ExecProcNode(child_ps);
 	if (TupIsNull(child_slot))
 	{
 		return NULL;
 	}
 
-	/*
-	 * Copy values from the child slot to the output slot using the output_map.
-	 * Each output column i gets its value from child_resnos[i].
-	 */
-	Datum *values = result_slot->tts_values;
-	bool *nulls = result_slot->tts_isnull;
-
+	TupleTableSlot *scan_slot = node->ss_ScanTupleSlot;
+	ExecStoreAllNullTuple(scan_slot);
 	for (int i = 0; i < state->num_outputs; i++)
 	{
-		if (state->child_resnos[i] == TableOidAttributeNumber)
+		bool isnull;
+		AttrNumber result_attno = state->result_attnos[i];
+		AttrNumber child_resno = state->child_resnos[i];
+		int result_index = AttrNumberGetAttrOffset(result_attno);
+
+		if (child_resno == TableOidAttributeNumber)
 		{
-			values[i] = ObjectIdGetDatum(node->ss.ss_currentRelation->rd_id);
-			nulls[i] = false;
+			scan_slot->tts_values[result_index] = ObjectIdGetDatum(node->ss_currentRelation->rd_id);
+			scan_slot->tts_isnull[result_index] = false;
 		}
 		else
 		{
-			values[i] = slot_getattr(child_slot, state->child_resnos[i], &nulls[i]);
+			scan_slot->tts_values[result_index] = slot_getattr(child_slot, child_resno, &isnull);
+			scan_slot->tts_isnull[result_index] = isnull;
 		}
 	}
 
-	return ExecStoreVirtualTuple(result_slot);
+	return scan_slot;
+}
+
+static bool
+columnar_index_scan_recheck(ScanState *node, TupleTableSlot *slot)
+{
+	return true;
+}
+
+static TupleTableSlot *
+columnar_index_scan_exec(CustomScanState *node)
+{
+	return ExecScan(&node->ss,
+					(ExecScanAccessMtd) columnar_index_scan_next,
+					(ExecScanRecheckMtd) columnar_index_scan_recheck);
 }
 
 static void
@@ -93,6 +104,7 @@ static void
 columnar_index_scan_rescan(CustomScanState *node)
 {
 	ExecReScan(linitial(node->custom_ps));
+	ExecScanReScan(&node->ss);
 }
 
 static struct CustomExecMethods exec_methods = {
@@ -107,8 +119,9 @@ static struct CustomExecMethods exec_methods = {
 Node *
 columnar_index_scan_state_create(CustomScan *cscan)
 {
-	ColumnarIndexScanState *state =
-		(ColumnarIndexScanState *) newNode(sizeof(ColumnarIndexScanState), T_CustomScanState);
+	ColumnarIndexScanState *state = palloc0(sizeof(ColumnarIndexScanState));
+	NodeSetTag(state, T_CustomScanState);
+
 	state->custom.methods = &exec_methods;
 	return (Node *) state;
 }

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -36,6 +36,7 @@
 #include "hypertable_cache.h"
 #include "import/allpaths.h"
 #include "import/planner.h"
+#include "nodes/columnar_index_scan/columnar_index_scan.h"
 #include "nodes/columnar_scan/columnar_scan.h"
 #include "nodes/columnar_scan/planner.h"
 #include "nodes/columnar_scan/qual_pushdown.h"
@@ -84,6 +85,7 @@ static SortInfo build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo
 							   const CompressionInfo *info, List *pathkeys);
 
 static Bitmapset *find_const_segmentby(RelOptInfo *chunk_rel, const CompressionInfo *info);
+static bool is_var_notnull(const CompressionInfo *compression_info, Var *var);
 
 static EquivalenceClass *
 append_ec_for_seqnum(PlannerInfo *root, const CompressionInfo *info, const SortInfo *sort_info,
@@ -1281,6 +1283,181 @@ make_chunk_sorted_path(PlannerInfo *root, RelOptInfo *chunk_rel, Path *path, Pat
 	return sorted_path;
 }
 
+static bool
+columnar_index_scan_query_supported(PlannerInfo *root)
+{
+	Query *query = root->parse;
+
+	if (!ts_guc_enable_optimizations || !ts_guc_enable_columnarindexscan)
+	{
+		return false;
+	}
+
+	if (root->limit_tuples <= 0 || root->limit_tuples > 1)
+	{
+		return false;
+	}
+
+	if (query->commandType != CMD_SELECT || query->limitCount == NULL ||
+		query->limitOffset != NULL || query->hasAggs || query->groupClause || query->groupingSets ||
+		query->hasWindowFuncs || query->distinctClause || query->setOperations ||
+		query->havingQual || query->hasModifyingCTE || query->rowMarks || query->hasTargetSRFs)
+	{
+		return false;
+	}
+
+	if (query->sortClause == NIL || query->jointree == NULL ||
+		list_length(query->jointree->fromlist) != 1 ||
+		!IsA(linitial(query->jointree->fromlist), RangeTblRef))
+	{
+		return false;
+	}
+
+	if (query->limitOption != LIMIT_OPTION_COUNT)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+static AttrNumber
+columnar_index_scan_metadata_attno(const CompressionInfo *info, const SortInfo *sort_info, Var *var)
+{
+	if ((Index) var->varno != info->chunk_rel->relid || var->varattno <= 0)
+	{
+		return InvalidAttrNumber;
+	}
+
+	char *col_name = get_attname(info->chunk_rte->relid, var->varattno, false);
+	if (ts_array_is_member(info->settings->fd.segmentby, col_name))
+	{
+		return get_attnum(info->compressed_rte->relid, col_name);
+	}
+
+	int16 orderby_pos = ts_array_position(info->settings->fd.orderby, col_name);
+	if (orderby_pos == 0)
+	{
+		return InvalidAttrNumber;
+	}
+
+	/*
+	 * Min/max sparse metadata is enough to reconstruct the boundary value for
+	 * the first orderby column. For nullable orderby columns, NULL ordering can
+	 * make the row boundary differ from min/max, so stay conservative.
+	 */
+	if (orderby_sparse_kind(info->settings, orderby_pos) == ORDERBY_SPARSE_MINMAX &&
+		(orderby_pos != 1 || !is_var_notnull(info, var)))
+	{
+		return InvalidAttrNumber;
+	}
+
+	AttrNumber lower_attno;
+	AttrNumber upper_attno;
+	orderby_sparse_metadata_attnos(info->settings,
+								   info->compressed_rte->relid,
+								   orderby_pos,
+								   &lower_attno,
+								   &upper_attno);
+
+	bool first_in_compression_order = !sort_info->reverse;
+	bool orderby_desc = ts_array_get_element_bool(info->settings->fd.orderby_desc, orderby_pos);
+	return first_in_compression_order == orderby_desc ? upper_attno : lower_attno;
+}
+
+static bool
+columnar_index_scan_output_map(const CompressionInfo *info, const SortInfo *sort_info,
+							   List **output_map)
+{
+	Bitmapset *attrs_needed = NULL;
+	List *map = NIL;
+
+	pull_varattnos((Node *) info->chunk_rel->reltarget->exprs,
+				   info->chunk_rel->relid,
+				   &attrs_needed);
+
+	int bit = -1;
+	while ((bit = bms_next_member(attrs_needed, bit)) >= 0)
+	{
+		AttrNumber chunk_attno = bit + FirstLowInvalidHeapAttributeNumber;
+		if (chunk_attno <= 0)
+		{
+			return false;
+		}
+
+		Var var = { .xpr.type = T_Var, .varno = info->chunk_rel->relid, .varattno = chunk_attno };
+		AttrNumber compressed_attno = columnar_index_scan_metadata_attno(info, sort_info, &var);
+		if (compressed_attno == InvalidAttrNumber)
+		{
+			return false;
+		}
+
+		map = lappend_int(map, chunk_attno);
+		map = lappend_int(map, compressed_attno);
+	}
+
+	*output_map = map;
+	return true;
+}
+
+static Path *
+columnar_index_scan_compressed_path(PlannerInfo *root, RelOptInfo *compressed_rel,
+									Path *compressed_path, const SortInfo *sort_info,
+									double limit_tuples)
+{
+	if ((!sort_info->use_compressed_sort && !sort_info->use_batch_sorted_merge) ||
+		sort_info->required_compressed_pathkeys == NIL || compressed_path->parallel_workers > 0 ||
+		!bms_is_empty(PATH_REQ_OUTER(compressed_path)))
+	{
+		return NULL;
+	}
+
+	if (pathkeys_contained_in(sort_info->required_compressed_pathkeys, compressed_path->pathkeys))
+	{
+		return compressed_path;
+	}
+
+	return (Path *) create_sort_path(root,
+									 compressed_rel,
+									 compressed_path,
+									 sort_info->required_compressed_pathkeys,
+									 limit_tuples);
+}
+
+static Path *
+columnar_index_scan_path(PlannerInfo *root, RelOptInfo *chunk_rel, Path *compressed_path,
+						 const SortInfo *sort_info, const CompressionInfo *compression_info,
+						 bool all_quals_pushed_down, double limit_tuples)
+{
+	if (chunk_rel->baserestrictinfo != NIL && !all_quals_pushed_down)
+	{
+		return NULL;
+	}
+
+	List *metadata_output_map = NIL;
+	if (!columnar_index_scan_output_map(compression_info, sort_info, &metadata_output_map))
+	{
+		return NULL;
+	}
+
+	Path *metadata_compressed_path =
+		columnar_index_scan_compressed_path(root,
+											compression_info->compressed_rel,
+											compressed_path,
+											sort_info,
+											limit_tuples);
+	if (metadata_compressed_path == NULL)
+	{
+		return NULL;
+	}
+
+	return columnar_index_scan_path_create(metadata_compressed_path,
+										   chunk_rel,
+										   root->query_pathkeys,
+										   metadata_output_map,
+										   limit_tuples);
+}
+
 static List *build_on_single_compressed_path(
 	PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel, Path *compressed_path,
 	bool add_uncompressed_part, List *uncompressed_table_pathlist, const SortInfo *sort_info,
@@ -1704,6 +1881,21 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 
 	if (!add_uncompressed_part)
 	{
+		if (columnar_index_scan_query_supported(root))
+		{
+			Path *metadata_path = columnar_index_scan_path(root,
+														   chunk_rel,
+														   compressed_path,
+														   sort_info,
+														   compression_info,
+														   all_quals_pushed_down,
+														   root->limit_tuples);
+			if (metadata_path != NULL)
+			{
+				decompressed_paths = lappend(decompressed_paths, metadata_path);
+			}
+		}
+
 		/*
 		 * If the chunk has only the compressed part, we're done.
 		 */

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -932,6 +932,82 @@ SET enable_partitionwise_aggregate = off;
 + on
  
   device | count 
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value < '5'::double precision)
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+                           Filter: (_ts_meta_v2_min_value < '5'::double precision)
+
+02:30
+d1|B|02:30
+d1|B|00:30
+02:30
+d1|B|02:30
+d1|B|00:30
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -932,6 +932,82 @@ SET enable_partitionwise_aggregate = off;
 + on
  
   device | count 
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value < '5'::double precision)
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+                           Filter: (_ts_meta_v2_min_value < '5'::double precision)
+
+02:30
+d1|B|02:30
+d1|B|00:30
+02:30
+d1|B|02:30
+d1|B|00:30
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -934,6 +934,82 @@ SET enable_partitionwise_aggregate = off;
 + on
  
   device | count 
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value < '5'::double precision)
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+                           Filter: (_ts_meta_v2_min_value < '5'::double precision)
+
+02:30
+d1|B|02:30
+d1|B|00:30
+02:30
+d1|B|02:30
+d1|B|00:30
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/columnar_index_scan-19.out
+++ b/tsl/test/expected/columnar_index_scan-19.out
@@ -934,6 +934,82 @@ SET enable_partitionwise_aggregate = off;
 + on
  
   device | count 
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_first_time DESC
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+               ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Sort
+                     Sort Key: _hyper_1_1_chunk_compressed._ts_meta_v2_last_time
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
+                     Index Cond: ((device = 'd1'::text) AND (sensor = 'B'::text))
+
+--- QUERY PLAN ---
+ Limit
+   ->  Result
+         ->  Sort
+               Sort Key: _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk
+                     Vectorized Filter: (value < '5'::double precision)
+                     ->  Seq Scan on _hyper_1_1_chunk_compressed
+                           Filter: (_ts_meta_v2_min_value < '5'::double precision)
+
+02:30
+d1|B|02:30
+d1|B|00:30
+02:30
+d1|B|02:30
+d1|B|00:30
 SET timescaledb.enable_columnarindexscan = on;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/sql/columnar_index_scan.sql.in
+++ b/tsl/test/sql/columnar_index_scan.sql.in
@@ -66,6 +66,41 @@ SET timescaledb.enable_columnarindexscan = on;
 -- compare optimized vs non-optimized results
 :DIFF_CMD
 
+-- ORDER BY/LIMIT should use ColumnarIndexScan without rewriting to an aggregate.
+\set PREFIX 'EXPLAIN (costs off)'
+SET timescaledb.enable_deferred_chunk_append = off;
+SET timescaledb.enable_columnarindexscan = on;
+:PREFIX SELECT time FROM metrics ORDER BY time DESC LIMIT 1;
+:PREFIX SELECT time_bucket('1h',time) FROM metrics ORDER BY time DESC LIMIT 1;
+:PREFIX SELECT to_char(time, 'HH24:MI') FROM metrics ORDER BY time DESC LIMIT 1;
+:PREFIX SELECT to_char(time, 'HH24:MI') FROM metrics WHERE device = 'd1' AND sensor = 'B' ORDER BY time DESC LIMIT 1;
+:PREFIX SELECT time FROM metrics ORDER BY time ASC LIMIT 1;
+:PREFIX SELECT time_bucket('1h',time) FROM metrics ORDER BY time ASC LIMIT 1;
+:PREFIX SELECT to_char(time, 'HH24:MI') FROM metrics ORDER BY time ASC LIMIT 1;
+:PREFIX SELECT to_char(time, 'HH24:MI') FROM metrics WHERE device = 'd1' AND sensor = 'B' ORDER BY time ASC LIMIT 1;
+-- A filter on a compressed data column requires decompression/recheck.
+:PREFIX SELECT format('%s|%s|%s', device, sensor, to_char(time, 'HH24:MI')) AS "d1|B|00:30"
+FROM metrics WHERE value < 5 ORDER BY time DESC LIMIT 1;
+SET timescaledb.enable_columnarindexscan = off;
+SELECT to_char(time, 'HH24:MI') AS latest_time FROM metrics ORDER BY time DESC LIMIT 1 \gset
+\echo :latest_time
+SELECT format('%s|%s|%s', device, sensor, to_char(time, 'HH24:MI')) AS filtered_latest
+FROM metrics WHERE device = 'd1' AND sensor = 'B' ORDER BY time DESC LIMIT 1 \gset
+\echo :filtered_latest
+SELECT format('%s|%s|%s', device, sensor, to_char(time, 'HH24:MI')) AS compressed_filter_latest
+FROM metrics WHERE value < 5 ORDER BY time DESC LIMIT 1 \gset
+\echo :compressed_filter_latest
+SET timescaledb.enable_columnarindexscan = on;
+SELECT to_char(time, 'HH24:MI') AS latest_time FROM metrics ORDER BY time DESC LIMIT 1 \gset
+\echo :latest_time
+SELECT format('%s|%s|%s', device, sensor, to_char(time, 'HH24:MI')) AS filtered_latest
+FROM metrics WHERE device = 'd1' AND sensor = 'B' ORDER BY time DESC LIMIT 1 \gset
+\echo :filtered_latest
+SELECT format('%s|%s|%s', device, sensor, to_char(time, 'HH24:MI')) AS compressed_filter_latest
+FROM metrics WHERE value < 5 ORDER BY time DESC LIMIT 1 \gset
+\echo :compressed_filter_latest
+RESET timescaledb.enable_deferred_chunk_append;
+
 -- make initial chunk partial
 INSERT INTO metrics VALUES
 ('2025-01-01 00:00:00 PST', 'd1', 'A', 1.0, 1.1, 11.0),
@@ -240,4 +275,3 @@ SET timescaledb.enable_columnarindexscan = on;
 
 -- compare optimized vs non-optimized results
 :DIFF_CMD
-


### PR DESCRIPTION
Create ColumnarIndexScan paths for eligible queries when all required
columns can be reconstructed from segment-by columns and sparse
order-by metadata. This allows boundary rows to be returned without
decompressing batches.

Extend the plan and executor output mapping to support projected scan
paths as well as aggregate rewrites. Only select the optimization when
all qualifications are pushed down and no decompression recheck is
required.
