### PR TITLE
Fix chunk merging with default sparse indexes

### DIFF
--- a/.unreleased/pr_10535
+++ b/.unreleased/pr_10535
@@ -1,0 +1,2 @@
+Fixes: #10535 Fix chunk merging with default sparse indexes
+Thanks: @esdanieljaegers for reporting the issue and providing steps for reproduction

--- a/src/ts_catalog/compression_settings.c
+++ b/src/ts_catalog/compression_settings.c
@@ -63,7 +63,8 @@ ts_compression_settings_equal_with_defaults(const CompressionSettings *ht,
 			ts_array_equal(ht->fd.orderby_desc, chunk->fd.orderby_desc)) &&
 		   (ht->fd.orderby_nullsfirst == NULL ||
 			ts_array_equal(ht->fd.orderby_nullsfirst, chunk->fd.orderby_nullsfirst)) &&
-		   (ht->fd.index == NULL || ts_sparse_index_equal(ht->fd.index, chunk->fd.index));
+		   (ts_can_set_default_sparse_index(ht) ||
+			ts_sparse_index_equal(ht->fd.index, chunk->fd.index));
 }
 
 /*
@@ -1105,9 +1106,10 @@ ts_accept_for_segmentby(CompressionSettings *settings, Form_pg_attribute attr)
 
 	return false;
 }
+
 /* Sparse indexes are only set by default when no user configuration exists */
 bool
-ts_can_set_default_sparse_index(CompressionSettings *settings)
+ts_can_set_default_sparse_index(const CompressionSettings *settings)
 {
 	return (settings->fd.index == NULL) ||
 		   !ts_jsonb_has_key_value_str_field(settings->fd.index,

--- a/src/ts_catalog/compression_settings.h
+++ b/src/ts_catalog/compression_settings.h
@@ -176,7 +176,7 @@ bool ts_contains_sparse_index_config(CompressionSettings *settings, const char *
 									 const char *sparse_index_type, bool skip_column_arrays);
 TSDLLEXPORT bool ts_column_has_sparse_index(CompressionSettings *settings, const char *attname);
 TSDLLEXPORT bool ts_accept_for_segmentby(CompressionSettings *settings, Form_pg_attribute attr);
-TSDLLEXPORT bool ts_can_set_default_sparse_index(CompressionSettings *settings);
+TSDLLEXPORT bool ts_can_set_default_sparse_index(const CompressionSettings *settings);
 TSDLLEXPORT Jsonb *ts_add_orderby_sparse_index(CompressionSettings *settings);
 
 TSDLLEXPORT Jsonb *ts_remove_orderby_sparse_index(CompressionSettings *settings);

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -860,3 +860,52 @@ SELECT 'test_defaults' AS "HYPERTABLE_NAME" \gset
  t           | t
 
 DROP TABLE test_defaults;
+-- Test chunk merging works with default sparse indexes
+CREATE TABLE test_sparse_default("Time" timestamptz NOT NULL, i integer, tag integer, value integer);
+SELECT table_name from create_hypertable('test_sparse_default', 'Time', chunk_time_interval => INTERVAL '1 hour');
+     table_name      
+---------------------
+ test_sparse_default
+
+-- A btree index so that default sparse indexes are set
+CREATE INDEX ON test_sparse_default (tag);
+-- This will generate 8 chunks
+INSERT INTO test_sparse_default
+SELECT t, i, i, gen_rand_minstd()
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 8:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+ALTER TABLE test_sparse_default
+SET (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='4 hours');
+SELECT count(compress_chunk(ch)) FROM show_chunks('test_sparse_default') ch;
+ count 
+-------
+     8
+
+SELECT index FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_sparse_default'::regclass;
+                                                           index                                                           
+---------------------------------------------------------------------------------------------------------------------------
+ [{"type": "minmax", "column": "Time", "source": "orderby"}, {"type": "firstlast", "column": "Time", "source": "orderby"}]
+
+SELECT DISTINCT cs.index
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch ON cs.relid = ch.relid
+JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'test_sparse_default';
+                                                                                       index                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"type": "bloom", "column": "tag", "source": "default"}, {"type": "minmax", "column": "Time", "source": "orderby"}, {"type": "firstlast", "column": "Time", "source": "orderby"}]
+
+-- chunks merged upon compression due to compress_chunk_time_interval
+SELECT count(*) AS chunk_count FROM show_chunks('test_sparse_default');
+ chunk_count 
+-------------
+           2
+
+SELECT range_start, range_end FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_sparse_default' ORDER BY 1;
+         range_start          |          range_end           
+------------------------------+------------------------------
+ Fri Mar 02 01:00:00 2018 PST | Fri Mar 02 05:00:00 2018 PST
+ Fri Mar 02 05:00:00 2018 PST | Fri Mar 02 09:00:00 2018 PST
+
+DROP TABLE test_sparse_default;

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -380,3 +380,36 @@ SELECT 'test_defaults' AS "HYPERTABLE_NAME" \gset
 \ir include/compression_test_hypertable_segment_meta.sql
 
 DROP TABLE test_defaults;
+
+-- Test chunk merging works with default sparse indexes
+CREATE TABLE test_sparse_default("Time" timestamptz NOT NULL, i integer, tag integer, value integer);
+SELECT table_name from create_hypertable('test_sparse_default', 'Time', chunk_time_interval => INTERVAL '1 hour');
+
+-- A btree index so that default sparse indexes are set
+CREATE INDEX ON test_sparse_default (tag);
+
+-- This will generate 8 chunks
+INSERT INTO test_sparse_default
+SELECT t, i, i, gen_rand_minstd()
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 8:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+
+ALTER TABLE test_sparse_default
+SET (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='4 hours');
+
+SELECT count(compress_chunk(ch)) FROM show_chunks('test_sparse_default') ch;
+
+SELECT index FROM _timescaledb_catalog.compression_settings WHERE relid = 'test_sparse_default'::regclass;
+
+SELECT DISTINCT cs.index
+FROM _timescaledb_catalog.compression_settings cs
+JOIN _timescaledb_catalog.chunk ch ON cs.relid = ch.relid
+JOIN _timescaledb_catalog.hypertable ht ON ch.hypertable_id = ht.id
+WHERE ht.table_name = 'test_sparse_default';
+
+-- chunks merged upon compression due to compress_chunk_time_interval
+SELECT count(*) AS chunk_count FROM show_chunks('test_sparse_default');
+SELECT range_start, range_end FROM timescaledb_information.chunks
+WHERE hypertable_name = 'test_sparse_default' ORDER BY 1;
+
+DROP TABLE test_sparse_default;


### PR DESCRIPTION
Sparse indexes with source "default" are derived per chunk, so they
appear in the chunk settings but never in the hypertable settings.

find_chunk_to_merge_into() compared the two verbatim, saw a mismatch,
and silently skipped the rollup. Compare sparse indexes only when the
hypertable has user-configured ones.

Fixes #10511 