### PR TITLE
Add primary key to bgw_policy_chunk_stats table

### DIFF
--- a/.unreleased/pr_10539
+++ b/.unreleased/pr_10539
@@ -1,0 +1,2 @@
+Fixes: #10539 Allow deletes from the policy chunk stats table when the database publishes all tables
+Thanks: @AlexFavre for reporting a failed extension update when a publication for all tables exists

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -300,7 +300,7 @@ CREATE TABLE _timescaledb_internal.bgw_policy_chunk_stats (
   num_times_job_run integer,
   last_time_job_run timestamptz,
   -- table constraints
-  CONSTRAINT bgw_policy_chunk_stats_job_id_chunk_id_key UNIQUE (job_id, chunk_id),
+  CONSTRAINT bgw_policy_chunk_stats_job_id_chunk_id_key PRIMARY KEY (job_id, chunk_id),
   CONSTRAINT bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE,
   CONSTRAINT bgw_policy_chunk_stats_job_id_fkey FOREIGN KEY (job_id) REFERENCES _timescaledb_catalog.bgw_job (id) ON DELETE CASCADE
 );

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -220,3 +220,27 @@ BEGIN
   END IF;
 END
 $$;
+
+-- Promote the (job_id, chunk_id) unique constraint on the policy chunk stats
+-- table to a primary key to avoid problems with publications.
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats
+  DROP CONSTRAINT bgw_policy_chunk_stats_job_id_chunk_id_key,
+  ADD CONSTRAINT bgw_policy_chunk_stats_job_id_chunk_id_key PRIMARY KEY (job_id, chunk_id);
+
+-- Anyone who hit this problem could work around it by pointing the replica identity at
+-- the unique index. Dropping that index leaves the setting behind naming
+-- nothing, so send it back to the new primary key.
+DO $$
+BEGIN
+  IF (SELECT relreplident FROM pg_class
+      WHERE oid = '_timescaledb_internal.bgw_policy_chunk_stats'::regclass) = 'i'
+     AND NOT EXISTS (
+       SELECT FROM pg_index
+       WHERE indrelid = '_timescaledb_internal.bgw_policy_chunk_stats'::regclass
+         AND indisreplident)
+  THEN
+    ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats
+      REPLICA IDENTITY DEFAULT;
+  END IF;
+END
+$$;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -147,3 +147,27 @@ DROP FUNCTION IF EXISTS _timescaledb_functions.tenant_tracking_map();
 
 ALTER TABLE _timescaledb_catalog.hypertable SET (user_catalog_table = true);
 ALTER TABLE _timescaledb_catalog.chunk SET (user_catalog_table = true);
+
+-- Turn the policy chunk stats primary key back into a unique constraint.
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats
+  DROP CONSTRAINT bgw_policy_chunk_stats_job_id_chunk_id_key,
+  ADD CONSTRAINT bgw_policy_chunk_stats_job_id_chunk_id_key UNIQUE (job_id, chunk_id);
+
+-- A replica identity naming the primary key index is left naming nothing once
+-- that index is gone, so point it at the unique constraint instead. The table
+-- has no primary key any more, so DEFAULT would leave it without a replica
+-- identity at all.
+DO $$
+BEGIN
+  IF (SELECT relreplident FROM pg_class
+      WHERE oid = '_timescaledb_internal.bgw_policy_chunk_stats'::regclass) = 'i'
+     AND NOT EXISTS (
+       SELECT FROM pg_index
+       WHERE indrelid = '_timescaledb_internal.bgw_policy_chunk_stats'::regclass
+         AND indisreplident)
+  THEN
+    ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats
+      REPLICA IDENTITY USING INDEX bgw_policy_chunk_stats_job_id_chunk_id_key;
+  END IF;
+END
+$$;

--- a/test/expected/chunk_publication.out
+++ b/test/expected/chunk_publication.out
@@ -1135,4 +1135,16 @@ SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks WHERE hypert
 -- Cleanup
 DROP PUBLICATION test_pub_guc CASCADE;
 DROP TABLE test_hypertable CASCADE;
+-- Test 10: A publication covering all tables must not block deletes from the
+-- policy chunk stats table. Postgres only allows deletes from a published table
+-- if it has a replica identity, which this table gets from its primary key.
+CREATE PUBLICATION test_pub_catalog FOR ALL TABLES;
+SELECT conname FROM pg_constraint
+WHERE conrelid = '_timescaledb_internal.bgw_policy_chunk_stats'::regclass AND contype = 'p';
+                  conname                   
+--------------------------------------------
+ bgw_policy_chunk_stats_job_id_chunk_id_key
+
+DELETE FROM _timescaledb_internal.bgw_policy_chunk_stats WHERE job_id = -1;
+DROP PUBLICATION test_pub_catalog;
 RESET client_min_messages;

--- a/test/sql/chunk_publication.sql
+++ b/test/sql/chunk_publication.sql
@@ -698,4 +698,16 @@ SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks WHERE hypert
 DROP PUBLICATION test_pub_guc CASCADE;
 DROP TABLE test_hypertable CASCADE;
 
+-- Test 10: A publication covering all tables must not block deletes from the
+-- policy chunk stats table. Postgres only allows deletes from a published table
+-- if it has a replica identity, which this table gets from its primary key.
+CREATE PUBLICATION test_pub_catalog FOR ALL TABLES;
+
+SELECT conname FROM pg_constraint
+WHERE conrelid = '_timescaledb_internal.bgw_policy_chunk_stats'::regclass AND contype = 'p';
+
+DELETE FROM _timescaledb_internal.bgw_policy_chunk_stats WHERE job_id = -1;
+
+DROP PUBLICATION test_pub_catalog;
+
 RESET client_min_messages;


### PR DESCRIPTION
This table already has a unique constraint/index on it so converting that to primary key is cheap and also reduces risk of creating problems down the line if somebody were to create publications for all tables.

Fixes #10477