### PR TITLE
Fix RLS checks after dropping hypertable columns

### DIFF
--- a/.unreleased/pr_10515
+++ b/.unreleased/pr_10515
@@ -1,0 +1,1 @@
+Fixes: #10515 Fix RLS checks after dropping hypertable columns

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -392,7 +392,7 @@ adjust_projections(ResultRelInfo *ht_rri, ModifyTableState *mtstate, ChunkInsert
 		returningLists = mt->returningLists;
 	}
 
-	if (returningLists)
+	if (returningLists || ht_rri->ri_WithCheckOptions)
 	{
 		/*
 		 * We need the opposite map from cis->hyper_to_chunk_map. The map needs
@@ -401,7 +401,36 @@ adjust_projections(ResultRelInfo *ht_rri, ModifyTableState *mtstate, ChunkInsert
 		 */
 		chunk_map =
 			convert_tuples_by_name(RelationGetDescr(chunk_rel), RelationGetDescr(hyper_rel));
+	}
 
+	if (chunk_map && ht_rri->ri_WithCheckOptions)
+	{
+		MemoryContext old_context = MemoryContextSwitchTo(mtstate->ps.state->es_query_cxt);
+		List *wco_exprs = NIL;
+		ListCell *lc;
+		bool found_whole_row;
+		List *wco_list = castNode(List,
+								  map_variable_attnos((Node *) ht_rri->ri_WithCheckOptions,
+													  ht_rri->ri_RangeTableIndex,
+													  0,
+													  chunk_map->attrMap,
+													  rowtype,
+													  &found_whole_row));
+
+		/* Mirror PostgreSQL's ExecInitPartitionInfo(). */
+		foreach (lc, wco_list)
+		{
+			WithCheckOption *wco = lfirst_node(WithCheckOption, lc);
+			wco_exprs = lappend(wco_exprs, ExecInitQual(castNode(List, wco->qual), &mtstate->ps));
+		}
+
+		chunk_rri->ri_WithCheckOptions = wco_list;
+		chunk_rri->ri_WithCheckOptionExprs = wco_exprs;
+		MemoryContextSwitchTo(old_context);
+	}
+
+	if (returningLists)
+	{
 		chunk_rri->ri_projectReturning =
 			get_adjusted_projection_info_returning(chunk_rri->ri_projectReturning,
 												   linitial(returningLists),

--- a/test/expected/rowsecurity-16.out
+++ b/test/expected/rowsecurity-16.out
@@ -4318,18 +4318,24 @@ DROP TABLE r1;
 --
 SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
-CREATE TABLE r1 (a int);
+-- New chunks omit dropped hypertable columns, so their WCOs need remapped attnos.
+CREATE TABLE r1 (scratch text, a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
 
+ALTER TABLE r1 DROP COLUMN scratch;
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-CREATE POLICY p2 ON r1 FOR INSERT WITH CHECK (true);
+CREATE POLICY p2 ON r1 FOR INSERT
+    WITH CHECK (a > 0 AND a IN (SELECT generate_series(1, 100)));
 ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
 -- Works fine
 INSERT INTO r1 VALUES (10), (20);
+-- Error
+INSERT INTO r1 VALUES (-10);
+ERROR:  new row violates row-level security policy for table "r1"
 -- No error, but no rows
 TABLE r1;
  a 

--- a/test/expected/rowsecurity-17.out
+++ b/test/expected/rowsecurity-17.out
@@ -4318,18 +4318,24 @@ DROP TABLE r1;
 --
 SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
-CREATE TABLE r1 (a int);
+-- New chunks omit dropped hypertable columns, so their WCOs need remapped attnos.
+CREATE TABLE r1 (scratch text, a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
 
+ALTER TABLE r1 DROP COLUMN scratch;
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-CREATE POLICY p2 ON r1 FOR INSERT WITH CHECK (true);
+CREATE POLICY p2 ON r1 FOR INSERT
+    WITH CHECK (a > 0 AND a IN (SELECT generate_series(1, 100)));
 ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
 -- Works fine
 INSERT INTO r1 VALUES (10), (20);
+-- Error
+INSERT INTO r1 VALUES (-10);
+ERROR:  new row violates row-level security policy for table "r1"
 -- No error, but no rows
 TABLE r1;
  a 

--- a/test/expected/rowsecurity-18.out
+++ b/test/expected/rowsecurity-18.out
@@ -4320,18 +4320,24 @@ DROP TABLE r1;
 --
 SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
-CREATE TABLE r1 (a int);
+-- New chunks omit dropped hypertable columns, so their WCOs need remapped attnos.
+CREATE TABLE r1 (scratch text, a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
 
+ALTER TABLE r1 DROP COLUMN scratch;
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-CREATE POLICY p2 ON r1 FOR INSERT WITH CHECK (true);
+CREATE POLICY p2 ON r1 FOR INSERT
+    WITH CHECK (a > 0 AND a IN (SELECT generate_series(1, 100)));
 ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
 -- Works fine
 INSERT INTO r1 VALUES (10), (20);
+-- Error
+INSERT INTO r1 VALUES (-10);
+ERROR:  new row violates row-level security policy for table "r1"
 -- No error, but no rows
 TABLE r1;
  a 

--- a/test/expected/rowsecurity-19.out
+++ b/test/expected/rowsecurity-19.out
@@ -4321,18 +4321,24 @@ DROP TABLE r1;
 --
 SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
-CREATE TABLE r1 (a int);
+-- New chunks omit dropped hypertable columns, so their WCOs need remapped attnos.
+CREATE TABLE r1 (scratch text, a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
       create_hypertable       
 ------------------------------
  (29,regress_rls_schema,r1,t)
 
+ALTER TABLE r1 DROP COLUMN scratch;
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-CREATE POLICY p2 ON r1 FOR INSERT WITH CHECK (true);
+CREATE POLICY p2 ON r1 FOR INSERT
+    WITH CHECK (a > 0 AND a IN (SELECT generate_series(1, 100)));
 ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
 -- Works fine
 INSERT INTO r1 VALUES (10), (20);
+-- Error
+INSERT INTO r1 VALUES (-10);
+ERROR:  new row violates row-level security policy for table "r1"
 -- No error, but no rows
 TABLE r1;
  a 

--- a/test/sql/rowsecurity.sql.in
+++ b/test/sql/rowsecurity.sql.in
@@ -1720,16 +1720,22 @@ DROP TABLE r1;
 --
 SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
-CREATE TABLE r1 (a int);
+-- New chunks omit dropped hypertable columns, so their WCOs need remapped attnos.
+CREATE TABLE r1 (scratch text, a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
+ALTER TABLE r1 DROP COLUMN scratch;
 
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-CREATE POLICY p2 ON r1 FOR INSERT WITH CHECK (true);
+CREATE POLICY p2 ON r1 FOR INSERT
+    WITH CHECK (a > 0 AND a IN (SELECT generate_series(1, 100)));
 ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
 
 -- Works fine
 INSERT INTO r1 VALUES (10), (20);
+
+-- Error
+INSERT INTO r1 VALUES (-10);
 
 -- No error, but no rows
 TABLE r1;


### PR DESCRIPTION
Properly remap WCOs to chunk-local state when it differs from
hypertable layout.

Fixes: #10136
