### PR TITLE
Block granular refresh on materialization hypertable

### DIFF
--- a/.unreleased/pr_10517
+++ b/.unreleased/pr_10517
@@ -1,0 +1,1 @@
+Implements: #10517 Block granular refresh on materialization hypertable

--- a/tsl/src/process_utility.c
+++ b/tsl/src/process_utility.c
@@ -90,6 +90,18 @@ parse_granular_refresh_offset(WithClauseResult option, Oid time_type)
 void
 tsl_process_granular_refresh_options(Hypertable *ht, WithClauseResult *with_clause_options)
 {
+	if ((ts_continuous_agg_hypertable_status(ht->fd.id) & HypertableIsMaterialization) != 0)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("Granular refresh is not supported on a materialized hypertable"),
+				 errhint("Granular refresh tracking can only be configured on a hypertable "
+						 "that is not a continuous aggregate's internal materialization "
+						 "table."),
+				 errdetail("Hypertable \"%s\" is a materialized hypertable.",
+						   NameStr(ht->fd.table_name))));
+	}
+
 	bool set_column = !with_clause_options[AlterTableFlagGranularRefreshColumn].is_default;
 	bool set_start_offset =
 		!with_clause_options[AlterTableFlagGranularRefreshStartOffset].is_default;

--- a/tsl/test/expected/cagg_granular_refresh_hierarchical.out
+++ b/tsl/test/expected/cagg_granular_refresh_hierarchical.out
@@ -1,15 +1,10 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
--- Regression test: granular refresh with hierarchical continuous
+-- Regression test: granular refresh on hierarchical continuous
 -- aggregates.
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SET timezone TO 'UTC';
-SET timescaledb.current_timestamp_mock = '2025-01-10 00:00:00+00';
--- Anchor the start offset safely before the fixed 2020 fixture dates below,
--- computed relative to today so the window keeps covering them regardless
--- of when this test actually runs.
-SELECT (CURRENT_DATE - DATE '2019-01-01')::text || ' days' AS granular_refresh_lookback \gset
 ----------------------------------------------------------------------
 -- Base hypertable + granular refresh + base cagg
 ----------------------------------------------------------------------
