### PR TITLE
Forbid batch sorted merge with sorting by sequence number

### DIFF
--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -53,7 +53,7 @@ typedef struct SortInfo
 {
 	List *required_compressed_pathkeys;
 	List *required_eq_classes;
-	bool needs_sequence_num;
+	bool needs_orderby_metadata;
 	bool use_compressed_sort; /* sort can be pushed below ColumnarScan */
 	bool use_batch_sorted_merge;
 	bool reverse;
@@ -78,7 +78,7 @@ static ColumnarScanPath *columnar_scan_path_create(PlannerInfo *root, const Comp
 
 static void columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info,
 										  const Chunk *chunk, RelOptInfo *chunk_rel,
-										  bool needs_sequence_num);
+										  bool needs_orderby_metadata);
 
 static SortInfo build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 							   const CompressionInfo *info, List *pathkeys);
@@ -247,7 +247,7 @@ build_compressed_scan_pathkeys(const SortInfo *sort_info, PlannerInfo *root, Lis
 	 * If pathkeys contains non-segmentby columns the rest of the ordering
 	 * requirements will be satisfied by ordering by the batch metadata columns.
 	 */
-	if (info->has_seq_num && sort_info->needs_sequence_num)
+	if (sort_info->needs_orderby_metadata && info->has_seq_num)
 	{
 		/* TODO: split up legacy sequence number path and non-sequence number path into dedicated
 		 * functions. */
@@ -287,7 +287,7 @@ build_compressed_scan_pathkeys(const SortInfo *sort_info, PlannerInfo *root, Lis
 
 		required_compressed_pathkeys = lappend(required_compressed_pathkeys, pk);
 	}
-	else if (sort_info->needs_sequence_num || sort_info->use_batch_sorted_merge)
+	else if (sort_info->needs_orderby_metadata || sort_info->use_batch_sorted_merge)
 	{
 		/* If there are no segmentby pathkeys, start from the beginning of the list */
 		if (info->num_segmentby_columns == 0)
@@ -1358,7 +1358,7 @@ ts_columnar_scan_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, const 
 								  compression_info,
 								  chunk,
 								  chunk_rel,
-								  sort_info.needs_sequence_num);
+								  sort_info.needs_orderby_metadata);
 
 	if (sort_info.use_compressed_sort || sort_info.use_batch_sorted_merge)
 	{
@@ -1616,7 +1616,7 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 			 */
 			ColumnarScanPath *path = (ColumnarScanPath *) chunk_path_no_sort;
 			path->reverse = sort_info->reverse;
-			path->needs_sequence_num = sort_info->needs_sequence_num;
+			path->needs_orderby_metadata = sort_info->needs_orderby_metadata;
 			path->required_compressed_pathkeys = sort_info->required_compressed_pathkeys;
 			path->custom_path.path.pathkeys = sort_info->decompressed_sort_pathkeys;
 
@@ -1633,7 +1633,7 @@ build_on_single_compressed_path(PlannerInfo *root, const Chunk *chunk, RelOptInf
 			ColumnarScanPath *path_copy =
 				copy_columnar_scan_path((ColumnarScanPath *) chunk_path_no_sort);
 			path_copy->reverse = sort_info->reverse;
-			path_copy->needs_sequence_num = sort_info->needs_sequence_num;
+			path_copy->needs_orderby_metadata = sort_info->needs_orderby_metadata;
 			path_copy->required_compressed_pathkeys = sort_info->required_compressed_pathkeys;
 			path_copy->custom_path.path.pathkeys = sort_info->decompressed_sort_pathkeys;
 
@@ -1934,7 +1934,7 @@ compressed_reltarget_add_var_for_column(RelOptInfo *compressed_rel, Oid compress
  */
 static void
 compressed_rel_setup_reltarget(RelOptInfo *compressed_rel, CompressionInfo *info,
-							   bool needs_sequence_num)
+							   bool needs_orderby_metadata)
 {
 	bool have_whole_row_var = false;
 	Bitmapset *attrs_used = NULL;
@@ -2020,7 +2020,7 @@ compressed_rel_setup_reltarget(RelOptInfo *compressed_rel, CompressionInfo *info
 											&attrs_used);
 
 	/* add the sequence number or orderby metadata columns if we try to order by them*/
-	if (needs_sequence_num)
+	if (needs_orderby_metadata)
 	{
 		if (info->has_seq_num)
 		{
@@ -3313,10 +3313,10 @@ build_sortinfo(PlannerInfo *root, const Chunk *chunk, RelOptInfo *chunk_rel,
 	}
 
 	/*
-	 * Pathkeys includes columns past segmentby columns, so we need sequence_num
+	 * Pathkeys includes columns past segmentby columns, so we need the orderby
 	 * in the targetlist for ordering.
 	 */
-	sort_info.needs_sequence_num = true;
+	sort_info.needs_orderby_metadata = true;
 
 	/*
 	 * loop over the rest of pathkeys

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -2486,7 +2486,7 @@ compressed_rel_setup_equivalence_classes(PlannerInfo *root, CompressionInfo *inf
  */
 static void
 columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Chunk *chunk,
-							  RelOptInfo *chunk_rel, bool needs_sequence_num)
+							  RelOptInfo *chunk_rel, bool needs_orderby_metadata)
 {
 	Index compressed_index = root->simple_rel_array_size;
 
@@ -2554,7 +2554,7 @@ columnar_scan_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, const Ch
 	}
 	table_close(r, NoLock);
 
-	compressed_rel_setup_reltarget(compressed_rel, info, needs_sequence_num);
+	compressed_rel_setup_reltarget(compressed_rel, info, needs_orderby_metadata);
 	compressed_rel_setup_equivalence_classes(root, info);
 	/* translate chunk_rel->joininfo for compressed_rel */
 	compressed_rel_setup_joininfo(compressed_rel, info);

--- a/tsl/src/nodes/columnar_scan/columnar_scan.c
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.c
@@ -245,246 +245,239 @@ build_compressed_scan_pathkeys(const SortInfo *sort_info, PlannerInfo *root, Lis
 
 	/*
 	 * If pathkeys contains non-segmentby columns the rest of the ordering
-	 * requirements will be satisfied by ordering by sequence_num.
+	 * requirements will be satisfied by ordering by the batch metadata columns.
 	 */
-	if (sort_info->needs_sequence_num || sort_info->use_batch_sorted_merge)
+	if (info->has_seq_num && sort_info->needs_sequence_num)
 	{
 		/* TODO: split up legacy sequence number path and non-sequence number path into dedicated
 		 * functions. */
-		if (info->has_seq_num)
+		bool nulls_first;
+		Oid sortop;
+		varattno =
+			get_attnum(info->compressed_rte->relid, COMPRESSION_COLUMN_METADATA_SEQUENCE_NUM_NAME);
+		var = makeVar(info->compressed_rel->relid, varattno, INT4OID, -1, InvalidOid, 0);
+
+		if (sort_info->reverse)
 		{
-			bool nulls_first;
-			Oid sortop;
-			varattno = get_attnum(info->compressed_rte->relid,
-								  COMPRESSION_COLUMN_METADATA_SEQUENCE_NUM_NAME);
-			var = makeVar(info->compressed_rel->relid, varattno, INT4OID, -1, InvalidOid, 0);
-
-			if (sort_info->reverse)
-			{
-				sortop = get_commutator(Int4LessOperator);
-				nulls_first = true;
-			}
-			else
-			{
-				sortop = Int4LessOperator;
-				nulls_first = false;
-			}
-
-			/*
-			 * Create the EquivalenceClass for the sequence number column of this
-			 * compressed chunk, so that we can build the PathKey that refers to it.
-			 */
-			EquivalenceClass *ec =
-				append_ec_for_seqnum(root, info, sort_info, var, sortop, nulls_first);
-
-			/* Find the operator in pg_amop --- failure shouldn't happen. */
-			Oid opfamily, opcintype;
-			CompareType strategy;
-			if (!get_ordering_op_properties(sortop, &opfamily, &opcintype, &strategy))
-			{
-				elog(ERROR, "operator %u is not a valid ordering operator", sortop);
-			}
-
-			pk = make_canonical_pathkey(root, ec, opfamily, strategy, nulls_first);
-
-			required_compressed_pathkeys = lappend(required_compressed_pathkeys, pk);
+			sortop = get_commutator(Int4LessOperator);
+			nulls_first = true;
 		}
 		else
 		{
-			/* If there are no segmentby pathkeys, start from the beginning of the list */
-			if (info->num_segmentby_columns == 0)
+			sortop = Int4LessOperator;
+			nulls_first = false;
+		}
+
+		/*
+		 * Create the EquivalenceClass for the sequence number column of this
+		 * compressed chunk, so that we can build the PathKey that refers to it.
+		 */
+		EquivalenceClass *ec =
+			append_ec_for_seqnum(root, info, sort_info, var, sortop, nulls_first);
+
+		/* Find the operator in pg_amop --- failure shouldn't happen. */
+		Oid opfamily, opcintype;
+		CompareType strategy;
+		if (!get_ordering_op_properties(sortop, &opfamily, &opcintype, &strategy))
+		{
+			elog(ERROR, "operator %u is not a valid ordering operator", sortop);
+		}
+
+		pk = make_canonical_pathkey(root, ec, opfamily, strategy, nulls_first);
+
+		required_compressed_pathkeys = lappend(required_compressed_pathkeys, pk);
+	}
+	else if (sort_info->needs_sequence_num || sort_info->use_batch_sorted_merge)
+	{
+		/* If there are no segmentby pathkeys, start from the beginning of the list */
+		if (info->num_segmentby_columns == 0)
+		{
+			lc = list_head(chunk_pathkeys);
+		}
+		Assert(lc != NULL);
+		Expr *expr;
+		char *column_name;
+		for (; lc != NULL; lc = lnext(chunk_pathkeys, lc))
+		{
+			pk = lfirst(lc);
+			EquivalenceMember *chunk_em = ts_find_em_for_rel(pk->pk_eclass, info->chunk_rel);
+
+			Assert(chunk_em);
+			expr = chunk_em->em_expr;
+			/*
+			 * Use em_datatype from the original equivalence member as the
+			 * opcintype. For polymorphic types like anyenum,
+			 * canonicalize_ec_expression will not add a RelabelType (it
+			 * replaces polymorphic req_type with the concrete type), so we
+			 * must explicitly pass the correct em_datatype to the metadata
+			 * column EC.
+			 */
+			Oid opcintype = chunk_em->em_datatype;
+			Oid collation = exprCollation((Node *) expr);
+			expr = (Expr *) strip_implicit_coercions((Node *) expr);
+			var = castNode(Var, expr);
+			Assert(var->varattno > 0);
+
+			column_name = get_attname(info->chunk_rte->relid, var->varattno, false);
+			int16 orderby_index = ts_array_position(info->settings->fd.orderby, column_name);
+			Assert(orderby_index != 0);
+
+			bool orderby_desc =
+				ts_array_get_element_bool(info->settings->fd.orderby_desc, orderby_index);
+
+			bool orderby_nullsfirst =
+				ts_array_get_element_bool(info->settings->fd.orderby_nullsfirst, orderby_index);
+
+			bool nulls_first;
+			CompareType strategy;
+
+			if (sort_info->reverse)
 			{
-				lc = list_head(chunk_pathkeys);
+				strategy = orderby_desc ? BTLessStrategyNumber : BTGreaterStrategyNumber;
+				nulls_first = !orderby_nullsfirst;
 			}
-			Assert(lc != NULL);
-			Expr *expr;
-			char *column_name;
-			for (; lc != NULL; lc = lnext(chunk_pathkeys, lc))
+			else
 			{
-				pk = lfirst(lc);
-				EquivalenceMember *chunk_em = ts_find_em_for_rel(pk->pk_eclass, info->chunk_rel);
+				strategy = orderby_desc ? BTGreaterStrategyNumber : BTLessStrategyNumber;
+				nulls_first = orderby_nullsfirst;
+			}
 
-				Assert(chunk_em);
-				expr = chunk_em->em_expr;
+			/* For Batch sorted merge we need to sort on specially chosen leading attribute for
+			 * each pathkey */
+			if (sort_info->use_batch_sorted_merge)
+			{
+				Oid sortop =
+					get_opfamily_member(pk->pk_opfamily, opcintype, opcintype, pk->pk_cmptype);
+				Oid opfamily, optype;
+				CompareType bsm_strategy;
+				if (!get_ordering_op_properties(sortop, &opfamily, &optype, &bsm_strategy))
+				{
+					elog(ERROR, "operator %u is not a valid ordering operator", sortop);
+				}
+				Assert(bsm_strategy == BTLessStrategyNumber ||
+					   bsm_strategy == BTGreaterStrategyNumber);
+				char *leading_name;
+				char *trailing_name;
+				orderby_sparse_metadata_names(info->settings,
+											  orderby_index,
+											  &leading_name,
+											  &trailing_name);
+				char *meta_col_name =
+					strategy == BTLessStrategyNumber ? leading_name : trailing_name;
+
+				AttrNumber attr_position = get_attnum(info->compressed_rte->relid, meta_col_name);
+
+				if (attr_position == InvalidAttrNumber)
+				{
+					elog(ERROR, "couldn't find metadata column \"%s\"", meta_col_name);
+				}
+				Var *metadata_var = makeVar(info->compressed_rel->relid,
+											attr_position,
+											var->vartype,
+											var->vartypmod,
+											var->varcollid,
+											var->varlevelsup);
+				Expr *leading_expr =
+					canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
+				EquivalenceClass *leading_ec =
+					append_ec_for_metadata_col(root, info, leading_expr, pk, opcintype);
+				PathKey *leading_pk = make_canonical_pathkey(root,
+															 leading_ec,
+															 pk->pk_opfamily,
+															 strategy,
+															 nulls_first);
+				required_compressed_pathkeys = lappend(required_compressed_pathkeys, leading_pk);
+			}
+			/* Need to sort on compressed pathkeys matching compressed indexscan order */
+			else
+			{
+				AttrNumber leading_attno;
+				AttrNumber trailing_attno;
+				orderby_sparse_metadata_attnos(info->settings,
+											   info->compressed_rte->relid,
+											   orderby_index,
+											   &leading_attno,
+											   &trailing_attno);
 				/*
-				 * Use em_datatype from the original equivalence member as the
-				 * opcintype. For polymorphic types like anyenum,
-				 * canonicalize_ec_expression will not add a RelabelType (it
-				 * replaces polymorphic req_type with the concrete type), so we
-				 * must explicitly pass the correct em_datatype to the metadata
-				 * column EC.
+				 * Compressed chunk indexes based on firstlast sparse indexes can have two
+				 * orderings. New chunks index them as (first, last); chunks compressed before
+				 * that change index a DESC column as (last, first). Only DESC columns can
+				 * differ, so for those we check the chunk's index and follow whichever order it
+				 * has.
 				 */
-				Oid opcintype = chunk_em->em_datatype;
-				Oid collation = exprCollation((Node *) expr);
-				expr = (Expr *) strip_implicit_coercions((Node *) expr);
-				var = castNode(Var, expr);
-				Assert(var->varattno > 0);
-
-				column_name = get_attname(info->chunk_rte->relid, var->varattno, false);
-				int16 orderby_index = ts_array_position(info->settings->fd.orderby, column_name);
-				Assert(orderby_index != 0);
-
-				bool orderby_desc =
-					ts_array_get_element_bool(info->settings->fd.orderby_desc, orderby_index);
-
-				bool orderby_nullsfirst =
-					ts_array_get_element_bool(info->settings->fd.orderby_nullsfirst, orderby_index);
-
-				bool nulls_first;
-				CompareType strategy;
-
-				if (sort_info->reverse)
+				if (orderby_desc &&
+					orderby_sparse_kind(info->settings, orderby_index) == ORDERBY_SPARSE_FIRSTLAST)
 				{
-					strategy = orderby_desc ? BTLessStrategyNumber : BTGreaterStrategyNumber;
-					nulls_first = !orderby_nullsfirst;
-				}
-				else
-				{
-					strategy = orderby_desc ? BTGreaterStrategyNumber : BTLessStrategyNumber;
-					nulls_first = orderby_nullsfirst;
-				}
+					orderby_firstlast_metadata_attnos(info->settings,
+													  info->compressed_rte->relid,
+													  orderby_index,
+													  &leading_attno,
+													  &trailing_attno);
 
-				/* For Batch sorted merge we need to sort on specially chosen leading attribute for
-				 * each pathkey */
-				if (sort_info->use_batch_sorted_merge)
-				{
-					Oid sortop =
-						get_opfamily_member(pk->pk_opfamily, opcintype, opcintype, pk->pk_cmptype);
-					Oid opfamily, optype;
-					CompareType bsm_strategy;
-					if (!get_ordering_op_properties(sortop, &opfamily, &optype, &bsm_strategy))
+					ListCell *index_lc;
+					foreach (index_lc, info->compressed_rel->indexlist)
 					{
-						elog(ERROR, "operator %u is not a valid ordering operator", sortop);
-					}
-					Assert(bsm_strategy == BTLessStrategyNumber ||
-						   bsm_strategy == BTGreaterStrategyNumber);
-					char *leading_name;
-					char *trailing_name;
-					orderby_sparse_metadata_names(info->settings,
-												  orderby_index,
-												  &leading_name,
-												  &trailing_name);
-					char *meta_col_name =
-						strategy == BTLessStrategyNumber ? leading_name : trailing_name;
-
-					AttrNumber attr_position =
-						get_attnum(info->compressed_rte->relid, meta_col_name);
-
-					if (attr_position == InvalidAttrNumber)
-					{
-						elog(ERROR, "couldn't find metadata column \"%s\"", meta_col_name);
-					}
-					Var *metadata_var = makeVar(info->compressed_rel->relid,
-												attr_position,
-												var->vartype,
-												var->vartypmod,
-												var->varcollid,
-												var->varlevelsup);
-					Expr *leading_expr =
-						canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
-					EquivalenceClass *leading_ec =
-						append_ec_for_metadata_col(root, info, leading_expr, pk, opcintype);
-					PathKey *leading_pk = make_canonical_pathkey(root,
-																 leading_ec,
-																 pk->pk_opfamily,
-																 strategy,
-																 nulls_first);
-					required_compressed_pathkeys =
-						lappend(required_compressed_pathkeys, leading_pk);
-				}
-				/* Need to sort on compressed pathkeys matching compressed indexscan order */
-				else
-				{
-					AttrNumber leading_attno;
-					AttrNumber trailing_attno;
-					orderby_sparse_metadata_attnos(info->settings,
-												   info->compressed_rte->relid,
-												   orderby_index,
-												   &leading_attno,
-												   &trailing_attno);
-					/*
-					 * Compressed chunk indexes based on firstlast sparse indexes can have two
-					 * orderings. New chunks index them as (first, last); chunks compressed before
-					 * that change index a DESC column as (last, first). Only DESC columns can
-					 * differ, so for those we check the chunk's index and follow whichever order it
-					 * has.
-					 */
-					if (orderby_desc && orderby_sparse_kind(info->settings, orderby_index) ==
-											ORDERBY_SPARSE_FIRSTLAST)
-					{
-						orderby_firstlast_metadata_attnos(info->settings,
-														  info->compressed_rte->relid,
-														  orderby_index,
-														  &leading_attno,
-														  &trailing_attno);
-
-						ListCell *index_lc;
-						foreach (index_lc, info->compressed_rel->indexlist)
+						IndexOptInfo *index = lfirst(index_lc);
+						int leading_pos = -1;
+						int trailing_pos = -1;
+						for (int k = 0; k < index->nkeycolumns; k++)
 						{
-							IndexOptInfo *index = lfirst(index_lc);
-							int leading_pos = -1;
-							int trailing_pos = -1;
-							for (int k = 0; k < index->nkeycolumns; k++)
+							if (index->indexkeys[k] == leading_attno)
 							{
-								if (index->indexkeys[k] == leading_attno)
-								{
-									leading_pos = k;
-								}
-								else if (index->indexkeys[k] == trailing_attno)
-								{
-									trailing_pos = k;
-								}
+								leading_pos = k;
 							}
-							if (leading_pos >= 0 && trailing_pos >= 0)
+							else if (index->indexkeys[k] == trailing_attno)
 							{
-								if (trailing_pos < leading_pos)
-								{
-									AttrNumber tmp = leading_attno;
-									leading_attno = trailing_attno;
-									trailing_attno = tmp;
-								}
-								break;
+								trailing_pos = k;
 							}
 						}
+						if (leading_pos >= 0 && trailing_pos >= 0)
+						{
+							if (trailing_pos < leading_pos)
+							{
+								AttrNumber tmp = leading_attno;
+								leading_attno = trailing_attno;
+								trailing_attno = tmp;
+							}
+							break;
+						}
 					}
-					Var *metadata_var;
-					metadata_var = makeVar(info->compressed_rel->relid,
-										   leading_attno,
-										   var->vartype,
-										   var->vartypmod,
-										   var->varcollid,
-										   var->varlevelsup);
-					Expr *leading_expr =
-						canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
-					EquivalenceClass *leading_ec =
-						append_ec_for_metadata_col(root, info, leading_expr, pk, opcintype);
-					PathKey *leading_pk = make_canonical_pathkey(root,
-																 leading_ec,
-																 pk->pk_opfamily,
-																 strategy,
-																 nulls_first);
-					required_compressed_pathkeys =
-						lappend(required_compressed_pathkeys, leading_pk);
-
-					metadata_var = makeVar(info->compressed_rel->relid,
-										   trailing_attno,
-										   var->vartype,
-										   var->vartypmod,
-										   var->varcollid,
-										   var->varlevelsup);
-					Expr *trailing_expr =
-						canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
-					EquivalenceClass *trailing_ec =
-						append_ec_for_metadata_col(root, info, trailing_expr, pk, opcintype);
-					PathKey *trailing_pk = make_canonical_pathkey(root,
-																  trailing_ec,
-																  pk->pk_opfamily,
-																  strategy,
-																  nulls_first);
-
-					required_compressed_pathkeys =
-						lappend(required_compressed_pathkeys, trailing_pk);
 				}
+				Var *metadata_var;
+				metadata_var = makeVar(info->compressed_rel->relid,
+									   leading_attno,
+									   var->vartype,
+									   var->vartypmod,
+									   var->varcollid,
+									   var->varlevelsup);
+				Expr *leading_expr =
+					canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
+				EquivalenceClass *leading_ec =
+					append_ec_for_metadata_col(root, info, leading_expr, pk, opcintype);
+				PathKey *leading_pk = make_canonical_pathkey(root,
+															 leading_ec,
+															 pk->pk_opfamily,
+															 strategy,
+															 nulls_first);
+				required_compressed_pathkeys = lappend(required_compressed_pathkeys, leading_pk);
+
+				metadata_var = makeVar(info->compressed_rel->relid,
+									   trailing_attno,
+									   var->vartype,
+									   var->vartypmod,
+									   var->varcollid,
+									   var->varlevelsup);
+				Expr *trailing_expr =
+					canonicalize_ec_expression((Expr *) metadata_var, opcintype, collation);
+				EquivalenceClass *trailing_ec =
+					append_ec_for_metadata_col(root, info, trailing_expr, pk, opcintype);
+				PathKey *trailing_pk = make_canonical_pathkey(root,
+															  trailing_ec,
+															  pk->pk_opfamily,
+															  strategy,
+															  nulls_first);
+
+				required_compressed_pathkeys = lappend(required_compressed_pathkeys, trailing_pk);
 			}
 		}
 	}

--- a/tsl/src/nodes/columnar_scan/columnar_scan.h
+++ b/tsl/src/nodes/columnar_scan/columnar_scan.h
@@ -57,7 +57,7 @@ typedef struct ColumnarScanPath
 	const CompressionInfo *info;
 
 	List *required_compressed_pathkeys;
-	bool needs_sequence_num;
+	bool needs_orderby_metadata;
 	bool reverse;
 	bool batch_sorted_merge;
 	bool enable_bulk_decompression;


### PR DESCRIPTION
This is not something that can work. Batch sorted merge needs ordering on the orderby column metadata. Not sure if it's still relevant, but there might be some very old chunks that still use sequence number.

The problem seems to be introduced here and not yet released: https://github.com/timescale/timescaledb/pull/10303 . No backport and no changelog entry therefore.

Disable-check: force-changelog-file

It's going to  be complicated to add a test for this in the CI, but I tested manually like this, compressing on 2.13 and then upgrading:
```
CREATE EXTENSION timescaledb VERSION '2.13.1';

CREATE TABLE grinder_temps(time timestamptz NOT NULL, grinder int);
SELECT create_hypertable('grinder_temps', 'time');
ALTER TABLE grinder_temps SET (timescaledb.compress,
    timescaledb.compress_segmentby = 'grinder',
    timescaledb.compress_orderby = 'time');
-- each grinder ran one shift; grinder 3 ran the earliest one
INSERT INTO grinder_temps
SELECT '2024-01-01'::timestamptz + interval '8 hours' * (3 - grinder)
       + interval '3 second' * reading, grinder
FROM generate_series(1, 3) grinder, generate_series(1, 2500) reading;
SELECT compress_chunk(show_chunks('grinder_temps'));
-- baseline: correctly returns the grinder 3 readings from 00:00
SELECT time, grinder FROM grinder_temps ORDER BY time LIMIT 5;

-- reconnect: the upgrade must run in a fresh session
\c
ALTER EXTENSION timescaledb UPDATE;

SELECT time, grinder FROM grinder_temps ORDER BY time LIMIT 5; -- returns grinder 2 rows from 08:00, expected grinder 3 rows from 00:00
```