### PR TITLE
Release 2.30.0

### DIFF
--- a/.unreleased/equiv-join
+++ b/.unreleased/equiv-join
@@ -1,1 +1,0 @@
-Fixes: #9905 Potentially incorrect result of a join when the join clause contains `time_bucket`

--- a/.unreleased/eval-vector
+++ b/.unreleased/eval-vector
@@ -1,1 +1,0 @@
-Fixes: #9920 Fix the "XX000: failed to evaluate runtime constant in vectorized filter" error in some queries that use stable functions in `WHERE` clause and the columnar aggregation pipeline.

--- a/.unreleased/fix_10058
+++ b/.unreleased/fix_10058
@@ -1,1 +1,0 @@
-Fixes: #10058 Apply new sortkeys for in-memory recompression

--- a/.unreleased/fix_remove_user_catalog_table
+++ b/.unreleased/fix_remove_user_catalog_table
@@ -1,1 +1,0 @@
-Fixes: Remove user_catalog_table option from catalog tables

--- a/.unreleased/git-build
+++ b/.unreleased/git-build
@@ -1,2 +1,0 @@
-Fixes: #10325 Avoid test errors when building from a source archive without a git repository
-Thanks: @tureba for reporting the problem with building from a source archive without a git repository

--- a/.unreleased/pr_10128
+++ b/.unreleased/pr_10128
@@ -1,1 +1,0 @@
-Fixes: #10128 Include hypertable chunks in publications created with FOR TABLES IN SCHEMA

--- a/.unreleased/pr_10147
+++ b/.unreleased/pr_10147
@@ -1,1 +1,0 @@
-Implements: #10147 Support segmentwise batch sorted merge for overlapping batches

--- a/.unreleased/pr_10279
+++ b/.unreleased/pr_10279
@@ -1,1 +1,0 @@
-Implements: #10279 Support ON CONFLICT DO SELECT with hypertables

--- a/.unreleased/pr_10291
+++ b/.unreleased/pr_10291
@@ -1,1 +1,0 @@
-Implements: #10291 Add support for REPACK

--- a/.unreleased/pr_10292
+++ b/.unreleased/pr_10292
@@ -1,1 +1,0 @@
-Implements: #10292 Add DeferredChunkAppend custom scan

--- a/.unreleased/pr_10354
+++ b/.unreleased/pr_10354
@@ -1,1 +1,0 @@
-Implements: #10354 Handle TM_Updated in compressed DML scan

--- a/.unreleased/pr_10357
+++ b/.unreleased/pr_10357
@@ -1,1 +1,0 @@
-Implements: #10357 Updates on cagg and invalidations catalogs to support granular refresh

--- a/.unreleased/pr_10388
+++ b/.unreleased/pr_10388
@@ -1,1 +1,0 @@
-Implements: #10388 Add custom toaster for compression

--- a/.unreleased/pr_10408
+++ b/.unreleased/pr_10408
@@ -1,1 +1,0 @@
-Fixes: #10408 Verify columns and their types in create_compressed_chunk

--- a/.unreleased/pr_10427
+++ b/.unreleased/pr_10427
@@ -1,1 +1,0 @@
-Implements: #10427 Granular refresh for continuous aggregates

--- a/.unreleased/pr_10443
+++ b/.unreleased/pr_10443
@@ -1,1 +1,0 @@
-Implements: #10443 Support granular refresh with direct compress

