### PR TITLE
Make the tenant unencodable flag per hypertable

### DIFF
--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -66,6 +66,7 @@ typedef struct ContinuousAggsCacheInvalEntry
 	AttrNumber open_dimension_attno;
 	TrackingColumnInfo tenant_col;
 	bool value_is_set;
+	bool tenant_buffer_unencodable;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 } ContinuousAggsCacheInvalEntry;
@@ -136,7 +137,6 @@ static HTAB *continuous_aggs_cache_hyper_inval_threshold_htab = NULL;
 
 /* Per-transaction tenant buffer (drained to shared memory at commit). */
 static HTAB *tenant_local_htab = NULL;
-static bool tenant_buffer_unencodable = false;
 
 /*
  * Generation this backend currently pins, or NULL.  A flush will not drain a
@@ -273,6 +273,7 @@ cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry, int32 hyperta
 		}
 	}
 	cache_entry->value_is_set = false;
+	cache_entry->tenant_buffer_unencodable = false;
 	cache_entry->lowest_modified_value = INVAL_POS_INFINITY;
 	cache_entry->greatest_modified_value = INVAL_NEG_INFINITY;
 	ts_cache_release(&ht_cache);
@@ -322,7 +323,7 @@ continuous_agg_invalidate_range(int32 hypertable_id, Oid chunk_relid, int64 star
 
 	if (tenants_unknown && cache_entry->tenant_col.attno != InvalidAttrNumber)
 	{
-		tenant_buffer_unencodable = true;
+		cache_entry->tenant_buffer_unencodable = true;
 	}
 
 	cache_entry->value_is_set = true;
@@ -479,7 +480,7 @@ resolve_tenant_tracker(int32 hypertable_id)
  * (continuous_agg_record_tenant_from_slot).
  */
 static void
