### PR TITLE
Fix disabled nodes counter in ChunkAppend path

### DIFF
--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -78,14 +78,23 @@ ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths, PathTarget *patht
 	memcpy(new, ca, sizeof(ChunkAppendPath));
 	new->cpath.custom_paths = subpaths;
 
+#if PG18_GE
+	int disabled_nodes = 0;
+#endif
 	foreach (lc, subpaths)
 	{
 		Path *child = lfirst(lc);
 		total_cost += child->total_cost;
 		rows += child->rows;
+#if PG18_GE
+		disabled_nodes += child->disabled_nodes;
+#endif
 	}
 	new->cpath.path.total_cost = total_cost;
 	new->cpath.path.rows = rows;
+#if PG18_GE
+	new->cpath.path.disabled_nodes = disabled_nodes;
+#endif
 	new->cpath.path.pathtarget = copy_pathtarget(pathtarget);
 
 	return new;

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -471,6 +471,9 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 		path->cpath.custom_paths = nested_children;
 	}
 
+#if PG18_GE
+	int disabled_nodes = 0;
+#endif
 	foreach (lc, path->cpath.custom_paths)
 	{
 		Path *child = lfirst(lc);
@@ -485,11 +488,17 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 		{
 			total_cost += child->total_cost;
 			rows += child->rows;
+#if PG18_GE
+			disabled_nodes += child->disabled_nodes;
+#endif
 		}
 	}
 
 	path->cpath.path.rows = rows;
 	path->cpath.path.total_cost = total_cost;
