### PR TITLE
Drop force_parallel_mode shim and references

### DIFF
--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -370,9 +370,9 @@ chunk_append_begin(CustomScanState *node, EState *estate, int eflags)
 		 * chunk_append_initialize_worker. We have to store estate and eflags here that are needed
 		 * for that initialization.
 		 *
-		 * Note: When force_parallel_mode debug GUC is set, a normal sequential ChunkAppend plan can
-		 * run inside a parallel worker. In this case, we have to perform the chunk exclusion right
-		 * away. We distinguish it by that the parallel_aware flag of the plan is not set.
+		 * Note: When debug_parallel_query debug GUC is set, a normal sequential ChunkAppend plan
+		 * can run inside a parallel worker. In this case, we have to perform the chunk exclusion
+		 * right away. We distinguish it by that the parallel_aware flag of the plan is not set.
 		 */
 		state->estate = estate;
 		state->eflags = eflags;

--- a/test/expected/append-16.out
+++ b/test/expected/append-16.out
@@ -50,18 +50,10 @@ CREATE OR REPLACE PROCEDURE force_parallel(on_or_off bool)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    IF current_setting('server_version_num')::int < 160000 THEN
-        IF on_or_off THEN
-            set force_parallel_mode = 'on';
-        ELSE
-            set force_parallel_mode = 'off';
-        END IF;
+    IF on_or_off THEN
+        set debug_parallel_query = 'on';
     ELSE
-        IF on_or_off THEN
-            set debug_parallel_query = 'on';
-        ELSE
-            set debug_parallel_query = 'off';
-        END IF;
+        set debug_parallel_query = 'off';
     END IF;
 END;
 $$;
@@ -107,7 +99,7 @@ VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:91: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:83: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -147,7 +139,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:123: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:115: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/append-17.out
+++ b/test/expected/append-17.out
@@ -50,18 +50,10 @@ CREATE OR REPLACE PROCEDURE force_parallel(on_or_off bool)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    IF current_setting('server_version_num')::int < 160000 THEN
-        IF on_or_off THEN
-            set force_parallel_mode = 'on';
-        ELSE
-            set force_parallel_mode = 'off';
-        END IF;
+    IF on_or_off THEN
+        set debug_parallel_query = 'on';
     ELSE
-        IF on_or_off THEN
-            set debug_parallel_query = 'on';
-        ELSE
-            set debug_parallel_query = 'off';
-        END IF;
+        set debug_parallel_query = 'off';
     END IF;
 END;
 $$;
@@ -107,7 +99,7 @@ VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:91: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:83: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -147,7 +139,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:123: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:115: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/append-18.out
+++ b/test/expected/append-18.out
@@ -50,18 +50,10 @@ CREATE OR REPLACE PROCEDURE force_parallel(on_or_off bool)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    IF current_setting('server_version_num')::int < 160000 THEN
-        IF on_or_off THEN
-            set force_parallel_mode = 'on';
-        ELSE
-            set force_parallel_mode = 'off';
-        END IF;
+    IF on_or_off THEN
+        set debug_parallel_query = 'on';
     ELSE
-        IF on_or_off THEN
-            set debug_parallel_query = 'on';
-        ELSE
-            set debug_parallel_query = 'off';
-        END IF;
+        set debug_parallel_query = 'off';
     END IF;
 END;
 $$;
@@ -107,7 +99,7 @@ VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:91: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:83: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -147,7 +139,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:123: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:115: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/append-19.out
+++ b/test/expected/append-19.out
@@ -50,18 +50,10 @@ CREATE OR REPLACE PROCEDURE force_parallel(on_or_off bool)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    IF current_setting('server_version_num')::int < 160000 THEN
-        IF on_or_off THEN
-            set force_parallel_mode = 'on';
-        ELSE
-            set force_parallel_mode = 'off';
-        END IF;
+    IF on_or_off THEN
+        set debug_parallel_query = 'on';
     ELSE
-        IF on_or_off THEN
-            set debug_parallel_query = 'on';
-        ELSE
-            set debug_parallel_query = 'off';
-        END IF;
+        set debug_parallel_query = 'off';
     END IF;
 END;
 $$;
