### PR TITLE
Keep hypertable out of leaf_result_relids

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1237,6 +1237,15 @@ expand_all_hypertables(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEn
 			 */
 			if (bms_is_member(i, root->all_result_relids))
 			{
+				/*
+				 * Side-effect of setting inh = false, Postgres might have included
+				 * the hypertable into leaf_result_relids in latest PG versions.
+				 * We remove it here because hypertable relation never contains
+				 * any heap tuples. This is compatible with older versions
+				 * which don't contain hypertable leaf result relid (its a no-op).
+				 */
+				root->leaf_result_relids = bms_del_member(root->leaf_result_relids, i);
+
 				distribute_row_identity_vars(root);
 			}
 

--- a/test/expected/plan_expand_hypertable-16.out
+++ b/test/expected/plan_expand_hypertable-16.out
@@ -836,17 +836,22 @@ joins
          ->  Seq Scan on _hyper_3_123_chunk
                Filter: ((hashed SubPlan 1) OR (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text)))
 
+-- Disabling nested loop join to keep the test cross-version stable
+-- between pg16.15/17.11/18.6 and newer
+SET enable_nestloop = off;
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.name='tag1') and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_3_116_chunk.value
-   ->  Nested Loop
-         Join Filter: (_hyper_3_116_chunk.tag_id = tag.id)
-         ->  Seq Scan on _hyper_3_116_chunk
-               Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
+   ->  Hash Join
+         Hash Cond: (tag.id = _hyper_3_116_chunk.tag_id)
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+         ->  Hash
+               ->  Seq Scan on _hyper_3_116_chunk
+                     Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
 
+RESET enable_nestloop;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -3711,15 +3716,35 @@ SELECT create_hypertable('self_join_test', 'time');
 CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
 INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
 ANALYZE self_join_test;
-EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+CREATE FUNCTION plan_lines(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE
+	ln text;
+BEGIN
+	FOR ln IN EXECUTE 'EXPLAIN (buffers off, costs off) ' || query
+	LOOP
+		RETURN NEXT ln;
+	END LOOP;
+END;
+$$;
+SELECT count(*) FILTER (WHERE ln LIKE '%Scan on %') AS scans,
+       count(*) FILTER (WHERE ln ~ 'Nested Loop|Hash Join|Merge Join') AS join_nodes
+FROM plan_lines('SELECT t1.val
+                 FROM self_join_test t1, self_join_test t2
+                 WHERE t1.device = t2.device AND t1.time = t2.time') AS ln;
+ scans | join_nodes 
+-------+------------
+     2 |          1
+
+SELECT t1.val
 FROM self_join_test t1, self_join_test t2
-WHERE t1.device = t2.device AND t1.time = t2.time;
---- QUERY PLAN ---
- Hash Join (actual rows=2.00 loops=1)
-   Hash Cond: ((t1.device = t2.device) AND (t1."time" = t2."time"))
-   ->  Seq Scan on _hyper_24_206_chunk t1 (actual rows=2.00 loops=1)
-   ->  Hash (actual rows=2.00 loops=1)
-         ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+WHERE t1.device = t2.device AND t1.time = t2.time
+ORDER BY t1.val;
+ val 
+-----
+   1
+   2
 
 CREATE VIEW join_removal_view AS
 SELECT m.time, m.device, m.val, a.extra

--- a/test/expected/plan_expand_hypertable-17.out
+++ b/test/expected/plan_expand_hypertable-17.out
@@ -836,17 +836,22 @@ joins
          ->  Seq Scan on _hyper_3_123_chunk
                Filter: ((ANY (tag_id = (hashed SubPlan 1).col1)) OR (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text)))
 
+-- Disabling nested loop join to keep the test cross-version stable
+-- between pg16.15/17.11/18.6 and newer
+SET enable_nestloop = off;
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.name='tag1') and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_3_116_chunk.value
-   ->  Nested Loop
-         Join Filter: (_hyper_3_116_chunk.tag_id = tag.id)
-         ->  Seq Scan on _hyper_3_116_chunk
-               Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
+   ->  Hash Join
+         Hash Cond: (tag.id = _hyper_3_116_chunk.tag_id)
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+         ->  Hash
+               ->  Seq Scan on _hyper_3_116_chunk
+                     Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
 
+RESET enable_nestloop;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -3711,15 +3716,35 @@ SELECT create_hypertable('self_join_test', 'time');
 CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
 INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
 ANALYZE self_join_test;
-EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+CREATE FUNCTION plan_lines(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE
+	ln text;
+BEGIN
+	FOR ln IN EXECUTE 'EXPLAIN (buffers off, costs off) ' || query
+	LOOP
+		RETURN NEXT ln;
+	END LOOP;
+END;
+$$;
+SELECT count(*) FILTER (WHERE ln LIKE '%Scan on %') AS scans,
+       count(*) FILTER (WHERE ln ~ 'Nested Loop|Hash Join|Merge Join') AS join_nodes
+FROM plan_lines('SELECT t1.val
+                 FROM self_join_test t1, self_join_test t2
+                 WHERE t1.device = t2.device AND t1.time = t2.time') AS ln;
+ scans | join_nodes 
+-------+------------
+     2 |          1
+
+SELECT t1.val
 FROM self_join_test t1, self_join_test t2
-WHERE t1.device = t2.device AND t1.time = t2.time;
---- QUERY PLAN ---
- Hash Join (actual rows=2.00 loops=1)
-   Hash Cond: ((t1.device = t2.device) AND (t1."time" = t2."time"))
-   ->  Seq Scan on _hyper_24_206_chunk t1 (actual rows=2.00 loops=1)
-   ->  Hash (actual rows=2.00 loops=1)
-         ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+WHERE t1.device = t2.device AND t1.time = t2.time
+ORDER BY t1.val;
+ val 
+-----
+   1
+   2
 
 CREATE VIEW join_removal_view AS
 SELECT m.time, m.device, m.val, a.extra

--- a/test/expected/plan_expand_hypertable-18.out
+++ b/test/expected/plan_expand_hypertable-18.out
@@ -836,17 +836,22 @@ joins
          ->  Seq Scan on _hyper_3_123_chunk
                Filter: ((ANY (tag_id = (hashed SubPlan 1).col1)) OR (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text)))
 
+-- Disabling nested loop join to keep the test cross-version stable
+-- between pg16.15/17.11/18.6 and newer
+SET enable_nestloop = off;
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.name='tag1') and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_3_116_chunk.value
-   ->  Nested Loop
-         Join Filter: (_hyper_3_116_chunk.tag_id = tag.id)
-         ->  Seq Scan on _hyper_3_116_chunk
-               Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
+   ->  Hash Join
+         Hash Cond: (tag.id = _hyper_3_116_chunk.tag_id)
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+         ->  Hash
+               ->  Seq Scan on _hyper_3_116_chunk
+                     Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
 
+RESET enable_nestloop;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -3711,12 +3716,35 @@ SELECT create_hypertable('self_join_test', 'time');
 CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
 INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
 ANALYZE self_join_test;
-EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+CREATE FUNCTION plan_lines(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE
+	ln text;
+BEGIN
+	FOR ln IN EXECUTE 'EXPLAIN (buffers off, costs off) ' || query
+	LOOP
+		RETURN NEXT ln;
+	END LOOP;
+END;
+$$;
+SELECT count(*) FILTER (WHERE ln LIKE '%Scan on %') AS scans,
+       count(*) FILTER (WHERE ln ~ 'Nested Loop|Hash Join|Merge Join') AS join_nodes
+FROM plan_lines('SELECT t1.val
+                 FROM self_join_test t1, self_join_test t2
+                 WHERE t1.device = t2.device AND t1.time = t2.time') AS ln;
+ scans | join_nodes 
+-------+------------
+     1 |          0
+
+SELECT t1.val
 FROM self_join_test t1, self_join_test t2
-WHERE t1.device = t2.device AND t1.time = t2.time;
---- QUERY PLAN ---
- Result (actual rows=2.00 loops=1)
-   ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+WHERE t1.device = t2.device AND t1.time = t2.time
+ORDER BY t1.val;
+ val 
+-----
+   1
+   2
 
 CREATE VIEW join_removal_view AS
 SELECT m.time, m.device, m.val, a.extra

--- a/test/expected/plan_expand_hypertable-19.out
+++ b/test/expected/plan_expand_hypertable-19.out
@@ -836,17 +836,22 @@ joins
          ->  Seq Scan on _hyper_3_123_chunk
                Filter: ((ANY (tag_id = (hashed SubPlan any_1).col1)) OR (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text)))
 
+-- Disabling nested loop join to keep the test cross-version stable
+-- between pg16.15/17.11/18.6 and newer
+SET enable_nestloop = off;
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.name='tag1') and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
    Sort Key: _hyper_3_116_chunk.value
-   ->  Nested Loop
-         Join Filter: (_hyper_3_116_chunk.tag_id = tag.id)
-         ->  Seq Scan on _hyper_3_116_chunk
-               Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
+   ->  Hash Join
+         Hash Cond: (tag.id = _hyper_3_116_chunk.tag_id)
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+         ->  Hash
+               ->  Seq Scan on _hyper_3_116_chunk
+                     Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
 