@@ -21,7 +16,7 @@ SELECT create_hypertable('sensors', 'time', chunk_time_interval => '1 day'::inte
 
 ALTER TABLE sensors SET (
     timescaledb.granular_refresh_column = 'sensor_id',
-    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_start_offset = '1 day',
     timescaledb.granular_refresh_end_offset = '1 hour'
 );
 CREATE MATERIALIZED VIEW sensors_hourly
@@ -47,74 +42,31 @@ JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
 WHERE ca.user_view_name = 'sensors_hourly' \gset
 ----------------------------------------------------------------------
 -- Attempt to enable granular refresh directly on the materialization
--- hypertable. NOT blocked: this succeeds like it would on any other
--- hypertable.
+-- hypertable. BLOCKED: ALTER TABLE is blocked if run on a
+-- continuous aggregate's materialization hypertable.
 ----------------------------------------------------------------------
+\set ON_ERROR_STOP 0
 ALTER TABLE :mat_ht_qualified SET (
     timescaledb.granular_refresh_column = 'sensor_id',
-    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_start_offset = '1 day',
     timescaledb.granular_refresh_end_offset = '1 hour'
 );
-SELECT h.table_name, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset
-FROM _timescaledb_catalog.hypertable_cagg_settings s
-JOIN _timescaledb_catalog.hypertable h ON h.id = s.hypertable_id
-ORDER BY h.id;
-         table_name         | granular_refresh_column | granular_refresh_start_offset | granular_refresh_end_offset 
-----------------------------+-------------------------+-------------------------------+-----------------------------
- sensors                    | sensor_id               | 2799 days                     | 1 hour
- _materialized_hypertable_2 | sensor_id               | 2799 days                     | 1 hour
-
+ERROR:  Granular refresh is not supported on a materialized hypertable
+\set ON_ERROR_STOP 1
 ----------------------------------------------------------------------
--- Create a hierarchical cagg on top of sensors_hourly and enable granular
--- refresh on it. NOT blocked: the "only one cagg per hypertable" guard
--- keys off raw_hypertable_id, and this cagg's raw_hypertable_id is the
--- materialization hypertable configured above, distinct from
--- sensors_hourly's own raw_hypertable_id (sensors).
+-- Attempt to enable granular refresh on a hierarchical CAgg
+-- BLOCKED: Errors since it is not configured on the hypertable
 ----------------------------------------------------------------------
 CREATE MATERIALIZED VIEW sensors_daily
 WITH (timescaledb.continuous) AS
-SELECT time_bucket('1 day'::interval, bucket) AS bucket, sensor_id, avg(avg_temp) AS avg_temp
+SELECT time_bucket('1 day', bucket) AS bucket, sensor_id, count(avg_temp) AS avg_temp
 FROM sensors_hourly
-GROUP BY 1, sensor_id
+GROUP BY 1, 2
 WITH NO DATA;
-SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
-FROM _timescaledb_catalog.continuous_agg
-WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
-ORDER BY user_view_name;
- user_view_name | raw_hypertable_id | parent_mat_hypertable_id | granular_refresh_enabled 
-----------------+-------------------+--------------------------+--------------------------
- sensors_daily  |                 2 |                        2 | f
- sensors_hourly |                 1 |                          | t
-
+\set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW sensors_daily SET (timescaledb.enable_granular_refresh = true);
-SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
-FROM _timescaledb_catalog.continuous_agg
-WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
-ORDER BY user_view_name;
- user_view_name | raw_hypertable_id | parent_mat_hypertable_id | granular_refresh_enabled 
-----------------+-------------------+--------------------------+--------------------------
- sensors_daily  |                 2 |                        2 | t
- sensors_hourly |                 1 |                          | t
-
-----------------------------------------------------------------------
--- Verify that granular refresh is used when refreshing the hierarchical cagg
-----------------------------------------------------------------------
-INSERT INTO sensors VALUES
-  ('2020-01-01 00:00+00', 1, 10),
-  ('2020-01-01 00:00+00', 2, 999);
-INSERT INTO sensors VALUES ('2025-01-01 00:00+00', 9, 0);
--- Baseline: first-ever materialization of this window is untracked
--- (seqnum 0), so it takes the full-refresh path for both tenants.
-CALL refresh_continuous_aggregate('sensors_hourly', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
-CALL refresh_continuous_aggregate('sensors_daily', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
-SELECT bucket, sensor_id, avg_temp FROM sensors_daily ORDER BY sensor_id;
-            bucket            | sensor_id | avg_temp 
-------------------------------+-----------+----------
- Wed Jan 01 00:00:00 2020 UTC |         1 |       10
- Wed Jan 01 00:00:00 2020 UTC |         2 |      999
-
+ERROR:  granular refresh is not configured on the hypertable
+\set ON_ERROR_STOP 1
 DROP MATERIALIZED VIEW sensors_daily;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 DROP MATERIALIZED VIEW sensors_hourly;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
 DROP TABLE sensors;

--- a/tsl/test/expected/cagg_granular_refresh_hierarchical.out
+++ b/tsl/test/expected/cagg_granular_refresh_hierarchical.out
@@ -1,0 +1,120 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Regression test: granular refresh with hierarchical continuous
+-- aggregates.
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SET timezone TO 'UTC';
+SET timescaledb.current_timestamp_mock = '2025-01-10 00:00:00+00';
+-- Anchor the start offset safely before the fixed 2020 fixture dates below,
+-- computed relative to today so the window keeps covering them regardless
+-- of when this test actually runs.
+SELECT (CURRENT_DATE - DATE '2019-01-01')::text || ' days' AS granular_refresh_lookback \gset
+----------------------------------------------------------------------
+-- Base hypertable + granular refresh + base cagg
+----------------------------------------------------------------------
+CREATE TABLE sensors (time timestamptz NOT NULL, sensor_id integer, temp float8);
+SELECT create_hypertable('sensors', 'time', chunk_time_interval => '1 day'::interval);
+  create_hypertable   
+----------------------
+ (1,public,sensors,t)
+
+ALTER TABLE sensors SET (
+    timescaledb.granular_refresh_column = 'sensor_id',
+    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_end_offset = '1 hour'
+);
+CREATE MATERIALIZED VIEW sensors_hourly
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', time) AS bucket, sensor_id, avg(temp) AS avg_temp
+FROM sensors
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+ALTER MATERIALIZED VIEW sensors_hourly SET (timescaledb.enable_granular_refresh = true);
+SELECT user_view_name, raw_hypertable_id, granular_refresh_enabled
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'sensors_hourly';
+ user_view_name | raw_hypertable_id | granular_refresh_enabled 
+----------------+-------------------+--------------------------
+ sensors_hourly |                 1 | t
+
+----------------------------------------------------------------------
+-- Locate the internal materialization hypertable backing sensors_hourly.
+----------------------------------------------------------------------
+SELECT format('%I.%I', h.schema_name, h.table_name) AS mat_ht_qualified, h.id AS mat_ht_id
+FROM _timescaledb_catalog.continuous_agg ca
+JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+WHERE ca.user_view_name = 'sensors_hourly' \gset
+----------------------------------------------------------------------
+-- Attempt to enable granular refresh directly on the materialization
+-- hypertable. NOT blocked: this succeeds like it would on any other
+-- hypertable.
+----------------------------------------------------------------------
+ALTER TABLE :mat_ht_qualified SET (
+    timescaledb.granular_refresh_column = 'sensor_id',
+    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_end_offset = '1 hour'
+);
+SELECT h.table_name, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset
+FROM _timescaledb_catalog.hypertable_cagg_settings s
+JOIN _timescaledb_catalog.hypertable h ON h.id = s.hypertable_id
+ORDER BY h.id;
+         table_name         | granular_refresh_column | granular_refresh_start_offset | granular_refresh_end_offset 
+----------------------------+-------------------------+-------------------------------+-----------------------------
+ sensors                    | sensor_id               | 2799 days                     | 1 hour
+ _materialized_hypertable_2 | sensor_id               | 2799 days                     | 1 hour
+
+----------------------------------------------------------------------
+-- Create a hierarchical cagg on top of sensors_hourly and enable granular
+-- refresh on it. NOT blocked: the "only one cagg per hypertable" guard
+-- keys off raw_hypertable_id, and this cagg's raw_hypertable_id is the
+-- materialization hypertable configured above, distinct from
+-- sensors_hourly's own raw_hypertable_id (sensors).
+----------------------------------------------------------------------
+CREATE MATERIALIZED VIEW sensors_daily
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day'::interval, bucket) AS bucket, sensor_id, avg(avg_temp) AS avg_temp
+FROM sensors_hourly
+GROUP BY 1, sensor_id
+WITH NO DATA;
+SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
+ORDER BY user_view_name;
+ user_view_name | raw_hypertable_id | parent_mat_hypertable_id | granular_refresh_enabled 
+----------------+-------------------+--------------------------+--------------------------
+ sensors_daily  |                 2 |                        2 | f
+ sensors_hourly |                 1 |                          | t
+
+ALTER MATERIALIZED VIEW sensors_daily SET (timescaledb.enable_granular_refresh = true);
+SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
+ORDER BY user_view_name;
+ user_view_name | raw_hypertable_id | parent_mat_hypertable_id | granular_refresh_enabled 
+----------------+-------------------+--------------------------+--------------------------
+ sensors_daily  |                 2 |                        2 | t
+ sensors_hourly |                 1 |                          | t
+
+----------------------------------------------------------------------
+-- Verify that granular refresh is used when refreshing the hierarchical cagg
+----------------------------------------------------------------------
+INSERT INTO sensors VALUES
+  ('2020-01-01 00:00+00', 1, 10),
+  ('2020-01-01 00:00+00', 2, 999);
+INSERT INTO sensors VALUES ('2025-01-01 00:00+00', 9, 0);
+-- Baseline: first-ever materialization of this window is untracked
+-- (seqnum 0), so it takes the full-refresh path for both tenants.
+CALL refresh_continuous_aggregate('sensors_hourly', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
+CALL refresh_continuous_aggregate('sensors_daily', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
+SELECT bucket, sensor_id, avg_temp FROM sensors_daily ORDER BY sensor_id;
+            bucket            | sensor_id | avg_temp 
+------------------------------+-----------+----------
+ Wed Jan 01 00:00:00 2020 UTC |         1 |       10
+ Wed Jan 01 00:00:00 2020 UTC |         2 |      999
+
+DROP MATERIALIZED VIEW sensors_daily;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
+DROP MATERIALIZED VIEW sensors_hourly;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
+DROP TABLE sensors;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -132,7 +132,8 @@ if(TMP_ENABLE_GRANULAR_REFRESH_TESTS)
     cagg_granular_refresh_api.sql
     cagg_granular_refresh_coltypes.sql
     cagg_granular_refresh_fallback.sql
-    cagg_granular_refresh_garbage_collector.sql)
+    cagg_granular_refresh_garbage_collector.sql
+    cagg_granular_refresh_hierarchical.sql)
 
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     list(APPEND TEST_FILES cagg_granular_refresh_errors.sql

--- a/tsl/test/sql/cagg_granular_refresh_hierarchical.sql
+++ b/tsl/test/sql/cagg_granular_refresh_hierarchical.sql
@@ -1,0 +1,115 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Regression test: granular refresh with hierarchical continuous
+-- aggregates.
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SET timezone TO 'UTC';
+SET timescaledb.current_timestamp_mock = '2025-01-10 00:00:00+00';
+
+-- Anchor the start offset safely before the fixed 2020 fixture dates below,
+-- computed relative to today so the window keeps covering them regardless
+-- of when this test actually runs.
+SELECT (CURRENT_DATE - DATE '2019-01-01')::text || ' days' AS granular_refresh_lookback \gset
+
+----------------------------------------------------------------------
+-- Base hypertable + granular refresh + base cagg
+----------------------------------------------------------------------
+
+CREATE TABLE sensors (time timestamptz NOT NULL, sensor_id integer, temp float8);
+SELECT create_hypertable('sensors', 'time', chunk_time_interval => '1 day'::interval);
+
+ALTER TABLE sensors SET (
+    timescaledb.granular_refresh_column = 'sensor_id',
+    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_end_offset = '1 hour'
+);
+
+CREATE MATERIALIZED VIEW sensors_hourly
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', time) AS bucket, sensor_id, avg(temp) AS avg_temp
+FROM sensors
+GROUP BY bucket, sensor_id
+WITH NO DATA;
+
+ALTER MATERIALIZED VIEW sensors_hourly SET (timescaledb.enable_granular_refresh = true);
+
+SELECT user_view_name, raw_hypertable_id, granular_refresh_enabled
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'sensors_hourly';
+
+----------------------------------------------------------------------
+-- Locate the internal materialization hypertable backing sensors_hourly.
+----------------------------------------------------------------------
+
+SELECT format('%I.%I', h.schema_name, h.table_name) AS mat_ht_qualified, h.id AS mat_ht_id
+FROM _timescaledb_catalog.continuous_agg ca
+JOIN _timescaledb_catalog.hypertable h ON h.id = ca.mat_hypertable_id
+WHERE ca.user_view_name = 'sensors_hourly' \gset
+
+----------------------------------------------------------------------
+-- Attempt to enable granular refresh directly on the materialization
+-- hypertable. NOT blocked: this succeeds like it would on any other
+-- hypertable.
+----------------------------------------------------------------------
+
+ALTER TABLE :mat_ht_qualified SET (
+    timescaledb.granular_refresh_column = 'sensor_id',
+    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_end_offset = '1 hour'
+);
+
+SELECT h.table_name, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset
+FROM _timescaledb_catalog.hypertable_cagg_settings s
+JOIN _timescaledb_catalog.hypertable h ON h.id = s.hypertable_id
+ORDER BY h.id;
+
+----------------------------------------------------------------------
+-- Create a hierarchical cagg on top of sensors_hourly and enable granular
+-- refresh on it. NOT blocked: the "only one cagg per hypertable" guard
+-- keys off raw_hypertable_id, and this cagg's raw_hypertable_id is the
+-- materialization hypertable configured above, distinct from
+-- sensors_hourly's own raw_hypertable_id (sensors).
+----------------------------------------------------------------------
+
+CREATE MATERIALIZED VIEW sensors_daily
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day'::interval, bucket) AS bucket, sensor_id, avg(avg_temp) AS avg_temp
+FROM sensors_hourly
+GROUP BY 1, sensor_id
+WITH NO DATA;
+
+SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
+ORDER BY user_view_name;
+
+ALTER MATERIALIZED VIEW sensors_daily SET (timescaledb.enable_granular_refresh = true);
+
+SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
+ORDER BY user_view_name;
+
+----------------------------------------------------------------------
+-- Verify that granular refresh is used when refreshing the hierarchical cagg
+----------------------------------------------------------------------
+
+INSERT INTO sensors VALUES
+  ('2020-01-01 00:00+00', 1, 10),
+  ('2020-01-01 00:00+00', 2, 999);
+INSERT INTO sensors VALUES ('2025-01-01 00:00+00', 9, 0);
+
+-- Baseline: first-ever materialization of this window is untracked
+-- (seqnum 0), so it takes the full-refresh path for both tenants.
+CALL refresh_continuous_aggregate('sensors_hourly', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
+CALL refresh_continuous_aggregate('sensors_daily', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
+
+SELECT bucket, sensor_id, avg_temp FROM sensors_daily ORDER BY sensor_id;
+
+DROP MATERIALIZED VIEW sensors_daily;
+DROP MATERIALIZED VIEW sensors_hourly;
+DROP TABLE sensors;

--- a/tsl/test/sql/cagg_granular_refresh_hierarchical.sql
+++ b/tsl/test/sql/cagg_granular_refresh_hierarchical.sql
@@ -2,18 +2,12 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
--- Regression test: granular refresh with hierarchical continuous
+-- Regression test: granular refresh on hierarchical continuous
 -- aggregates.
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 SET timezone TO 'UTC';
-SET timescaledb.current_timestamp_mock = '2025-01-10 00:00:00+00';
-
--- Anchor the start offset safely before the fixed 2020 fixture dates below,
--- computed relative to today so the window keeps covering them regardless
--- of when this test actually runs.
-SELECT (CURRENT_DATE - DATE '2019-01-01')::text || ' days' AS granular_refresh_lookback \gset
 
 ----------------------------------------------------------------------
 -- Base hypertable + granular refresh + base cagg
@@ -24,7 +18,7 @@ SELECT create_hypertable('sensors', 'time', chunk_time_interval => '1 day'::inte
 
 ALTER TABLE sensors SET (
     timescaledb.granular_refresh_column = 'sensor_id',
-    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_start_offset = '1 day',
     timescaledb.granular_refresh_end_offset = '1 hour'
 );
 
@@ -52,63 +46,33 @@ WHERE ca.user_view_name = 'sensors_hourly' \gset
 
 ----------------------------------------------------------------------
 -- Attempt to enable granular refresh directly on the materialization
--- hypertable. NOT blocked: this succeeds like it would on any other
--- hypertable.
+-- hypertable. BLOCKED: ALTER TABLE is blocked if run on a
+-- continuous aggregate's materialization hypertable.
 ----------------------------------------------------------------------
 
+\set ON_ERROR_STOP 0
 ALTER TABLE :mat_ht_qualified SET (
     timescaledb.granular_refresh_column = 'sensor_id',
-    timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
+    timescaledb.granular_refresh_start_offset = '1 day',
     timescaledb.granular_refresh_end_offset = '1 hour'
 );
-
-SELECT h.table_name, granular_refresh_column, granular_refresh_start_offset, granular_refresh_end_offset
-FROM _timescaledb_catalog.hypertable_cagg_settings s
-JOIN _timescaledb_catalog.hypertable h ON h.id = s.hypertable_id
-ORDER BY h.id;
+\set ON_ERROR_STOP 1
 
 ----------------------------------------------------------------------
--- Create a hierarchical cagg on top of sensors_hourly and enable granular
--- refresh on it. NOT blocked: the "only one cagg per hypertable" guard
--- keys off raw_hypertable_id, and this cagg's raw_hypertable_id is the
--- materialization hypertable configured above, distinct from
--- sensors_hourly's own raw_hypertable_id (sensors).
+-- Attempt to enable granular refresh on a hierarchical CAgg
+-- BLOCKED: Errors since it is not configured on the hypertable
 ----------------------------------------------------------------------
 
 CREATE MATERIALIZED VIEW sensors_daily
 WITH (timescaledb.continuous) AS
-SELECT time_bucket('1 day'::interval, bucket) AS bucket, sensor_id, avg(avg_temp) AS avg_temp
+SELECT time_bucket('1 day', bucket) AS bucket, sensor_id, count(avg_temp) AS avg_temp
 FROM sensors_hourly
-GROUP BY 1, sensor_id
+GROUP BY 1, 2
 WITH NO DATA;
 
-SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
-FROM _timescaledb_catalog.continuous_agg
-WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
-ORDER BY user_view_name;
-
+\set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW sensors_daily SET (timescaledb.enable_granular_refresh = true);
-
-SELECT user_view_name, raw_hypertable_id, parent_mat_hypertable_id, granular_refresh_enabled
-FROM _timescaledb_catalog.continuous_agg
-WHERE user_view_name IN ('sensors_hourly', 'sensors_daily')
-ORDER BY user_view_name;
-
-----------------------------------------------------------------------
--- Verify that granular refresh is used when refreshing the hierarchical cagg
-----------------------------------------------------------------------
-
-INSERT INTO sensors VALUES
-  ('2020-01-01 00:00+00', 1, 10),
-  ('2020-01-01 00:00+00', 2, 999);
-INSERT INTO sensors VALUES ('2025-01-01 00:00+00', 9, 0);
-
--- Baseline: first-ever materialization of this window is untracked
--- (seqnum 0), so it takes the full-refresh path for both tenants.
-CALL refresh_continuous_aggregate('sensors_hourly', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
-CALL refresh_continuous_aggregate('sensors_daily', '2020-01-01 00:00+00', '2020-01-02 00:00+00');
-
-SELECT bucket, sensor_id, avg_temp FROM sensors_daily ORDER BY sensor_id;
+\set ON_ERROR_STOP 1
 
 DROP MATERIALIZED VIEW sensors_daily;
 DROP MATERIALIZED VIEW sensors_hourly;


### PR DESCRIPTION
Blocks the ALTER TABLE ... command to enable granular refresh if the specified hypertable is the materialization hypertable of a continuous aggregate.