@@ -107,7 +99,7 @@ VACUUM (ANALYZE) metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
-psql:include/append_load.sql:91: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/append_load.sql:83: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -147,7 +139,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
-psql:include/append_load.sql:123: WARNING:  column type "character varying" used for "name" does not follow best practices
+psql:include/append_load.sql:115: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/loader.out
+++ b/test/expected/loader.out
@@ -439,11 +439,7 @@ SELECT * FROM test.extension;
 CREATE TABLE test (i int, j double precision);
 INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
 DISCARD ALL;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 1;
 SELECT count(*) FROM test;
 WARNING:  mock init "mock-2"

--- a/test/expected/parallel-16.out
+++ b/test/expected/parallel-16.out
@@ -19,11 +19,7 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 SET timescaledb.enable_deferred_chunk_append TO false;
@@ -431,22 +427,14 @@ WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
 RESET parallel_leader_participation;
 -- Same result from a sequential query.
 SET max_parallel_workers_per_gather = 0;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 SELECT count(*) FROM monitoring_sites m JOIN sensor_data s ON (TRUE)
 WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
  count 
 -------
      6
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 -- initplan filter: no startup exclusion
 SELECT count(*) AS expected_i FROM "test" WHERE i = (SELECT max(i) FROM "test") \gset
 SELECT count(*) AS expected_j FROM "test" WHERE j = (SELECT max(j) FROM "test") \gset

--- a/test/expected/parallel-17.out
+++ b/test/expected/parallel-17.out
@@ -19,11 +19,7 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 SET timescaledb.enable_deferred_chunk_append TO false;
@@ -431,22 +427,14 @@ WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
 RESET parallel_leader_participation;
 -- Same result from a sequential query.
 SET max_parallel_workers_per_gather = 0;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 SELECT count(*) FROM monitoring_sites m JOIN sensor_data s ON (TRUE)
 WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
  count 
 -------
      6
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 -- initplan filter: no startup exclusion
 SELECT count(*) AS expected_i FROM "test" WHERE i = (SELECT max(i) FROM "test") \gset
 SELECT count(*) AS expected_j FROM "test" WHERE j = (SELECT max(j) FROM "test") \gset

--- a/test/expected/parallel-18.out
+++ b/test/expected/parallel-18.out
@@ -19,11 +19,7 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 SET timescaledb.enable_deferred_chunk_append TO false;
@@ -427,22 +423,14 @@ WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
 RESET parallel_leader_participation;
 -- Same result from a sequential query.
 SET max_parallel_workers_per_gather = 0;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 SELECT count(*) FROM monitoring_sites m JOIN sensor_data s ON (TRUE)
 WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
  count 
 -------
      6
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 -- initplan filter: no startup exclusion
 SELECT count(*) AS expected_i FROM "test" WHERE i = (SELECT max(i) FROM "test") \gset
 SELECT count(*) AS expected_j FROM "test" WHERE j = (SELECT max(j) FROM "test") \gset

--- a/test/expected/parallel-19.out
+++ b/test/expected/parallel-19.out
@@ -19,11 +19,7 @@ ANALYZE test;
 ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 SET timescaledb.enable_deferred_chunk_append TO false;
@@ -425,22 +421,14 @@ WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
 RESET parallel_leader_participation;
 -- Same result from a sequential query.
 SET max_parallel_workers_per_gather = 0;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 SELECT count(*) FROM monitoring_sites m JOIN sensor_data s ON (TRUE)
 WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
  count 
 -------
      6
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 -- initplan filter: no startup exclusion
 SELECT count(*) AS expected_i FROM "test" WHERE i = (SELECT max(i) FROM "test") \gset
 SELECT count(*) AS expected_j FROM "test" WHERE j = (SELECT max(j) FROM "test") \gset

--- a/test/sql/include/append_load.sql
+++ b/test/sql/include/append_load.sql
@@ -35,18 +35,10 @@ CREATE OR REPLACE PROCEDURE force_parallel(on_or_off bool)
 LANGUAGE PLPGSQL AS
 $$
 BEGIN
-    IF current_setting('server_version_num')::int < 160000 THEN
-        IF on_or_off THEN
-            set force_parallel_mode = 'on';
-        ELSE
-            set force_parallel_mode = 'off';
-        END IF;
+    IF on_or_off THEN
+        set debug_parallel_query = 'on';
     ELSE
