### PR TITLE
Fix chunk skipping when a column holds the biggest value of its type

### DIFF
--- a/.unreleased/fix_chunk_skipping_range_end_overflow
+++ b/.unreleased/fix_chunk_skipping_range_end_overflow
@@ -1,0 +1,1 @@
+Fixes: #0000 Fix wrong query results when a chunk skipping column holds the largest value of its type

--- a/src/ts_catalog/chunk_column_stats.c
+++ b/src/ts_catalog/chunk_column_stats.c
@@ -30,6 +30,7 @@
 #include "dimension_slice.h"
 #include "guc.h"
 #include "hypertable_cache.h"
+#include "time_utils.h"
 #include "ts_catalog/catalog.h"
 
 #include "chunk_column_stats.h"
@@ -611,7 +612,12 @@ create_col_stats_check_constraint(const Form_chunk_column_stats info, Oid main_t
 		compexprs = lappend(compexprs, ge_expr);
 	}
 
-	if (info->range_end != PG_INT64_MAX)
+	/*
+	 * The end of the range is exclusive, so it can be one past the largest
+	 * value the column type can hold. Such a bound is true for every value of
+	 * the type, so skip it instead of converting it and wrapping around.
+	 */
+	if (info->range_end != PG_INT64_MAX && info->range_end <= ts_time_get_max(col_type))
 	{
 		A_Const *end_const = makeNode(A_Const);
 		memcpy(&end_const->val,
@@ -622,14 +628,17 @@ create_col_stats_check_constraint(const Form_chunk_column_stats info, Oid main_t
 		compexprs = lappend(compexprs, lt_expr);
 	}
 
+	if (compexprs == NIL)
+	{
+		return NULL;
+	}
+
 	constr = makeNode(Constraint);
 	constr->contype = CONSTR_CHECK;
 	constr->conname = name ? pstrdup(name) : NULL;
 	constr->deferrable = false;
 	constr->skip_validation = true;
 	constr->initially_valid = true;
-
-	Assert(list_length(compexprs) >= 1);
 
 	if (list_length(compexprs) == 2)
 	{

--- a/tsl/test/expected/chunk_column_stats.out
+++ b/tsl/test/expected/chunk_column_stats.out
@@ -842,4 +842,70 @@ SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775805;
 -------
      2
 
+-- Test chunk skipping with the largest value of a 4 byte and 2 byte range column
+CREATE TABLE chunk_skip_int_max(
+    ts     timestamptz NOT NULL,
+    ranged int,
+    small  smallint
+);
+SELECT * FROM create_hypertable('chunk_skip_int_max', 'ts',
+                         chunk_time_interval => interval '1 day');
+ hypertable_id | schema_name |     table_name     | created 
+---------------+-------------+--------------------+---------
+             8 | public      | chunk_skip_int_max | t
+
+SELECT * FROM enable_chunk_skipping('chunk_skip_int_max', 'ranged');
+ column_stats_id | enabled 
+-----------------+---------
+              21 | t
+
+SELECT * FROM enable_chunk_skipping('chunk_skip_int_max', 'small');
+ column_stats_id | enabled 
+-----------------+---------
+              22 | t
+
+ALTER TABLE chunk_skip_int_max SET (timescaledb.compress);
+INSERT INTO chunk_skip_int_max VALUES
+    ('2025-01-01', 2147483647, 32767), -- PG_INT32_MAX, PG_INT16_MAX
+    ('2025-01-01 01:00', 100, 100),
+    ('2025-01-02', 2147483646, 32766);
+SELECT count(compress_chunk(c)) FROM show_chunks('chunk_skip_int_max') c;
+ count 
+-------
+     2
+
+SELECT chunk_id IS NOT NULL AS have_chunk, column_name, range_start, range_end
+FROM _timescaledb_catalog.chunk_column_stats
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'chunk_skip_int_max')
+ORDER BY chunk_id, column_name;
+ have_chunk | column_name |     range_start      |      range_end      
+------------+-------------+----------------------+---------------------
+ t          | ranged      |                  100 |          2147483648
+ t          | small       |                  100 |               32768
+ t          | ranged      |           2147483646 |          2147483647
+ t          | small       |                32766 |               32767
+ f          | ranged      | -9223372036854775808 | 9223372036854775807
+ f          | small       | -9223372036854775808 | 9223372036854775807
+
+-- The now() expression makes the chunks get excluded at executor startup
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND ranged >= 0;
+ count 
+-------
+     3
+
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND small >= 0;
+ count 
+-------
+     3
+
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND ranged >= 2147483647;
+ count 
+-------
+     1
+
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND ranged < 50;
+ count 
+-------
+     0
+
 RESET timescaledb.enable_chunk_skipping;

--- a/tsl/test/sql/chunk_column_stats.sql
+++ b/tsl/test/sql/chunk_column_stats.sql
@@ -381,4 +381,34 @@ SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged >= 9223372036854775806;
 SELECT count(*) FROM chunk_skip_bigint_max WHERE ranged > 9223372036854775805;
 
 
+-- Test chunk skipping with the largest value of a 4 byte and 2 byte range column
+CREATE TABLE chunk_skip_int_max(
+    ts     timestamptz NOT NULL,
+    ranged int,
+    small  smallint
+);
+SELECT * FROM create_hypertable('chunk_skip_int_max', 'ts',
+                         chunk_time_interval => interval '1 day');
+SELECT * FROM enable_chunk_skipping('chunk_skip_int_max', 'ranged');
+SELECT * FROM enable_chunk_skipping('chunk_skip_int_max', 'small');
+ALTER TABLE chunk_skip_int_max SET (timescaledb.compress);
+
+INSERT INTO chunk_skip_int_max VALUES
+    ('2025-01-01', 2147483647, 32767), -- PG_INT32_MAX, PG_INT16_MAX
+    ('2025-01-01 01:00', 100, 100),
+    ('2025-01-02', 2147483646, 32766);
+
+SELECT count(compress_chunk(c)) FROM show_chunks('chunk_skip_int_max') c;
+
+SELECT chunk_id IS NOT NULL AS have_chunk, column_name, range_start, range_end
+FROM _timescaledb_catalog.chunk_column_stats
+WHERE hypertable_id = (SELECT id FROM _timescaledb_catalog.hypertable WHERE table_name = 'chunk_skip_int_max')
+ORDER BY chunk_id, column_name;
+
+-- The now() expression makes the chunks get excluded at executor startup
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND ranged >= 0;
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND small >= 0;
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND ranged >= 2147483647;
+SELECT count(*) FROM chunk_skip_int_max WHERE ts > now() - interval '100 years' AND ranged < 50;
+
 RESET timescaledb.enable_chunk_skipping;


### PR DESCRIPTION
Queries on a hypertable with chunk skipping enabled could silently miss
rows. The end of a tracked range is exclusive, so it gets stored as the
biggest value in the chunk plus one. When that value is already the
largest one the column type can hold, the sum no longer fits and wraps
around to a negative number as soon as it is converted back to the
column type. Chunk exclusion at query start builds a range check from
the stored range, so the chunk got a check that no row can satisfy and
was left out of every query.

Leave out the upper bound when it does not fit the column type. Such a
bound is true for every value the column can store, so we do not lose
any exclusion.
