### PR TITLE
Add pg_depend dependency for compressed chunks

### DIFF
--- a/.unreleased/pr_10561
+++ b/.unreleased/pr_10561
@@ -1,0 +1,1 @@
+Implements: #10561 Add pg_depend dependency for compressed chunks

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,21 @@
+-- Add dependency from internal compressed chunks to their hypertables
+WITH deps AS (
+    SELECT cs.compress_relid, format('%I.%I', ht.schema_name, ht.table_name)::regclass AS hypertable_relid
+    FROM _timescaledb_catalog.compression_settings cs
+    JOIN _timescaledb_catalog.chunk ch ON ch.relid = cs.relid
+    JOIN _timescaledb_catalog.hypertable ht ON ht.id = ch.hypertable_id
+    WHERE cs.compress_relid IS NOT NULL
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT 'pg_class'::regclass, deps.compress_relid, 0, 'pg_class'::regclass, deps.hypertable_relid, 0, 'a'
+FROM deps
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_depend d
+    WHERE d.classid = 'pg_class'::regclass
+      AND d.objid = deps.compress_relid
+      AND d.objsubid = 0
+      AND d.refclassid = 'pg_class'::regclass
+      AND d.refobjid = deps.hypertable_relid
+      AND d.refobjsubid = 0
+      AND d.deptype = 'a'
+);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,10 @@
+-- Remove dependency from internal compressed chunks to their hypertables
+DELETE FROM pg_depend d
+USING _timescaledb_catalog.compression_settings cs
+WHERE cs.compress_relid IS NOT NULL
+  AND d.classid = 'pg_class'::regclass
+  AND d.objid = cs.compress_relid
+  AND d.objsubid = 0
+  AND d.refclassid = 'pg_class'::regclass
+  AND d.refobjsubid = 0
+  AND d.deptype = 'a';

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -8,10 +8,12 @@
 #include <access/reloptions.h>
 #include <access/tupdesc.h>
 #include <access/xact.h>
+#include <catalog/dependency.h>
 #include <catalog/index.h>
 #include <catalog/indexing.h>
 #include <catalog/objectaccess.h>
 #include <catalog/pg_am_d.h>
+#include <catalog/pg_class.h>
 #include <catalog/pg_constraint.h>
 #include <catalog/pg_constraint_d.h>
 #include <catalog/pg_type.h>
