### PR TITLE
 Release 2.30.0

### DIFF
--- a/.unreleased/chunk-fix
+++ b/.unreleased/chunk-fix
@@ -1,2 +1,0 @@
-Fixes: #10499 Potentially wrong query result when hypertable chunks are filtered out at query run time, the filter condition uses an uncorrelated subquery, and the query uses a parallel execution plan
-Thanks: @peterecofit for reporting potentially wrong query result when hypertable chunks are filtered out at query run time

--- a/.unreleased/equiv-join
+++ b/.unreleased/equiv-join
@@ -1,1 +1,0 @@
-Fixes: #9905 Potentially incorrect result of a join when the join clause contains `time_bucket`

--- a/.unreleased/eval-vector
+++ b/.unreleased/eval-vector
@@ -1,1 +1,0 @@
-Fixes: #9920 Fix the "XX000: failed to evaluate runtime constant in vectorized filter" error in some queries that use stable functions in `WHERE` clause and the columnar aggregation pipeline.

--- a/.unreleased/fix_10058
+++ b/.unreleased/fix_10058
@@ -1,1 +1,0 @@
-Fixes: #10058 Apply new sortkeys for in-memory recompression

--- a/.unreleased/fix_10482
+++ b/.unreleased/fix_10482
@@ -1,1 +1,0 @@
-Fixes: #10524 Shared memory leak in the chunk stats subsystem when databases are dropped

--- a/.unreleased/fix_remove_user_catalog_table
+++ b/.unreleased/fix_remove_user_catalog_table
@@ -1,1 +1,0 @@
-Fixes: Remove user_catalog_table option from catalog tables

--- a/.unreleased/git-build
+++ b/.unreleased/git-build
@@ -1,2 +1,0 @@
-Fixes: #10325 Avoid test errors when building from a source archive without a git repository
-Thanks: @tureba for reporting the problem with building from a source archive without a git repository

--- a/.unreleased/pr_10128
+++ b/.unreleased/pr_10128
@@ -1,1 +1,0 @@
-Fixes: #10128 Include hypertable chunks in publications created with FOR TABLES IN SCHEMA

--- a/.unreleased/pr_10147
+++ b/.unreleased/pr_10147
@@ -1,1 +1,0 @@
-Implements: #10147 Support segmentwise batch sorted merge for overlapping batches

--- a/.unreleased/pr_10279
+++ b/.unreleased/pr_10279
@@ -1,1 +1,0 @@
-Implements: #10279 Support ON CONFLICT DO SELECT with hypertables

--- a/.unreleased/pr_10291
+++ b/.unreleased/pr_10291
@@ -1,1 +1,0 @@
-Implements: #10291 Add support for REPACK

--- a/.unreleased/pr_10292
+++ b/.unreleased/pr_10292
@@ -1,1 +1,0 @@
-Implements: #10292 Add DeferredChunkAppend custom scan

--- a/.unreleased/pr_10354
+++ b/.unreleased/pr_10354
@@ -1,1 +1,0 @@
-Implements: #10354 Handle TM_Updated in compressed DML scan

--- a/.unreleased/pr_10357
+++ b/.unreleased/pr_10357
@@ -1,1 +1,0 @@
-Implements: #10357 Updates on cagg and invalidations catalogs to support granular refresh

--- a/.unreleased/pr_10388
+++ b/.unreleased/pr_10388
@@ -1,1 +1,0 @@
-Implements: #10388 Add custom toaster for compression

--- a/.unreleased/pr_10408
+++ b/.unreleased/pr_10408
@@ -1,1 +1,0 @@
-Fixes: #10408 Verify columns and their types in create_compressed_chunk

--- a/.unreleased/pr_10427
+++ b/.unreleased/pr_10427
@@ -1,1 +1,0 @@
-Implements: #10427 Granular refresh for continuous aggregates

--- a/.unreleased/pr_10443
+++ b/.unreleased/pr_10443
@@ -1,1 +1,0 @@
-Implements: #10443 Support granular refresh with direct compress

--- a/.unreleased/pr_10506
+++ b/.unreleased/pr_10506
@@ -1,1 +1,0 @@
-Fixes: #10506 Correctly match NULL tuples to compressed batches with NULL boundaries during recompression

--- a/.unreleased/pr_10515
+++ b/.unreleased/pr_10515
@@ -1,1 +1,0 @@
-Fixes: #10515 Fix RLS checks after dropping hypertable columns

--- a/.unreleased/pr_10526
+++ b/.unreleased/pr_10526
@@ -1,1 +1,0 @@
-Implements: #10526 Support disabling granular refresh for a continuous aggregate