-        IF on_or_off THEN
-            set debug_parallel_query = 'on';
-        ELSE
-            set debug_parallel_query = 'off';
-        END IF;
+        set debug_parallel_query = 'off';
     END IF;
 END;
 $$;

--- a/test/sql/loader.sql
+++ b/test/sql/loader.sql
@@ -204,7 +204,7 @@ CREATE TABLE test (i int, j double precision);
 INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
 
 DISCARD ALL;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 1;
 SELECT count(*) FROM test;
 

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -20,7 +20,7 @@ ALTER TABLE :CHUNK1 SET (parallel_workers=2);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 
 SET work_mem TO '50MB';
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost TO 0;
 SET timescaledb.enable_deferred_chunk_append TO false;
@@ -136,10 +136,10 @@ RESET parallel_leader_participation;
 
 -- Same result from a sequential query.
 SET max_parallel_workers_per_gather = 0;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 SELECT count(*) FROM monitoring_sites m JOIN sensor_data s ON (TRUE)
 WHERE s.time > '2020-01-01 00:00:30'::text::timestamptz AND s.sensor_id > 50;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 
 
 -- initplan filter: no startup exclusion

--- a/tsl/test/expected/agg_partials_pushdown.out
+++ b/tsl/test/expected/agg_partials_pushdown.out
@@ -339,11 +339,7 @@ SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t 
                                  Output: _hyper_2_3_chunk.timecustom, _hyper_2_3_chunk.series_0
 
 -- Force parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;
 SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
@@ -515,11 +511,7 @@ SET cpu_operator_cost = 0;
 SET enable_hashagg = off;
 RESET parallel_setup_cost;
 RESET parallel_tuple_cost;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END, 'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 :PREFIX
 SELECT
     start_time, sensor_id,

--- a/tsl/test/expected/cagg.out
+++ b/tsl/test/expected/cagg.out
@@ -2100,11 +2100,7 @@ FROM conditions
 GROUP BY 1
 ORDER BY 2 DESC;
 NOTICE:  refreshing continuous aggregate "conditions_daily"
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/expected/columnar_index_scan-16.out
+++ b/tsl/test/expected/columnar_index_scan-16.out
@@ -451,11 +451,7 @@ SELECT * FROM agg_data ORDER BY device;
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -463,11 +459,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -1704,11 +1696,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Sort
@@ -1724,11 +1712,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                      Group Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -3300,11 +3284,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -3320,11 +3300,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -5114,11 +5090,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -5134,11 +5106,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL

--- a/tsl/test/expected/columnar_index_scan-17.out
+++ b/tsl/test/expected/columnar_index_scan-17.out
@@ -451,11 +451,7 @@ SELECT * FROM agg_data ORDER BY device;
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -463,11 +459,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -1778,11 +1770,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -1799,11 +1787,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -3419,11 +3403,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -3439,11 +3419,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -5231,11 +5207,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -5251,11 +5223,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL

--- a/tsl/test/expected/columnar_index_scan-18.out
+++ b/tsl/test/expected/columnar_index_scan-18.out
@@ -451,11 +451,7 @@ SELECT * FROM agg_data ORDER BY device;
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -463,11 +459,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -1780,11 +1772,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -1801,11 +1789,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -3423,11 +3407,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -3443,11 +3423,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -5237,11 +5213,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -5257,11 +5229,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL

--- a/tsl/test/expected/columnar_index_scan-19.out
+++ b/tsl/test/expected/columnar_index_scan-19.out
@@ -451,11 +451,7 @@ SELECT * FROM agg_data ORDER BY device;
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  GroupAggregate
@@ -463,11 +459,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
    ->  Custom Scan (ColumnarIndexScan) on _hyper_1_1_chunk metrics
          ->  Index Scan using _hyper_1_1_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_1_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -1780,11 +1772,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Seq Scan on _hyper_1_1_chunk
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -1801,11 +1789,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                      Sort Key: _hyper_1_1_chunk.device
                      ->  Seq Scan on _hyper_1_1_chunk
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -3423,11 +3407,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -3443,11 +3423,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL
@@ -5237,11 +5213,7 @@ SELECT * FROM agg_data ORDER BY device;
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
 --- QUERY PLAN ---
  Finalize GroupAggregate
