### PR TITLE
Fix shared memory leak when dropping databases

### DIFF
--- a/.unreleased/fix_10482
+++ b/.unreleased/fix_10482
@@ -1,0 +1,1 @@
+Fixes: #10524 Shared memory leak in the chunk stats subsystem when databases are dropped

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -642,9 +642,7 @@ timescaledb_shmem_startup_hook(void)
 	ts_lwlocks_shmem_startup();
 	ts_tenant_tracker_shmem_startup();
 	ts_function_telemetry_shmem_startup();
-#if PG17_LT
 	ts_stats_shmem_startup();
-#endif
 }
 
 static void
@@ -660,9 +658,7 @@ timescaledb_shmem_request_hook(void)
 	ts_lwlocks_shmem_alloc();
 	ts_tenant_tracker_shmem_alloc();
 	ts_function_telemetry_shmem_alloc();
-#if PG17_LT
 	ts_stats_shmem_request();
-#endif
 }
 
 static void

--- a/src/loader/ts_stats_handles.c
+++ b/src/loader/ts_stats_handles.c
@@ -13,13 +13,11 @@
 #include <utils/memutils.h>
 
 /*
- * This is the fallback implementation for PG 15-16 of the per-database shared memory
- * segment for chunk observability. In PG 17+ we can use the DSM registry and avoid this complexity.
- * The fallback implementation uses a rendezvous-based registry of DSM segments keyed by database
- * OID.
+ * Registry of the per-database shared memory segments for chunk observability,
+ * keyed by database OID. We cannot use the DSM registry (GetNamedDSMSegment)
+ * for this, because it pins the named segments forever and offers no way to
+ * remove them, so the segments of dropped databases would leak.
  */
-
-#if PG17_LT
 
 static Size
 ts_stats_handle_table_size(void)
