### PR TITLE
Increase lock timeouts on concurrent tests

### DIFF
--- a/tsl/test/isolation/expected/cagg_insert.out
+++ b/tsl/test/isolation/expected/cagg_insert.out
@@ -9,7 +9,7 @@ step Refresh: <... completed>
 step Refresh3: <... completed>
 
 starting permutation: Ib LockCagg1 I1 Refresh Ic UnLockCagg1
-step Ib: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ib: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockCagg1: BEGIN; SELECT lock_cagg('continuous_view_1');
 lock_cagg
 ---------
@@ -22,7 +22,7 @@ step UnLockCagg1: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ib LockCagg1 Refresh I1 Ic UnLockCagg1
-step Ib: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ib: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockCagg1: BEGIN; SELECT lock_cagg('continuous_view_1');
 lock_cagg
 ---------
@@ -35,7 +35,7 @@ step UnLockCagg1: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: I2b LockCagg2 I21 Refresh Refresh3 I2c UnLockCagg2
-step I2b: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step I2b: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockCagg2: BEGIN; SELECT lock_cagg('continuous_view_2');
 lock_cagg
 ---------
@@ -49,7 +49,7 @@ step UnLockCagg2: ROLLBACK;
 step Refresh3: <... completed>
 
 starting permutation: I2b LockCagg2 Refresh3 Refresh I21 I2c UnLockCagg2
-step I2b: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step I2b: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockCagg2: BEGIN; SELECT lock_cagg('continuous_view_2');
 lock_cagg
 ---------
@@ -64,7 +64,7 @@ step Refresh3: <... completed>
 step Refresh: <... completed>
 
 starting permutation: Sb LockCagg1 Refresh S1 Sc UnLockCagg1
-step Sb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Sb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockCagg1: BEGIN; SELECT lock_cagg('continuous_view_1');
 lock_cagg
 ---------
@@ -81,7 +81,7 @@ step UnLockCagg1: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Sb LockCagg1 S1 Refresh Sc UnLockCagg1
-step Sb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Sb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockCagg1: BEGIN; SELECT lock_cagg('continuous_view_1');
 lock_cagg
 ---------
@@ -98,7 +98,7 @@ step UnLockCagg1: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ib LockInvalThr Refresh I1 Ic UnlockInvalThr
-step Ib: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ib: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockInvalThr: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold IN SHARE MODE;
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15); <waiting ...>
 step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
@@ -107,7 +107,7 @@ step UnlockInvalThr: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ib LockInvalThr I1 Refresh Ic UnlockInvalThr
-step Ib: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ib: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockInvalThr: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold IN SHARE MODE;
 step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15); <waiting ...>
@@ -116,7 +116,7 @@ step UnlockInvalThr: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ib LockInval I1 Ic Refresh UnlockInval
-step Ib: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ib: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
 step Ic: COMMIT;
@@ -125,7 +125,7 @@ step UnlockInval: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ipb LockInval Refresh Ip1 Ipc UnlockInval
-step Ipb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ipb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15); <waiting ...>
 step Ip1: INSERT INTO ts_continuous_test_1 VALUES (29, 29);
@@ -134,7 +134,7 @@ step UnlockInval: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ipb LockInval Ip1 Refresh Ipc UnlockInval
-step Ipb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ipb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Ip1: INSERT INTO ts_continuous_test_1 VALUES (29, 29);
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15); <waiting ...>
@@ -143,7 +143,7 @@ step UnlockInval: ROLLBACK;
 step Refresh: <... completed>
 
 starting permutation: Ipb LockInval Ip1 Ipc Refresh UnlockInval
-step Ipb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ipb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Ip1: INSERT INTO ts_continuous_test_1 VALUES (29, 29);
 step Ipc: COMMIT;
@@ -162,7 +162,7 @@ time_bucket|count
 
 step LockMatInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
 step Refresh1: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15); <waiting ...>
-step Ib: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Ib: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
 step LockInvalThrEx: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold ; <waiting ...>
 step Ic: COMMIT; <waiting ...>
@@ -184,7 +184,7 @@ step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15);
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15); <waiting ...>
-step Sb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Sb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step S1: SELECT count(*) FROM ts_continuous_test_1;
 count
 -----
