### PR TITLE
Fixing APT mirrors

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -43,6 +43,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        touch /etc/apt/apt-mirrors.txt
+        sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Add repositories
       timeout-minutes: 15
       run: |

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -37,6 +37,11 @@ jobs:
             runner: "cloud-image-runner-ubuntu-24-arm64"
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        touch /etc/apt/apt-mirrors.txt
+        sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Add repositories
       timeout-minutes: 15
       run: |
@@ -51,7 +56,6 @@ jobs:
         else
           wget --quiet --tries=6 --waitretry=15 -O - https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor -o /etc/apt/trusted.gpg.d/timescale_timescaledb.gpg
         fi
-
 
     - name: Install timescaledb
       timeout-minutes: 15

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -104,6 +104,11 @@ jobs:
     env:
       LLVM_VER: 17
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -100,6 +100,11 @@ jobs:
     runs-on: timescaledb-runner-arm64
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     steps:
+      - name: Replace unreliable Azure APT mirror
+        run: |
+          sudo touch /etc/apt/apt-mirrors.txt
+          sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
       - name: Install Linux Dependencies
         timeout-minutes: 15
         run: |

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -21,6 +21,11 @@ jobs:
       PG_INSTALL_DIR: postgresql
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -99,6 +99,10 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        touch /etc/apt/apt-mirrors.txt
+        sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
 
     # /__e/node16/bin/node (used by actions/checkout@v4) needs 64-bit libraries
     - name: Install 64-bit libraries for GitHub actions

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -70,6 +70,12 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      if: runner.os == 'Linux'
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
       timeout-minutes: 15

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -90,6 +90,11 @@ jobs:
             display_name: "Hypertable ON-OFF"
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -18,6 +18,11 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -76,6 +76,10 @@ jobs:
       - name: Checkout TimescaleDB
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Replace unreliable Azure APT mirror
+        run: |
+          sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
       - name: Install Linux Dependencies
         # we want the right version of Postgres for handling any dump file
         timeout-minutes: 15

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -14,6 +14,10 @@ jobs:
       LLVM_CONFIG: llvm-config-19
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
 
     - name: Install Linux Dependencies
       timeout-minutes: 15

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -41,6 +41,11 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/pg_upgrade_test
 
     steps:
+      - name: Replace unreliable Azure APT mirror
+        run: |
+          sudo touch /etc/apt/apt-mirrors.txt
+          sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
       - name: Install Linux Dependencies
         timeout-minutes: 15
         run: |

--- a/.github/workflows/release_feature_freeze_ceremony.yaml
+++ b/.github/workflows/release_feature_freeze_ceremony.yaml
@@ -74,6 +74,11 @@ jobs:
       name: Release Ceremonies
 
     steps:
+      - name: Replace unreliable Azure APT mirror
+        run: |
+          sudo touch /etc/apt/apt-mirrors.txt
+          sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
       - name: Checkout TimescaleDB
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -79,6 +79,11 @@ jobs:
         os: ["ubuntu-22.04"]
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -28,6 +28,11 @@ jobs:
     runs-on: timescaledb-runner-arm64
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -55,6 +55,10 @@ jobs:
             abi_min: ${{ fromJson(needs.config.outputs.pg18_abi_min) }}
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
 
     - name: Install Linux Dependencies
       timeout-minutes: 15

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -30,6 +30,11 @@ jobs:
       JOB_NAME: SQLsmith PG${{ matrix.pg }}
 
     steps:
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -78,6 +78,11 @@ jobs:
         echo "should_run=true" >> $GITHUB_OUTPUT
         echo "changed_tests=${CHANGED_TESTS[*]}" >> $GITHUB_OUTPUT
 
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       if: steps.check.outputs.should_run == 'true'
       timeout-minutes: 15

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -40,9 +40,15 @@ jobs:
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+    - name: Replace unreliable Azure APT mirror
+      run: |
+        sudo touch /etc/apt/apt-mirrors.txt
+        sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |
+        cat /etc/apt/apt-mirrors.txt
         sudo apt-get update
         sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev
         yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh


### PR DESCRIPTION
Azure ubuntu mirror often fails to download packages and makes
workflows unreliable. This patch replaces it with the AWS mirror.

Disable-check: force-changelog-file