### PR TITLE
Fix wrong cost labels on Sort under ordered ChunkAppend

### DIFF
--- a/src/import/createplan.h
+++ b/src/import/createplan.h
@@ -9,8 +9,6 @@
 #include <postgres.h>
 
 
-extern TSDLLEXPORT Sort *ts_make_sort_from_pathkeys(Plan *lefttree, List *pathkeys, Relids relids);
-
 extern TSDLLEXPORT Sort *ts_make_sort(Plan *lefttree, int numCols, AttrNumber *sortColIdx,
 									  Oid *sortOperators, Oid *collations, bool *nullsFirst);
 

--- a/src/import/optimizer/plan/createplan.c
+++ b/src/import/optimizer/plan/createplan.c
@@ -503,40 +503,6 @@ ts_prepare_sort_from_pathkeys(Plan *lefttree, List *pathkeys,
 }
 
 /*
- * make_sort_from_pathkeys
- *	  Create sort plan to sort according to given pathkeys
- *
- *	  'lefttree' is the node which yields input tuples
- *	  'pathkeys' is the list of pathkeys by which the result is to be sorted
- *	  'relids' is the set of relations required by prepare_sort_from_pathkeys()
- */
-Sort *
-ts_make_sort_from_pathkeys(Plan *lefttree, List *pathkeys, Relids relids)
-{
-	int			numsortkeys;
-	AttrNumber *sortColIdx;
-	Oid		   *sortOperators;
-	Oid		   *collations;
-	bool	   *nullsFirst;
-
-	/* Compute sort column info, and adjust lefttree as needed */
-	lefttree = ts_prepare_sort_from_pathkeys(lefttree, pathkeys,
-										  relids,
-										  NULL,
-										  false,
-										  &numsortkeys,
-										  &sortColIdx,
-										  &sortOperators,
-										  &collations,
-										  &nullsFirst);
-
-	/* Now build the Sort node */
-	return ts_make_sort(lefttree, numsortkeys,
-					 sortColIdx, sortOperators,
-					 collations, nullsFirst);
-}
-
-/*
  * make_result
  *	  Build a Result plan node
  */

--- a/src/nodes/chunk_append/planner.c
+++ b/src/nodes/chunk_append/planner.c
@@ -27,9 +27,7 @@
 #include "nodes/chunk_append/transform.h"
 #include "nodes/modify_hypertable.h"
 #include "nodes/vector_agg.h"
-
-static Plan *adjust_childscan(PlannerInfo *root, Plan *plan, Path *path, List *pathkeys,
-							  List *tlist, AttrNumber *sortColIdx);
+#include "planner/planner.h"
 
 static CustomScanMethods chunk_append_plan_methods = {
 	.CustomName = "ChunkAppend",
@@ -47,39 +45,6 @@ void
 _chunk_append_init(void)
 {
 	TryRegisterCustomScanMethods(&chunk_append_plan_methods);
-}
-
-static Plan *
-adjust_childscan(PlannerInfo *root, Plan *plan, Path *path, List *pathkeys, List *tlist,
-				 AttrNumber *sortColIdx)
-{
-	int childSortCols;
-	Oid *sortOperators;
-	Oid *collations;
-	bool *nullsFirst;
-	AttrNumber *childColIdx;
-
-	/* Compute sort column info, and adjust subplan's tlist as needed */
-	plan = ts_prepare_sort_from_pathkeys(plan,
-										 pathkeys,
-										 path->parent->relids,
-										 sortColIdx,
-										 true,
-										 &childSortCols,
-										 &childColIdx,
-										 &sortOperators,
-										 &collations,
-										 &nullsFirst);
-
-	/* inject sort node if child sort order does not match desired order */
-	if (!pathkeys_contained_in(pathkeys, path->pathkeys))
-	{
-		Assert(!IsA(plan, Sort));
-
-		plan = (Plan *)
-			ts_make_sort(plan, childSortCols, childColIdx, sortOperators, collations, nullsFirst);
-	}
-	return plan;
 }
 
 Plan *
@@ -240,12 +205,12 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 			 */
 			if (!IsA(lfirst(lc_plan), MergeAppend))
 			{
-				lfirst(lc_plan) = adjust_childscan(root,
-												   lfirst(lc_plan),
-												   lfirst(lc_path),
-												   path->path.pathkeys,
-												   orig_tlist,
-												   sortColIdx);
+				lfirst(lc_plan) = add_sort_if_needed(root,
+													  lfirst(lc_plan),
+													  lfirst(lc_path),
+													  path->path.pathkeys,
+													  sortColIdx,
+													  capath->limit_tuples);
 			}
 		}
 	}