--- a/.unreleased/pr_10535
+++ b/.unreleased/pr_10535
@@ -1,2 +1,0 @@
-Fixes: #10535 Fix chunk merging with default sparse indexes
-Thanks: @esdanieljaegers for reporting the issue and providing steps for reproduction

--- a/.unreleased/pr_10536
+++ b/.unreleased/pr_10536
@@ -1,1 +1,0 @@
-Fixes: #10536 Skip batch size check when direct compress is set as hypertable option

--- a/.unreleased/pr_10539
+++ b/.unreleased/pr_10539
@@ -1,2 +1,0 @@
-Fixes: #10539 Allow deletes from the policy chunk stats table when the database publishes all tables
-Thanks: @AlexFavre for reporting a failed extension update when a publication for all tables exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 **Please note: When updating your database, you should connect using `psql` with the `-X` flag to prevent any `.psqlrc` commands from accidentally triggering the load of a previous TimescaleDB version.**
 
+## 2.30.0 (2026-09-08)
+
+This release contains performance improvements and bug fixes since the 2.29.2 release. We recommend that you upgrade at the next available opportunity.
+
+**Highlighted features in TimescaleDB v2.30.0**
+Blazing fast `LIMIT` queries with the newly introduced `DeferredChunkAppend`. This custom node reduces planning significantly by delaying chunk expansion. During planning the hypertable stays unexpanded and only during execution are chunks enumerated on demand. Combined with the optimizations to `FIRST` and `LAST` sparse indexes, this addition executes last-point queries far more efficiently and quickly.  This changes the scaling of the "What is the last reading from this sensor" query from linear with number of chunks to constant if it can be found in the most recent chunk. The true power of the custom node starts to show with increasing amount of chunks, see [more elaborate benchmarks](https://github.com/timescale/timescaledb/pull/10292).
+
+**Features**
+* [#10147](https://github.com/timescale/timescaledb/pull/10147) Support segmentwise batch sorted merge for overlapping batches
+* [#10292](https://github.com/timescale/timescaledb/pull/10292) Add `DeferredChunkAppend` custom scan
+* [#10354](https://github.com/timescale/timescaledb/pull/10354) Adds DML support for concurrent compaction
+* [#10388](https://github.com/timescale/timescaledb/pull/10388) Add custom toaster for compression
+
+**Bugfixes**
+* [#10058](https://github.com/timescale/timescaledb/pull/10058) Apply new sortkeys for in-memory recompression
+* [#10128](https://github.com/timescale/timescaledb/pull/10128) Include hypertable chunks in publications created with `FOR TABLES IN SCHEMA`
+* [#10325](https://github.com/timescale/timescaledb/pull/10325) Avoid test errors when building from a source archive without a git repository
+* [#10408](https://github.com/timescale/timescaledb/pull/10408) Verify columns and their types in `create_compressed_chunk`
+* [#10515](https://github.com/timescale/timescaledb/pull/10515) Fix row level security checks after dropping hypertable columns
+* [#9905](https://github.com/timescale/timescaledb/pull/9905) Potentially incorrect result of a join when the join clause contains `time_bucket`
+* [#9920](https://github.com/timescale/timescaledb/pull/9920) Fix the "XX000: failed to evaluate runtime constant in vectorized filter" error in some queries that use stable functions in `WHERE` clause and the columnar aggregation pipeline
+* [#10499](https://github.com/timescale/timescaledb/pull/10499) Potentially wrong query result when hypertable chunks are filtered out at query run time, the filter condition uses an uncorrelated subquery, and the query uses a parallel execution plan
+* [#10513](https://github.com/timescale/timescaledb/pull/10513) Remove `user_catalog_table` option from catalog tables
+* [#10506](https://github.com/timescale/timescaledb/pull/10506) Correctly match `NULL` tuples to compressed batches with `NULL` boundaries during recompression
+* [#10524](https://github.com/timescale/timescaledb/pull/10524) Shared memory leak in the chunk stats subsystem when databases are dropped
+* [#10535](https://github.com/timescale/timescaledb/pull/10535) Fix chunk merging with default sparse indexes
+* [#10536](https://github.com/timescale/timescaledb/pull/10536) Skip batch size check when direct compress is set as hypertable option
+* [#10539](https://github.com/timescale/timescaledb/pull/10539) Allow deletes from the policy chunk stats table when the database publishes all tables
+
+**GUCs**
+* `enable_deferred_chunk_append`: Custom scan node for hypertables that iterates chunks at execution instead of expanding every chunk at plan time. Default: true.
+* `use_custom_toaster`: Use a custom TOAST writer for compressed row inserts. Default: false.
+
+**Thanks**
+* @tureba for reporting the problem with building from a source archive without a git repository [#10325](https://github.com/timescale/timescaledb/issues/10325)
+* @AlexFavre for reporting a failed extension update when a publication for all tables exists [#10477](https://github.com/timescale/timescaledb/issues/10477)
+* @peterecofit for reporting potentially wrong query result when hypertable chunks are filtered out at query run time [#10503](https://github.com/timescale/timescaledb/issues/10503)
+* @esdanieljaegers for reporting the issue and providing steps for reproduction [#10511](https://github.com/timescale/timescaledb/issues/10511)
+
 ## 2.29.2 (2026-08-18)
 
 This release contains bug fixes since the 2.29.1 release. We recommend that you upgrade at the next available opportunity.


### PR DESCRIPTION
## 2.30.0 (2026-09-08)

This release contains performance improvements and bug fixes since the 2.29.2 release. We recommend that you upgrade at the next available opportunity.

**Highlighted features in TimescaleDB v2.30.0**
Blazing fast `LIMIT` queries with the newly introduced `DeferredChunkAppend`. This custom node reduces planning significantly by delaying chunk expansion. During planning the hypertable stays unexpanded and only during execution are chunks enumerated on demand. Combined with the optimizations to `FIRST` and `LAST` sparse indexes, this addition executes last-point queries far more efficiently and quickly.  This changes the scaling of the "What is the last reading from this sensor" query from linear with number of chunks to constant if it can be found in the most recent chunk. The true power of the custom node starts to show with increasing amount of chunks, see [more elaborate benchmarks](https://github.com/timescale/timescaledb/pull/10292).

**Features**
* [#10147](https://github.com/timescale/timescaledb/pull/10147) Support segmentwise batch sorted merge for overlapping batches
* [#10292](https://github.com/timescale/timescaledb/pull/10292) Add `DeferredChunkAppend` custom scan
* [#10354](https://github.com/timescale/timescaledb/pull/10354) Adds DML support for concurrent compaction
* [#10388](https://github.com/timescale/timescaledb/pull/10388) Add custom toaster for compression

**Bugfixes**
* [#10058](https://github.com/timescale/timescaledb/pull/10058) Apply new sortkeys for in-memory recompression
* [#10128](https://github.com/timescale/timescaledb/pull/10128) Include hypertable chunks in publications created with `FOR TABLES IN SCHEMA`
* [#10325](https://github.com/timescale/timescaledb/pull/10325) Avoid test errors when building from a source archive without a git repository
* [#10408](https://github.com/timescale/timescaledb/pull/10408) Verify columns and their types in `create_compressed_chunk`
* [#10515](https://github.com/timescale/timescaledb/pull/10515) Fix row level security checks after dropping hypertable columns
* [#9905](https://github.com/timescale/timescaledb/pull/9905) Potentially incorrect result of a join when the join clause contains `time_bucket`
* [#9920](https://github.com/timescale/timescaledb/pull/9920) Fix the "XX000: failed to evaluate runtime constant in vectorized filter" error in some queries that use stable functions in `WHERE` clause and the columnar aggregation pipeline
* [#10499](https://github.com/timescale/timescaledb/pull/10499) Potentially wrong query result when hypertable chunks are filtered out at query run time, the filter condition uses an uncorrelated subquery, and the query uses a parallel execution plan
* [#10513](https://github.com/timescale/timescaledb/pull/10513) Remove `user_catalog_table` option from catalog tables
* [#10506](https://github.com/timescale/timescaledb/pull/10506) Correctly match `NULL` tuples to compressed batches with `NULL` boundaries during recompression
* [#10524](https://github.com/timescale/timescaledb/pull/10524) Shared memory leak in the chunk stats subsystem when databases are dropped
* [#10535](https://github.com/timescale/timescaledb/pull/10535) Fix chunk merging with default sparse indexes
* [#10536](https://github.com/timescale/timescaledb/pull/10536) Skip batch size check when direct compress is set as hypertable option
* [#10539](https://github.com/timescale/timescaledb/pull/10539) Allow deletes from the policy chunk stats table when the database publishes all tables

**GUCs**
* `enable_deferred_chunk_append`: Custom scan node for hypertables that iterates chunks at execution instead of expanding every chunk at plan time. Default: true.
* `use_custom_toaster`: Use a custom TOAST writer for compressed row inserts. Default: false.

**Thanks**
* @tureba for reporting the problem with building from a source archive without a git repository [#10325](https://github.com/timescale/timescaledb/issues/10325)
* @AlexFavre for reporting a failed extension update when a publication for all tables exists [#10477](https://github.com/timescale/timescaledb/issues/10477)
* @peterecofit for reporting potentially wrong query result when hypertable chunks are filtered out at query run time [#10503](https://github.com/timescale/timescaledb/issues/10503)
* @esdanieljaegers for reporting the issue and providing steps for reproduction [#10511](https://github.com/timescale/timescaledb/issues/10511)