@@ -198,7 +198,7 @@ starting permutation: I1 Refresh LockInval Sb S1 Refresh Sc UnlockInval
 step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
 step Refresh: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15);
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
-step Sb: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step Sb: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step S1: SELECT count(*) FROM ts_continuous_test_1;
 count
 -----
@@ -218,7 +218,7 @@ step Refresh3: CALL refresh_continuous_aggregate('continuous_view_2', NULL, 15);
 
 starting permutation: I1 I2b I21 Refresh2 Refresh3 I2c Refresh3
 step I1: INSERT INTO ts_continuous_test_1 VALUES (1, 1);
-step I2b: BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';
+step I2b: BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';
 step I21: INSERT INTO ts_continuous_test_2 VALUES (1, 1);
 step Refresh2: CALL refresh_continuous_aggregate('continuous_view_1', NULL, 15);
 step Refresh3: CALL refresh_continuous_aggregate('continuous_view_2', NULL, 15);

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -19,7 +19,7 @@ step I1:
  <waiting ...>
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -72,7 +72,7 @@ step I1:
  <waiting ...>
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -125,7 +125,7 @@ step I1:
  <waiting ...>
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -178,7 +178,7 @@ step Iu1:
  <waiting ...>
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -236,7 +236,7 @@ step Iu1:
  <waiting ...>
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -294,7 +294,7 @@ step Iu1:
  <waiting ...>
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -348,7 +348,7 @@ lock_chunktable
 
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -410,7 +410,7 @@ lock_chunktable
 
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -472,7 +472,7 @@ lock_chunktable
 
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -534,7 +534,7 @@ lock_chunktable
 
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -596,7 +596,7 @@ lock_chunktable
 
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -658,7 +658,7 @@ lock_chunktable
 
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -708,7 +708,7 @@ status
 starting permutation: C1 Cc LockChunkTuple IB I1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -764,7 +764,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBRR I1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -820,7 +820,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBS I1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -876,7 +876,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IB I1 INu1 UnlockChunkTuple Ic INc SChunkStat SU SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -937,7 +937,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBRR I1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -993,7 +993,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBS I1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -1049,7 +1049,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IB Iu1 IN1 UnlockChunkTuple Ic INc SChunkStat SU SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -1110,7 +1110,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBRR Iu1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -1166,7 +1166,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBS Iu1 IN1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -1222,7 +1222,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IB Iu1 INu1 UnlockChunkTuple Ic INc SChunkStat SU SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -1283,7 +1283,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBRR Iu1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress
@@ -1339,7 +1339,7 @@ time|device|location|value
 starting permutation: C1 Cc LockChunkTuple IBS Iu1 INu1 UnlockChunkTuple Ic INc SChunkStat SA
 step C1: 
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress

--- a/tsl/test/isolation/specs/cagg_cancel_kill_refresh.spec
+++ b/tsl/test/isolation/specs/cagg_cancel_kill_refresh.spec
@@ -134,7 +134,7 @@ step "wp3_release"
 session "R1"
 setup
 {
-    SET SESSION lock_timeout = '500ms';
+    SET SESSION lock_timeout = '2s';
     SET SESSION deadlock_timeout = '500ms';
 }
 step "r1_register_pid"
@@ -226,7 +226,7 @@ step "s1_registered_ranges"
 session "R2"
 setup
 {
-    SET SESSION lock_timeout = '500ms';
+    SET SESSION lock_timeout = '2s';
     SET SESSION deadlock_timeout = '500ms';
 }
 step "r2_refresh"

