### PR TITLE
Remove user_catalog back-and-forth when upgrading from before 2.28.0

### DIFF
--- a/sql/updates/2.27.2--2.28.0.sql
+++ b/sql/updates/2.27.2--2.28.0.sql
@@ -64,9 +64,6 @@ BEGIN
 END
 $$;
 
-ALTER TABLE _timescaledb_catalog.hypertable SET (user_catalog_table = true);
-ALTER TABLE _timescaledb_catalog.chunk SET (user_catalog_table = true);
-
 -- Add chunk_id to `_timescaledb_catalog.dimension_slice`
 CREATE TABLE _timescaledb_internal.tmp_dimension_slice AS
     SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/sql/updates/2.28.3--2.29.0.sql
+++ b/sql/updates/2.28.3--2.29.0.sql
@@ -111,7 +111,7 @@ CREATE TABLE _timescaledb_catalog.chunk (
   creation_time timestamptz NOT NULL,
   CONSTRAINT chunk_pkey PRIMARY KEY (id),
   CONSTRAINT chunk_relid_key UNIQUE (relid)
-) WITH (user_catalog_table = true);
+);
 
 INSERT INTO _timescaledb_catalog.chunk
   (id, relid, hypertable_id, status, osm_chunk, creation_time)

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -210,5 +210,13 @@ $$;
 --
 
 -- Remove the user_catalog_table option from the catalog tables.
-ALTER TABLE _timescaledb_catalog.hypertable RESET (user_catalog_table);
-ALTER TABLE _timescaledb_catalog.chunk RESET (user_catalog_table);
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_catalog.pg_class c WHERE oid = '_timescaledb_catalog.hypertable'::regclass AND 'user_catalog_table=true' = ANY(reloptions)) THEN
+    ALTER TABLE _timescaledb_catalog.hypertable RESET (user_catalog_table);
+  END IF;
+  IF EXISTS (SELECT FROM pg_catalog.pg_class c WHERE oid = '_timescaledb_catalog.chunk'::regclass AND 'user_catalog_table=true' = ANY(reloptions)) THEN
+    ALTER TABLE _timescaledb_catalog.chunk RESET (user_catalog_table);
+  END IF;
+END
+$$;


### PR DESCRIPTION
With TimescaleDB 2.28.0 we enabled user_catalog_table on chunk and
hypertable catalog table which we revert again in 2.30.0.
This patch skips the add / remove cycle for user_catalog_table when
coming from before 2.28.0 so extension update does not require logical
replication to be caught up.

Disable-check: force-changelog-file