--- a/.unreleased/pr_10515
+++ b/.unreleased/pr_10515
@@ -1,1 +1,0 @@
-Fixes: #10515 Fix RLS checks after dropping hypertable columns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.30.0 (2026-09-02)
+
+This release contains performance improvements and bug fixes since the 2.29.2 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.30.0**
+* 
+
+**Backward-Incompatible Changes**
+
+**Features**
+* [#10147](https://github.com/timescale/timescaledb/pull/10147) Support segmentwise batch sorted merge for overlapping batches
+* [#10279](https://github.com/timescale/timescaledb/pull/10279) Support ON CONFLICT DO SELECT with hypertables
+* [#10291](https://github.com/timescale/timescaledb/pull/10291) Add support for REPACK
+* [#10292](https://github.com/timescale/timescaledb/pull/10292) Add DeferredChunkAppend custom scan
+* [#10354](https://github.com/timescale/timescaledb/pull/10354) Handle TM_Updated in compressed DML scan
+* [#10357](https://github.com/timescale/timescaledb/pull/10357) Updates on cagg and invalidations catalogs to support granular refresh
+* [#10388](https://github.com/timescale/timescaledb/pull/10388) Add custom toaster for compression
+* [#10427](https://github.com/timescale/timescaledb/pull/10427) Granular refresh for continuous aggregates
+* [#10443](https://github.com/timescale/timescaledb/pull/10443) Support granular refresh with direct compress
+
+**Bugfixes**
+* [#10058](https://github.com/timescale/timescaledb/pull/10058) Apply new sortkeys for in-memory recompression
+* [#10128](https://github.com/timescale/timescaledb/pull/10128) Include hypertable chunks in publications created with FOR TABLES IN SCHEMA
+* [#10325](https://github.com/timescale/timescaledb/pull/10325) Avoid test errors when building from a source archive without a git repository
+* [#10408](https://github.com/timescale/timescaledb/pull/10408) Verify columns and their types in create_compressed_chunk
+* [#10515](https://github.com/timescale/timescaledb/pull/10515) Fix RLS checks after dropping hypertable columns
+* [#9905](https://github.com/timescale/timescaledb/pull/9905) Potentially incorrect result of a join when the join clause contains `time_bucket`
+* [#9920](https://github.com/timescale/timescaledb/pull/9920) Fix the "XX000: failed to evaluate runtime constant in vectorized filter" error in some queries that use stable functions in `WHERE` clause and the columnar aggregation pipeline.
+* Remove user_catalog_table option from catalog tables
+
+**New Settings**
+
+**GUCs**
+* `debug_require_deferred_chunk_scan`
+* `direct_compress_insert_tuple_sort_limit`
+* `enable_deferred_chunk_append`
+* `enable_foreign_key_propagation`
+* `use_custom_toaster`
+
+**Thanks**
+* @tureba for reporting the problem with building from a source archive without a git repository
+
 ## 2.29.2 (2026-08-18)
 
 This release contains bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.


### PR DESCRIPTION
## 2.30.0 (2026-09-02)

This release contains performance improvements and bug fixes since the 2.29.2 release. We recommend that you upgrade at the next available opportunity.

**Highlighted features in TimescaleDB v2.30.0**
* 

**Backward-Incompatible Changes**

**Features**
* [#10147](https://github.com/timescale/timescaledb/pull/10147) Support segmentwise batch sorted merge for overlapping batches
* [#10279](https://github.com/timescale/timescaledb/pull/10279) Support ON CONFLICT DO SELECT with hypertables
* [#10291](https://github.com/timescale/timescaledb/pull/10291) Add support for REPACK
* [#10292](https://github.com/timescale/timescaledb/pull/10292) Add DeferredChunkAppend custom scan
* [#10354](https://github.com/timescale/timescaledb/pull/10354) Handle TM_Updated in compressed DML scan
* [#10357](https://github.com/timescale/timescaledb/pull/10357) Updates on cagg and invalidations catalogs to support granular refresh
* [#10388](https://github.com/timescale/timescaledb/pull/10388) Add custom toaster for compression
* [#10427](https://github.com/timescale/timescaledb/pull/10427) Granular refresh for continuous aggregates
* [#10443](https://github.com/timescale/timescaledb/pull/10443) Support granular refresh with direct compress

**Bugfixes**
* [#10058](https://github.com/timescale/timescaledb/pull/10058) Apply new sortkeys for in-memory recompression
* [#10128](https://github.com/timescale/timescaledb/pull/10128) Include hypertable chunks in publications created with FOR TABLES IN SCHEMA
* [#10325](https://github.com/timescale/timescaledb/pull/10325) Avoid test errors when building from a source archive without a git repository
* [#10408](https://github.com/timescale/timescaledb/pull/10408) Verify columns and their types in create_compressed_chunk
* [#10515](https://github.com/timescale/timescaledb/pull/10515) Fix RLS checks after dropping hypertable columns
* [#9905](https://github.com/timescale/timescaledb/pull/9905) Potentially incorrect result of a join when the join clause contains `time_bucket`
* [#9920](https://github.com/timescale/timescaledb/pull/9920) Fix the "XX000: failed to evaluate runtime constant in vectorized filter" error in some queries that use stable functions in `WHERE` clause and the columnar aggregation pipeline.
* Remove user_catalog_table option from catalog tables

**New Settings**

**GUCs**
* `debug_require_deferred_chunk_scan`
* `direct_compress_insert_tuple_sort_limit`
* `enable_deferred_chunk_append`
* `enable_foreign_key_propagation`
* `use_custom_toaster`

**Thanks**
* @tureba for reporting the problem with building from a source archive without a git repository