--- a/src/nodes/chunk_append/planner.c
+++ b/src/nodes/chunk_append/planner.c
@@ -205,12 +205,12 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 			 */
 			if (!IsA(lfirst(lc_plan), MergeAppend))
 			{
-				lfirst(lc_plan) = add_sort_if_needed(root,
-													  lfirst(lc_plan),
-													  lfirst(lc_path),
-													  path->path.pathkeys,
-													  sortColIdx,
-													  capath->limit_tuples);
+				lfirst(lc_plan) = ts_add_sort_if_needed(root,
+														lfirst(lc_plan),
+														lfirst(lc_path),
+														path->path.pathkeys,
+														sortColIdx,
+														capath->limit_tuples);
 			}
 		}
 	}

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -50,6 +50,7 @@
 #include "hypertable.h"
 #include "hypertable_cache.h"
 #include "import/allpaths.h"
+#include "import/createplan.h"
 #include "import/optimizer/plancat.h"
 #include "license_guc.h"
 #include "nodes/chunk_append/chunk_append.h"
@@ -2176,6 +2177,45 @@ cagg_reorder_groupby_clause(RangeTblEntry *subq_rte, Index rtno, List *outer_sor
 			subq->groupClause = fill_missing_groupclause(new_groupclause, subq_groupclause_copy);
 		}
 	}