+RESET enable_nestloop;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 --- QUERY PLAN ---
  Sort
@@ -3710,12 +3715,35 @@ SELECT create_hypertable('self_join_test', 'time');
 CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
 INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
 ANALYZE self_join_test;
-EXPLAIN (buffers off, costs off, timing off, summary off, analyze) SELECT t1.val
+CREATE FUNCTION plan_lines(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE
+	ln text;
+BEGIN
+	FOR ln IN EXECUTE 'EXPLAIN (buffers off, costs off) ' || query
+	LOOP
+		RETURN NEXT ln;
+	END LOOP;
+END;
+$$;
+SELECT count(*) FILTER (WHERE ln LIKE '%Scan on %') AS scans,
+       count(*) FILTER (WHERE ln ~ 'Nested Loop|Hash Join|Merge Join') AS join_nodes
+FROM plan_lines('SELECT t1.val
+                 FROM self_join_test t1, self_join_test t2
+                 WHERE t1.device = t2.device AND t1.time = t2.time') AS ln;
+ scans | join_nodes 
+-------+------------
+     1 |          0
+
+SELECT t1.val
 FROM self_join_test t1, self_join_test t2
-WHERE t1.device = t2.device AND t1.time = t2.time;
---- QUERY PLAN ---
- Result (actual rows=2.00 loops=1)
-   ->  Seq Scan on _hyper_24_206_chunk t2 (actual rows=2.00 loops=1)
+WHERE t1.device = t2.device AND t1.time = t2.time
+ORDER BY t1.val;
+ val 
+-----
+   1
+   2
 
 CREATE VIEW join_removal_view AS
 SELECT m.time, m.device, m.val, a.extra

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -149,7 +149,11 @@ SELECT * FROM cte ORDER BY value;
 \qecho joins
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.id=1) and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.id=1) or (time < to_timestamp(10) and device_id = 'dev1') ORDER BY value;
+-- Disabling nested loop join to keep the test cross-version stable
+-- between pg16.15/17.11/18.6 and newer
+SET enable_nestloop = off;
 :PREFIX SELECT * FROM hyper_ts WHERE tag_id IN (SELECT id FROM tag WHERE tag.name='tag1') and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
+RESET enable_nestloop;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE tag.name = 'tag1' and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 

--- a/test/sql/plan_expand_hypertable.sql.in
+++ b/test/sql/plan_expand_hypertable.sql.in
@@ -198,9 +198,31 @@ CREATE UNIQUE INDEX self_join_test_uq ON self_join_test (device, time);
 INSERT INTO self_join_test VALUES ('2021-01-01', 1, 1.0), ('2021-01-02', 2, 2.0);
 ANALYZE self_join_test;
 
-:PREFIX SELECT t1.val
+-- Assert on scan and join counts rather than on the shape of the plan tree.
+-- This is to keep the test stable across versions pg16.15/17.11/18.6 and newer.
+CREATE FUNCTION plan_lines(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE
+	ln text;
+BEGIN
+	FOR ln IN EXECUTE 'EXPLAIN (buffers off, costs off) ' || query
+	LOOP
+		RETURN NEXT ln;
+	END LOOP;
+END;
+$$;
+
+SELECT count(*) FILTER (WHERE ln LIKE '%Scan on %') AS scans,
+       count(*) FILTER (WHERE ln ~ 'Nested Loop|Hash Join|Merge Join') AS join_nodes
+FROM plan_lines('SELECT t1.val
+                 FROM self_join_test t1, self_join_test t2
+                 WHERE t1.device = t2.device AND t1.time = t2.time') AS ln;
+
+SELECT t1.val
 FROM self_join_test t1, self_join_test t2
-WHERE t1.device = t2.device AND t1.time = t2.time;
+WHERE t1.device = t2.device AND t1.time = t2.time
+ORDER BY t1.val;
 
 -- test that the same useless-join elimination still fires when the
 -- hypertable is only reached through an inlined view, not referenced


### PR DESCRIPTION
PG commit 9f25197bf27 ("Perform join removal by editing the query's jointree", back-patched to 16) moved the test that decides whether the DML target is a leaf result relation out of subquery_planner() and into query_planner().

Remove the hypertable from leaf_result_relids once we have expanded it. On Postgres versions that still run the test early this is a no-op, so one build stays correct against both the current and upcoming minor releases.

Two plan_expand_hypertable queries also become insensitive to details that are not what they test.

Link to passed ABI CI check: https://github.com/timescale/timescaledb/actions/runs/34132926150

Disable-check: force-changelog-file