### PR TITLE
Adapt PG patch for AddressSanitizer for new releases

### DIFF
--- a/test/postgres-asan-instrumentation-PG18GE.patch
+++ b/test/postgres-asan-instrumentation-PG18GE.patch
@@ -1,20 +1,3 @@
-diff --git a/src/backend/utils/misc/stack_depth.c b/src/backend/utils/misc/stack_depth.c
-index 8f7cf531fbc..2f7b1cebbe6 100644
---- a/src/backend/utils/misc/stack_depth.c
-+++ b/src/backend/utils/misc/stack_depth.c
-@@ -108,6 +108,12 @@ check_stack_depth(void)
- bool
- stack_is_too_deep(void)
- {
-+       /*
-+        * Pointer arithmetics to determine stack depth doesn't work under
-+        * AddressSanitizer.
-+        */
-+       return false;
-+
-        char            stack_top_loc;
-        ssize_t         stack_depth;
-
 diff --git a/src/include/utils/memdebug.h b/src/include/utils/memdebug.h
 index e88b4c6e8e..4ccbbf0146 100644
 --- a/src/include/utils/memdebug.h

--- a/test/postgres-asan-instrumentation.patch
+++ b/test/postgres-asan-instrumentation.patch
@@ -1,20 +1,3 @@
-diff --git a/src/backend/tcop/postgres.c b/src/backend/tcop/postgres.c
-index 2c50575b37..11b6c688c7 100644
---- a/src/backend/tcop/postgres.c
-+++ b/src/backend/tcop/postgres.c
-@@ -3492,6 +4476,12 @@ check_stack_depth(void)
- bool
- stack_is_too_deep(void)
- {
-+	/*
-+	 * Pointer arithmetics to determine stack depth doesn't work under
-+	 * AddressSanitizer.
-+	 */
-+	return false;
-+
- 	char		stack_top_loc;
- 	long		stack_depth;
- 
 diff --git a/src/include/utils/memdebug.h b/src/include/utils/memdebug.h
 index e88b4c6e8e..4ccbbf0146 100644
 --- a/src/include/utils/memdebug.h


### PR DESCRIPTION
New releases stopped compiling with our patch. They actually fixed the problematic stack depth check upstream and it works unmodified under asan now, so we can remove the patched part.

Upstream change: https://github.com/postgres/postgres/commit/c0bf1d89df2

Example failure: https://github.com/timescale/timescaledb/actions/runs/32349453156/job/96365227866