--- a/tsl/test/isolation/specs/cagg_concurrent_refresh.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_refresh.spec
@@ -216,7 +216,7 @@ step "WP_after_materialization_release"
 session "R1"
 setup
 {
-    SET SESSION lock_timeout = '500ms';
+    SET SESSION lock_timeout = '2s';
     SET SESSION deadlock_timeout = '500ms';
     INSERT INTO cancelpid VALUES (pg_backend_pid())
     ON CONFLICT (pid) DO NOTHING;

--- a/tsl/test/isolation/specs/cagg_concurrent_refresh_invalidation_cutting.spec
+++ b/tsl/test/isolation/specs/cagg_concurrent_refresh_invalidation_cutting.spec
@@ -120,7 +120,7 @@ step "wp_release"
 session "R1"
 setup
 {
-    SET SESSION lock_timeout = '500ms';
+    SET SESSION lock_timeout = '2s';
     SET SESSION deadlock_timeout = '500ms';
 }
 step "r1_refresh"
@@ -132,7 +132,7 @@ step "r1_refresh"
 session "R2"
 setup
 {
-    SET SESSION lock_timeout = '500ms';
+    SET SESSION lock_timeout = '2s';
     SET SESSION deadlock_timeout = '500ms';
 }
 step "r2_refresh"

--- a/tsl/test/isolation/specs/cagg_insert.spec
+++ b/tsl/test/isolation/specs/cagg_insert.spec
@@ -54,22 +54,22 @@ teardown {
 }
 
 session "I"
-step "Ib"	{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+step "Ib"	{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';}
 step "I1"	{ INSERT INTO ts_continuous_test_1 VALUES (1, 1); }
 step "Ic"	{ COMMIT; }
 
 session "Ip"
-step "Ipb"	{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+step "Ipb"	{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';}
 step "Ip1"	{ INSERT INTO ts_continuous_test_1 VALUES (29, 29); }
 step "Ipc"	{ COMMIT; }
 
 session "I2"
-step "I2b"	{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+step "I2b"	{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';}
 step "I21"	{ INSERT INTO ts_continuous_test_2 VALUES (1, 1); }
 step "I2c"	{ COMMIT; }
 
 session "S"
-step "Sb"	{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+step "Sb"	{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';}
 step "S1"	{ SELECT count(*) FROM ts_continuous_test_1; }
 step "Sc"	{ COMMIT; }
 

--- a/tsl/test/isolation/specs/compression_conflicts_iso.spec
+++ b/tsl/test/isolation/specs/compression_conflicts_iso.spec
@@ -82,7 +82,7 @@ step "UnlockChunk" {ROLLBACK;}
 session "C"
 step "C1"   {
   BEGIN;
-  SET LOCAL lock_timeout = '500ms';
+  SET LOCAL lock_timeout = '2s';
   SET LOCAL deadlock_timeout = '10ms';
   SELECT
     CASE WHEN compress_chunk(ch.relid) IS NOT NULL THEN true ELSE false END AS compress

--- a/tsl/test/isolation/specs/deadlock_drop_chunks_compress.spec
+++ b/tsl/test/isolation/specs/deadlock_drop_chunks_compress.spec
@@ -23,7 +23,7 @@ session "s1"
 setup	{
 	BEGIN;
 	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
-	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL lock_timeout = '2s';
 	SET LOCAL deadlock_timeout = '300ms';
 }
 
@@ -38,7 +38,7 @@ session "s2"
 setup	{
 	BEGIN;
 	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
-	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL lock_timeout = '2s';
 	SET LOCAL deadlock_timeout = '300ms';
 
 	CREATE TEMPORARY TABLE IF NOT EXISTS chunks_to_compress ON COMMIT DROP AS

--- a/tsl/test/isolation/specs/deadlock_drop_index_vacuum.spec
+++ b/tsl/test/isolation/specs/deadlock_drop_index_vacuum.spec
@@ -89,7 +89,7 @@ session "S1"
 setup {
     START TRANSACTION;
     SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
-    SET LOCAL lock_timeout = '500ms';
+    SET LOCAL lock_timeout = '2s';
     SET LOCAL deadlock_timeout = '300ms';
 }
 
@@ -105,7 +105,7 @@ session "S2"
 setup {
     START TRANSACTION;
     SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
-    SET LOCAL lock_timeout = '500ms';
+    SET LOCAL lock_timeout = '2s';
     SET LOCAL deadlock_timeout = '300ms';
 }
 

--- a/tsl/test/isolation/specs/merge_chunks_concurrent.spec
+++ b/tsl/test/isolation/specs/merge_chunks_concurrent.spec
@@ -117,7 +117,7 @@ step "s1_commit" { commit; }
 
 session "s2"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -145,7 +145,7 @@ step "s2_commit" {
 
 session "s3"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -190,7 +190,7 @@ step "s3_commit" { commit; }
 
 session "s4"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -200,7 +200,7 @@ step "s4_insert_result_chunk" {
 
 session "s5"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -224,7 +224,7 @@ step "s5_merge_cleanup" {
 
 session "s6"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -242,7 +242,7 @@ step "s6_merge_1_3_concurrently" {
 
 session "s7"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 

--- a/tsl/test/isolation/specs/parallel_compression.spec
+++ b/tsl/test/isolation/specs/parallel_compression.spec
@@ -27,7 +27,7 @@ teardown {
 
 session "s1"
 setup	{
-	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL lock_timeout = '2s';
 	SET LOCAL deadlock_timeout = '300ms';
 }
 
@@ -42,7 +42,7 @@ step "s1_commit" { COMMIT; }
 
 session "s2"
 setup	{
-	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL lock_timeout = '2s';
 	SET LOCAL deadlock_timeout = '300ms';
 }
 

--- a/tsl/test/isolation/specs/reorder_vs_insert.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_insert.spec.in
@@ -28,17 +28,17 @@ teardown {
 }
 
 session "I"
-setup		{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+setup		{ BEGIN; SET LOCAL lock_timeout = '2500ms'; SET LOCAL deadlock_timeout = '10ms';}
 step "I1"	{ INSERT INTO ts_reorder_test VALUES (1, 19.5, 3); }
 step "Ic"	{ COMMIT; }
 
 session "R"
-setup		{ BEGIN; SET LOCAL lock_timeout = '250ms'; SET LOCAL deadlock_timeout = '10ms'; }
+setup		{ BEGIN; SET LOCAL lock_timeout = '2250ms'; SET LOCAL deadlock_timeout = '10ms'; }
 step "R1"	{ SELECT reorder_chunk_i((SELECT show_chunks('ts_reorder_test') LIMIT 1), 'ts_reorder_test_time_idx', wait_on => 'waiter'); }
 step "Rc"	{ COMMIT; }
 
 session "B"
-setup		{ BEGIN; LOCK TABLE waiter; }
+setup		{ BEGIN; SET LOCAL lock_timeout = '2s'; LOCK TABLE waiter; }
 step "Bc"   { COMMIT; }
 
 

--- a/tsl/test/isolation/specs/reorder_vs_insert_other_chunk.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_insert_other_chunk.spec.in
@@ -26,12 +26,12 @@ teardown {
 }
 
 session "I"
-setup		{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+setup		{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';}
 step "I1"	{ INSERT INTO ts_reorder_test VALUES (11, 19.5, 3); }
 step "Ic"	{ COMMIT; }
 
 session "R"
-setup		{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms'; }
+setup		{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms'; }
 step "R1"	{ SELECT reorder_chunk_i((SELECT show_chunks('ts_reorder_test') LIMIT 1), 'ts_reorder_test_time_idx'); }
 step "Rc"	{ COMMIT; }
 

--- a/tsl/test/isolation/specs/reorder_vs_select.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_select.spec.in
@@ -27,17 +27,17 @@ teardown {
 }
 
 session "S"
-setup		{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
+setup		{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms';}
 step "S1"	{ SELECT * FROM ts_reorder_test; }
 step "Sc"	{ COMMIT; }
 
 session "R"
-setup		{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms'; }
+setup		{ BEGIN; SET LOCAL lock_timeout = '2s'; SET LOCAL deadlock_timeout = '10ms'; }
 step "R1"	{ SELECT reorder_chunk_i((SELECT show_chunks('ts_reorder_test') LIMIT 1), 'ts_reorder_test_time_idx', wait_on => 'waiter'); }
 step "Rc"	{ COMMIT; }
 
 session "B"
-setup		{ BEGIN; LOCK TABLE waiter; }
+setup		{ BEGIN; SET LOCAL lock_timeout = '2s'; LOCK TABLE waiter; }
 step "Bc"   { COMMIT; }
 
 permutation "Bc" "S1" "Sc" "R1" "Rc"

--- a/tsl/test/isolation/specs/split_chunk_concurrent.spec
+++ b/tsl/test/isolation/specs/split_chunk_concurrent.spec
@@ -107,7 +107,7 @@ step "s1_delete_from_splitting_chunk" {
 
 session "s2"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -128,7 +128,7 @@ step "s2_insert_into_splitting_chunk" {
 
 session "s3"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 
@@ -154,7 +154,7 @@ step "s3_vacuum_freeze_chunks" {
 
 session "s4"
 setup	{
-    set local lock_timeout = '500ms';
+    set local lock_timeout = '2s';
     set local deadlock_timeout = '100ms';
 }
 


### PR DESCRIPTION
The MacOS CI on github tend to have random timeouts at 500ms in various concurrent tests. Here I bump these timeouts.

Disable-check: force-changelog-file