+}
+
+/*
+ * Add Sort over a given plan if it's not sufficiently ordered.
+ */
+Plan *
+add_sort_if_needed(PlannerInfo *root, Plan *plan, Path *path, List *pathkeys,
+					const AttrNumber *reqColIdx, double limit_tuples)
+{
+	int numsortkeys;
+	AttrNumber *sortColIdx;
+	Oid *sortOperators;
+	Oid *collations;
+	bool *nullsFirst;
+
+	/* Compute sort column info, and adjust the child's tlist as needed */
+	plan = ts_prepare_sort_from_pathkeys(plan,
+										 pathkeys,
+										 path->parent->relids,
+										 reqColIdx,
+										 true,
+										 &numsortkeys,
+										 &sortColIdx,
+										 &sortOperators,
+										 &collations,
+										 &nullsFirst);
+
+	/* Now, insert a Sort node if child isn't sufficiently ordered */
+	if (!pathkeys_contained_in(pathkeys, path->pathkeys))
+	{
+		Sort *sort;
+
+		Assert(!IsA(plan, Sort));
+		sort = ts_make_sort(plan, numsortkeys, sortColIdx, sortOperators, collations, nullsFirst);
+		ts_label_sort_with_costsize(root, sort, limit_tuples);
+		plan = (Plan *) sort;
+	}
+
+	return plan;
 }
 
 void

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -2183,8 +2183,8 @@ cagg_reorder_groupby_clause(RangeTblEntry *subq_rte, Index rtno, List *outer_sor
  * Add Sort over a given plan if it's not sufficiently ordered.
  */
 Plan *
-add_sort_if_needed(PlannerInfo *root, Plan *plan, Path *path, List *pathkeys,
-					const AttrNumber *reqColIdx, double limit_tuples)
+ts_add_sort_if_needed(PlannerInfo *root, Plan *plan, Path *path, List *pathkeys,
+					  const AttrNumber *reqColIdx, double limit_tuples)
 {
 	int numsortkeys;
 	AttrNumber *sortColIdx;

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -54,6 +54,9 @@ extern TSDLLEXPORT bool ts_rte_is_marked_for_expansion(const RangeTblEntry *rte)
 extern TSDLLEXPORT void ts_rte_mark_compressed_relation(RangeTblEntry *rte);
 extern TSDLLEXPORT bool ts_contains_external_param(Node *node);
 extern TSDLLEXPORT bool ts_contains_join_param(Node *node);
+extern TSDLLEXPORT Plan *add_sort_if_needed(PlannerInfo *root, Plan *plan, Path *path,
+											 List *pathkeys, const AttrNumber *reqColIdx,
+											 double limit_tuples);
 
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -54,9 +54,9 @@ extern TSDLLEXPORT bool ts_rte_is_marked_for_expansion(const RangeTblEntry *rte)
 extern TSDLLEXPORT void ts_rte_mark_compressed_relation(RangeTblEntry *rte);
 extern TSDLLEXPORT bool ts_contains_external_param(Node *node);
 extern TSDLLEXPORT bool ts_contains_join_param(Node *node);
-extern TSDLLEXPORT Plan *add_sort_if_needed(PlannerInfo *root, Plan *plan, Path *path,
-											 List *pathkeys, const AttrNumber *reqColIdx,
-											 double limit_tuples);
+extern TSDLLEXPORT Plan *ts_add_sort_if_needed(PlannerInfo *root, Plan *plan, Path *path,
+											   List *pathkeys, const AttrNumber *reqColIdx,
+											   double limit_tuples);
 
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)

--- a/tsl/src/nodes/columnar_scan/planner.c
+++ b/tsl/src/nodes/columnar_scan/planner.c
@@ -28,7 +28,6 @@
 #include "compression/create.h"
 #include "custom_type_cache.h"
 #include "guc.h"
-#include "import/createplan.h"
 #include "import/list.h"
 #include "import/planner.h"
 #include "nodes/chunk_append/transform.h"
@@ -37,6 +36,7 @@
 #include "nodes/columnar_scan/planner.h"
 #include "nodes/columnar_scan/vector_quals.h"
 #include "nodes/vector_agg/exec.h"
+#include "planner/planner.h"
 #include "ts_catalog/array_utils.h"
 #include "vector_predicates.h"
 
@@ -1263,23 +1263,13 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 	/*
 	 * Add a sort if the compressed scan is not ordered appropriately.
 	 */
-	if (!pathkeys_contained_in(dcpath->required_compressed_pathkeys, compressed_path->pathkeys))
-	{
-		List *compressed_pks = dcpath->required_compressed_pathkeys;
-		Sort *sort = ts_make_sort_from_pathkeys((Plan *) compressed_scan,
-												compressed_pks,
-												bms_make_singleton(compressed_scan->scanrelid));
-
-		ts_label_sort_with_costsize(root, sort, /* limit_tuples = */ -1.0);
-
-		decompress_plan->custom_plans = list_make1(sort);
-	}
-	else
-	{
-		decompress_plan->custom_plans = custom_plans;
-	}
-
-	Assert(list_length(custom_plans) == 1);
+	decompress_plan->custom_plans =
+		list_make1(add_sort_if_needed(root,
+									   (Plan *) compressed_scan,
+									   compressed_path,
+									   dcpath->required_compressed_pathkeys,
+									   /* reqColIdx = */ NULL,
+									   /* limit_tuples = */ -1.0));
 
 	/*
 	 * For some predicates, we have more efficient implementation that work on

--- a/tsl/src/nodes/columnar_scan/planner.c
+++ b/tsl/src/nodes/columnar_scan/planner.c
@@ -1264,12 +1264,12 @@ columnar_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 	 * Add a sort if the compressed scan is not ordered appropriately.
 	 */
 	decompress_plan->custom_plans =
-		list_make1(add_sort_if_needed(root,
-									   (Plan *) compressed_scan,
-									   compressed_path,
-									   dcpath->required_compressed_pathkeys,
-									   /* reqColIdx = */ NULL,
-									   /* limit_tuples = */ -1.0));
+		list_make1(ts_add_sort_if_needed(root,
+										 (Plan *) compressed_scan,
+										 compressed_path,
+										 dcpath->required_compressed_pathkeys,
+										 /* reqColIdx = */ NULL,
+										 /* limit_tuples = */ -1.0));
 
 	/*
 	 * For some predicates, we have more efficient implementation that work on

--- a/tsl/test/expected/columnar_scan_cost-16.out
+++ b/tsl/test/expected/columnar_scan_cost-16.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
--- Some primitive tests that show cost of DecompressChunk node so that we can
+-- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
@@ -343,3 +343,34 @@ select * from lastmax where ts = 500;
    ->  Seq Scan on _hyper_4_14_chunk_compressed
          Filter: ((_ts_meta_v2_first_ts <= 500) AND (_ts_meta_v2_last_ts >= 500))
 
+-- Cost of an ordered ChunkAppend that has to sort a child.
+truncate estimate_count;
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,
+  generate_series(1, 100) d;
+select count(compress_chunk(c)) from show_chunks('estimate_count') c;
+ count 
+-------
+     2
+
+vacuum analyze estimate_count;
+set timescaledb.enable_deferred_chunk_append to off;
+set enable_indexscan to off;
+explain (buffers off)
+select * from estimate_count order by time limit 5;
+--- QUERY PLAN ---
+ Limit  (cost=8.57..8.92 rows=5 width=20)
+   ->  Custom Scan (ChunkAppend) on estimate_count  (cost=8.57..451.62 rows=6400 width=20)
+         Order: estimate_count."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_2_15_chunk  (cost=8.57..451.62 rows=6400 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_15_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_15_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_16_chunk  (cost=8.57..901.60 rows=12900 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+
+reset enable_indexscan;
+reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-16.out
+++ b/tsl/test/expected/columnar_scan_cost-16.out
@@ -345,6 +345,7 @@ select * from lastmax where ts = 500;
 
 -- Cost of an ordered ChunkAppend that has to sort a child.
 truncate estimate_count;
+drop index estimate_count_time_idx;
 insert into estimate_count
 select t, d, 1
 from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,

--- a/tsl/test/expected/columnar_scan_cost-16.out
+++ b/tsl/test/expected/columnar_scan_cost-16.out
@@ -355,6 +355,10 @@ select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 -------
      2
 
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-16'::timestamptz,'2025-01-17','15 min') t,
+  generate_series(1, 100) d;
 vacuum analyze estimate_count;
 set timescaledb.enable_deferred_chunk_append to off;
 set enable_indexscan to off;
@@ -372,6 +376,9 @@ select * from estimate_count order by time limit 5;
                ->  Sort  (cost=8.32..8.57 rows=100 width=88)
                      Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
                      ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Sort  (cost=320.11..344.36 rows=9700 width=20)
+               Sort Key: _hyper_2_17_chunk."time"
+               ->  Seq Scan on _hyper_2_17_chunk  (cost=0.00..159.00 rows=9700 width=20)
 
 reset enable_indexscan;
 reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-17.out
+++ b/tsl/test/expected/columnar_scan_cost-17.out
@@ -1,8 +1,9 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
--- Some primitive tests that show cost of DecompressChunk node so that we can
+-- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
+set timescaledb.enable_deferred_chunk_append to off;
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
   create_hypertable   
@@ -343,3 +344,44 @@ select * from lastmax where ts = 500;
    ->  Seq Scan on _hyper_4_14_chunk_compressed
          Filter: ((_ts_meta_v2_first_ts <= 500) AND (_ts_meta_v2_last_ts >= 500))
 
+-- Cost of an ordered ChunkAppend that has to sort a child.
+truncate estimate_count;
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,
+  generate_series(1, 100) d;
+select count(compress_chunk(c)) from show_chunks('estimate_count') c;
+ count 
+-------
+     2
+
+-- Decompress the first chunk and drop its index, so that it has no path
+-- producing the required order.
+select count(decompress_chunk(c)) from (select min(c) c from show_chunks('estimate_count') c) x;
+ count 
+-------
+     1
+
+select format('drop index %I.%I', schemaname, indexname)
+from pg_indexes
+where tablename = (select relname from pg_class
+    where oid = (select min(x) from show_chunks('estimate_count') x))
+\gexec
+drop index _timescaledb_internal._hyper_2_15_chunk_estimate_count_time_idx
+vacuum analyze estimate_count;
+set timescaledb.enable_deferred_chunk_append to off;
+explain (buffers off)
+select * from estimate_count order by time limit 5;
+--- QUERY PLAN ---
+ Limit  (cost=0.00..0.08 rows=5 width=20)
+   ->  Custom Scan (ChunkAppend) on estimate_count  (cost=0.00..105.00 rows=6400 width=20)
+         Order: estimate_count."time"
+         ->  Sort  (cost=211.30..227.30 rows=6400 width=20)
+               Sort Key: _hyper_2_15_chunk."time"
+               ->  Seq Scan on _hyper_2_15_chunk  (cost=0.00..105.00 rows=6400 width=20)
+         ->  Sort  (cost=348.27..380.52 rows=12900 width=20)
+               Sort Key: _hyper_2_16_chunk."time"
+               ->  Custom Scan (ColumnarScan) on _hyper_2_16_chunk  (cost=1.34..134.00 rows=12900 width=20)
+                     ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+
+reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-17.out
+++ b/tsl/test/expected/columnar_scan_cost-17.out
@@ -3,7 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
-set timescaledb.enable_deferred_chunk_append to off;
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
   create_hypertable   
@@ -355,33 +354,23 @@ select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 -------
      2
 
--- Decompress the first chunk and drop its index, so that it has no path
--- producing the required order.
-select count(decompress_chunk(c)) from (select min(c) c from show_chunks('estimate_count') c) x;
- count 
--------
-     1
-
-select format('drop index %I.%I', schemaname, indexname)
-from pg_indexes
-where tablename = (select relname from pg_class
-    where oid = (select min(x) from show_chunks('estimate_count') x))
-\gexec
-drop index _timescaledb_internal._hyper_2_15_chunk_estimate_count_time_idx
 vacuum analyze estimate_count;
 set timescaledb.enable_deferred_chunk_append to off;
+set enable_indexscan to off;
 explain (buffers off)
 select * from estimate_count order by time limit 5;
 --- QUERY PLAN ---
- Limit  (cost=0.00..0.08 rows=5 width=20)
-   ->  Custom Scan (ChunkAppend) on estimate_count  (cost=0.00..105.00 rows=6400 width=20)
+ Limit  (cost=8.57..8.92 rows=5 width=20)
+   ->  Custom Scan (ChunkAppend) on estimate_count  (cost=8.57..451.62 rows=6400 width=20)
          Order: estimate_count."time"
-         ->  Sort  (cost=211.30..227.30 rows=6400 width=20)
-               Sort Key: _hyper_2_15_chunk."time"
-               ->  Seq Scan on _hyper_2_15_chunk  (cost=0.00..105.00 rows=6400 width=20)
-         ->  Sort  (cost=348.27..380.52 rows=12900 width=20)
-               Sort Key: _hyper_2_16_chunk."time"
-               ->  Custom Scan (ColumnarScan) on _hyper_2_16_chunk  (cost=1.34..134.00 rows=12900 width=20)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_15_chunk  (cost=8.57..451.62 rows=6400 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_15_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_15_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_16_chunk  (cost=8.57..901.60 rows=12900 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
                      ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
 
+reset enable_indexscan;
 reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-17.out
+++ b/tsl/test/expected/columnar_scan_cost-17.out
@@ -345,6 +345,7 @@ select * from lastmax where ts = 500;
 
 -- Cost of an ordered ChunkAppend that has to sort a child.
 truncate estimate_count;
+drop index estimate_count_time_idx;
 insert into estimate_count
 select t, d, 1
 from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,

--- a/tsl/test/expected/columnar_scan_cost-17.out
+++ b/tsl/test/expected/columnar_scan_cost-17.out
@@ -355,6 +355,10 @@ select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 -------
      2
 
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-16'::timestamptz,'2025-01-17','15 min') t,
+  generate_series(1, 100) d;
 vacuum analyze estimate_count;
 set timescaledb.enable_deferred_chunk_append to off;
 set enable_indexscan to off;
@@ -372,6 +376,9 @@ select * from estimate_count order by time limit 5;
                ->  Sort  (cost=8.32..8.57 rows=100 width=88)
                      Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
                      ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Sort  (cost=320.11..344.36 rows=9700 width=20)
+               Sort Key: _hyper_2_17_chunk."time"
+               ->  Seq Scan on _hyper_2_17_chunk  (cost=0.00..159.00 rows=9700 width=20)
 
 reset enable_indexscan;
 reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-18.out
+++ b/tsl/test/expected/columnar_scan_cost-18.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
--- Some primitive tests that show cost of DecompressChunk node so that we can
+-- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
@@ -343,3 +343,34 @@ select * from lastmax where ts = 500;
    ->  Seq Scan on _hyper_4_14_chunk_compressed
          Filter: ((_ts_meta_v2_first_ts <= 500) AND (_ts_meta_v2_last_ts >= 500))
 
+-- Cost of an ordered ChunkAppend that has to sort a child.
+truncate estimate_count;
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,
+  generate_series(1, 100) d;
+select count(compress_chunk(c)) from show_chunks('estimate_count') c;
+ count 
+-------
+     2
+
+vacuum analyze estimate_count;
+set timescaledb.enable_deferred_chunk_append to off;
+set enable_indexscan to off;
+explain (buffers off)
+select * from estimate_count order by time limit 5;
+--- QUERY PLAN ---
+ Limit  (cost=8.57..8.92 rows=5 width=20)
+   ->  Custom Scan (ChunkAppend) on estimate_count  (cost=8.57..451.62 rows=6400 width=20)
+         Order: estimate_count."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_2_15_chunk  (cost=8.57..451.62 rows=6400 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_15_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_15_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_16_chunk  (cost=8.57..901.60 rows=12900 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+
+reset enable_indexscan;
+reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-18.out
+++ b/tsl/test/expected/columnar_scan_cost-18.out
@@ -345,6 +345,7 @@ select * from lastmax where ts = 500;
 
 -- Cost of an ordered ChunkAppend that has to sort a child.
 truncate estimate_count;
+drop index estimate_count_time_idx;
 insert into estimate_count
 select t, d, 1
 from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,

--- a/tsl/test/expected/columnar_scan_cost-18.out
+++ b/tsl/test/expected/columnar_scan_cost-18.out
@@ -355,6 +355,10 @@ select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 -------
      2
 
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-16'::timestamptz,'2025-01-17','15 min') t,
+  generate_series(1, 100) d;
 vacuum analyze estimate_count;
 set timescaledb.enable_deferred_chunk_append to off;
 set enable_indexscan to off;
@@ -372,6 +376,9 @@ select * from estimate_count order by time limit 5;
                ->  Sort  (cost=8.32..8.57 rows=100 width=88)
                      Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
                      ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Sort  (cost=320.11..344.36 rows=9700 width=20)
+               Sort Key: _hyper_2_17_chunk."time"
+               ->  Seq Scan on _hyper_2_17_chunk  (cost=0.00..159.00 rows=9700 width=20)
 
 reset enable_indexscan;
 reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-19.out
+++ b/tsl/test/expected/columnar_scan_cost-19.out
@@ -1,7 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
--- Some primitive tests that show cost of DecompressChunk node so that we can
+-- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
@@ -343,3 +343,34 @@ select * from lastmax where ts = 500;
    ->  Seq Scan on _hyper_4_14_chunk_compressed
          Filter: ((_ts_meta_v2_first_ts <= 500) AND (_ts_meta_v2_last_ts >= 500))
 
+-- Cost of an ordered ChunkAppend that has to sort a child.
+truncate estimate_count;
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,
+  generate_series(1, 100) d;
+select count(compress_chunk(c)) from show_chunks('estimate_count') c;
+ count 
+-------
+     2
+
+vacuum analyze estimate_count;
+set timescaledb.enable_deferred_chunk_append to off;
+set enable_indexscan to off;
+explain (buffers off)
+select * from estimate_count order by time limit 5;
+--- QUERY PLAN ---
+ Limit  (cost=8.57..8.92 rows=5 width=20)
+   ->  Custom Scan (ChunkAppend) on estimate_count  (cost=8.57..451.62 rows=6400 width=20)
+         Order: estimate_count."time"
+         ->  Custom Scan (ColumnarScan) on _hyper_2_15_chunk  (cost=8.57..451.62 rows=6400 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_15_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_15_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Custom Scan (ColumnarScan) on _hyper_2_16_chunk  (cost=8.57..901.60 rows=12900 width=20)
+               ->  Sort  (cost=8.32..8.57 rows=100 width=88)
+                     Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
+                     ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+
+reset enable_indexscan;
+reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/expected/columnar_scan_cost-19.out
+++ b/tsl/test/expected/columnar_scan_cost-19.out
@@ -345,6 +345,7 @@ select * from lastmax where ts = 500;
 
 -- Cost of an ordered ChunkAppend that has to sort a child.
 truncate estimate_count;
+drop index estimate_count_time_idx;
 insert into estimate_count
 select t, d, 1
 from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,

--- a/tsl/test/expected/columnar_scan_cost-19.out
+++ b/tsl/test/expected/columnar_scan_cost-19.out
@@ -355,6 +355,10 @@ select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 -------
      2
 
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-16'::timestamptz,'2025-01-17','15 min') t,
+  generate_series(1, 100) d;
 vacuum analyze estimate_count;
 set timescaledb.enable_deferred_chunk_append to off;
 set enable_indexscan to off;
@@ -372,6 +376,9 @@ select * from estimate_count order by time limit 5;
                ->  Sort  (cost=8.32..8.57 rows=100 width=88)
                      Sort Key: _hyper_2_16_chunk_compressed._ts_meta_v2_first_time
                      ->  Seq Scan on _hyper_2_16_chunk_compressed  (cost=0.00..5.00 rows=100 width=88)
+         ->  Sort  (cost=320.11..344.36 rows=9700 width=20)
+               Sort Key: _hyper_2_17_chunk."time"
+               ->  Seq Scan on _hyper_2_17_chunk  (cost=0.00..159.00 rows=9700 width=20)
 
 reset enable_indexscan;
 reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/sql/columnar_scan_cost.sql.in
+++ b/tsl/test/sql/columnar_scan_cost.sql.in
@@ -2,8 +2,10 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
--- Some primitive tests that show cost of DecompressChunk node so that we can
+-- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
+
+set timescaledb.enable_deferred_chunk_append to off;
 
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
@@ -212,3 +214,25 @@ reset timescaledb.restoring;
 
 explain (costs off)
 select * from lastmax where ts = 500;
+
+
+-- Cost of an ordered ChunkAppend that has to sort a child.
+truncate estimate_count;
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,
+  generate_series(1, 100) d;
+
+select count(compress_chunk(c)) from show_chunks('estimate_count') c;
+
+vacuum analyze estimate_count;
+
+set enable_indexscan to off;
+
+explain (buffers off)
+select * from estimate_count order by time limit 5;
+
+reset enable_indexscan;
+
+
+reset timescaledb.enable_deferred_chunk_append;

--- a/tsl/test/sql/columnar_scan_cost.sql.in
+++ b/tsl/test/sql/columnar_scan_cost.sql.in
@@ -5,8 +5,6 @@
 -- Some primitive tests that show cost of ColumnarScan node so that we can
 -- monitor the changes.
 
-set timescaledb.enable_deferred_chunk_append to off;
-
 create table costtab(ts int, s text, c text, ti text, fi float);
 select create_hypertable('costtab', 'ts');
 alter table costtab set (timescaledb.compress, timescaledb.compress_segmentby = 's',
@@ -227,6 +225,7 @@ select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 
 vacuum analyze estimate_count;
 
+set timescaledb.enable_deferred_chunk_append to off;
 set enable_indexscan to off;
 
 explain (buffers off)

--- a/tsl/test/sql/columnar_scan_cost.sql.in
+++ b/tsl/test/sql/columnar_scan_cost.sql.in
@@ -224,6 +224,11 @@ from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,
 
 select count(compress_chunk(c)) from show_chunks('estimate_count') c;
 
+insert into estimate_count
+select t, d, 1
+from generate_series('2025-01-16'::timestamptz,'2025-01-17','15 min') t,
+  generate_series(1, 100) d;
+
 vacuum analyze estimate_count;
 
 set timescaledb.enable_deferred_chunk_append to off;

--- a/tsl/test/sql/columnar_scan_cost.sql.in
+++ b/tsl/test/sql/columnar_scan_cost.sql.in
@@ -216,6 +216,7 @@ select * from lastmax where ts = 500;
 
 -- Cost of an ordered ChunkAppend that has to sort a child.
 truncate estimate_count;
+drop index estimate_count_time_idx;
 insert into estimate_count
 select t, d, 1
 from generate_series('2025-01-01'::timestamptz,'2025-01-03','15 min') t,


### PR DESCRIPTION
This is purely cosmetic, in some cases Sort shows zero cost in EXPLAIN. We had similar problem in ColumnarScan that was fixed but this one was not, add a helper function to use in both places.


Disable-check: force-changelog-file