### PR TITLE
Fix PG version dependant test infrastructure

### DIFF
--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -28,7 +28,6 @@ IGNORES=${IGNORES:-}
 SKIPS=${SKIPS:-}
 # PG_BINDIR is passed from CMake via environment
 PSQL="${PSQL:-${PG_BINDIR}/psql} -X" # Prevent any .psqlrc files from being executed during the tests
-PG_VERSION_MAJOR=$(${PSQL} --version | awk '{split($3,v,"[.a-z]"); print v[1]}')
 
 # check if test matches any of the patterns in a list
 # $1 list of patterns or test names
@@ -54,21 +53,16 @@ fi
 # so as an workaround if we have any IGNORES entry then
 # we merge it together with SKIPS and cleanup the IGNORES
 # https://github.com/postgres/postgres/commit/bd8d453e9b5f8b632a400a9e796fc041aed76d82
-if [[ ${PG_VERSION_MAJOR} -ge 16 ]]; then
-  if [[ -n ${IGNORES} ]]; then
-    if [[ -n ${SKIPS} ]]; then
-      SKIPS="${SKIPS} ${IGNORES}"
-    else
-      SKIPS="${IGNORES}"
-    fi
-    IGNORES=""
+if [[ -n ${IGNORES} ]]; then
+  if [[ -n ${SKIPS} ]]; then
+    SKIPS="${SKIPS} ${IGNORES}"
+  else
+    SKIPS="${IGNORES}"
   fi
+  IGNORES=""
 fi
 
 echo "TESTS ${TESTS}"
-if [[ ${PG_VERSION_MAJOR} -lt 16 ]]; then
-  echo "IGNORES ${IGNORES}"
-fi
 echo "SKIPS ${SKIPS}"
 
 if [[ -z ${TESTS} ]] && [[ -z ${SKIPS} ]] && [[ -z ${IGNORES} ]]; then

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -2,16 +2,12 @@ set(PG_REGRESS_DIR
     ${PG_SOURCE_DIR}/src/test/regress
     CACHE PATH "Path to PostgreSQL's regress directory")
 
-# input and output directory got removed in PG15
 set(PGTEST_DIRS ${PG_REGRESS_DIR}/data ${PG_REGRESS_DIR}/sql
                 ${PG_REGRESS_DIR}/expected)
-if(EXISTS ${PG_REGRESS_DIR}/input AND EXISTS ${PG_REGRESS_DIR}/output)
-  list(APPEND PGTEST_DIRS ${PG_REGRESS_DIR}/input ${PG_REGRESS_DIR}/output)
-endif()
 
-# Copy the input and output files from PostgreSQL's test suite. The test suite
-# generates some SQL scripts and output files from template source files and
-# require directories to be colocated
+# Copy the test files from PostgreSQL's test suite. The test suite generates
+# some SQL scripts and output files from template source files and require
+# directories to be colocated
 file(COPY ${PGTEST_DIRS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 file(READ ${PG_REGRESS_DIR}/parallel_schedule PG_TEST_SCHEDULE)
@@ -37,20 +33,14 @@ set(PG_IGNORE_TESTS
 
 # Modify the test schedule to ignore some tests
 foreach(IGNORE_TEST ${PG_IGNORE_TESTS})
-  # ignored schedules was removed in PG16
+  # pg_regress dropped the ignore feature in PG16, so drop the test from the
+  # schedule instead
   # https://github.com/postgres/postgres/commit/bd8d453e9b5f8b632a400a9e796fc041aed76d82
-  if(${PG_VERSION_MAJOR} LESS "16")
-    string(CONCAT PG_TEST_SCHEDULE "ignore: ${IGNORE_TEST}\n"
-                  ${PG_TEST_SCHEDULE})
-  else()
-    # remove the ignored test from the schedule
-    string(REPLACE "test: ${IGNORE_TEST}\n" "" PG_TEST_SCHEDULE
-                   "${PG_TEST_SCHEDULE}")
-    string(REPLACE " ${IGNORE_TEST} " " " PG_TEST_SCHEDULE
-                   "${PG_TEST_SCHEDULE}")
-    string(REPLACE " ${IGNORE_TEST}\n" "\n" PG_TEST_SCHEDULE
-                   "${PG_TEST_SCHEDULE}")
-  endif()
+  string(REPLACE "test: ${IGNORE_TEST}\n" "" PG_TEST_SCHEDULE
+                 "${PG_TEST_SCHEDULE}")
+  string(REPLACE " ${IGNORE_TEST} " " " PG_TEST_SCHEDULE "${PG_TEST_SCHEDULE}")
+  string(REPLACE " ${IGNORE_TEST}\n" "\n" PG_TEST_SCHEDULE
+                 "${PG_TEST_SCHEDULE}")
 endforeach(IGNORE_TEST)
 
 # Write the final test schedule

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -84,19 +84,13 @@ if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
   ${PSQL} "$@" -U ${USER} -d template1 -v ECHO=none >/dev/null 2>&1 <<EOF
     SET client_min_messages=ERROR;
 
-    DO \$\$
-      BEGIN
-        IF current_setting('server_version_num')::int >= 150000 THEN
-          GRANT CREATE ON SCHEMA public TO ${TEST_PGUSER};
-          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER};
-          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER_2};
-          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_1};
-          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_2};
-          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_3};
-          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_4};
-        END IF;
-      END
-    \$\$ LANGUAGE PLPGSQL;
+    GRANT CREATE ON SCHEMA public TO ${TEST_PGUSER};
+    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER};
+    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER_2};
+    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_1};
+    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_2};
+    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_3};
+    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_4};
 
     ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;
     ALTER USER ${TEST_ROLE_1} WITH CREATEDB CREATEROLE;

--- a/tsl/test/expected/decompress_vector_qual.out
+++ b/tsl/test/expected/decompress_vector_qual.out
@@ -904,11 +904,9 @@ select count(*) from vectorqual where ts > '2024-01-01' or (metric3 = 888 and me
 -------
      1
 
--- On versions >= 14, the Postgres planner chooses to build a hash table for
--- large arrays. We currently don't vectorize in this case.
-select 1 from set_config('timescaledb.debug_require_vector_qual',
-    case when current_setting('server_version_num')::int >= 140000 then 'forbid' else 'require' end,
-    false);
+-- Postgres planner chooses to build a hash table for large arrays. We
+-- currently don't vectorize in this case.
+select 1 from set_config('timescaledb.debug_require_vector_qual', 'forbid', false);
  ?column? 
 ----------
         1

--- a/tsl/test/sql/decompress_vector_qual.sql
+++ b/tsl/test/sql/decompress_vector_qual.sql
@@ -330,11 +330,9 @@ select count(*) from vectorqual where ts > '2024-01-01' or (metric3 = 888 and me
 select count(*) from vectorqual where ts > '2024-01-01' or (metric3 = 888 and metric2 = 666);
 
 
--- On versions >= 14, the Postgres planner chooses to build a hash table for
--- large arrays. We currently don't vectorize in this case.
-select 1 from set_config('timescaledb.debug_require_vector_qual',
-    case when current_setting('server_version_num')::int >= 140000 then 'forbid' else 'require' end,
-    false);
+-- Postgres planner chooses to build a hash table for large arrays. We
+-- currently don't vectorize in this case.
+select 1 from set_config('timescaledb.debug_require_vector_qual', 'forbid', false);
 
 select count(*) from singlebatch where metric2 = any(array[
  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,


### PR DESCRIPTION
Removing leftover branching checking for versions lower than PG16 which is now the lowest supported version.

Disable-check: force-changelog-file