### PR TITLE
Apply new sortkeys for in-memory recompression

### DIFF
--- a/.unreleased/fix_10058
+++ b/.unreleased/fix_10058
@@ -1,0 +1,1 @@
+Fixes: #10058 Apply new sortkeys for in-memory recompression

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1657,15 +1657,11 @@ perform_recompression(RecompressContext *recompress_ctx, Relation compressed_chu
 									  RelationGetRelid(compressed_chunk_rel),
 									  RelationGetRelid(uncompressed_chunk_rel));
 
-	tuplesortstate = tuplesort_begin_heap(RelationGetDescr(uncompressed_chunk_rel),
-										  recompress_ctx->n_keys,
-										  recompress_ctx->sort_keys,
-										  recompress_ctx->sort_operators,
-										  recompress_ctx->sort_collations,
-										  recompress_ctx->nulls_first,
-										  maintenance_work_mem,
-										  NULL,
-										  false);
+	/*
+	 * Need to sort with the new settings
+	 */
+	tuplesortstate =
+		compression_create_tuplesort_state(new_settings, uncompressed_chunk_rel, false);
 
 	row_compressor_init(&row_compressor,
 						new_settings,

--- a/tsl/test/expected/recompression_integrity_tests.out
+++ b/tsl/test/expected/recompression_integrity_tests.out
@@ -575,3 +575,41 @@ SELECT * FROM recomp_guc_test ORDER BY time, device;
 
 RESET timescaledb.enable_in_memory_recompression;
 DROP TABLE recomp_guc_test CASCADE;
+-- Test Case 7: Orderby direction change
+CREATE TABLE rideshare_trips(started_at int NOT NULL, vehicle_id int NOT NULL);
+SELECT create_hypertable('rideshare_trips', 'started_at');
+      create_hypertable       
+------------------------------
+ (7,public,rideshare_trips,t)
+
+INSERT INTO rideshare_trips SELECT i, 0 FROM generate_series(0, 9) i;
+ALTER TABLE rideshare_trips SET (timescaledb.compress,
+                                 timescaledb.compress_orderby = 'started_at',
+                                 timescaledb.compress_segmentby = 'vehicle_id');
+SELECT compress_chunk(c) FROM show_chunks('rideshare_trips') c;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_10_chunk
+
+ALTER TABLE rideshare_trips SET (timescaledb.compress_orderby = 'started_at DESC');
+NOTICE:  updated compression settings will only apply to future compressions
+SELECT compress_chunk(c, recompress => true) FROM show_chunks('rideshare_trips') c;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_7_10_chunk
+
+-- Should return 9, 8, 7 on the first recompression, not after a second one
+SELECT started_at FROM rideshare_trips ORDER BY started_at DESC LIMIT 3;
+ started_at 
+------------
+          9
+          8
+          7
+
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+                  relid                  |                   compress_relid                   |  segmentby   |   orderby    | orderby_desc | orderby_nullsfirst |                                                                 index                                                                 
+-----------------------------------------+----------------------------------------------------+--------------+--------------+--------------+--------------------+---------------------------------------------------------------------------------------------------------------------------------------
+ rideshare_trips                         |                                                    | {vehicle_id} | {started_at} | {t}          | {t}                | [{"type": "minmax", "column": "started_at", "source": "orderby"}, {"type": "firstlast", "column": "started_at", "source": "orderby"}]
+ _timescaledb_internal._hyper_7_10_chunk | _timescaledb_internal._hyper_7_10_chunk_compressed | {vehicle_id} | {started_at} | {t}          | {t}                | [{"type": "minmax", "column": "started_at", "source": "orderby"}, {"type": "firstlast", "column": "started_at", "source": "orderby"}]
+
+DROP TABLE IF EXISTS rideshare_trips CASCADE;

--- a/tsl/test/sql/recompression_integrity_tests.sql
+++ b/tsl/test/sql/recompression_integrity_tests.sql
@@ -221,5 +221,21 @@ SELECT * FROM recomp_guc_test ORDER BY time, device;
 RESET timescaledb.enable_in_memory_recompression;
 DROP TABLE recomp_guc_test CASCADE;
 
+-- Test Case 7: Orderby direction change
+CREATE TABLE rideshare_trips(started_at int NOT NULL, vehicle_id int NOT NULL);
+SELECT create_hypertable('rideshare_trips', 'started_at');
+INSERT INTO rideshare_trips SELECT i, 0 FROM generate_series(0, 9) i;
+ALTER TABLE rideshare_trips SET (timescaledb.compress,
+                                 timescaledb.compress_orderby = 'started_at',
+                                 timescaledb.compress_segmentby = 'vehicle_id');
+SELECT compress_chunk(c) FROM show_chunks('rideshare_trips') c;
+
+ALTER TABLE rideshare_trips SET (timescaledb.compress_orderby = 'started_at DESC');
+SELECT compress_chunk(c, recompress => true) FROM show_chunks('rideshare_trips') c;
+
+-- Should return 9, 8, 7 on the first recompression, not after a second one
+SELECT started_at FROM rideshare_trips ORDER BY started_at DESC LIMIT 3;
+SELECT * FROM _timescaledb_catalog.compression_settings ORDER BY relid;
+DROP TABLE IF EXISTS rideshare_trips CASCADE;
 
 


### PR DESCRIPTION
In-memory recompression built its tuplesort from the chunk's existing
compression settings. Build it from the new settings instead.

Fixes #10058
