### PR TITLE
Move some parts of ordered ChunkAppend planning closer to path creation

### DIFF
--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -1012,21 +1012,12 @@ chunk_cmp_reverse(const void *c1, const void *c2)
  *
  * if "chunks" is NULL, we get all the chunks from the catalog. Otherwise we
  * restrict ourselves to the passed in chunks list.
- *
- * nested_oids is a list of lists, chunks that occupy the same time slice will be
- * in the same list. In the list [[1,2,3],[4,5,6]] chunks 1, 2 and 3 are space partitions of
- * the same time slice and 4, 5 and 6 are space partitions of the next time slice.
- *
  */
 Chunk **
 ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri, Hypertable *ht,
 											   bool include_osm, Chunk **chunks, bool reverse,
-											   List **nested_oids, unsigned int *num_chunks)
+											   unsigned int *num_chunks)
 {
-	List *slot_chunk_oids = NIL;
-	DimensionSlice *slice = NULL;
-	unsigned int i;
-
 	if (chunks == NULL)
 	{
 		chunks = ts_hypertable_restrict_info_get_chunks(hri, ht, include_osm, num_chunks);
@@ -1047,30 +1038,6 @@ ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri, Hype
 	else
 	{
 		qsort((void *) chunks, *num_chunks, sizeof(Chunk *), chunk_cmp);
-	}
-
-	for (i = 0; i < *num_chunks; i++)
-	{
-		Chunk *chunk = chunks[i];
-
-		if (NULL != slice && ts_dimension_slice_cmp(slice, chunk->cube->slices[0]) != 0 &&
-			slot_chunk_oids != NIL)
-		{
-			*nested_oids = lappend(*nested_oids, slot_chunk_oids);
-			slot_chunk_oids = NIL;
-		}
-
-		if (NULL != nested_oids)
-		{
-			slot_chunk_oids = lappend_oid(slot_chunk_oids, chunk->fd.relid);
-		}
-
-		slice = chunk->cube->slices[0];
-	}
-
-	if (slot_chunk_oids != NIL)
-	{
-		*nested_oids = lappend(*nested_oids, slot_chunk_oids);
 	}
 
 	return chunks;

--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -65,5 +65,4 @@ extern Chunk **ts_hypertable_restrict_info_get_chunks(HypertableRestrictInfo *hr
 extern Chunk **ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri,
 															  Hypertable *ht, bool include_osm,
 															  Chunk **chunks, bool reverse,
-															  List **nested_oids,
 															  unsigned int *num_chunks);

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -12,6 +12,8 @@
 #include <utils/builtins.h>
 #include <utils/typcache.h>
 
+#include "chunk.h"
+#include "dimension_slice.h"
 #include "func_cache.h"
 #include "guc.h"
 #include "nodes/chunk_append/chunk_append.h"
@@ -35,6 +37,54 @@ static bool
 has_joins(FromExpr *jointree)
 {
 	return list_length(jointree->fromlist) != 1 || !IsA(linitial(jointree->fromlist), RangeTblRef);
+}
+
+/*
+ * Build the nested oids list for the ChunkAppend with ordering with space
+ * partitioning.
+ *
+ * nested_oids is a list of lists, chunks that occupy the same time slice will be
+ * in the same list. In the list [[1,2,3],[4,5,6]] chunks 1, 2 and 3 are space partitions of
+ * the same time slice and 4, 5 and 6 are space partitions of the next time slice.
+ */
+static List *
+build_nested_oids(PlannerInfo *root, List *children)
+{
+	List *nested_oids = NIL;
+	List *slice_oids = NIL;
+	const DimensionSlice *prev_slice = NULL;
+
+	ListCell *lc;
+	foreach (lc, children)
+	{
+		Path *child = (Path *) lfirst(lc);
+		const Chunk *chunk = ts_planner_chunk_fetch(root, child->parent);
+
+		/*
+		 * The children should be only plain chunks since we're creating a
+		 * ChunkAppend, but don't segfault.
+		 */
+		Ensure(chunk != NULL,
+			   "unexpected ChunkAppend child relation (index %d)",
+			   child->parent->relid);
+
+		if (prev_slice != NULL && ts_dimension_slice_cmp(prev_slice, chunk->cube->slices[0]) != 0)
+		{
+			nested_oids = lappend(nested_oids, slice_oids);
+			slice_oids = NIL;
+		}
+
+		slice_oids = lappend_oid(slice_oids, chunk->fd.relid);
+
+		prev_slice = chunk->cube->slices[0];
+	}
+
+	if (slice_oids != NIL)
+	{
+		nested_oids = lappend(nested_oids, slice_oids);
+	}
+
+	return nested_oids;
 }
 
 /*
@@ -102,7 +152,7 @@ ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths, PathTarget *patht
 
 Path *
 ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, Path *subpath,
-							bool parallel_aware, bool ordered, List *nested_oids)
+							bool parallel_aware, bool ordered)
 {
 	ChunkAppendPath *path;
 	ListCell *lc;
@@ -389,6 +439,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 		 * We do not check sort order at this stage but injecting of Sort
 		 * nodes happens when the plan is created instead.
 		 */
+		List *nested_oids = build_nested_oids(root, children);
 		ListCell *flat = list_head(children);
 		List *nested_children = NIL;
 		bool has_scan_childs = false;

--- a/src/nodes/chunk_append/chunk_append.h
+++ b/src/nodes/chunk_append/chunk_append.h
@@ -50,8 +50,7 @@ typedef struct ChunkAppendPath
 extern TSDLLEXPORT ChunkAppendPath *ts_chunk_append_path_copy(ChunkAppendPath *ca, List *subpaths,
 															  PathTarget *pathtarget);
 extern Path *ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht,
-										 Path *subpath, bool parallel_aware, bool ordered,
-										 List *nested_oids);
+										 Path *subpath, bool parallel_aware, bool ordered);
 extern Plan *ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
 										 List *tlist, List *clauses, List *custom_plans);
 extern Node *ts_chunk_append_state_create(CustomScan *cscan);

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1103,8 +1103,6 @@ get_simplified_restrictions(PlannerInfo *root, List *restrictions)
  * If appends are returned in order appends_ordered on rel->fdw_private is set to true.
  * To make verifying pathkeys easier in set_rel_pathlist the hypertable attno of the column
  * ordered by is stored in rel->fdw_private.