@@ -5257,11 +5229,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarIndexScan) on _hyper_1_2_chunk metrics
                      ->  Index Scan using _hyper_1_2_chunk_compressed_device_sensor__ts_meta_v2_first_idx on _hyper_1_2_chunk_compressed
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device
 UNION ALL

--- a/tsl/test/expected/plan_skip_scan-16.out
+++ b/tsl/test/expected/plan_skip_scan-16.out
@@ -1234,11 +1234,7 @@ UNION SELECT b.* FROM
                            ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=1.00 loops=13)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=12.00 loops=1)
@@ -1246,11 +1242,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1.00 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3526,11 +3518,7 @@ UNION SELECT b.* FROM
                                  ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1.00 loops=12)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -3549,11 +3537,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1.00 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -6229,11 +6213,7 @@ UNION SELECT b.* FROM
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -6252,11 +6232,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=1.00 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=1.00 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan-17.out
+++ b/tsl/test/expected/plan_skip_scan-17.out
@@ -1231,11 +1231,7 @@ UNION SELECT b.* FROM
                            ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=1.00 loops=13)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=12.00 loops=1)
@@ -1243,11 +1239,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1.00 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3524,11 +3516,7 @@ UNION SELECT b.* FROM
                                  ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1.00 loops=12)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -3547,11 +3535,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1.00 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -6228,11 +6212,7 @@ UNION SELECT b.* FROM
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -6251,11 +6231,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=1.00 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=1.00 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan-18.out
+++ b/tsl/test/expected/plan_skip_scan-18.out
@@ -1228,11 +1228,7 @@ UNION SELECT b.* FROM
                            ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0.92 loops=13)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=12.00 loops=1)
@@ -1240,11 +1236,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=0.92 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3521,11 +3513,7 @@ UNION SELECT b.* FROM
                                  ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0.92 loops=12)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -3544,11 +3532,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0.92 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -6225,11 +6209,7 @@ UNION SELECT b.* FROM
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -6248,11 +6228,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=0.92 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=0.92 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan-19.out
+++ b/tsl/test/expected/plan_skip_scan-19.out
@@ -1228,11 +1228,7 @@ UNION SELECT b.* FROM
                            ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0.92 loops=13)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=12.00 loops=1)
@@ -1240,11 +1236,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=0.92 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -3521,11 +3513,7 @@ UNION SELECT b.* FROM
                                  ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0.92 loops=12)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -3544,11 +3532,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0.92 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -6225,11 +6209,7 @@ UNION SELECT b.* FROM
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
 --- QUERY PLAN ---
  Unique (actual rows=11.00 loops=1)
@@ -6248,11 +6228,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=0.92 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=0.92 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan_dagg-16.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-16.out
@@ -972,11 +972,7 @@ DEALLOCATE prep;
                            Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -984,11 +980,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1.00 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -2747,11 +2739,7 @@ DEALLOCATE prep;
                                  Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -2770,11 +2758,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1.00 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -4987,11 +4971,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -5010,11 +4990,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=1.00 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=1.00 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan_dagg-17.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-17.out
@@ -972,11 +972,7 @@ DEALLOCATE prep;
                            Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -984,11 +980,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1.00 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -2747,11 +2739,7 @@ DEALLOCATE prep;
                                  Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -2770,11 +2758,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1.00 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -4987,11 +4971,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -5010,11 +4990,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=1.00 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=1.00 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan_dagg-18.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-18.out
@@ -970,11 +970,7 @@ DEALLOCATE prep;
                            Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -982,11 +978,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=0.92 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -2745,11 +2737,7 @@ DEALLOCATE prep;
                                  Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -2768,11 +2756,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0.92 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -4985,11 +4969,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -5008,11 +4988,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=0.92 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=0.92 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/plan_skip_scan_dagg-19.out
+++ b/tsl/test/expected/plan_skip_scan_dagg-19.out
@@ -970,11 +970,7 @@ DEALLOCATE prep;
                            Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -982,11 +978,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
          ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=0.92 loops=13)
                Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -2745,11 +2737,7 @@ DEALLOCATE prep;
                                  Index Cond: (dev > NULL::integer)
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -2768,11 +2756,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0.92 loops=12)
                      Index Cond: (dev > NULL::integer)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -4982,11 +4966,7 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
- set_config 
-------------
- on
-
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
 --- QUERY PLAN ---
  Aggregate (actual rows=1.00 loops=1)
