### PR TITLE
Fix missing CAgg invalidations during MERGE UPDATE/DELETE

### DIFF
--- a/.unreleased/pr_10508
+++ b/.unreleased/pr_10508
@@ -1,0 +1,1 @@
+Fixes: #10508 Fix missing CAgg invalidations during MERGE UPDATE/DELETE

--- a/src/nodes/modify_hypertable_exec.c
+++ b/src/nodes/modify_hypertable_exec.c
@@ -3511,6 +3511,38 @@ lmerge_matched:;
 									   NULL,
 									   newslot);
 					mtstate->mt_merge_updated += 1;
+
+					if (context->ht_state->has_continuous_aggregate &&
+						!ts_guc_skip_cagg_invalidation)
+					{
+						Relation rel = resultRelInfo->ri_RelationDesc;
+						bool should_free_old = false, should_free_new = false;
+						TupleTableSlot *invalidation_slot =
+							table_slot_create(rel, NULL);
+						table_tuple_fetch_row_version(rel,
+													  tupleid,
+													  SnapshotAny,
+													  invalidation_slot);
+						HeapTuple old_ht =
+							ExecFetchSlotHeapTuple(invalidation_slot,
+												   false,
+												   &should_free_old);
+						HeapTuple new_ht =
+							ExecFetchSlotHeapTuple(newslot,
+												   false,
+												   &should_free_new);
+						ts_cm_functions->continuous_agg_dml_invalidate(
+							context->ht_state->ht->fd.id,
+							rel,
+							old_ht,
+							new_ht,
+							true);
+						if (should_free_old)
+							heap_freetuple(old_ht);
+						if (should_free_new)
+							heap_freetuple(new_ht);
+						ExecDropSingleTupleTableSlot(invalidation_slot);
+					}
 				}
 
 				break;
@@ -3532,6 +3564,32 @@ lmerge_matched:;
 				result = ExecDeleteAct(context, resultRelInfo, tupleid, false);
 				if (result == TM_Ok)
 				{
+					if (context->ht_state->has_continuous_aggregate &&
+						!ts_guc_skip_cagg_invalidation)
+					{
+						Relation rel = resultRelInfo->ri_RelationDesc;
+						bool should_free;
+						TupleTableSlot *cagg_slot =
+							table_slot_create(rel, NULL);
+						table_tuple_fetch_row_version(rel,
+													  tupleid,
+													  SnapshotAny,
+													  cagg_slot);
+						HeapTuple tuple =
+							ExecFetchSlotHeapTuple(cagg_slot,
+												   false,
+												   &should_free);
+						ts_cm_functions->continuous_agg_dml_invalidate(
+							context->ht_state->ht->fd.id,
+							rel,
+							tuple,
+							NULL,
+							false);
+						if (should_free)
+							heap_freetuple(tuple);
+						ExecDropSingleTupleTableSlot(cagg_slot);
+					}
+
 					ExecDeleteEpilogue(context, resultRelInfo, tupleid, NULL, false);
 					mtstate->mt_merge_deleted = 1;
 				}

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1926,8 +1926,14 @@ replace_modify_hypertable_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 					 * - INSERT actions need chunk tuple routing
 					 * - Compressed chunks need decompression for correct
 					 *   join evaluation of matched vs not-matched rows
