### PR TITLE
Account for cost of sorting children when copying a ChunkAppend path

### DIFF
--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -100,6 +100,9 @@ ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths, PathTarget *patht
 			cost_sort(&sort_path,
 					  /* root = */ NULL,
 					  pathkeys,
+#if PG18_GE
+					  child->disabled_nodes,
+#endif
 					  child->total_cost,
 					  child->rows,
 					  child->pathtarget->width,

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -5,6 +5,7 @@
  */
 #include <postgres.h>
 #include <nodes/nodeFuncs.h>
+#include <optimizer/cost.h>
 #include <optimizer/optimizer.h>
 #include <optimizer/pathnode.h>
 #include <optimizer/paths.h>
@@ -73,7 +74,10 @@ ChunkAppendPath *
 ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths, PathTarget *pathtarget)
 {
 	ListCell *lc;
-	double total_cost = 0, rows = 0;
+	double startup_cost = 0;
+	double total_cost = 0;
+	double rows = 0;
+	List *pathkeys = ca->cpath.path.pathkeys;
 	ChunkAppendPath *new = palloc(sizeof(ChunkAppendPath));
 	memcpy(new, ca, sizeof(ChunkAppendPath));
 	new->cpath.custom_paths = subpaths;
@@ -84,12 +88,38 @@ ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths, PathTarget *patht
 	foreach (lc, subpaths)
 	{
 		Path *child = lfirst(lc);
-		total_cost += child->total_cost;
+
+		/*
+		 * cost_append() accounts for the cost of sorting the children separately,
+		 * so here we must follow this logic.
+		 */
+		if (pathkeys != NIL && !pathkeys_contained_in(pathkeys, child->pathkeys))
+		{
+			Path sort_path; /* dummy for result of cost_sort */
+
+			cost_sort(&sort_path,
+					  /* root = */ NULL,
+					  pathkeys,
+					  child->total_cost,
+					  child->rows,
+					  child->pathtarget->width,
+					  0.0,
+					  work_mem,
+					  /* limit_tuples = */ -1);
+			startup_cost += sort_path.startup_cost;
+			total_cost += sort_path.total_cost;
+		}
+		else
+		{
+			startup_cost += child->startup_cost;
+			total_cost += child->total_cost;
+		}
 		rows += child->rows;
 #if PG18_GE
 		disabled_nodes += child->disabled_nodes;
 #endif
 	}
+	new->cpath.path.startup_cost = startup_cost;
 	new->cpath.path.total_cost = total_cost;
 	new->cpath.path.rows = rows;
 #if PG18_GE

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -560,3 +560,81 @@ RESET enable_seqscan;
 RESET random_page_cost;
 RESET cpu_operator_cost;
 RESET enable_hashagg;
+-- Chunkwise aggregation must account for the cost of sorting the per-chunk
+-- partially aggregated results.
+SET enable_seqscan = OFF;
+CREATE TABLE sensor_readings(ts bigint NOT NULL, sensor_id bigint);
+SELECT create_hypertable('sensor_readings', 'ts', chunk_time_interval => 1000);
+      create_hypertable       
+------------------------------
+ (4,public,sensor_readings,t)
+
+INSERT INTO sensor_readings
+SELECT g, g % 7 FROM generate_series(1, 3000) g;
+VACUUM ANALYZE sensor_readings;
+SELECT ts, sensor_id, count(*) FROM sensor_readings
+GROUP BY ts, sensor_id ORDER BY ts, sensor_id LIMIT 5;
+ ts | sensor_id | count 
+----+-----------+-------
+  1 |         1 |     1
+  2 |         2 |     1
+  3 |         3 |     1
+  4 |         4 |     1
+  5 |         5 |     1
+
+:PREFIX
+SELECT ts, sensor_id, count(*) FROM sensor_readings
+GROUP BY ts, sensor_id ORDER BY ts, sensor_id LIMIT 5;
+--- QUERY PLAN ---
+ Limit (actual rows=5.00 loops=1)
+   Output: sensor_readings.ts, sensor_readings.sensor_id, (count(*))
+   ->  Finalize GroupAggregate (actual rows=5.00 loops=1)
+         Output: sensor_readings.ts, sensor_readings.sensor_id, count(*)
+         Group Key: sensor_readings.ts, sensor_readings.sensor_id
+         ->  Sort (actual rows=6.00 loops=1)
+               Output: sensor_readings.ts, sensor_readings.sensor_id, (PARTIAL count(*))
+               Sort Key: sensor_readings.ts, sensor_readings.sensor_id
+               Sort Method: quicksort 
+               ->  Custom Scan (ChunkAppend) on public.sensor_readings (actual rows=3000.00 loops=1)
+                     Output: sensor_readings.ts, sensor_readings.sensor_id, (PARTIAL count(*))
+                     Order: sensor_readings.ts
+                     Startup Exclusion: false
+                     Runtime Exclusion: false
+                     ->  Partial GroupAggregate (actual rows=999.00 loops=1)
+                           Output: _hyper_4_17_chunk.ts, _hyper_4_17_chunk.sensor_id, PARTIAL count(*)
+                           Group Key: _hyper_4_17_chunk.ts, _hyper_4_17_chunk.sensor_id
+                           ->  Sort (actual rows=999.00 loops=1)
+                                 Output: _hyper_4_17_chunk.ts, _hyper_4_17_chunk.sensor_id
+                                 Sort Key: _hyper_4_17_chunk.ts, _hyper_4_17_chunk.sensor_id
+                                 Sort Method: quicksort 
+                                 ->  Index Scan Backward using _hyper_4_17_chunk_sensor_readings_ts_idx on _timescaledb_internal._hyper_4_17_chunk (actual rows=999.00 loops=1)
+                                       Output: _hyper_4_17_chunk.ts, _hyper_4_17_chunk.sensor_id
+                     ->  Partial GroupAggregate (actual rows=1000.00 loops=1)
+                           Output: _hyper_4_18_chunk.ts, _hyper_4_18_chunk.sensor_id, PARTIAL count(*)
+                           Group Key: _hyper_4_18_chunk.ts, _hyper_4_18_chunk.sensor_id
+                           ->  Sort (actual rows=1000.00 loops=1)
+                                 Output: _hyper_4_18_chunk.ts, _hyper_4_18_chunk.sensor_id
+                                 Sort Key: _hyper_4_18_chunk.ts, _hyper_4_18_chunk.sensor_id
+                                 Sort Method: quicksort 
+                                 ->  Index Scan Backward using _hyper_4_18_chunk_sensor_readings_ts_idx on _timescaledb_internal._hyper_4_18_chunk (actual rows=1000.00 loops=1)
+                                       Output: _hyper_4_18_chunk.ts, _hyper_4_18_chunk.sensor_id
+                     ->  Partial GroupAggregate (actual rows=1000.00 loops=1)
+                           Output: _hyper_4_19_chunk.ts, _hyper_4_19_chunk.sensor_id, PARTIAL count(*)
+                           Group Key: _hyper_4_19_chunk.ts, _hyper_4_19_chunk.sensor_id
+                           ->  Sort (actual rows=1000.00 loops=1)
+                                 Output: _hyper_4_19_chunk.ts, _hyper_4_19_chunk.sensor_id
+                                 Sort Key: _hyper_4_19_chunk.ts, _hyper_4_19_chunk.sensor_id
+                                 Sort Method: quicksort 
+                                 ->  Index Scan Backward using _hyper_4_19_chunk_sensor_readings_ts_idx on _timescaledb_internal._hyper_4_19_chunk (actual rows=1000.00 loops=1)
+                                       Output: _hyper_4_19_chunk.ts, _hyper_4_19_chunk.sensor_id
+                     ->  Partial GroupAggregate (actual rows=1.00 loops=1)
+                           Output: _hyper_4_20_chunk.ts, _hyper_4_20_chunk.sensor_id, PARTIAL count(*)
+                           Group Key: _hyper_4_20_chunk.ts, _hyper_4_20_chunk.sensor_id
+                           ->  Sort (actual rows=1.00 loops=1)
+                                 Output: _hyper_4_20_chunk.ts, _hyper_4_20_chunk.sensor_id
+                                 Sort Key: _hyper_4_20_chunk.ts, _hyper_4_20_chunk.sensor_id
+                                 Sort Method: quicksort 
+                                 ->  Index Scan Backward using _hyper_4_20_chunk_sensor_readings_ts_idx on _timescaledb_internal._hyper_4_20_chunk (actual rows=1.00 loops=1)
+                                       Output: _hyper_4_20_chunk.ts, _hyper_4_20_chunk.sensor_id
+
+RESET enable_seqscan;

--- a/tsl/test/sql/agg_partials_pushdown.sql
+++ b/tsl/test/sql/agg_partials_pushdown.sql
@@ -185,3 +185,24 @@ RESET enable_seqscan;
 RESET random_page_cost;
 RESET cpu_operator_cost;
 RESET enable_hashagg;
+
+-- Chunkwise aggregation must account for the cost of sorting the per-chunk
+-- partially aggregated results.
+SET enable_seqscan = OFF;
+
+CREATE TABLE sensor_readings(ts bigint NOT NULL, sensor_id bigint);
+SELECT create_hypertable('sensor_readings', 'ts', chunk_time_interval => 1000);
+
+INSERT INTO sensor_readings
+SELECT g, g % 7 FROM generate_series(1, 3000) g;
+
+VACUUM ANALYZE sensor_readings;
+
+SELECT ts, sensor_id, count(*) FROM sensor_readings
+GROUP BY ts, sensor_id ORDER BY ts, sensor_id LIMIT 5;
+
+:PREFIX
+SELECT ts, sensor_id, count(*) FROM sensor_readings
+GROUP BY ts, sensor_id ORDER BY ts, sensor_id LIMIT 5;
+
+RESET enable_seqscan;


### PR DESCRIPTION
We're changing the list of children, so the cost must be recomputed. Follow the logic of Postgres' cost_append() in the Ordered Append case as well.

Disable-check: force-changelog-file