- * If the hypertable uses space partitioning the nested oids are stored in nested_oids
- * on rel->fdw_private when appends are ordered.
  */
 static Chunk **
 get_chunks(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, bool include_osm,

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1155,26 +1155,15 @@ get_chunks(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, bool include_osm,
 	if (rel->fdw_private != NULL && should_order_append(root, rel, ht, &order_attno, &reverse))
 	{
 		TimescaleDBPrivate *priv = ts_get_private_reloptinfo(rel);
-		List **nested_oids = NULL;
 
 		priv->appends_ordered = true;
 		priv->order_attno = order_attno;
-
-		/*
-		 * for space partitioning we need extra information about the
-		 * time slices of the chunks
-		 */
-		if (ht->space->num_dimensions > 1)
-		{
-			nested_oids = &priv->nested_oids;
-		}
 
 		return ts_hypertable_restrict_info_get_chunks_ordered(hri,
 															  ht,
 															  include_osm,
 															  NULL,
 															  reverse,
-															  nested_oids,
 															  num_chunks);
 	}
 

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1397,7 +1397,6 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 		TimescaleDBPrivate *private = ts_get_private_reloptinfo(rel);
 		bool ordered = private->appends_ordered;
 		int order_attno = private->order_attno;
-		List *nested_oids = private->nested_oids;
 		ListCell *lc;
 
 		Assert(ht != NULL);
@@ -1412,13 +1411,8 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 				case T_MergeAppendPath:
 					if (should_chunk_append(ht, root, rel, *pathptr, ordered, order_attno))
 					{
-						*pathptr = ts_chunk_append_path_create(root,
-															   rel,
-															   ht,
-															   *pathptr,
-															   false,
-															   ordered,
-															   nested_oids);
+						*pathptr =
+							ts_chunk_append_path_create(root, rel, ht, *pathptr, false, ordered);
 					}
 					else if (should_constraint_aware_append(root, ht, *pathptr))
 					{
@@ -1441,7 +1435,7 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 					if (should_chunk_append(ht, root, rel, *pathptr, false, 0))
 					{
 						*pathptr =
-							ts_chunk_append_path_create(root, rel, ht, *pathptr, true, false, NIL);
+							ts_chunk_append_path_create(root, rel, ht, *pathptr, true, false);
 					}
 					else if (should_constraint_aware_append(root, ht, *pathptr))
 					{

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -32,7 +32,6 @@ typedef struct TimescaleDBPrivate
 	bool appends_ordered;
 	/* attno of the time dimension in the parent table if appends are ordered */
 	int order_attno;
-	List *nested_oids;
 	List *chunk_oids;
 
 	/* Cached chunk data for the chunk relinfo. */

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -32,7 +32,6 @@ typedef struct TimescaleDBPrivate
 	bool appends_ordered;
 	/* attno of the time dimension in the parent table if appends are ordered */
 	int order_attno;
-	List *chunk_oids;
 
 	/* Cached chunk data for the chunk relinfo. */
 	Chunk *cached_chunk_struct;


### PR DESCRIPTION
At the moment, for ordered ChunkAppend we have to do some chunk sorting very early in the planning, at the hypertable expansion stage. At this point, the required order is not even fully known, hence the need for brittle hacks like reading the parse tree. Ideally we want the ordering to happen at path creation stage. The full code is complicated, so I'm going to change it in small parts. For starters, move the "nested_oids" list computation to happen just before it is used. No functional changes.

An example of such a problem: https://github.com/timescale/timescaledb/issues/9999

The next thing to do would be probably to eliminate the `ts_hypertable_restrict_info_get_chunks_ordered` entirely by handling the `reverse` flag in a way similar to what this PR does. After that, the `should_ordered_append` function could be removed: this is where the "checking the order too early" happens.

Disable-check: force-changelog-file