@@ -5005,11 +4985,7 @@ SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 
                ->  Custom Scan (ColumnarScan) on _hyper_2_8_chunk (actual rows=0.92 loops=12)
                      ->  Index Scan using _hyper_2_8_chunk_compressed_dev_val__ts_meta_v2_first_time__idx on _hyper_2_8_chunk_compressed (actual rows=0.92 loops=12)
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
- set_config 
-------------
- off
-
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -358,9 +358,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -611,9 +611,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -882,9 +882,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -1135,9 +1135,9 @@ UNION SELECT b.* FROM
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
@@ -1405,9 +1405,9 @@ UNION SELECT b.* FROM
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
@@ -1651,9 +1651,9 @@ UNION SELECT b.* FROM
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE where val IS NULL;
@@ -2063,9 +2063,9 @@ set enable_seqscan=0;
     LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 SET timescaledb.enable_multikey_skipscan TO false;
 \o :TEST_RESULTS_UNOPTIMIZED
@@ -2143,9 +2143,9 @@ set enable_seqscan=0;
     LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 RESET timescaledb.enable_multikey_skipscan;
 -- compare SkipScan results on table
@@ -2235,9 +2235,9 @@ set enable_seqscan=0;
     LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 SET timescaledb.enable_multikey_skipscan TO false;
 \o :TEST_RESULTS_UNOPTIMIZED
@@ -2315,9 +2315,9 @@ set enable_seqscan=0;
     LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 RESET timescaledb.enable_multikey_skipscan;
 -- compare SkipScan results on hypertable
@@ -2407,9 +2407,9 @@ set enable_seqscan=0;
     LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 SET timescaledb.enable_multikey_skipscan TO false;
 \o :TEST_RESULTS_UNOPTIMIZED
@@ -2487,9 +2487,9 @@ set enable_seqscan=0;
     LATERAL (SELECT DISTINCT ON (status, region, dev) * FROM :TABLE WHERE dev >= a.v) b) c;
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 RESET timescaledb.enable_multikey_skipscan;
 -- compare SkipScan results on compressed hypertable
@@ -2605,10 +2605,10 @@ psql:include/skip_scan_multi_query.sql:86: INFO:  SkipScan used on mskip_scan_st
 psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on mskip_scan_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 \set TABLE mskip_scan_ht
 \o :TEST_RESULTS_OPTIMIZED
@@ -2779,13 +2779,13 @@ psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_4_15_c
 psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_4_16_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_4_13_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_4_14_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_4_15_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_4_16_chunk_mskip_scan_ht_status_region_dev_dev_name_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 \set TABLE mskip_scan_htc
 \o :TEST_RESULTS_OPTIMIZED
@@ -2944,12 +2944,12 @@ psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_5_19_c
 psql:include/skip_scan_multi_query.sql:91: INFO:  SkipScan used on _hyper_5_20_chunk_compressed_status_region_dev_dev_name__ts_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 reset enable_seqscan;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_5_17_chunk_compressed_status_region_dev_dev_name__ts_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_5_18_chunk_compressed_status_region_dev_dev_name__ts_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_5_19_chunk_compressed_status_region_dev_dev_name__ts_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
 psql:include/skip_scan_multi_query.sql:96: INFO:  SkipScan used on _hyper_5_20_chunk_compressed_status_region_dev_dev_name__ts_idx(status NOT NULL, region NOT NULL, dev NOT NULL)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 \o
 RESET timescaledb.debug_skip_scan_info;

--- a/tsl/test/expected/skip_scan_dagg.out
+++ b/tsl/test/expected/skip_scan_dagg.out
@@ -306,9 +306,9 @@ DEALLOCATE prep;
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -499,9 +499,9 @@ DEALLOCATE prep;
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -706,9 +706,9 @@ DEALLOCATE prep;
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -899,9 +899,9 @@ DEALLOCATE prep;
 -- SkipScan into INSERT
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT time) FROM skip_scan_nulls;
@@ -1123,9 +1123,9 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;
@@ -1333,9 +1333,9 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 -- parallel query
 RESET max_parallel_workers_per_gather;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 TRUNCATE skip_scan_insert;
 -- table with only nulls
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE where val IS NULL;