-record_tenant_invalidation_values(const ContinuousAggsCacheInvalEntry *cache_entry, int64 timeval,
+record_tenant_invalidation_values(ContinuousAggsCacheInvalEntry *cache_entry, int64 timeval,
 								  Datum tenant_datum)
 {
 	char *key;
@@ -539,7 +540,7 @@ record_tenant_invalidation_values(const ContinuousAggsCacheInvalEntry *cache_ent
 		/* Cannot key this tenant -> tracking is incomplete for this transaction;
 		 * force the tracker INVALID at commit so the refresh falls back. */
 		pfree(key);
-		tenant_buffer_unencodable = true;
+		cache_entry->tenant_buffer_unencodable = true;
 		return;
 	}
 
@@ -577,7 +578,7 @@ record_tenant_invalidation_values(const ContinuousAggsCacheInvalEntry *cache_ent
  * buffer them for tenant-level invalidation tracking.
  */
 static void
-record_tenant_invalidation(const ContinuousAggsCacheInvalEntry *cache_entry, Relation chunk_rel,
+record_tenant_invalidation(ContinuousAggsCacheInvalEntry *cache_entry, Relation chunk_rel,
 						   HeapTuple tuple)
 {
 	TupleDesc tupdesc = RelationGetDescr(chunk_rel);
@@ -605,7 +606,7 @@ record_tenant_invalidation(const ContinuousAggsCacheInvalEntry *cache_entry, Rel
 		/* A NULL tenant is a valid group but cannot be keyed -> tracking is
 		 * incomplete for this transaction; force the tracker INVALID at commit
 		 * so the refresh falls back. */
-		tenant_buffer_unencodable = true;
+		cache_entry->tenant_buffer_unencodable = true;
 		return;
 	}
 
@@ -646,7 +647,7 @@ continuous_agg_record_tenant_from_slot(int32 hypertable_id, Oid chunk_relid, Tup
 		/* A NULL tenant is a valid group but cannot be keyed -> tracking is
 		 * incomplete for this transaction; force the tracker INVALID at commit
 		 * so the refresh falls back. */
-		tenant_buffer_unencodable = true;
+		cache_entry->tenant_buffer_unencodable = true;
 		return;
 	}
 
@@ -664,12 +665,30 @@ tenant_local_htab_write(void)
 	HASH_SEQ_STATUS hash_seq;
 	TenantLocalEntry *entry;
 	List *hypertable_ids = NIL;
+	List *unencodable_ids = NIL;
 	List *hypertable_seqnums = NIL;
 	ListCell *lc;
 
 	if (tenant_local_htab == NULL)
 	{
 		return NIL;
+	}
+
+	/* Hypertables with a tenant this transaction could not store.  Held per
+	 * chunk entry, so collect the distinct hypertable ids once up front. */
+	{
+		HASH_SEQ_STATUS inval_seq;
+		ContinuousAggsCacheInvalEntry *inval_entry;
+
+		hash_seq_init(&inval_seq, continuous_aggs_cache_inval_htab);
+		while ((inval_entry = hash_seq_search(&inval_seq)) != NULL)
+		{
+			if (inval_entry->tenant_buffer_unencodable)
+			{
+				unencodable_ids =
+					list_append_unique_int(unencodable_ids, inval_entry->hypertable_id);
+			}
+		}
 	}
 
 	/* Distinct hypertables present in the buffer (usually just one). */
@@ -723,7 +742,7 @@ tenant_local_htab_write(void)
 			continue;
 		}
 
-		if (tenant_buffer_unencodable)
+		if (list_member_int(unencodable_ids, hypertable_id))
 		{
 			/* A tenant key could not be stored this transaction; force a
 			 * fall back for this hypertable's tracker (seqnum 0). */
@@ -778,6 +797,7 @@ tenant_local_htab_write(void)
 	}
 
 	list_free(hypertable_ids);
+	list_free(unencodable_ids);
 	return hypertable_seqnums;
 }
 
@@ -930,7 +950,6 @@ cache_inval_cleanup(void)
 	continuous_aggs_cache_inval_htab = NULL;
 	continuous_aggs_cache_hyper_inval_threshold_htab = NULL;
 	tenant_local_htab = NULL;
-	tenant_buffer_unencodable = false;
 	continuous_aggs_invalidation_mctx = NULL;
 };
 

--- a/tsl/test/expected/cagg_granular_refresh_fallback.out
+++ b/tsl/test/expected/cagg_granular_refresh_fallback.out
@@ -230,10 +230,7 @@ WHERE hypertable_id = (
 
 DROP MATERIALIZED VIEW cond_untracked_daily;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_4_14_chunk
-DROP MATERIALIZED VIEW cond_daily;
-NOTICE:  drop cascades to 6 other objects
 DROP TABLE conditions_untracked;
-DROP TABLE conditions;
 -- ============================================================================
 -- Outside the late-arrival window: an invalidation entry disjoint from the
 -- window has no tracking entries behind it, so its seqnum is NULL and the
@@ -353,6 +350,66 @@ SELECT sensor_id, avg FROM readings_daily ORDER BY sensor_id;
  inside_window  |   2
  while_disabled |   4
 
+-- ============================================================================
+-- Two tracked hypertables in one transaction: a tenant that cannot be stored
+-- on one of them must not disturb the other's tracker.  `conditions` is kept
+-- alive past its own sections for this, and 2022-09-01 is inside both
+-- late-arrival windows -- [2019-01-01, today - 1 day] for `conditions` and
+-- [2021-01-01, 2023-01-01) for `readings` -- so both sides are tracked.
+-- ============================================================================
+BEGIN;
+INSERT INTO conditions VALUES ('2022-09-01 00:00+00', 'paired', 10),
+                              ('2022-09-01 00:00+00', NULL, 20);
+INSERT INTO readings VALUES ('2022-09-01 00:00+00', 'paired', 30);
+COMMIT;
+-- conditions: the NULL tenant tripped its generation INVALID, which also
+-- discards the storable tenant buffered alongside it.
+SELECT nentries, status
+FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('conditions'::regclass);
+ nentries | status 
+----------+--------
+        0 |      1
+
+-- readings: unaffected by the other hypertable's failure -- still VALID with
+-- its own tenant tracked.
+SELECT nentries, status
+FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('readings'::regclass);
+ nentries | status 
+----------+--------
+        1 |      0
+
+-- Same split in the log: conditions' entry is untracked (NULL seqnum) and falls
+-- back, readings' entry keeps a live seqnum and stays granular.
+SELECT ca.user_view_name::text AS cagg, l.seqnum IS NOT NULL AS tracked
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log l
+JOIN _timescaledb_catalog.continuous_agg ca ON ca.raw_hypertable_id = l.hypertable_id
+WHERE l.lowest_modified_value =
+      _timescaledb_functions.to_unix_microseconds('2022-09-01 00:00+00'::timestamptz)
+ORDER BY 1;
+      cagg      | tracked 
+----------------+---------
+ cond_daily     | f
+ readings_daily | t
+
+-- Both materialize correctly, one via the fall back and one via the granular path.
+CALL refresh_continuous_aggregate('cond_daily', '2022-09-01 00:00+00', '2022-09-02 00:00+00');
+CALL refresh_continuous_aggregate('readings_daily', '2022-09-01 00:00+00', '2022-09-02 00:00+00');
+SELECT sensor_id, avg FROM cond_daily
+WHERE bucket = '2022-09-01 00:00+00' ORDER BY sensor_id NULLS LAST;
+ sensor_id | avg 
+-----------+-----
+ paired    |  10
+           |  20
+
+SELECT sensor_id, avg FROM readings_daily
+WHERE bucket = '2022-09-01 00:00+00' ORDER BY sensor_id;
+ sensor_id | avg 
+-----------+-----
+ paired    |  30
+
 DROP MATERIALIZED VIEW readings_daily;
 NOTICE:  drop cascades to 4 other objects
+DROP MATERIALIZED VIEW cond_daily;
+NOTICE:  drop cascades to 7 other objects
 DROP TABLE readings;
+DROP TABLE conditions;

--- a/tsl/test/sql/cagg_granular_refresh_fallback.sql
+++ b/tsl/test/sql/cagg_granular_refresh_fallback.sql
@@ -201,9 +201,7 @@ WHERE hypertable_id = (
   AND tenant_id IS NULL;
 
 DROP MATERIALIZED VIEW cond_untracked_daily;
-DROP MATERIALIZED VIEW cond_daily;
 DROP TABLE conditions_untracked;
-DROP TABLE conditions;
 
 -- ============================================================================
 -- Outside the late-arrival window: an invalidation entry disjoint from the
@@ -301,5 +299,47 @@ FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('readings'::regc
 -- Every group is materialized correctly across the disable and re-enable.
 SELECT sensor_id, avg FROM readings_daily ORDER BY sensor_id;
 
+-- ============================================================================
+-- Two tracked hypertables in one transaction: a tenant that cannot be stored
+-- on one of them must not disturb the other's tracker.  `conditions` is kept
+-- alive past its own sections for this, and 2022-09-01 is inside both
+-- late-arrival windows -- [2019-01-01, today - 1 day] for `conditions` and
+-- [2021-01-01, 2023-01-01) for `readings` -- so both sides are tracked.
+-- ============================================================================
+BEGIN;
+INSERT INTO conditions VALUES ('2022-09-01 00:00+00', 'paired', 10),
+                              ('2022-09-01 00:00+00', NULL, 20);
+INSERT INTO readings VALUES ('2022-09-01 00:00+00', 'paired', 30);
+COMMIT;
+
+-- conditions: the NULL tenant tripped its generation INVALID, which also
+-- discards the storable tenant buffered alongside it.
+SELECT nentries, status
+FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('conditions'::regclass);
+
+-- readings: unaffected by the other hypertable's failure -- still VALID with
+-- its own tenant tracked.
+SELECT nentries, status
+FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('readings'::regclass);
+
+-- Same split in the log: conditions' entry is untracked (NULL seqnum) and falls
+-- back, readings' entry keeps a live seqnum and stays granular.
+SELECT ca.user_view_name::text AS cagg, l.seqnum IS NOT NULL AS tracked
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log l
+JOIN _timescaledb_catalog.continuous_agg ca ON ca.raw_hypertable_id = l.hypertable_id
+WHERE l.lowest_modified_value =
+      _timescaledb_functions.to_unix_microseconds('2022-09-01 00:00+00'::timestamptz)
+ORDER BY 1;
+
+-- Both materialize correctly, one via the fall back and one via the granular path.
+CALL refresh_continuous_aggregate('cond_daily', '2022-09-01 00:00+00', '2022-09-02 00:00+00');
+CALL refresh_continuous_aggregate('readings_daily', '2022-09-01 00:00+00', '2022-09-02 00:00+00');
+SELECT sensor_id, avg FROM cond_daily
+WHERE bucket = '2022-09-01 00:00+00' ORDER BY sensor_id NULLS LAST;
+SELECT sensor_id, avg FROM readings_daily
+WHERE bucket = '2022-09-01 00:00+00' ORDER BY sensor_id;
+
 DROP MATERIALIZED VIEW readings_daily;
+DROP MATERIALIZED VIEW cond_daily;
 DROP TABLE readings;
+DROP TABLE conditions;


### PR DESCRIPTION
A tenant key that cannot be stored (a NULL tenant, an empty or oversized key, or a range invalidated without enumerating its tenants) marks the hypertable's tracker INVALID at commit so the refresh falls back to the full invalidation log.

The flag recording that was a single backend-global bool, but the drain consults it once per hypertable it iterates. An unstorable tenant on one hypertable therefore also invalidated every other tracked hypertable written in the same transaction, which lost granular refresh for that generation for no reason.