@@ -45,8 +43,13 @@ ts_stats_shmem_startup(void)
 	if (!found)
 	{
 		memset(tbl, 0, ts_stats_handle_table_size());
+#if PG19_GE
+		/* PG19 merged tranche registration into LWLockNewTrancheId(name). */
+		LWLockInitialize(&tbl->lock, LWLockNewTrancheId("ts_stats_handles"));
+#else
 		LWLockInitialize(&tbl->lock, LWLockNewTrancheId());
 		LWLockRegisterTranche(tbl->lock.tranche, "ts_stats_handles");
+#endif
 		tbl->max_entries = TS_STATS_MAX_DATABASES;
 		for (int i = 0; i < TS_STATS_MAX_DATABASES; i++)
 		{
@@ -61,5 +64,3 @@ ts_stats_shmem_startup(void)
 		(TsObservHandleTable **) find_rendezvous_variable("ts_stats_handles");
 	*rv = tbl;
 }
-
-#endif /* PG17_LT */

--- a/src/loader/ts_stats_handles.h
+++ b/src/loader/ts_stats_handles.h
@@ -12,11 +12,13 @@
 #include <storage/lwlock.h>
 
 /*
- * See more details in ts_stats_segment.c these declaration are only for the fallback
- * implementation of the per-database DSM segment for PG 15-16.
+ * See more details in ts_stats_segment.c. These declarations are for the
+ * registry of per-database DSM segments keyed by database OID. We cannot use
+ * the DSM registry (GetNamedDSMSegment) for this, because it pins the named
+ * segments forever and offers no way to remove them, so segments of dropped
+ * databases would leak.
  */
 
-#if PG17_LT
 #define TS_STATS_MAX_DATABASES 1024
 
 /* Segment types */
@@ -38,4 +40,3 @@ typedef struct TsObservHandleTable
 
 void ts_stats_shmem_request(void);
 void ts_stats_shmem_startup(void);
-#endif /* PG17_LT */

--- a/src/ts_stats/ts_stats_segment.c
+++ b/src/ts_stats/ts_stats_segment.c
@@ -13,24 +13,15 @@
 #include <storage/lwlock.h>
 #include <utils/timestamp.h>
 
-#if PG17_GE
-#include <storage/dsm_registry.h>
-#else
 #include "../loader/ts_stats_handles.h"
 #include <storage/dsm.h>
 #include <storage/shmem.h>
-#endif
 
 /*
  * One-time init.
  */
 static void
-#if PG19_GE
-/* PG19 added an extra argument to the GetNamedDSMSegment init callback. */
-ts_stats_chunk_init_segment(void *ptr, void *arg)
-#else
 ts_stats_chunk_init_segment(void *ptr)
-#endif
 {
 	TsStatsChunkSegment *seg = (TsStatsChunkSegment *) ptr;
 	uint32 num_slots = (uint32) ts_guc_stats_max_chunks;
@@ -73,50 +64,14 @@ ts_stats_chunk_segment_reset(TsStatsChunkSegment *seg)
  */
 static TsStatsChunkSegment *cached_segment = NULL;
 
-/* GetNamedDSMSegment was introduced in PG 17, so we need separate
- * logic for older versions. */
-#if PG17_GE
-
-TsStatsChunkSegment *
-ts_get_stats_chunk_segment(void)
-{
-	if (!IS_STATS_CHUNKS_ENABLED())
-	{
-		return NULL;
-	}
-
-	if (likely(cached_segment != NULL))
-	{
-		return cached_segment;
-	}
-
-	Size seg_size = ts_stats_chunk_segment_size((uint32) ts_guc_stats_max_chunks);
-
-	char name[64];
-	snprintf(name, sizeof(name), "ts_stats_chunk_db_%u", MyDatabaseId);
-
-	bool found;
-#if PG19_GE
-	cached_segment = GetNamedDSMSegment(name, seg_size, ts_stats_chunk_init_segment, &found, NULL);
-#else
-	cached_segment = GetNamedDSMSegment(name, seg_size, ts_stats_chunk_init_segment, &found);
-#endif
-
-	if (cached_segment != NULL && cached_segment->magic != TS_STATS_SHMEM_MAGIC)
-	{
-		elog(WARNING,
-			 "ts_stats_chunk: segment for database %u has unexpected magic, disabling",
-			 MyDatabaseId);
-		cached_segment = NULL;
-	}
-	return cached_segment;
-}
-
-#else /* PG17_LT */
-
-/* The below section is about handling older PostgreSQL version, before PG 17.
- * The memory segments for each database are registered in a global handle table.
- * When the handle table is full, we sweep through the entries and remove the
+/*
+ * The memory segments for each database are registered in a global handle
+ * table, created by the loader. We cannot use the DSM registry
+ * (GetNamedDSMSegment) here, because it pins the named segments forever and
+ * offers no way to remove them, so the segments of dropped databases would
+ * leak.
+ *
+ * When a new segment is created, we sweep through the entries and remove the
  * segments for the databases that have been dropped. If there are more than
  * TS_STATS_MAX_DATABASES databases, or if the segment creation fails for any
  * reason, we disable stats tracking for the current database.
@@ -213,6 +168,14 @@ ts_stats_chunk_sweep_stale(TsObservHandleTable *tbl)
 static TsStatsChunkSegment *
 ts_stats_chunk_create_segment(TsObservHandleTable *tbl)
 {
+	/*
+	 * A new segment is needed, which usually means that this backend
+	 * connected to a freshly created database. Take this opportunity to
+	 * remove the segments of the databases that have been dropped, so that
+	 * they don't accumulate.
+	 */
+	ts_stats_chunk_sweep_stale(tbl);
+
 	Size seg_size = ts_stats_chunk_segment_size((uint32) ts_guc_stats_max_chunks);
 
 	dsm_segment *local_seg = dsm_create(seg_size, 0);
@@ -226,11 +189,7 @@ ts_stats_chunk_create_segment(TsObservHandleTable *tbl)
 	dsm_handle local_handle = dsm_segment_handle(local_seg);
 
 	TsStatsChunkSegment *obs = dsm_segment_address(local_seg);
-#if PG19_GE
-	ts_stats_chunk_init_segment(obs, NULL);
-#else
 	ts_stats_chunk_init_segment(obs);
-#endif
 
 	LWLockAcquire(&tbl->lock, LW_EXCLUSIVE);
 
@@ -253,15 +212,7 @@ ts_stats_chunk_create_segment(TsObservHandleTable *tbl)
 		return dsm_segment_address(winner_seg);
 	}
 
-	/* Find a free slot, with one sweep retry. */
 	entry = ts_stats_chunk_find_free_entry(tbl);
-	if (entry == NULL)
-	{
-		LWLockRelease(&tbl->lock);
-		ts_stats_chunk_sweep_stale(tbl);
-		LWLockAcquire(&tbl->lock, LW_EXCLUSIVE);
-		entry = ts_stats_chunk_find_free_entry(tbl);
-	}
 
 	/* Table full. */
 	if (entry == NULL)
@@ -270,7 +221,7 @@ ts_stats_chunk_create_segment(TsObservHandleTable *tbl)
 		dsm_unpin_segment(local_handle);
 		dsm_detach(local_seg);
 		elog(LOG,
-			 "ts_stats_chunk: handle table full after sweep, chunk statistics disabled "
+			 "ts_stats_chunk: handle table full, chunk statistics disabled "
 			 "for database %u",
 			 MyDatabaseId);
 		return NULL;
@@ -351,8 +302,6 @@ ts_get_stats_chunk_segment(void)
 	cached_segment = ts_stats_chunk_create_segment(tbl);
 	return cached_segment;
 }
-
-#endif /* PG17_GE */
 
 /*
  * Knuth's multiplicative hash. The constant 0x9E3779B9 = floor(2^32 / phi).


### PR DESCRIPTION
For PG17 and later we used the 'GetNamedDSMSegment' function. Unfortunately this API doesn't offer releasing the allocated shared memory. On PG16 we already had an alternative solution based on the dsm_create/dsm_attach and family API functions.

This change gets rid of the GetNamedDSMSegment API calls and sticks to the former PG16 only solution. This handles max 1024 databases in parallel and gracefully disables the chunk stats collection for the databases when it goes over the limit.

Fixes #10482

Disable-check: loader-change