@@ -974,6 +976,17 @@ create_compress_chunk(Chunk *src_chunk, Oid table_id, bool skip_segmentby_defaul
 	{
 		List *column_defs = build_columndefs(settings, src_chunk->fd.relid);
 		table_id = compression_table_create(src_chunk, column_defs, tablespace_oid, settings);
+
+		/*
+		 * Add dependency from the compressed chunk to its hypertable.
+		 * DEPENDENCY_AUTO type doesn't require CASCADE when dropping the hypertable
+		 * and doesn't restrict dropping the chunk separately from the hypertable
+		 */
+		ObjectAddress compressed_chunk_addr = { .classId = RelationRelationId,
+												.objectId = table_id };
+		ObjectAddress hypertable_addr = { .classId = RelationRelationId,
+										  .objectId = src_chunk->hypertable_relid };
+		recordDependencyOn(&compressed_chunk_addr, &hypertable_addr, DEPENDENCY_AUTO);
 	}
 	else
 	{

--- a/tsl/test/expected/compression_dependency.out
+++ b/tsl/test/expected/compression_dependency.out
@@ -1,0 +1,86 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Verify that creating a compressed chunk records a pg_depend dependency on
+-- its hypertable, and that decompressing, dropping the chunk or the hypertable
+-- cleans it up correctly.
+create table test (time timestamptz not null, device text, value float8);
+select create_hypertable('test', 'time');
+ create_hypertable 
+-------------------
+ (1,public,test,t)
+
+insert into test
+select '2024-01-01'::timestamptz + (i || ' hour')::interval, 'd' || (i % 3), i
+from generate_series(1, 50) i;
+alter table test set (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+select count(compress_chunk(x)) from show_chunks('test') x;
+ count 
+-------
+     1
+
+select compress_relid::oid as compressed_chunk_oid
+from _timescaledb_catalog.compression_settings
+where compress_relid is not null \gset
+-- a pg_depend row should link the compressed chunk relation to the hypertable
+select classid::regclass, refclassid::regclass, refobjid::regclass, deptype
+from pg_depend
+where classid = 'pg_class'::regclass
+  and objid = :compressed_chunk_oid
+  and refclassid = 'pg_class'::regclass
+  and refobjid = 'test'::regclass;
+ classid  | refclassid | refobjid | deptype 
+----------+------------+----------+---------
+ pg_class | pg_class   | test     | a
+
+-- decompressing drops the compressed relation and its pg_depend row
+select count(decompress_chunk(x)) from show_chunks('test') x;
+ count 
+-------
+     1
+
+select count(*) from pg_depend where objid = :compressed_chunk_oid;
+ count 
+-------
+     0
+
+select count(*) from pg_class where oid = :compressed_chunk_oid;
+ count 
+-------
+     0
+
+-- recompress
+alter table test set (timescaledb.compress);
+select count(compress_chunk(x)) from show_chunks('test') x;
+ count 
+-------
+     1
+
+select compress_relid::oid as compressed_chunk_oid
+from _timescaledb_catalog.compression_settings
+where compress_relid is not null \gset
+-- dropping a chunk deletes its compressed chunk's pg_depend row
+begin;
+select _timescaledb_functions.drop_chunk(x) from show_chunks('test') x;
+ drop_chunk 
+------------
+ t
+
+select count(*) from pg_depend where objid = :compressed_chunk_oid;
+ count 
+-------
+     0
+
+rollback;
+-- dropping the hypertable deletes the compressed chunk's pg_depend row
+drop table test;
+select count(*) from pg_depend where objid = :compressed_chunk_oid;
+ count 
+-------
+     0
+
+select count(*) from pg_class where oid = :compressed_chunk_oid;
+ count 
+-------
+     0
+

--- a/tsl/test/expected/compression_sequence_num_removal.out
+++ b/tsl/test/expected/compression_sequence_num_removal.out
@@ -535,6 +535,10 @@ UPDATE pg_attribute SET attrelid = :CHUNK_NEW_OID
 WHERE attrelid = :CHUNK_OID;
 UPDATE _timescaledb_catalog.compression_settings SET compress_relid = :CHUNK_NEW_OID
 WHERE compress_relid = :CHUNK_OID;
+-- the compressed chunk's pg_depend entry still points at the old OID and must be renumbered too,
+-- otherwise DROP TABLE will fail
+UPDATE pg_depend SET objid = :CHUNK_NEW_OID
+WHERE classid = 'pg_class'::regclass AND objid = :CHUNK_OID;
 :EXPLAIN SELECT * FROM hyper
 WHERE device_id = 1 ORDER BY time;
 --- QUERY PLAN ---

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_FILES
     compression_constraints.sql
     compression_create_compressed_table.sql
     compression_defaults.sql
+    compression_dependency.sql
     compression_fks.sql
     compression_indexcreate.sql
     compression_insert.sql

--- a/tsl/test/sql/compression_dependency.sql
+++ b/tsl/test/sql/compression_dependency.sql
@@ -1,0 +1,53 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Verify that creating a compressed chunk records a pg_depend dependency on
+-- its hypertable, and that decompressing, dropping the chunk or the hypertable
+-- cleans it up correctly.
+create table test (time timestamptz not null, device text, value float8);
+select create_hypertable('test', 'time');
+insert into test
+select '2024-01-01'::timestamptz + (i || ' hour')::interval, 'd' || (i % 3), i
+from generate_series(1, 50) i;
+alter table test set (timescaledb.compress, timescaledb.compress_segmentby = 'device');
+
+select count(compress_chunk(x)) from show_chunks('test') x;
+
+select compress_relid::oid as compressed_chunk_oid
+from _timescaledb_catalog.compression_settings
+where compress_relid is not null \gset
+
+-- a pg_depend row should link the compressed chunk relation to the hypertable
+select classid::regclass, refclassid::regclass, refobjid::regclass, deptype
+from pg_depend
+where classid = 'pg_class'::regclass
+  and objid = :compressed_chunk_oid
+  and refclassid = 'pg_class'::regclass
+  and refobjid = 'test'::regclass;
+
+-- decompressing drops the compressed relation and its pg_depend row
+select count(decompress_chunk(x)) from show_chunks('test') x;
+
+select count(*) from pg_depend where objid = :compressed_chunk_oid;
+select count(*) from pg_class where oid = :compressed_chunk_oid;
+
+-- recompress
+alter table test set (timescaledb.compress);
+select count(compress_chunk(x)) from show_chunks('test') x;
+
+select compress_relid::oid as compressed_chunk_oid
+from _timescaledb_catalog.compression_settings
+where compress_relid is not null \gset
+
+-- dropping a chunk deletes its compressed chunk's pg_depend row
+begin;
+select _timescaledb_functions.drop_chunk(x) from show_chunks('test') x;
+select count(*) from pg_depend where objid = :compressed_chunk_oid;
+rollback;
+
+-- dropping the hypertable deletes the compressed chunk's pg_depend row
+drop table test;
+
+select count(*) from pg_depend where objid = :compressed_chunk_oid;
+select count(*) from pg_class where oid = :compressed_chunk_oid;

--- a/tsl/test/sql/compression_sequence_num_removal.sql
+++ b/tsl/test/sql/compression_sequence_num_removal.sql
@@ -218,6 +218,10 @@ UPDATE pg_attribute SET attrelid = :CHUNK_NEW_OID
 WHERE attrelid = :CHUNK_OID;
 UPDATE _timescaledb_catalog.compression_settings SET compress_relid = :CHUNK_NEW_OID
 WHERE compress_relid = :CHUNK_OID;
+-- the compressed chunk's pg_depend entry still points at the old OID and must be renumbered too,
+-- otherwise DROP TABLE will fail
+UPDATE pg_depend SET objid = :CHUNK_NEW_OID
+WHERE classid = 'pg_class'::regclass AND objid = :CHUNK_OID;
 
 :EXPLAIN SELECT * FROM hyper
 WHERE device_id = 1 ORDER BY time;


### PR DESCRIPTION
Compressed chunk relations were tracked only in TimescaleDB's own catalog (`compression_settings`), with no corresponding `pg_depend` entry, so Postgres itself had no record of the relationship to the hypertable.

With the drop of the `user_catalog_table` reloption we need some postgres catalog record to attribute compressed chunks to their hypertables in a historical snapshot.