### PR TITLE
Remove windows from generic package workflow

### DIFF
--- a/.github/workflows/release_build_packages.yml
+++ b/.github/workflows/release_build_packages.yml
@@ -72,18 +72,6 @@ jobs:
           echo "HAS_FAILURES=true" >> $GITHUB_ENV
         fi
 
-    - name: Build Windows Packages
-      env:
-        GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
-      run: |
-        echo "🪟 Triggering Windows package build..." | tee -a build.log
-        if gh workflow run timescaledb-windows.yml -R timescale/release-build-scripts -f version=${{ github.event.release.tag_name }} -f upload-artifacts=true; then
-          echo "| 🪟 Windows Packages | ✅ Triggered | [summary](https://github.com/timescale/release-build-scripts/actions/workflows/timescaledb-windows.yml) |" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "| 🪟 Windows Packages | ❌ Failed | [summary](https://github.com/timescale/release-build-scripts/actions/workflows/timescaledb-windows.yml) |" >> $GITHUB_STEP_SUMMARY
-          echo "HAS_FAILURES=true" >> $GITHUB_ENV
-        fi
-
     - name: Generate final summary
       if: always()
       run: |


### PR DESCRIPTION
Windows packages need to be built before release is published
as they need to be attached to the release which becomes immutable
once published.
