### PR TITLE
Fix UUID timezone bucket offset forwarding

### DIFF
--- a/.unreleased/fix_uuid_timezone_offset
+++ b/.unreleased/fix_uuid_timezone_offset
@@ -1,0 +1,1 @@
+Fixes: #10555 UUID time_bucket timezone overload dropped the offset argument

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -595,10 +595,10 @@ ts_uuid_timezone_bucket(PG_FUNCTION_ARGS)
 				 errmsg("not a version 7 UUID: %s", uuid_to_str(uuid))));
 	}
 
-	LOCAL_FCINFO(fcinfo_local, 4);
+	LOCAL_FCINFO(fcinfo_local, 5);
 	Datum result;
 
-	InitFunctionCallInfoData(*fcinfo_local, NULL, 4, InvalidOid, NULL, NULL);
+	InitFunctionCallInfoData(*fcinfo_local, NULL, 5, InvalidOid, NULL, NULL);
 
 	fcinfo_local->args[0].value = PG_GETARG_DATUM(0); /* Period */
 	fcinfo_local->args[0].isnull = PG_ARGISNULL(0);
@@ -606,8 +606,10 @@ ts_uuid_timezone_bucket(PG_FUNCTION_ARGS)
 	fcinfo_local->args[1].isnull = PG_ARGISNULL(1);
 	fcinfo_local->args[2].value = PG_GETARG_DATUM(2);
 	fcinfo_local->args[2].isnull = PG_ARGISNULL(2);
-	fcinfo_local->args[3].value = PG_GETARG_DATUM(3);
-	fcinfo_local->args[3].isnull = PG_ARGISNULL(3);
+	fcinfo_local->args[3].value = PG_NARGS() > 3 ? PG_GETARG_DATUM(3) : (Datum) 0;
+	fcinfo_local->args[3].isnull = PG_NARGS() <= 3 || PG_ARGISNULL(3);
+	fcinfo_local->args[4].value = PG_NARGS() > 4 ? PG_GETARG_DATUM(4) : (Datum) 0;
+	fcinfo_local->args[4].isnull = PG_NARGS() <= 4 || PG_ARGISNULL(4);
 
 	result = ts_timestamptz_timezone_bucket(fcinfo_local);
 

--- a/test/expected/uuid.out
+++ b/test/expected/uuid.out
@@ -314,6 +314,16 @@ GROUP BY id ORDER BY id DESC;
  Wed Jan 01 00:00:00 2025 PST |   2
  Wed Jan 01 00:00:00 2025 PST |   1
 
+-- UUID timezone overload must forward a non-NULL offset.
+WITH x AS (
+    SELECT '01942117-de80-7000-8121-f12b2b69dd96'::uuid AS id
+)
+SELECT time_bucket('1 hour', id, 'UTC'::text, NULL::timestamptz, '30 minutes'::interval) =
+       time_bucket('1 hour', uuid_timestamp(id), 'UTC'::text, NULL::timestamptz, '30 minutes'::interval)
+       AS uuid_timezone_offset_matches_timestamp
+FROM x \gset
+\echo :uuid_timezone_offset_matches_timestamp
+t
 -- Test UUID time_bucket in WHERE clause. Note that there is currently no chunk
 -- exclusion when using time_bucket() in the WHERE clause qual. This requires
 -- special handling of the time_bucket() transform optimizatios for different

--- a/test/sql/uuid.sql
+++ b/test/sql/uuid.sql
@@ -173,6 +173,16 @@ SELECT time_bucket('1 day', id, 'Europe/Stockholm'::text, '2000-01-01 00:00'::ti
 FROM uuid_events WHERE id < to_uuidv7_boundary(:'chunk_range_end')
 GROUP BY id ORDER BY id DESC;
 
+-- UUID timezone overload must forward a non-NULL offset.
+WITH x AS (
+    SELECT '01942117-de80-7000-8121-f12b2b69dd96'::uuid AS id
+)
+SELECT time_bucket('1 hour', id, 'UTC'::text, NULL::timestamptz, '30 minutes'::interval) =
+       time_bucket('1 hour', uuid_timestamp(id), 'UTC'::text, NULL::timestamptz, '30 minutes'::interval)
+       AS uuid_timezone_offset_matches_timestamp
+FROM x \gset
+\echo :uuid_timezone_offset_matches_timestamp
+
 -- Test UUID time_bucket in WHERE clause. Note that there is currently no chunk
 -- exclusion when using time_bucket() in the WHERE clause qual. This requires
 -- special handling of the time_bucket() transform optimizatios for different


### PR DESCRIPTION
## What does this PR do?

Fix the UUID `time_bucket` timezone overload so that it forwards the optional `offset` argument to `ts_timestamptz_timezone_bucket()`.

The SQL signature supports:

time_bucket(interval, uuid, text, timestamptz, interval)

but the UUID wrapper previously initialized a function call with only four arguments. As a result, a non-NULL offset was silently ignored.

This change also preserves compatibility with C callers that provide fewer than five arguments.



Fixes https://github.com/timescale/timescaledb/issues/10555