+#if PG18_GE
+	path->cpath.path.disabled_nodes = disabled_nodes;
+#endif
 
 	if (path->cpath.custom_paths != NIL)
 	{

--- a/test/expected/parallel-18.out
+++ b/test/expected/parallel-18.out
@@ -252,17 +252,20 @@ SET enable_indexscan = OFF;
    ->  Merge Left Join
          Merge Cond: (test.i = _hyper_1_1_chunk_1.i)
          ->  Limit
-               ->  Result
-                     One-Time Filter: (length(version()) > 0)
-                     ->  Custom Scan (ChunkAppend) on test
-                           Order: test.i
-                           Chunks excluded during startup: 0
+               ->  Gather Merge
+                     Workers Planned: 2
+                     ->  Sort
+                           Sort Key: test.i
                            ->  Result
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk
-                           ->  Result
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk
+                                 ->  Parallel Custom Scan (ChunkAppend) on test
+                                       Chunks excluded during startup: 0
+                                       ->  Result
+                                             One-Time Filter: (length(version()) > 0)
+                                             ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Result
+                                             One-Time Filter: (length(version()) > 0)
+                                             ->  Parallel Seq Scan on _hyper_1_2_chunk
          ->  Materialize
                ->  Limit
                      ->  Gather Merge

--- a/test/expected/parallel-19.out
+++ b/test/expected/parallel-19.out
@@ -252,17 +252,20 @@ SET enable_indexscan = OFF;
    ->  Merge Left Join
          Merge Cond: (test.i = _hyper_1_1_chunk_1.i)
          ->  Limit
-               ->  Result
-                     One-Time Filter: (length(version()) > 0)
-                     ->  Custom Scan (ChunkAppend) on test
-                           Order: test.i
-                           Chunks excluded during startup: 0
+               ->  Gather Merge
+                     Workers Planned: 2
+                     ->  Sort
+                           Sort Key: test.i
                            ->  Result
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Index Scan Backward using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk
-                           ->  Result
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk
+                                 ->  Parallel Custom Scan (ChunkAppend) on test
+                                       Chunks excluded during startup: 0
+                                       ->  Result
+                                             One-Time Filter: (length(version()) > 0)
+                                             ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Result
+                                             One-Time Filter: (length(version()) > 0)
+                                             ->  Parallel Seq Scan on _hyper_1_2_chunk
          ->  Materialize
                ->  Limit
                      ->  Gather Merge

--- a/tsl/test/expected/transparent_decompression-18.out
+++ b/tsl/test/expected/transparent_decompression-18.out
@@ -304,25 +304,18 @@ ORDER BY time,
     device_id
 ;
 --- QUERY PLAN ---
- Result (actual rows=3456.00 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=3456.00 loops=1)
-         Order: metrics."time", metrics.device_id
-         ->  Sort (actual rows=1440.00 loops=1)
-               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-               Sort Method: quicksort 
+ Sort (actual rows=3456.00 loops=1)
+   Sort Key: metrics."time", metrics.device_id
+   Sort Method: quicksort 
+   ->  Result (actual rows=3456.00 loops=1)
+         ->  Append (actual rows=3456.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1440.00 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk_compressed (actual rows=2.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 3
-         ->  Sort (actual rows=1344.00 loops=1)
-               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=1344.00 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
                      Rows Removed by Filter: 2016
-         ->  Sort (actual rows=672.00 loops=1)
-               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
-               Sort Method: quicksort 
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=672.00 loops=1)
                      ->  Seq Scan on _hyper_1_3_chunk_compressed (actual rows=2.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
@@ -404,15 +397,11 @@ WHERE v3 > 10.0
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on public.metrics (actual rows=0.00 loops=1)
+ Sort (actual rows=0.00 loops=1)
    Output: metrics."time", metrics.device_id, metrics.device_id_peer, metrics.v0, metrics.v1, metrics.v2, metrics.v3
-   Order: metrics."time", metrics.device_id
-   Startup Exclusion: false
-   Runtime Exclusion: false
-   ->  Sort (actual rows=0.00 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-         Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: quicksort 
+   Sort Key: metrics."time", metrics.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=0.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0.00 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Vectorized Filter: (_hyper_1_1_chunk.v3 > '10'::double precision)
@@ -421,18 +410,10 @@ ORDER BY time,
                Bulk Decompression: true
                ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk_compressed (actual rows=5.00 loops=1)
                      Output: _hyper_1_1_chunk_compressed._ts_meta_count, _hyper_1_1_chunk_compressed.device_id, _hyper_1_1_chunk_compressed.device_id_peer, _hyper_1_1_chunk_compressed._ts_meta_min_3, _hyper_1_1_chunk_compressed._ts_meta_max_3, _hyper_1_1_chunk_compressed._ts_meta_v2_first_time, _hyper_1_1_chunk_compressed._ts_meta_v2_last_time, _hyper_1_1_chunk_compressed."time", _hyper_1_1_chunk_compressed._ts_meta_min_1, _hyper_1_1_chunk_compressed._ts_meta_max_1, _hyper_1_1_chunk_compressed._ts_meta_v2_first_v0, _hyper_1_1_chunk_compressed._ts_meta_v2_last_v0, _hyper_1_1_chunk_compressed.v0, _hyper_1_1_chunk_compressed._ts_meta_min_2, _hyper_1_1_chunk_compressed._ts_meta_max_2, _hyper_1_1_chunk_compressed._ts_meta_v2_first_v1, _hyper_1_1_chunk_compressed._ts_meta_v2_last_v1, _hyper_1_1_chunk_compressed.v1, _hyper_1_1_chunk_compressed.v2, _hyper_1_1_chunk_compressed.v3
-   ->  Sort (actual rows=0.00 loops=1)
-         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-         Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
-         Sort Method: quicksort 
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0.00 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 3360
-   ->  Sort (actual rows=0.00 loops=1)
-         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-         Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
-         Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0.00 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Vectorized Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
@@ -3091,51 +3072,29 @@ ORDER BY time,
     device_id
 ;
 --- QUERY PLAN ---
- Result (actual rows=3456.00 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=3456.00 loops=1)
-         Order: metrics_space."time", metrics_space.device_id
-         ->  Merge Append (actual rows=1440.00 loops=1)
-               Sort Key: metrics_space."time", metrics_space.device_id
-               ->  Sort (actual rows=720.00 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
-                           ->  Seq Scan on _hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=720.00 loops=1)
-                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=720.00 loops=1)
-                           ->  Seq Scan on _hyper_2_5_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 2
-         ->  Merge Append (actual rows=1344.00 loops=1)
-               Sort Key: metrics_space."time", metrics_space.device_id
-               ->  Sort (actual rows=672.00 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
+ Sort (actual rows=3456.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Result (actual rows=3456.00 loops=1)
+         ->  Append (actual rows=3456.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+                     ->  Seq Scan on _hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=672.00 loops=1)
-                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=672.00 loops=1)
-                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-         ->  Merge Append (actual rows=672.00 loops=1)
-               Sort Key: metrics_space."time", metrics_space.device_id
-               ->  Sort (actual rows=336.00 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
-                           ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=336.00 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=336.00 loops=1)
-                           ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 2
+               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=720.00 loops=1)
+                     ->  Seq Scan on _hyper_2_5_chunk_compressed (actual rows=1.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=672.00 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+                     ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=336.00 loops=1)
+                     ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=1.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
 
 -- test constraints not present in targetlist
 :PREFIX
@@ -3204,109 +3163,67 @@ WHERE v3 > 10.0
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on public.metrics_space (actual rows=0.00 loops=1)
+ Sort (actual rows=0.00 loops=1)
    Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-   Order: metrics_space."time", metrics_space.device_id
-   Startup Exclusion: false
-   Runtime Exclusion: false
-   ->  Merge Append (actual rows=0.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=0.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=0.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-                     Vectorized Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 720
-                     Batches Removed by Filter: 1
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_4_chunk_compressed._ts_meta_count, _hyper_2_4_chunk_compressed.device_id, _hyper_2_4_chunk_compressed.device_id_peer, _hyper_2_4_chunk_compressed._ts_meta_min_3, _hyper_2_4_chunk_compressed._ts_meta_max_3, _hyper_2_4_chunk_compressed._ts_meta_v2_first_time, _hyper_2_4_chunk_compressed._ts_meta_v2_last_time, _hyper_2_4_chunk_compressed."time", _hyper_2_4_chunk_compressed._ts_meta_min_1, _hyper_2_4_chunk_compressed._ts_meta_max_1, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_4_chunk_compressed.v0, _hyper_2_4_chunk_compressed._ts_meta_min_2, _hyper_2_4_chunk_compressed._ts_meta_max_2, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_4_chunk_compressed.v1, _hyper_2_4_chunk_compressed.v2, _hyper_2_4_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 720
+               Batches Removed by Filter: 1
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_4_chunk_compressed._ts_meta_count, _hyper_2_4_chunk_compressed.device_id, _hyper_2_4_chunk_compressed.device_id_peer, _hyper_2_4_chunk_compressed._ts_meta_min_3, _hyper_2_4_chunk_compressed._ts_meta_max_3, _hyper_2_4_chunk_compressed._ts_meta_v2_first_time, _hyper_2_4_chunk_compressed._ts_meta_v2_last_time, _hyper_2_4_chunk_compressed."time", _hyper_2_4_chunk_compressed._ts_meta_min_1, _hyper_2_4_chunk_compressed._ts_meta_max_1, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_4_chunk_compressed.v0, _hyper_2_4_chunk_compressed._ts_meta_min_2, _hyper_2_4_chunk_compressed._ts_meta_max_2, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_4_chunk_compressed.v1, _hyper_2_4_chunk_compressed.v2, _hyper_2_4_chunk_compressed.v3
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-               Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-                     Vectorized Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 2160
-                     Batches Removed by Filter: 3
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_5_chunk_compressed (actual rows=3.00 loops=1)
-                           Output: _hyper_2_5_chunk_compressed._ts_meta_count, _hyper_2_5_chunk_compressed.device_id, _hyper_2_5_chunk_compressed.device_id_peer, _hyper_2_5_chunk_compressed._ts_meta_min_3, _hyper_2_5_chunk_compressed._ts_meta_max_3, _hyper_2_5_chunk_compressed._ts_meta_v2_first_time, _hyper_2_5_chunk_compressed._ts_meta_v2_last_time, _hyper_2_5_chunk_compressed."time", _hyper_2_5_chunk_compressed._ts_meta_min_1, _hyper_2_5_chunk_compressed._ts_meta_max_1, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_5_chunk_compressed.v0, _hyper_2_5_chunk_compressed._ts_meta_min_2, _hyper_2_5_chunk_compressed._ts_meta_max_2, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_5_chunk_compressed.v1, _hyper_2_5_chunk_compressed.v2, _hyper_2_5_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 2160
+               Batches Removed by Filter: 3
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_5_chunk_compressed (actual rows=3.00 loops=1)
+                     Output: _hyper_2_5_chunk_compressed._ts_meta_count, _hyper_2_5_chunk_compressed.device_id, _hyper_2_5_chunk_compressed.device_id_peer, _hyper_2_5_chunk_compressed._ts_meta_min_3, _hyper_2_5_chunk_compressed._ts_meta_max_3, _hyper_2_5_chunk_compressed._ts_meta_v2_first_time, _hyper_2_5_chunk_compressed._ts_meta_v2_last_time, _hyper_2_5_chunk_compressed."time", _hyper_2_5_chunk_compressed._ts_meta_min_1, _hyper_2_5_chunk_compressed._ts_meta_max_1, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_5_chunk_compressed.v0, _hyper_2_5_chunk_compressed._ts_meta_min_2, _hyper_2_5_chunk_compressed._ts_meta_max_2, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_5_chunk_compressed.v1, _hyper_2_5_chunk_compressed.v2, _hyper_2_5_chunk_compressed.v3
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-               Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-                     Vectorized Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 720
-                     Batches Removed by Filter: 1
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_6_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_6_chunk_compressed._ts_meta_count, _hyper_2_6_chunk_compressed.device_id, _hyper_2_6_chunk_compressed.device_id_peer, _hyper_2_6_chunk_compressed._ts_meta_min_3, _hyper_2_6_chunk_compressed._ts_meta_max_3, _hyper_2_6_chunk_compressed._ts_meta_v2_first_time, _hyper_2_6_chunk_compressed._ts_meta_v2_last_time, _hyper_2_6_chunk_compressed."time", _hyper_2_6_chunk_compressed._ts_meta_min_1, _hyper_2_6_chunk_compressed._ts_meta_max_1, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_6_chunk_compressed.v0, _hyper_2_6_chunk_compressed._ts_meta_min_2, _hyper_2_6_chunk_compressed._ts_meta_max_2, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_6_chunk_compressed.v1, _hyper_2_6_chunk_compressed.v2, _hyper_2_6_chunk_compressed.v3
-   ->  Merge Append (actual rows=0.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 720
+               Batches Removed by Filter: 1
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_6_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_6_chunk_compressed._ts_meta_count, _hyper_2_6_chunk_compressed.device_id, _hyper_2_6_chunk_compressed.device_id_peer, _hyper_2_6_chunk_compressed._ts_meta_min_3, _hyper_2_6_chunk_compressed._ts_meta_max_3, _hyper_2_6_chunk_compressed._ts_meta_v2_first_time, _hyper_2_6_chunk_compressed._ts_meta_v2_last_time, _hyper_2_6_chunk_compressed."time", _hyper_2_6_chunk_compressed._ts_meta_min_1, _hyper_2_6_chunk_compressed._ts_meta_max_1, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_6_chunk_compressed.v0, _hyper_2_6_chunk_compressed._ts_meta_min_2, _hyper_2_6_chunk_compressed._ts_meta_max_2, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_6_chunk_compressed.v1, _hyper_2_6_chunk_compressed.v2, _hyper_2_6_chunk_compressed.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-                     Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 672
-         ->  Sort (actual rows=0.00 loops=1)
+               Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 672
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-                     Filter: (_hyper_2_8_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 2016
-         ->  Sort (actual rows=0.00 loops=1)
+               Filter: (_hyper_2_8_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 2016
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-                     Filter: (_hyper_2_9_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 672
-   ->  Merge Append (actual rows=0.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=0.00 loops=1)
+               Filter: (_hyper_2_9_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 672
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Vectorized Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 336
-                     Batches Removed by Filter: 1
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 336
+               Batches Removed by Filter: 1
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Vectorized Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 1008
-                     Batches Removed by Filter: 3
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
-                           Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 1008
+               Batches Removed by Filter: 3
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
+                     Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-                     Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 336
+               Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 336
 
 -- device_id constraint should be pushed down
 :PREFIX
@@ -4814,68 +4731,40 @@ WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on public.metrics_space (actual rows=3915.00 loops=1)
+ Sort (actual rows=3915.00 loops=1)
    Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-   Order: metrics_space."time", metrics_space.device_id
-   Startup Exclusion: false
-   Runtime Exclusion: false
-   ->  Merge Append (actual rows=2235.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=447.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=3915.00 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=447.00 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=447.00 loops=1)
-                     Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-                     Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-         ->  Sort (actual rows=1341.00 loops=1)
+               Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341.00 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341.00 loops=1)
-                     Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-                     Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 675
-         ->  Sort (actual rows=447.00 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 675
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=447.00 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=447.00 loops=1)
-                     Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-                     Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-   ->  Merge Append (actual rows=1680.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=336.00 loops=1)
+               Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
-                           Filter: (_hyper_2_10_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=1008.00 loops=1)
+               Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
+                     Filter: (_hyper_2_10_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008.00 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008.00 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
-                           Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
-                           Filter: (_hyper_2_11_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=336.00 loops=1)
+               Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
+                     Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
+                     Filter: (_hyper_2_11_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=336.00 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=336.00 loops=1)
-                     Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-                     Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 
 RESET enable_sort;
 -- should produce ordered path
@@ -5282,49 +5171,29 @@ WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on metrics_space (actual rows=3915.00 loops=1)
-   Order: metrics_space."time", metrics_space.device_id
-   ->  Merge Append (actual rows=2235.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=447.00 loops=1)
-               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=447.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-         ->  Sort (actual rows=1341.00 loops=1)
-               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1341.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 675
-         ->  Sort (actual rows=447.00 loops=1)
-               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=447.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-   ->  Merge Append (actual rows=1680.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=336.00 loops=1)
-               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                           Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=1008.00 loops=1)
-               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
-                     Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
-                           Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=336.00 loops=1)
-               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+ Sort (actual rows=3915.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=3915.00 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=447.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1341.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 675
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=447.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 
 RESET enable_sort;
 -- test runtime exclusion

--- a/tsl/test/expected/transparent_decompression-19.out
+++ b/tsl/test/expected/transparent_decompression-19.out
@@ -304,25 +304,18 @@ ORDER BY time,
     device_id
 ;
 --- QUERY PLAN ---
- Result (actual rows=3456.00 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=3456.00 loops=1)
-         Order: metrics."time", metrics.device_id
-         ->  Sort (actual rows=1440.00 loops=1)
-               Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-               Sort Method: quicksort 
+ Sort (actual rows=3456.00 loops=1)
+   Sort Key: metrics."time", metrics.device_id
+   Sort Method: quicksort 
+   ->  Result (actual rows=3456.00 loops=1)
+         ->  Append (actual rows=3456.00 loops=1)
                ->  Custom Scan (ColumnarScan) on _hyper_1_1_chunk (actual rows=1440.00 loops=1)
                      ->  Seq Scan on _hyper_1_1_chunk_compressed (actual rows=2.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
                            Rows Removed by Filter: 3
-         ->  Sort (actual rows=1344.00 loops=1)
-               Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
-               Sort Method: quicksort 
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=1344.00 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
                      Rows Removed by Filter: 2016
-         ->  Sort (actual rows=672.00 loops=1)
-               Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
-               Sort Method: quicksort 
                ->  Custom Scan (ColumnarScan) on _hyper_1_3_chunk (actual rows=672.00 loops=1)
                      ->  Seq Scan on _hyper_1_3_chunk_compressed (actual rows=2.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
@@ -404,15 +397,11 @@ WHERE v3 > 10.0
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on public.metrics (actual rows=0.00 loops=1)
+ Sort (actual rows=0.00 loops=1)
    Output: metrics."time", metrics.device_id, metrics.device_id_peer, metrics.v0, metrics.v1, metrics.v2, metrics.v3
-   Order: metrics."time", metrics.device_id
-   Startup Exclusion: false
-   Runtime Exclusion: false
-   ->  Sort (actual rows=0.00 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-         Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: quicksort 
+   Sort Key: metrics."time", metrics.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=0.00 loops=1)
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0.00 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Vectorized Filter: (_hyper_1_1_chunk.v3 > '10'::double precision)
@@ -421,18 +410,10 @@ ORDER BY time,
                Bulk Decompression: true
                ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk_compressed (actual rows=5.00 loops=1)
                      Output: _hyper_1_1_chunk_compressed._ts_meta_count, _hyper_1_1_chunk_compressed.device_id, _hyper_1_1_chunk_compressed.device_id_peer, _hyper_1_1_chunk_compressed._ts_meta_min_3, _hyper_1_1_chunk_compressed._ts_meta_max_3, _hyper_1_1_chunk_compressed._ts_meta_v2_first_time, _hyper_1_1_chunk_compressed._ts_meta_v2_last_time, _hyper_1_1_chunk_compressed."time", _hyper_1_1_chunk_compressed._ts_meta_min_1, _hyper_1_1_chunk_compressed._ts_meta_max_1, _hyper_1_1_chunk_compressed._ts_meta_v2_first_v0, _hyper_1_1_chunk_compressed._ts_meta_v2_last_v0, _hyper_1_1_chunk_compressed.v0, _hyper_1_1_chunk_compressed._ts_meta_min_2, _hyper_1_1_chunk_compressed._ts_meta_max_2, _hyper_1_1_chunk_compressed._ts_meta_v2_first_v1, _hyper_1_1_chunk_compressed._ts_meta_v2_last_v1, _hyper_1_1_chunk_compressed.v1, _hyper_1_1_chunk_compressed.v2, _hyper_1_1_chunk_compressed.v3
-   ->  Sort (actual rows=0.00 loops=1)
-         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-         Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
-         Sort Method: quicksort 
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0.00 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.v3 > '10'::double precision)
                Rows Removed by Filter: 3360
-   ->  Sort (actual rows=0.00 loops=1)
-         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-         Sort Key: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
-         Sort Method: quicksort 
          ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0.00 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Vectorized Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
@@ -3091,51 +3072,29 @@ ORDER BY time,
     device_id
 ;
 --- QUERY PLAN ---
- Result (actual rows=3456.00 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=3456.00 loops=1)
-         Order: metrics_space."time", metrics_space.device_id
-         ->  Merge Append (actual rows=1440.00 loops=1)
-               Sort Key: metrics_space."time", metrics_space.device_id
-               ->  Sort (actual rows=720.00 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
-                           ->  Seq Scan on _hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=720.00 loops=1)
-                     Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=720.00 loops=1)
-                           ->  Seq Scan on _hyper_2_5_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 2
-         ->  Merge Append (actual rows=1344.00 loops=1)
-               Sort Key: metrics_space."time", metrics_space.device_id
-               ->  Sort (actual rows=672.00 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
+ Sort (actual rows=3456.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Result (actual rows=3456.00 loops=1)
+         ->  Append (actual rows=3456.00 loops=1)
+               ->  Custom Scan (ColumnarScan) on _hyper_2_4_chunk (actual rows=720.00 loops=1)
+                     ->  Seq Scan on _hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=672.00 loops=1)
-                     Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=672.00 loops=1)
-                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-         ->  Merge Append (actual rows=672.00 loops=1)
-               Sort Key: metrics_space."time", metrics_space.device_id
-               ->  Sort (actual rows=336.00 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
-                           ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=336.00 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=336.00 loops=1)
-                           ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=1.00 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 2
+               ->  Custom Scan (ColumnarScan) on _hyper_2_5_chunk (actual rows=720.00 loops=1)
+                     ->  Seq Scan on _hyper_2_5_chunk_compressed (actual rows=1.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=672.00 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=672.00 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+                     ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=336.00 loops=1)
+                     ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=1.00 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
 
 -- test constraints not present in targetlist
 :PREFIX
@@ -3204,109 +3163,67 @@ WHERE v3 > 10.0
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on public.metrics_space (actual rows=0.00 loops=1)
+ Sort (actual rows=0.00 loops=1)
    Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-   Order: metrics_space."time", metrics_space.device_id
-   Startup Exclusion: false
-   Runtime Exclusion: false
-   ->  Merge Append (actual rows=0.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=0.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=0.00 loops=1)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-                     Vectorized Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 720
-                     Batches Removed by Filter: 1
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_4_chunk_compressed._ts_meta_count, _hyper_2_4_chunk_compressed.device_id, _hyper_2_4_chunk_compressed.device_id_peer, _hyper_2_4_chunk_compressed._ts_meta_min_3, _hyper_2_4_chunk_compressed._ts_meta_max_3, _hyper_2_4_chunk_compressed._ts_meta_v2_first_time, _hyper_2_4_chunk_compressed._ts_meta_v2_last_time, _hyper_2_4_chunk_compressed."time", _hyper_2_4_chunk_compressed._ts_meta_min_1, _hyper_2_4_chunk_compressed._ts_meta_max_1, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_4_chunk_compressed.v0, _hyper_2_4_chunk_compressed._ts_meta_min_2, _hyper_2_4_chunk_compressed._ts_meta_max_2, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_4_chunk_compressed.v1, _hyper_2_4_chunk_compressed.v2, _hyper_2_4_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 720
+               Batches Removed by Filter: 1
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_4_chunk_compressed._ts_meta_count, _hyper_2_4_chunk_compressed.device_id, _hyper_2_4_chunk_compressed.device_id_peer, _hyper_2_4_chunk_compressed._ts_meta_min_3, _hyper_2_4_chunk_compressed._ts_meta_max_3, _hyper_2_4_chunk_compressed._ts_meta_v2_first_time, _hyper_2_4_chunk_compressed._ts_meta_v2_last_time, _hyper_2_4_chunk_compressed."time", _hyper_2_4_chunk_compressed._ts_meta_min_1, _hyper_2_4_chunk_compressed._ts_meta_max_1, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_4_chunk_compressed.v0, _hyper_2_4_chunk_compressed._ts_meta_min_2, _hyper_2_4_chunk_compressed._ts_meta_max_2, _hyper_2_4_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_4_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_4_chunk_compressed.v1, _hyper_2_4_chunk_compressed.v2, _hyper_2_4_chunk_compressed.v3
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-               Sort Key: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-                     Vectorized Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 2160
-                     Batches Removed by Filter: 3
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_5_chunk_compressed (actual rows=3.00 loops=1)
-                           Output: _hyper_2_5_chunk_compressed._ts_meta_count, _hyper_2_5_chunk_compressed.device_id, _hyper_2_5_chunk_compressed.device_id_peer, _hyper_2_5_chunk_compressed._ts_meta_min_3, _hyper_2_5_chunk_compressed._ts_meta_max_3, _hyper_2_5_chunk_compressed._ts_meta_v2_first_time, _hyper_2_5_chunk_compressed._ts_meta_v2_last_time, _hyper_2_5_chunk_compressed."time", _hyper_2_5_chunk_compressed._ts_meta_min_1, _hyper_2_5_chunk_compressed._ts_meta_max_1, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_5_chunk_compressed.v0, _hyper_2_5_chunk_compressed._ts_meta_min_2, _hyper_2_5_chunk_compressed._ts_meta_max_2, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_5_chunk_compressed.v1, _hyper_2_5_chunk_compressed.v2, _hyper_2_5_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 2160
+               Batches Removed by Filter: 3
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_5_chunk_compressed (actual rows=3.00 loops=1)
+                     Output: _hyper_2_5_chunk_compressed._ts_meta_count, _hyper_2_5_chunk_compressed.device_id, _hyper_2_5_chunk_compressed.device_id_peer, _hyper_2_5_chunk_compressed._ts_meta_min_3, _hyper_2_5_chunk_compressed._ts_meta_max_3, _hyper_2_5_chunk_compressed._ts_meta_v2_first_time, _hyper_2_5_chunk_compressed._ts_meta_v2_last_time, _hyper_2_5_chunk_compressed."time", _hyper_2_5_chunk_compressed._ts_meta_min_1, _hyper_2_5_chunk_compressed._ts_meta_max_1, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_5_chunk_compressed.v0, _hyper_2_5_chunk_compressed._ts_meta_min_2, _hyper_2_5_chunk_compressed._ts_meta_max_2, _hyper_2_5_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_5_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_5_chunk_compressed.v1, _hyper_2_5_chunk_compressed.v2, _hyper_2_5_chunk_compressed.v3
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-               Sort Key: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-                     Vectorized Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 720
-                     Batches Removed by Filter: 1
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_6_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_6_chunk_compressed._ts_meta_count, _hyper_2_6_chunk_compressed.device_id, _hyper_2_6_chunk_compressed.device_id_peer, _hyper_2_6_chunk_compressed._ts_meta_min_3, _hyper_2_6_chunk_compressed._ts_meta_max_3, _hyper_2_6_chunk_compressed._ts_meta_v2_first_time, _hyper_2_6_chunk_compressed._ts_meta_v2_last_time, _hyper_2_6_chunk_compressed."time", _hyper_2_6_chunk_compressed._ts_meta_min_1, _hyper_2_6_chunk_compressed._ts_meta_max_1, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_6_chunk_compressed.v0, _hyper_2_6_chunk_compressed._ts_meta_min_2, _hyper_2_6_chunk_compressed._ts_meta_max_2, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_6_chunk_compressed.v1, _hyper_2_6_chunk_compressed.v2, _hyper_2_6_chunk_compressed.v3
-   ->  Merge Append (actual rows=0.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 720
+               Batches Removed by Filter: 1
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_6_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_6_chunk_compressed._ts_meta_count, _hyper_2_6_chunk_compressed.device_id, _hyper_2_6_chunk_compressed.device_id_peer, _hyper_2_6_chunk_compressed._ts_meta_min_3, _hyper_2_6_chunk_compressed._ts_meta_max_3, _hyper_2_6_chunk_compressed._ts_meta_v2_first_time, _hyper_2_6_chunk_compressed._ts_meta_v2_last_time, _hyper_2_6_chunk_compressed."time", _hyper_2_6_chunk_compressed._ts_meta_min_1, _hyper_2_6_chunk_compressed._ts_meta_max_1, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_6_chunk_compressed.v0, _hyper_2_6_chunk_compressed._ts_meta_min_2, _hyper_2_6_chunk_compressed._ts_meta_max_2, _hyper_2_6_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_6_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_6_chunk_compressed.v1, _hyper_2_6_chunk_compressed.v2, _hyper_2_6_chunk_compressed.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-                     Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 672
-         ->  Sort (actual rows=0.00 loops=1)
+               Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 672
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-                     Filter: (_hyper_2_8_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 2016
-         ->  Sort (actual rows=0.00 loops=1)
+               Filter: (_hyper_2_8_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 2016
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-                     Filter: (_hyper_2_9_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 672
-   ->  Merge Append (actual rows=0.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=0.00 loops=1)
+               Filter: (_hyper_2_9_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 672
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Vectorized Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 336
-                     Batches Removed by Filter: 1
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 336
+               Batches Removed by Filter: 1
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Vectorized Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 1008
-                     Batches Removed by Filter: 3
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
-                           Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
-         ->  Sort (actual rows=0.00 loops=1)
+               Vectorized Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 1008
+               Batches Removed by Filter: 3
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
+                     Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0.00 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0.00 loops=1)
-                     Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-                     Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
-                     Rows Removed by Filter: 336
+               Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
+               Rows Removed by Filter: 336
 
 -- device_id constraint should be pushed down
 :PREFIX
@@ -4814,68 +4731,40 @@ WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on public.metrics_space (actual rows=3915.00 loops=1)
+ Sort (actual rows=3915.00 loops=1)
    Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-   Order: metrics_space."time", metrics_space.device_id
-   Startup Exclusion: false
-   Runtime Exclusion: false
-   ->  Merge Append (actual rows=2235.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=447.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=3915.00 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=447.00 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=447.00 loops=1)
-                     Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-                     Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-         ->  Sort (actual rows=1341.00 loops=1)
+               Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341.00 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1341.00 loops=1)
-                     Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-                     Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 675
-         ->  Sort (actual rows=447.00 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 675
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=447.00 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=447.00 loops=1)
-                     Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-                     Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-   ->  Merge Append (actual rows=1680.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=336.00 loops=1)
+               Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                           Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
-                           Filter: (_hyper_2_10_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=1008.00 loops=1)
+               Vectorized Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                     Output: _hyper_2_10_chunk_compressed._ts_meta_count, _hyper_2_10_chunk_compressed.device_id, _hyper_2_10_chunk_compressed.device_id_peer, _hyper_2_10_chunk_compressed._ts_meta_min_3, _hyper_2_10_chunk_compressed._ts_meta_max_3, _hyper_2_10_chunk_compressed._ts_meta_v2_first_time, _hyper_2_10_chunk_compressed._ts_meta_v2_last_time, _hyper_2_10_chunk_compressed."time", _hyper_2_10_chunk_compressed._ts_meta_min_1, _hyper_2_10_chunk_compressed._ts_meta_max_1, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_10_chunk_compressed.v0, _hyper_2_10_chunk_compressed._ts_meta_min_2, _hyper_2_10_chunk_compressed._ts_meta_max_2, _hyper_2_10_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_10_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_10_chunk_compressed.v1, _hyper_2_10_chunk_compressed.v2, _hyper_2_10_chunk_compressed.v3
+                     Filter: (_hyper_2_10_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008.00 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008.00 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Bulk Decompression: true
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
-                           Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
-                           Filter: (_hyper_2_11_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=336.00 loops=1)
+               Vectorized Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Bulk Decompression: true
+               ->  Seq Scan on _timescaledb_internal._hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
+                     Output: _hyper_2_11_chunk_compressed._ts_meta_count, _hyper_2_11_chunk_compressed.device_id, _hyper_2_11_chunk_compressed.device_id_peer, _hyper_2_11_chunk_compressed._ts_meta_min_3, _hyper_2_11_chunk_compressed._ts_meta_max_3, _hyper_2_11_chunk_compressed._ts_meta_v2_first_time, _hyper_2_11_chunk_compressed._ts_meta_v2_last_time, _hyper_2_11_chunk_compressed."time", _hyper_2_11_chunk_compressed._ts_meta_min_1, _hyper_2_11_chunk_compressed._ts_meta_max_1, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v0, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v0, _hyper_2_11_chunk_compressed.v0, _hyper_2_11_chunk_compressed._ts_meta_min_2, _hyper_2_11_chunk_compressed._ts_meta_max_2, _hyper_2_11_chunk_compressed._ts_meta_v2_first_v1, _hyper_2_11_chunk_compressed._ts_meta_v2_last_v1, _hyper_2_11_chunk_compressed.v1, _hyper_2_11_chunk_compressed.v2, _hyper_2_11_chunk_compressed.v3
+                     Filter: (_hyper_2_11_chunk_compressed._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=336.00 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=336.00 loops=1)
-                     Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-                     Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 
 RESET enable_sort;
 -- should produce ordered path
@@ -5274,49 +5163,29 @@ WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
 --- QUERY PLAN ---
- Custom Scan (ChunkAppend) on metrics_space (actual rows=3915.00 loops=1)
-   Order: metrics_space."time", metrics_space.device_id
-   ->  Merge Append (actual rows=2235.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=447.00 loops=1)
-               Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=447.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-         ->  Sort (actual rows=1341.00 loops=1)
-               Sort Key: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1341.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 675
-         ->  Sort (actual rows=447.00 loops=1)
-               Sort Key: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=447.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 225
-   ->  Merge Append (actual rows=1680.00 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         ->  Sort (actual rows=336.00 loops=1)
-               Sort Key: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
-                     Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
-                           Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=1008.00 loops=1)
-               Sort Key: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
-                     Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
-                           Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=336.00 loops=1)
-               Sort Key: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
-                     Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+ Sort (actual rows=3915.00 loops=1)
+   Sort Key: metrics_space."time", metrics_space.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=3915.00 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=447.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1341.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 675
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=447.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 225
+         ->  Custom Scan (ColumnarScan) on _hyper_2_10_chunk (actual rows=336.00 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_10_chunk_compressed (actual rows=1.00 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_11_chunk (actual rows=1008.00 loops=1)
+               Vectorized Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_11_chunk_compressed (actual rows=3.00 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=336.00 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 
 RESET enable_sort;
 -- test runtime exclusion

--- a/tsl/test/shared/expected/gapfill-18.out
+++ b/tsl/test/shared/expected/gapfill-18.out
@@ -3751,9 +3751,9 @@ AND time < (select max(time) from  metrics_tstz m2)
 GROUP BY 1,2 ORDER BY 2,1;
 --- QUERY PLAN ---
  Custom Scan (GapFill)
-   InitPlan 4
+   InitPlan 3
      ->  Result
-           InitPlan 3
+           InitPlan 2
              ->  Limit
                    ->  Custom Scan (DeferredChunkScan) on metrics_tstz m2_2
                          Order: "time" DESC
@@ -3765,15 +3765,12 @@ GROUP BY 1,2 ORDER BY 2,1;
                ->  Result
                      ->  Custom Scan (ChunkAppend) on metrics_tstz m1
                            ->  Seq Scan on _hyper_X_X_chunk m1_1
-                                 Filter: (("time" < (InitPlan 4).col1) AND ("time" >= (SubPlan 2)))
-                                 SubPlan 2
-                                   ->  Result
-                                         InitPlan 1
-                                           ->  Limit
-                                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m2
-                                                       Order: m2."time"
-                                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_tstz_time_idx on _hyper_X_X_chunk m2_1
-                                                             Filter: (device_id = m1_1.device_id)
+                                 Filter: (("time" < (InitPlan 3).col1) AND ("time" >= (SubPlan 1)))
+                                 SubPlan 1
+                                   ->  Aggregate
+                                         ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                               ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                                     Filter: (device_id = m1_1.device_id)
 
 \set ON_ERROR_STOP 0
 SELECT

--- a/tsl/test/shared/expected/gapfill-19.out
+++ b/tsl/test/shared/expected/gapfill-19.out
@@ -3770,13 +3770,10 @@ GROUP BY 1,2 ORDER BY 2,1;
                            ->  Seq Scan on _hyper_X_X_chunk m1_1
                                  Filter: (("time" < (InitPlan expr_2).col1) AND ("time" >= (SubPlan expr_1)))
                                  SubPlan expr_1
-                                   ->  Result
-                                         InitPlan minmax_1
-                                           ->  Limit
-                                                 ->  Custom Scan (ChunkAppend) on metrics_tstz m2
-                                                       Order: m2."time"
-                                                       ->  Index Scan Backward using _hyper_X_X_chunk_metrics_tstz_time_idx on _hyper_X_X_chunk m2_1
-                                                             Filter: (device_id = m1_1.device_id)
+                                   ->  Aggregate
+                                         ->  Custom Scan (ChunkAppend) on metrics_tstz m2
+                                               ->  Seq Scan on _hyper_X_X_chunk m2_1
+                                                     Filter: (device_id = m1_1.device_id)
 
 \set ON_ERROR_STOP 0
 SELECT


### PR DESCRIPTION
PG18 added the disabled_nodes counter besides the disable_cost, and we're not properly tracking that for the ChunkAppend path at the moment. Fix it.

Disable-check: force-changelog-file