--- a/tsl/test/sql/agg_partials_pushdown.sql
+++ b/tsl/test/sql/agg_partials_pushdown.sql
@@ -108,7 +108,7 @@ SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t 
 SELECT timeCustom t, min(series_0) FROM PUBLIC.testtable2 GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
 
 -- Force parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;
 
@@ -165,7 +165,7 @@ SET cpu_operator_cost = 0;
 SET enable_hashagg = off;
 RESET parallel_setup_cost;
 RESET parallel_tuple_cost;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END, 'off', false);
+SET debug_parallel_query = 'off';
 
 :PREFIX
 SELECT

--- a/tsl/test/sql/cagg.sql
+++ b/tsl/test/sql/cagg.sql
@@ -1511,7 +1511,7 @@ FROM conditions
 GROUP BY 1
 ORDER BY 2 DESC;
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 SET max_parallel_workers_per_gather = 4;
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/sql/include/columnar_index_scan_query.sql
+++ b/tsl/test/sql/include/columnar_index_scan_query.sql
@@ -122,9 +122,9 @@ SELECT * FROM agg_data ORDER BY device;
 SELECT * FROM agg_data ORDER BY device;
 
 -- test parallel queries (not supported with ColumnarIndexScan)
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT device, min(time), max(time) FROM metrics GROUP BY device ORDER BY device;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 
 -- test with UNION ALL (Append node)
 :PREFIX SELECT device, min(time) FROM metrics WHERE device = 'd1' GROUP BY device

--- a/tsl/test/sql/include/skip_scan_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_comp_query.sql
@@ -276,9 +276,9 @@ UNION SELECT b.* FROM
 -- parallel query
 RESET max_parallel_workers_per_gather;
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 
 TRUNCATE skip_scan_insert;
 

--- a/tsl/test/sql/include/skip_scan_dagg_comp_query.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_comp_query.sql
@@ -238,9 +238,9 @@ SELECT compress_chunk(ch) FROM show_chunks('skip_scan_htc') ch;
 -- parallel query
 RESET max_parallel_workers_per_gather;
 
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 
 TRUNCATE skip_scan_insert;
 

--- a/tsl/test/sql/include/skip_scan_dagg_query.sql
+++ b/tsl/test/sql/include/skip_scan_dagg_query.sql
@@ -219,9 +219,9 @@ DEALLOCATE prep;
 :PREFIX INSERT INTO skip_scan_insert(dev, val, query) SELECT dev, sd, 'q10_1' FROM (SELECT sum(DISTINCT dev) sd, dev FROM :TABLE GROUP BY dev) a;
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT count(DISTINCT dev) FROM :TABLE;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 
 TRUNCATE skip_scan_insert;
 

--- a/tsl/test/sql/include/skip_scan_multi_query.sql
+++ b/tsl/test/sql/include/skip_scan_multi_query.sql
@@ -92,6 +92,6 @@ set enable_seqscan=0;
 reset enable_seqscan;
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT status, region, dev FROM :TABLE ORDER BY status, region, dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -273,9 +273,9 @@ UNION SELECT b.* FROM
 :PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
 
 -- parallel query
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+SET debug_parallel_query = 'on';
 :PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
-SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'off', false);
+SET debug_parallel_query = 'off';
 
 TRUNCATE skip_scan_insert;
 

--- a/tsl/test/t/003_mvcc_cagg.pl
+++ b/tsl/test/t/003_mvcc_cagg.pl
@@ -92,7 +92,7 @@ for (my $iteration = 0; $iteration < 10; $iteration++)
 	{
 		# Encourage the use of parallel workers
 		my $sql = q{
-           SELECT set_config(CASE WHEN current_setting('server_version_num')::int < 160000 THEN 'force_parallel_mode' ELSE 'debug_parallel_query' END,'on', false);
+           SET debug_parallel_query = 'on';
            SET enable_bitmapscan = 0;
            SET parallel_setup_cost = 0;
            SET parallel_tuple_cost = 0;


### PR DESCRIPTION
Tests now name the GUC directly instead of picking it at runtime.

PG16 renamed force_parallel_mode to debug_parallel_query, so tests chose the name with set_config() and a CASE on server_version_num. We only support PG16 and up, so the CASE always picked the new name.

Also fix a comment in chunk_append that still called the GUC by its pre-PG16 name.

Disable-check: force-changelog-file