### PR TITLE
Fix further CI issues

### DIFF
--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -72,12 +72,19 @@ jobs:
     - name: Get version of latest release
       id: versions
       run: |
-        version=$(wget -q --tries=6 --waitretry=15 https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
-        echo "version=${version}"
-        echo "version=${version}" >>$GITHUB_OUTPUT
+        retry_flags="--tries=9 --wait=20 --random-wait --retry-on-http-error=503,403"
+        version_url="https://api.github.com/repos/timescale/timescaledb/releases/latest"
+        version=$(wget -q ${retry_flags} --header="Authorization: token ${{ github.token }}" ${version_url} -O - | jq -r .tag_name)
+        if [ -z "$version" ]; then
+          echo "ERROR: Failed to get api version from github. This is a CI issue." >>$GITHUB_OUTPUT
+          false
+        else
+          echo "version=${version}"
+          echo "version=${version}" >>$GITHUB_OUTPUT
 
-        grep PRETTY_NAME /etc/os-release >> $GITHUB_OUTPUT
-        echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+          grep PRETTY_NAME /etc/os-release >> $GITHUB_OUTPUT
+          echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+        fi
 
     - name: Test Installation
       id: installation
@@ -89,6 +96,7 @@ jobs:
         installed_version=$(sudo -u postgres psql -X -t \
           -c "SELECT extversion FROM pg_extension WHERE extname='timescaledb';" | sed -e 's! !!g')
         if [ "${{ steps.versions.outputs.version }}" != "$installed_version" ];then
+          echo "ERROR: Version mismatch: ${{ steps.versions.outputs.version }} != $installed_version" >>$GITHUB_OUTPUT
           false
         fi
 

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -79,9 +79,16 @@ jobs:
     - name: Get version of latest release
       id: versions
       run: |
-        version=$(wget -q --tries=6 --waitretry=15 https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
-        echo "version=${version}"
-        echo "version=${version}" >>$GITHUB_OUTPUT
+        retry_flags="--tries=9 --wait=20 --random-wait --retry-on-http-error=503,403"
+        version_url="https://api.github.com/repos/timescale/timescaledb/releases/latest"
+        version=$(wget -q ${retry_flags} --header="Authorization: token ${{ github.token }}" ${version_url} -O - | jq -r .tag_name)
+        if [ -z "$version" ]; then
+          echo "ERROR: Failed to get api version from github. This is a CI issue." >>$GITHUB_OUTPUT
+          false
+        else
+          echo "version=${version}"
+          echo "version=${version}" >>$GITHUB_OUTPUT
+        fi
 
     - name: Test Installation
       run: |
@@ -91,6 +98,7 @@ jobs:
         installed_version=$(sudo -u postgres psql -X -t \
           -c "SELECT extversion FROM pg_extension WHERE extname='timescaledb';" | sed -e 's! !!g')
         if [ "${{ steps.versions.outputs.version }}" != "$installed_version" ];then
+          echo "ERROR: Version mismatch: ${{ steps.versions.outputs.version }} != $installed_version" >>$GITHUB_OUTPUT
           false
         fi
 

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -112,7 +112,7 @@ jobs:
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |
-        gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+        gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 || gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 15CF4D18AF4F7421
         gpg --batch --export --export-options export-minimal --armor 15CF4D18AF4F7421 | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
 
         . /etc/os-release
@@ -153,7 +153,7 @@ jobs:
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |
-        gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+        gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 || gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 15CF4D18AF4F7421
         gpg --batch --export --export-options export-minimal --armor 15CF4D18AF4F7421 | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
 
         . /etc/os-release

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -73,9 +73,16 @@ jobs:
     - name: Get version of latest release
       id: versions
       run: |
-        version=$(wget -q --tries=6 --waitretry=15 https://api.github.com/repos/timescale/timescaledb/releases/latest -O - | jq -r .tag_name)
-        echo "version=${version}"
-        echo "version=${version}" >>$GITHUB_OUTPUT
+        retry_flags="--tries=9 --wait=20 --random-wait --retry-on-http-error=503,403"
+        version_url="https://api.github.com/repos/timescale/timescaledb/releases/latest"
+        version=$(wget -q ${retry_flags} --header="Authorization: token ${{ github.token }}" ${version_url} -O - | jq -r .tag_name)
+        if [ -z "$version" ]; then
+          echo "ERROR: Failed to get api version from github. This is a CI issue." >>$GITHUB_OUTPUT
+          false
+        else
+          echo "version=${version}"
+          echo "version=${version}" >>$GITHUB_OUTPUT
+        fi
 
     - name: Test Installation
       run: |
@@ -86,6 +93,7 @@ jobs:
         installed_version=$(sudo -u postgres psql -X -t \
           -c "SELECT extversion FROM pg_extension WHERE extname='timescaledb';" | sed -e 's! !!g')
         if [ "${{ steps.versions.outputs.version }}" != "$installed_version" ];then
+          echo "ERROR: Version mismatch: ${{ steps.versions.outputs.version }} != $installed_version" >>$GITHUB_OUTPUT
           false
         fi
 


### PR DESCRIPTION
Occasionally, we can't get the latest version from GitHub, causing intermittent CI errors. The culprit is this URL: `api.github.com/repos/timescale/timescaledb/releases/latest`. I added better reporting in the CI workflows so it is more obvious when this happens, and I also added more retries and error handling to 'wget'.

The 'keyserver.ubuntu.com' also started failing requests, so I added a fallback to 'keys.openpgp.org' for the code-style/clang-tidy tests.

Disable-check: force-changelog-file