+					 * - Continuous aggregates need invalidation for
+					 *   UPDATE/DELETE actions
 					 */
 					bool need_modify = (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
+					if (!need_modify && ht != NULL)
+					{
+						need_modify = ts_hypertable_has_continuous_aggregates(ht->fd.id);
+					}
 					if (!need_modify)
 					{
 						List *firstMergeActionList = linitial(mt->mergeActionLists);

--- a/tsl/test/expected/cagg_invalidation.out
+++ b/tsl/test/expected/cagg_invalidation.out
@@ -1999,4 +1999,104 @@ WHERE materialization_id = (SELECT mat_hypertable_id
 DROP MATERIALIZED VIEW tenant_copy_daily;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_32_94_chunk
 DROP TABLE tenant_copy;
+----------------------------------------------
+-- Test MERGE invalidations
+-- https://github.com/timescale/timescaledb/issues/10463
+----------------------------------------------
+-- MERGE UPDATE and DELETE on hypertables should
+-- generate continuous aggregate invalidations
+-- just like regular UPDATE and DELETE.
+CREATE TABLE merge_conditions (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('merge_conditions', 'time', chunk_time_interval => 10);
+       create_hypertable        
+--------------------------------
+ (33,public,merge_conditions,t)
+
+CREATE OR REPLACE FUNCTION merge_bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM merge_conditions
+$$;
+SELECT set_integer_now_func('merge_conditions', 'merge_bigint_now');
+ set_integer_now_func 
+----------------------
+ 
+
+CREATE MATERIALIZED VIEW merge_cond_10
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
+FROM merge_conditions
+GROUP BY 1,2 WITH NO DATA;
+SELECT raw_hypertable_id AS merge_raw_id, mat_hypertable_id AS merge_cagg_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'merge_cond_10' \gset
+-- Seed data and refresh to set the invalidation threshold
+INSERT INTO merge_conditions VALUES (1, 1, 10.0), (15, 1, 20.0), (25, 1, 30.0);
+CALL refresh_continuous_aggregate('merge_cond_10', NULL, NULL);
+-- Verify baseline materialized data
+SELECT * FROM merge_cond_10 ORDER BY 1, 2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |       10
+     10 |      1 |       20
+     20 |      1 |       30
+
+-- No invalidations should exist yet
+SELECT hyper_id, start, "end" FROM hyper_invals
+WHERE hyper_id = :merge_raw_id;
+ hyper_id | start | end 
+----------+-------+-----
+
+-- Create staging table and MERGE UPDATE a value
+CREATE TABLE merge_staging (time bigint NOT NULL, device int, temp float);
+INSERT INTO merge_staging VALUES (1, 1, 99.0);
+MERGE INTO merge_conditions AS t
+USING merge_staging AS s
+ON t.time = s.time AND t.device = s.device
+WHEN MATCHED THEN UPDATE SET temp = s.temp;
+-- Should see invalidation entry for the MERGE UPDATE
+SELECT hyper_id, start, "end" FROM hyper_invals
+WHERE hyper_id = :merge_raw_id;
+ hyper_id | start | end 
+----------+-------+-----
+       33 |     1 |   1
+
+-- Refresh and verify the cagg reflects the update
+CALL refresh_continuous_aggregate('merge_cond_10', NULL, NULL);
+SELECT * FROM merge_cond_10 ORDER BY 1, 2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |       99
+     10 |      1 |       20
+     20 |      1 |       30
+
+-- Now test MERGE DELETE
+DELETE FROM merge_staging;
+INSERT INTO merge_staging VALUES (15, 1, 20.0);
+MERGE INTO merge_conditions AS t
+USING merge_staging AS s
+ON t.time = s.time AND t.device = s.device
+WHEN MATCHED THEN DELETE;
+-- Should see invalidation entry for the MERGE DELETE
+SELECT hyper_id, start, "end" FROM hyper_invals
+WHERE hyper_id = :merge_raw_id;
+ hyper_id | start | end 
+----------+-------+-----
+       33 |    15 |  15
+
+-- Refresh and verify the deleted row is gone from the cagg
+CALL refresh_continuous_aggregate('merge_cond_10', NULL, NULL);
+SELECT * FROM merge_cond_10 ORDER BY 1, 2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |       99
+     20 |      1 |       30
+
+DROP TABLE merge_staging;
+DROP MATERIALIZED VIEW merge_cond_10;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_34_98_chunk
+DROP TABLE merge_conditions;
 RESET timezone;

--- a/tsl/test/sql/cagg_invalidation.sql
+++ b/tsl/test/sql/cagg_invalidation.sql
@@ -1279,4 +1279,84 @@ WHERE materialization_id = (SELECT mat_hypertable_id
 
 DROP MATERIALIZED VIEW tenant_copy_daily;
 DROP TABLE tenant_copy;
+
+----------------------------------------------
+-- Test MERGE invalidations
+-- https://github.com/timescale/timescaledb/issues/10463
+----------------------------------------------
+-- MERGE UPDATE and DELETE on hypertables should
+-- generate continuous aggregate invalidations
+-- just like regular UPDATE and DELETE.
+CREATE TABLE merge_conditions (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('merge_conditions', 'time', chunk_time_interval => 10);
+
+CREATE OR REPLACE FUNCTION merge_bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM merge_conditions
+$$;
+
+SELECT set_integer_now_func('merge_conditions', 'merge_bigint_now');
+
+CREATE MATERIALIZED VIEW merge_cond_10
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
+FROM merge_conditions
+GROUP BY 1,2 WITH NO DATA;
+
+SELECT raw_hypertable_id AS merge_raw_id, mat_hypertable_id AS merge_cagg_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'merge_cond_10' \gset
+
+-- Seed data and refresh to set the invalidation threshold
+INSERT INTO merge_conditions VALUES (1, 1, 10.0), (15, 1, 20.0), (25, 1, 30.0);
+CALL refresh_continuous_aggregate('merge_cond_10', NULL, NULL);
+
+-- Verify baseline materialized data
+SELECT * FROM merge_cond_10 ORDER BY 1, 2;
+
+-- No invalidations should exist yet
+SELECT hyper_id, start, "end" FROM hyper_invals
+WHERE hyper_id = :merge_raw_id;
+
+-- Create staging table and MERGE UPDATE a value
+CREATE TABLE merge_staging (time bigint NOT NULL, device int, temp float);
+INSERT INTO merge_staging VALUES (1, 1, 99.0);
+
+MERGE INTO merge_conditions AS t
+USING merge_staging AS s
+ON t.time = s.time AND t.device = s.device
+WHEN MATCHED THEN UPDATE SET temp = s.temp;
+
+-- Should see invalidation entry for the MERGE UPDATE
+SELECT hyper_id, start, "end" FROM hyper_invals
+WHERE hyper_id = :merge_raw_id;
+
+-- Refresh and verify the cagg reflects the update
+CALL refresh_continuous_aggregate('merge_cond_10', NULL, NULL);
+SELECT * FROM merge_cond_10 ORDER BY 1, 2;
+
+-- Now test MERGE DELETE
+DELETE FROM merge_staging;
+INSERT INTO merge_staging VALUES (15, 1, 20.0);
+
+MERGE INTO merge_conditions AS t
+USING merge_staging AS s
+ON t.time = s.time AND t.device = s.device
+WHEN MATCHED THEN DELETE;
+
+-- Should see invalidation entry for the MERGE DELETE
+SELECT hyper_id, start, "end" FROM hyper_invals
+WHERE hyper_id = :merge_raw_id;
+
+-- Refresh and verify the deleted row is gone from the cagg
+CALL refresh_continuous_aggregate('merge_cond_10', NULL, NULL);
+SELECT * FROM merge_cond_10 ORDER BY 1, 2;
+
+DROP TABLE merge_staging;
+DROP MATERIALIZED VIEW merge_cond_10;
+DROP TABLE merge_conditions;
 RESET timezone;


### PR DESCRIPTION
MERGE UPDATE/DELETE operations on hypertables did not generate CAgg invalidations. This fixes the missing invalidations by 1) integrating `continuous_agg_dml_invalidate` in the `ExecMerge` path and 2) modifying the planner code to use the custom ModifyHypertable path when the hypertable has continuous aggregates on it.

Fixes #10463 