### PR TITLE
Fix matching NULL tuples to compressed batches with NULL boundaries for recompress

### DIFF
--- a/.unreleased/pr_10506
+++ b/.unreleased/pr_10506
@@ -1,0 +1,1 @@
+Fixes: #10506 Correctly match NULL tuples to compressed batches with NULL boundaries during recompression

--- a/tsl/src/compression/compression_scankey.c
+++ b/tsl/src/compression/compression_scankey.c
@@ -33,7 +33,7 @@ static bool create_segment_filter_scankey(Relation in_rel, char *segment_filter_
  * and (key <= NULL) returns True for !nulls_first (i.e. for NULLS LAST).
  */
 bool
-slot_key_test(TupleTableSlot *compressed_slot, ScanKey key, bool nulls_first)
+slot_key_test(TupleTableSlot *compressed_slot, ScanKey key, bool null_slot_attribute_passes_test)
 {
 	/* No need to get the datum if we are only checking for NULL key */
 	if (key->sk_flags & SK_ISNULL)
@@ -47,21 +47,7 @@ slot_key_test(TupleTableSlot *compressed_slot, ScanKey key, bool nulls_first)
 
 	if (is_null)
 	{
-		/* NULL < key i.e. NULL sorts before key argument */
-		if (nulls_first && (key->sk_strategy == BTLessStrategyNumber ||
-							key->sk_strategy == BTLessEqualStrategyNumber))
-		{
-			return true;
-		}
-
-		/* NULL > key i.e. NULL sorts after key argument */
-		if (!nulls_first && (key->sk_strategy == BTGreaterStrategyNumber ||
-							 key->sk_strategy == BTGreaterEqualStrategyNumber))
-		{
-			return true;
-		}
-
-		return false;
+		return null_slot_attribute_passes_test;
 	}
 
 	return DatumGetBool(FunctionCall2Coll(&key->sk_func, key->sk_collation, val, key->sk_argument));

--- a/tsl/src/compression/recompress.c
+++ b/tsl/src/compression/recompress.c
@@ -1941,16 +1941,38 @@ update_orderby_scankeys(Datum *values, bool *isnulls, int num_segmentby, int num
 	}
 }
 
+/* Uncompressed tuple key is NULL:
+ * if NULLS FIRST, Tuple_match if compressed slot lower boundary is NULL,
+ * else Tuple_before as NULL tuple sorts before anything but NULL,
+ * if NULLS LAST, Tuple_match if compressed slot upper boundary is NULL,
+ * else Tuple_after as NULL tuple sorts after anything but NULL. */
 static enum Batch_match_result
-handle_null_scan(int key_flags, bool nulls_first, enum Batch_match_result result)
+handle_isnull_scankey(TupleTableSlot *compressed_slot, ScanKey orderby_scankeys, bool nulls_first)
 {
-	/* uncompressed tuple key is NULL */
-	if (key_flags & SK_ISNULL)
+	if (nulls_first)
 	{
-		return nulls_first ? Tuple_before : Tuple_after;
+		ScanKey lower_key = &orderby_scankeys[0];
+		if (slot_attisnull(compressed_slot, lower_key->sk_attno))
+		{
+			return Tuple_match;
+		}
+		else
+		{
+			return Tuple_before;
+		}
 	}
-
-	return result;
+	else
+	{
+		ScanKey upper_key = &orderby_scankeys[1];
+		if (slot_attisnull(compressed_slot, upper_key->sk_attno))
+		{
+			return Tuple_match;
+		}
+		else
+		{
+			return Tuple_after;
+		}
+	}
 }
 
 static enum Batch_match_result
@@ -1968,15 +1990,26 @@ match_tuple_batch(TupleTableSlot *compressed_slot, int num_orderby, ScanKey orde
 	if (num_orderby >= 1)
 	{
 		ScanKey key = &orderby_scankeys[0];
-		if (!slot_key_test(compressed_slot, key, nulls_first[0]))
+		/* Uncompressed ScanKey is a comparison with NULL */
+		if (key->sk_flags & SK_ISNULL)
 		{
-			return handle_null_scan(key->sk_flags, nulls_first[0], Tuple_before);
+			return handle_isnull_scankey(compressed_slot, orderby_scankeys, nulls_first[0]);
 		}
 
-		key = &orderby_scankeys[1];
-		if (!slot_key_test(compressed_slot, key, nulls_first[0]))
+		/* Uncompressed ScanKey is a comparison with a non-null value */
+
+		/* check if sorts before lower boundary */
+		bool key_sorts_after_lower_null_boundary = nulls_first[0];
+		if (!slot_key_test(compressed_slot, key, key_sorts_after_lower_null_boundary))
 		{
-			return handle_null_scan(key->sk_flags, nulls_first[0], Tuple_after);
+			return Tuple_before;
+		}
+		key = &orderby_scankeys[1];
+		/* check if sorts after upper boundary */
+		bool key_sorts_before_upper_null_boundary = !nulls_first[0];
+		if (!slot_key_test(compressed_slot, key, key_sorts_before_upper_null_boundary))
+		{
+			return Tuple_after;
 		}
 	}
 	return Tuple_match;

--- a/tsl/test/expected/recompression_nullable_orderby.out
+++ b/tsl/test/expected/recompression_nullable_orderby.out
@@ -180,6 +180,12 @@ SELECT compress_chunk(show_chunks('test1'));
 
 -- Now this chunk is partial, this batch should match [1, NULL] batch instead of sorting after it
 INSERT INTO test1 SELECT 1, 1, g FROM generate_series(901,1400) g;
+--Same for a batch with NULL tuples:
+INSERT INTO test1 VALUES
+    (1, 1, NULL),
+    (1, 1, 903),
+    (1, 1, NULL),
+    (1, 1, 505);
 -- Should not see info about nullable order by
 SET timescaledb.debug_compression_path_info TO ON;
 SELECT compress_chunk(show_chunks('test1'), if_not_compressed => true);
@@ -215,6 +221,12 @@ SELECT compress_chunk(show_chunks('test2'));
 
 -- Now this chunk is partial, recompress will be applied
 INSERT INTO test2 SELECT 1, g FROM generate_series(1300,1600) g;
+--batch with NULL tuples:
+INSERT INTO test2 VALUES
+    (1, NULL),
+    (1, 303),
+    (1, 1603),
+    (1, 1305);
 SELECT compress_chunk(show_chunks('test2'), if_not_compressed => true);
              compress_chunk             
 ----------------------------------------
@@ -245,6 +257,12 @@ SELECT compress_chunk(show_chunks('test3'));
 
 -- Now this chunk is partial, recompress will be applied
 INSERT INTO test3 SELECT 1, g FROM generate_series(400,600) g;
+--batch with NULL tuples:
+INSERT INTO test3 VALUES
+    (1, NULL),
+    (1, 503),
+    (1, 300),
+    (1, 1505);
 SELECT compress_chunk(show_chunks('test3'), if_not_compressed => true);
              compress_chunk             
 ----------------------------------------
@@ -278,6 +296,12 @@ SELECT compress_chunk(show_chunks('test4'));
 -- Now this chunk is partial, recompress will be applied
 -- This batch should match [NULL... 1001...1800] batch instead of going before it
 INSERT INTO test4 SELECT 1, 1, g FROM generate_series(500,900) g;
+--Same for a batch with NULL tuples:
+INSERT INTO test4 VALUES
+    (1, 1, NULL),
+    (1, 1, 503),
+    (1, 1, NULL),
+    (1, 1, 1803);
 SELECT compress_chunk(show_chunks('test4'), if_not_compressed => true);
              compress_chunk             
 ----------------------------------------
@@ -296,5 +320,99 @@ drop table test1 cascade;
 drop table test2 cascade;
 drop table test3 cascade;
 drop table test4 cascade;
+-- Fix issue #10400: correctly match NULL tuple to NULL boundary with NULLS FIRST
+CREATE TABLE t_10400 (
+    time timestamptz NOT NULL,
+    seg int NOT NULL,
+    rank int,          -- nullable orderby column
+    val int NOT NULL
+);
+SELECT create_hypertable('t_10400', 'time', chunk_time_interval => interval '1 year');
+  create_hypertable   
+----------------------
+ (7,public,t_10400,t)
+
+ALTER TABLE t_10400 SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'rank DESC NULLS FIRST, time'
+);
+-- Compressed batch (NULL, 5)
+INSERT INTO t_10400 VALUES
+    ('2024-01-01 01:00:00+00', 1, NULL, 10),
+    ('2024-01-01 02:00:00+00', 1, NULL, 20),
+    ('2024-01-01 03:00:00+00', 1, 5, 30),
+    ('2024-01-01 04:00:00+00', 1, 3, 40),
+    ('2024-01-01 05:00:00+00', 1, 1, 50);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+ count 
+-------
+     1
+
+-- Delayed insert into the compressed chunk, then recompress -> second batch.
+INSERT INTO t_10400 VALUES
+    ('2024-01-01 01:30:00+00', 1, NULL, 15),
+    ('2024-01-01 03:30:00+00', 1, 4, 35),
+    ('2024-01-01 06:00:00+00', 1, NULL, 60),
+    ('2024-01-01 02:30:00+00', 1, 10, 25);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+ count 
+-------
+     1
+
+-- Should correctly merge NULL tuples into the batch (NULL, 5) with NULLS FIRST
+SELECT rank, time, val
+FROM t_10400
+WHERE seg = 1
+ORDER BY rank DESC NULLS FIRST, time;
+ rank |             time             | val 
+------+------------------------------+-----
+      | Sun Dec 31 17:00:00 2023 PST |  10
+      | Sun Dec 31 17:30:00 2023 PST |  15
+      | Sun Dec 31 18:00:00 2023 PST |  20
+      | Sun Dec 31 22:00:00 2023 PST |  60
+   10 | Sun Dec 31 18:30:00 2023 PST |  25
+    5 | Sun Dec 31 19:00:00 2023 PST |  30
+    4 | Sun Dec 31 19:30:00 2023 PST |  35
+    3 | Sun Dec 31 20:00:00 2023 PST |  40
+    1 | Sun Dec 31 21:00:00 2023 PST |  50
+
+drop table t_10400 cascade;
+-- Correctly match non-null tuple with a batch with lower NULL boundary and DESC order
+CREATE TABLE t_10400 (time timestamptz NOT NULL, seg int NOT NULL, rank int, val int NOT NULL);
+SELECT count(*) FROM (SELECT create_hypertable('t_10400', 'time', chunk_time_interval => interval '1 year')) t;
+ count 
+-------
+     1
+
+ALTER TABLE t_10400 SET (timescaledb.compress, timescaledb.compress_segmentby = 'seg', timescaledb.compress_orderby = 'rank DESC NULLS FIRST, time');
+INSERT INTO t_10400 VALUES
+    ('2024-01-01 01:00:00+00', 1, NULL, 10),
+    ('2024-01-01 02:00:00+00', 1, NULL, 20),
+    ('2024-01-01 03:00:00+00', 1, 5, 30),
+    ('2024-01-01 04:00:00+00', 1, 3, 40),
+    ('2024-01-01 05:00:00+00', 1, 1, 50);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+ count 
+-------
+     1
+
+INSERT INTO t_10400 VALUES ('2024-01-01 03:30:00+00', 1, 4, 35);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+ count 
+-------
+     1
+
+SELECT rank, val FROM t_10400 WHERE seg = 1 ORDER BY rank DESC NULLS FIRST, time;
+ rank | val 
+------+-----
+      |  10
+      |  20
+    5 |  30
+    4 |  35
+    3 |  40
+    1 |  50
+
+drop table t_10400 cascade;
 RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.batch_sorted_merge;

--- a/tsl/test/sql/recompression_nullable_orderby.sql
+++ b/tsl/test/sql/recompression_nullable_orderby.sql
@@ -139,6 +139,12 @@ SELECT compress_chunk(show_chunks('test1'));
 
 -- Now this chunk is partial, this batch should match [1, NULL] batch instead of sorting after it
 INSERT INTO test1 SELECT 1, 1, g FROM generate_series(901,1400) g;
+--Same for a batch with NULL tuples:
+INSERT INTO test1 VALUES
+    (1, 1, NULL),
+    (1, 1, 903),
+    (1, 1, NULL),
+    (1, 1, 505);
 
 -- Should not see info about nullable order by
 SET timescaledb.debug_compression_path_info TO ON;
@@ -162,6 +168,12 @@ SELECT compress_chunk(show_chunks('test2'));
 
 -- Now this chunk is partial, recompress will be applied
 INSERT INTO test2 SELECT 1, g FROM generate_series(1300,1600) g;
+--batch with NULL tuples:
+INSERT INTO test2 VALUES
+    (1, NULL),
+    (1, 303),
+    (1, 1603),
+    (1, 1305);
 SELECT compress_chunk(show_chunks('test2'), if_not_compressed => true);
 
 -- Should return 0
@@ -180,6 +192,12 @@ SELECT compress_chunk(show_chunks('test3'));
 
 -- Now this chunk is partial, recompress will be applied
 INSERT INTO test3 SELECT 1, g FROM generate_series(400,600) g;
+--batch with NULL tuples:
+INSERT INTO test3 VALUES
+    (1, NULL),
+    (1, 503),
+    (1, 300),
+    (1, 1505);
 SELECT compress_chunk(show_chunks('test3'), if_not_compressed => true);
 
 -- Should return 0
@@ -201,6 +219,12 @@ SELECT compress_chunk(show_chunks('test4'));
 -- Now this chunk is partial, recompress will be applied
 -- This batch should match [NULL... 1001...1800] batch instead of going before it
 INSERT INTO test4 SELECT 1, 1, g FROM generate_series(500,900) g;
+--Same for a batch with NULL tuples:
+INSERT INTO test4 VALUES
+    (1, 1, NULL),
+    (1, 1, 503),
+    (1, 1, NULL),
+    (1, 1, 1803);
 SELECT compress_chunk(show_chunks('test4'), if_not_compressed => true);
 
 -- This query orders NULLS FIRST, so we can't have a non-NULL value before a NULL value.
@@ -213,6 +237,68 @@ drop table test1 cascade;
 drop table test2 cascade;
 drop table test3 cascade;
 drop table test4 cascade;
+
+-- Fix issue #10400: correctly match NULL tuple to NULL boundary with NULLS FIRST
+CREATE TABLE t_10400 (
+    time timestamptz NOT NULL,
+    seg int NOT NULL,
+    rank int,          -- nullable orderby column
+    val int NOT NULL
+);
+SELECT create_hypertable('t_10400', 'time', chunk_time_interval => interval '1 year');
+
+ALTER TABLE t_10400 SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'seg',
+    timescaledb.compress_orderby = 'rank DESC NULLS FIRST, time'
+);
+
+-- Compressed batch (NULL, 5)
+INSERT INTO t_10400 VALUES
+    ('2024-01-01 01:00:00+00', 1, NULL, 10),
+    ('2024-01-01 02:00:00+00', 1, NULL, 20),
+    ('2024-01-01 03:00:00+00', 1, 5, 30),
+    ('2024-01-01 04:00:00+00', 1, 3, 40),
+    ('2024-01-01 05:00:00+00', 1, 1, 50);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+
+-- Delayed insert into the compressed chunk, then recompress -> second batch.
+INSERT INTO t_10400 VALUES
+    ('2024-01-01 01:30:00+00', 1, NULL, 15),
+    ('2024-01-01 03:30:00+00', 1, 4, 35),
+    ('2024-01-01 06:00:00+00', 1, NULL, 60),
+    ('2024-01-01 02:30:00+00', 1, 10, 25);
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+
+-- Should correctly merge NULL tuples into the batch (NULL, 5) with NULLS FIRST
+SELECT rank, time, val
+FROM t_10400
+WHERE seg = 1
+ORDER BY rank DESC NULLS FIRST, time;
+
+drop table t_10400 cascade;
+
+-- Correctly match non-null tuple with a batch with lower NULL boundary and DESC order
+CREATE TABLE t_10400 (time timestamptz NOT NULL, seg int NOT NULL, rank int, val int NOT NULL);
+SELECT count(*) FROM (SELECT create_hypertable('t_10400', 'time', chunk_time_interval => interval '1 year')) t;
+ALTER TABLE t_10400 SET (timescaledb.compress, timescaledb.compress_segmentby = 'seg', timescaledb.compress_orderby = 'rank DESC NULLS FIRST, time');
+
+INSERT INTO t_10400 VALUES
+    ('2024-01-01 01:00:00+00', 1, NULL, 10),
+    ('2024-01-01 02:00:00+00', 1, NULL, 20),
+    ('2024-01-01 03:00:00+00', 1, 5, 30),
+    ('2024-01-01 04:00:00+00', 1, 3, 40),
+    ('2024-01-01 05:00:00+00', 1, 1, 50);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+
+INSERT INTO t_10400 VALUES ('2024-01-01 03:30:00+00', 1, 4, 35);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('t_10400') c;
+
+SELECT rank, val FROM t_10400 WHERE seg = 1 ORDER BY rank DESC NULLS FIRST, time;
+
+drop table t_10400 cascade;
 
 RESET timescaledb.enable_direct_compress_insert;
 RESET timescaledb.batch_sorted_merge;


### PR DESCRIPTION
Fixes #10400.

We need to properly match NULL uncompressed tuples to compressed batches with NULL boundaries.
