### PR TITLE
Migrate CI workflows to RunsOn runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,13 @@
 self-hosted-runner:
   labels:
+    # RunsOn fleets (see env/aws-ci/us-east-1/runson/config.yaml in
+    # savannah-infra for the fleet catalog).
+    - runs-on/fleet=linux-2cpu/env=ue1
+    - runs-on/fleet=linux-2cpu-x64/env=ue1
+    - runs-on/fleet=linux-8cpu-x64/env=ue1
+    - runs-on/fleet=linux-8cpu-ubuntu24/env=ue1
+    - runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
+    # Legacy self-hosted runners, still referenced on backport branches.
     - timescaledb-runner-arm64
     - cloud-image-runner-ubuntu-24-arm64
 

--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -201,10 +201,8 @@ m["include"].append(
     )
 )
 
-# Also test on ARM. The custom arm64 runner is only available in the
+# Also test on ARM. The RunsOn arm64 runners are only available in the
 # timescale/timescaledb repository.
-# See the available runners here:
-# https://github.com/timescale/timescaledb/actions/runners
 if os.environ.get("GITHUB_REPOSITORY") == "timescale/timescaledb":
     m["include"].append(
         build_debug_config(
@@ -397,6 +395,24 @@ elif len(sys.argv) > 2:
                     }
                 )
             )
+
+# Map the "os" name of each configuration to a RunsOn (runs-on.com) runner
+# label. The "os" value is kept as a plain name because it is used in job
+# names, cache keys and artifact names, where the slashes and run id of a
+# RunsOn label are not allowed or would break caching.
+RUNS_ON_RUNNERS = {
+    "ubuntu-22.04": "runner=4cpu-linux-x64/image=ubuntu22-full-x64",
+    "ubuntu-24.04": "runner=4cpu-linux-x64/image=ubuntu24-full-x64",
+    "timescaledb-runner-arm64": "runner=4cpu-linux-arm64/image=ubuntu24-full-arm64",
+}
+
+for config in m["include"]:
+    spec = RUNS_ON_RUNNERS.get(config["os"])
+    if spec:
+        config["runner"] = f"runs-on={os.environ.get('GITHUB_RUN_ID', '')}/{spec}"
+    else:
+        # macOS jobs stay on GitHub-hosted runners.
+        config["runner"] = config["os"]
 
 # generate command to set github action variable
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:

--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -396,23 +396,21 @@ elif len(sys.argv) > 2:
                 )
             )
 
-# Map the "os" name of each configuration to a RunsOn (runs-on.com) runner
-# label. The "os" value is kept as a plain name because it is used in job
-# names, cache keys and artifact names, where the slashes and run id of a
-# RunsOn label are not allowed or would break caching.
-RUNS_ON_RUNNERS = {
-    "ubuntu-22.04": "runner=4cpu-linux-x64/image=ubuntu22-full-x64",
-    "ubuntu-24.04": "runner=4cpu-linux-x64/image=ubuntu24-full-x64",
-    "timescaledb-runner-arm64": "runner=4cpu-linux-arm64/image=ubuntu24-full-arm64",
+# Map the "os" name of each configuration to a RunsOn fleet label (see
+# env/aws-ci/us-east-1/runson/config.yaml in savannah-infra for the fleet
+# catalog). The "os" value is kept as a plain name because it is used in job
+# names, cache keys and artifact names, where the slashes of a fleet label
+# are not allowed or would break caching. Note that the fleets run ubuntu
+# 24.04 images; there is no ubuntu 22.04 fleet.
+RUNS_ON_FLEETS = {
+    "ubuntu-22.04": "runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1",
+    "ubuntu-24.04": "runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1",
+    "timescaledb-runner-arm64": "runs-on/fleet=linux-8cpu-ubuntu24/env=ue1",
 }
 
 for config in m["include"]:
-    spec = RUNS_ON_RUNNERS.get(config["os"])
-    if spec:
-        config["runner"] = f"runs-on={os.environ.get('GITHUB_RUN_ID', '')}/{spec}"
-    else:
-        # macOS jobs stay on GitHub-hosted runners.
-        config["runner"] = config["os"]
+    # macOS jobs stay on GitHub-hosted runners.
+    config["runner"] = RUNS_ON_FLEETS.get(config["os"], config["os"])
 
 # generate command to set github action variable
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -20,7 +20,7 @@ name: ABI Test
   workflow_dispatch:
 jobs:
   config:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       pg16_abi_min: ${{ steps.config.outputs.pg16_abi_min }}
       pg17_abi_min: ${{ steps.config.outputs.pg17_abi_min }}
@@ -38,7 +38,7 @@ jobs:
 
   abi_test:
     name: ABI Test PG${{ matrix.pg }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     needs: config
     strategy:
       fail-fast: false

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -20,7 +20,7 @@ name: ABI Test
   workflow_dispatch:
 jobs:
   config:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       pg16_abi_min: ${{ steps.config.outputs.pg16_abi_min }}
       pg17_abi_min: ${{ steps.config.outputs.pg17_abi_min }}
@@ -30,6 +30,8 @@ jobs:
       pg18_latest: ${{ steps.config.outputs.pg18_latest }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Read configuration
@@ -38,7 +40,7 @@ jobs:
 
   abi_test:
     name: ABI Test PG${{ matrix.pg }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
     needs: config
     strategy:
       fail-fast: false
@@ -58,6 +60,8 @@ jobs:
             tester: ${{ fromJson(needs.config.outputs.pg18_latest) }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -34,15 +34,17 @@ jobs:
           - "TSL"
         include:
           - arch: AMD64
-            runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+            runner: runs-on/fleet=linux-2cpu-x64/env=ue1
           - arch: ARM
-            runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+            runner: runs-on/fleet=linux-2cpu/env=ue1
           - image: ubuntu:22.04
             image_friendly: Ubuntu 22.04
 
     runs-on: ${{ matrix.runner }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -15,7 +15,7 @@ name: "Packaging tests: Installcheck for APT"
   workflow_dispatch:
 jobs:
   apt_tests:
-    name: APT ${{ matrix.runner }} ${{ matrix.image }} PG${{ matrix.pg }} ${{ matrix.license }}
+    name: APT ${{ matrix.arch }} ${{ matrix.image }} PG${{ matrix.pg }} ${{ matrix.license }}
     container:
       image: ${{ matrix.image }}
       env:
@@ -23,9 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-latest
-          - timescaledb-runner-arm64
+        arch:
+          - AMD64
+          - ARM
         image:
           - ubuntu:22.04
         pg:
@@ -33,10 +33,10 @@ jobs:
         license:
           - "TSL"
         include:
-          - runner: ubuntu-latest
-            arch: AMD64
-          - runner: timescaledb-runner-arm64
-            arch: ARM
+          - arch: AMD64
+            runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+          - arch: ARM
+            runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
           - image: ubuntu:22.04
             image_friendly: Ubuntu 22.04
 
@@ -147,7 +147,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: Installcheck logs ${{ matrix.runner }} ${{ matrix.image_friendly }} PG ${{ matrix.pg }}
+        name: Installcheck logs ${{ matrix.arch }} ${{ matrix.image_friendly }} PG ${{ matrix.pg }}
         path: |
             postmaster.*
             initdb.log

--- a/.github/workflows/apt-installcheck.yaml
+++ b/.github/workflows/apt-installcheck.yaml
@@ -49,6 +49,13 @@ jobs:
       run: |
         touch /etc/apt/apt-mirrors.txt
         sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -32,11 +32,13 @@ jobs:
           - license: Apache
             pkg_suffix: "-oss"
           - arch: "x86"
-            runner: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64"
+            runner: runs-on/fleet=linux-2cpu-x64/env=ue1
           - arch: "ARM"
-            runner: "runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64"
+            runner: runs-on/fleet=linux-2cpu/env=ue1
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -43,6 +43,13 @@ jobs:
       run: |
         touch /etc/apt/apt-mirrors.txt
         sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -32,9 +32,9 @@ jobs:
           - license: Apache
             pkg_suffix: "-oss"
           - arch: "x86"
-            runner: "ubuntu-latest"
+            runner: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64"
           - arch: "ARM"
-            runner: "cloud-image-runner-ubuntu-24-arm64"
+            runner: "runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64"
 
     steps:
     - name: Replace unreliable Azure APT mirror

--- a/.github/workflows/backport-trigger.yaml
+++ b/.github/workflows/backport-trigger.yaml
@@ -11,8 +11,10 @@ name: Trigger the Backport Workflow
 
 jobs:
   backport_trigger:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout TimescaleDB
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/backport-trigger.yaml
+++ b/.github/workflows/backport-trigger.yaml
@@ -11,7 +11,7 @@ name: Trigger the Backport Workflow
 
 jobs:
   backport_trigger:
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Checkout TimescaleDB
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -26,9 +26,11 @@ permissions:
 jobs:
   backport:
     name: Backport Bug Fixes
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Install Python Dependencies
         run: |
           pip install PyGithub requests

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   backport:
     name: Backport Bug Fixes
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
 
     steps:
       - name: Install Python Dependencies

--- a/.github/workflows/build-deb-artifacts.yaml
+++ b/.github/workflows/build-deb-artifacts.yaml
@@ -22,12 +22,14 @@ permissions:
 jobs:
   dispatch:
     name: Dispatch .deb build
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     env:
       GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
       WORKFLOW_REPO: timescale/release-build-scripts
       WORKFLOW_FILE: timescaledb-apt-tsbench.yml
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compute build inputs

--- a/.github/workflows/build-deb-artifacts.yaml
+++ b/.github/workflows/build-deb-artifacts.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   dispatch:
     name: Dispatch .deb build
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     env:
       GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
       WORKFLOW_REPO: timescale/release-build-scripts

--- a/.github/workflows/catalog-updates-check.yaml
+++ b/.github/workflows/catalog-updates-check.yaml
@@ -8,8 +8,10 @@ name: Check for unsafe catalog updates
 jobs:
   check_catalog_correctly_updated:
     name: Check updates to latest-dev and reverse-dev are properly handled by PR
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/catalog-updates-check.yaml
+++ b/.github/workflows/catalog-updates-check.yaml
@@ -8,7 +8,7 @@ name: Check for unsafe catalog updates
 jobs:
   check_catalog_correctly_updated:
     name: Check updates to latest-dev and reverse-dev are properly handled by PR
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -20,7 +20,7 @@ jobs:
   # Implements: #NNNN <feature description> (mandatory in case of new features)
   check_changelog_file:
     name: Check for file with CHANGELOG entry
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -20,8 +20,10 @@ jobs:
   # Implements: #NNNN <feature description> (mandatory in case of new features)
   check_changelog_file:
     name: Check for file with CHANGELOG entry
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -16,7 +16,7 @@ jobs:
   claude-review:
     if: github.event_name == 'workflow_dispatch'
 
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     permissions:
       contents: read
       pull-requests: read
@@ -24,6 +24,8 @@ jobs:
       id-token: write
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -58,7 +60,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
 
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     permissions:
       contents: read
       pull-requests: read
@@ -68,6 +70,8 @@ jobs:
       actions: read
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -16,7 +16,7 @@ jobs:
   claude-review:
     if: github.event_name == 'workflow_dispatch'
 
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     permissions:
       contents: read
       pull-requests: read
@@ -58,7 +58,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
 
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -18,6 +18,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -9,7 +9,7 @@ name: Coccinelle
 jobs:
   coccinelle:
     name: Coccinelle
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
 
     steps:
     - name: Replace unreliable Azure APT mirror

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -9,9 +9,11 @@ name: Coccinelle
 jobs:
   coccinelle:
     name: Coccinelle
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -9,8 +9,10 @@ name: Code style
 jobs:
   cmake_checks:
     name: Check CMake files
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Install prerequisites
         run: pip install cmakelang
       - name: Checkout source
@@ -24,8 +26,10 @@ jobs:
 
   perl_checks:
     name: Check Perl code in tree
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Install prerequisites
         run: sudo apt install perltidy
       - name: Checkout source
@@ -44,8 +48,10 @@ jobs:
 
   yaml_checks:
     name: Check YAML code in tree
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Install prerequisites
         run: |
           pip install yamllint
@@ -57,11 +63,13 @@ jobs:
 
   workflow_checks:
     name: Check GitHub Actions workflows
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     env:
       ACTIONLINT_VERSION: 1.7.12
       ACTIONLINT_SHA256: 325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install actionlint
@@ -84,8 +92,10 @@ jobs:
 
   spelling_checks:
     name: Check spelling
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Install prerequisites
         run: |
           pip install codespell
@@ -98,12 +108,14 @@ jobs:
 
   cc_checks:
     name: Check code formatting
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     strategy:
       fail-fast: false
     env:
       LLVM_VER: 17
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
@@ -154,10 +166,12 @@ jobs:
 
   clang_tidy:
     name: clang-tidy
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-8cpu-ubuntu24/env=ue1
     env:
       LLVM_VER: 17
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Install Linux Dependencies
       timeout-minutes: 15
       run: |
@@ -235,8 +249,10 @@ jobs:
 
   python_checks:
     name: Check Python code in tree
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Install prerequisites
         run: |
           pip install --upgrade pip
@@ -262,10 +278,12 @@ jobs:
 
   misc_checks:
     name: Check license, update scripts, git hooks, missing gitignore entries and unnecessary template tests
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     strategy:
       fail-fast: false
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Install prerequisites
       if: always()
       run: |

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -9,7 +9,7 @@ name: Code style
 jobs:
   cmake_checks:
     name: Check CMake files
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Install prerequisites
         run: pip install cmakelang
@@ -24,7 +24,7 @@ jobs:
 
   perl_checks:
     name: Check Perl code in tree
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Install prerequisites
         run: sudo apt install perltidy
@@ -44,7 +44,7 @@ jobs:
 
   yaml_checks:
     name: Check YAML code in tree
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Install prerequisites
         run: |
@@ -57,7 +57,7 @@ jobs:
 
   workflow_checks:
     name: Check GitHub Actions workflows
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     env:
       ACTIONLINT_VERSION: 1.7.12
       ACTIONLINT_SHA256: 325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6
@@ -84,7 +84,7 @@ jobs:
 
   spelling_checks:
     name: Check spelling
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Install prerequisites
         run: |
@@ -98,7 +98,7 @@ jobs:
 
   cc_checks:
     name: Check code formatting
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     strategy:
       fail-fast: false
     env:
@@ -154,7 +154,7 @@ jobs:
 
   clang_tidy:
     name: clang-tidy
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     env:
       LLVM_VER: 17
     steps:
@@ -235,7 +235,7 @@ jobs:
 
   python_checks:
     name: Check Python code in tree
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Install prerequisites
         run: |
@@ -262,7 +262,7 @@ jobs:
 
   misc_checks:
     name: Check license, update scripts, git hooks, missing gitignore entries and unnecessary template tests
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -31,7 +31,9 @@ jobs:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
 
       - name: Install prerequisites
-        run: sudo apt install perltidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y perltidy
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check trailing whitespace
@@ -108,7 +110,7 @@ jobs:
 
   cc_checks:
     name: Check code formatting
-    runs-on: runs-on/fleet=linux-2cpu/env=ue1
+    runs-on: runs-on/fleet=linux-8cpu-ubuntu24/env=ue1
     strategy:
       fail-fast: false
     env:
@@ -120,6 +122,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |
@@ -249,7 +258,7 @@ jobs:
 
   python_checks:
     name: Check Python code in tree
-    runs-on: runs-on/fleet=linux-2cpu/env=ue1
+    runs-on: runs-on/fleet=linux-8cpu-ubuntu24/env=ue1
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
 

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -19,7 +19,7 @@ name: "Packaging tests: Docker images"
 jobs:
   docker_tests:
     name: ${{ matrix.image }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     services:
       ts:
         image: timescale/${{ matrix.image }}

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -19,7 +19,7 @@ name: "Packaging tests: Docker images"
 jobs:
   docker_tests:
     name: ${{ matrix.image }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
     services:
       ts:
         image: timescale/${{ matrix.image }}
@@ -47,6 +47,8 @@ jobs:
           ]
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Get version of latest release

--- a/.github/workflows/extras-diagnostic.yaml
+++ b/.github/workflows/extras-diagnostic.yaml
@@ -13,7 +13,7 @@ name: "timescaledb-extras diagnostic"
 jobs:
   diagnostic_test:
     name: timescaledb-extras PG${{ matrix.pg }} nightly
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     services:
       ts:
         image: timescaledev/timescaledb:nightly-pg${{ matrix.pg }}

--- a/.github/workflows/extras-diagnostic.yaml
+++ b/.github/workflows/extras-diagnostic.yaml
@@ -13,7 +13,7 @@ name: "timescaledb-extras diagnostic"
 jobs:
   diagnostic_test:
     name: timescaledb-extras PG${{ matrix.pg }} nightly
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     services:
       ts:
         image: timescaledev/timescaledb:nightly-pg${{ matrix.pg }}
@@ -34,6 +34,8 @@ jobs:
         pg: [16,17,18]
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -13,8 +13,10 @@ jobs:
     # pull requests. To avoid adding pull requests to the bug board,
     # filter out pull requests
     if: ${{ !github.event.issue.pull_request }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Add to bugs board
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
@@ -31,7 +33,7 @@ jobs:
 
   notify-sec:
     name: Notify security channel
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     if: >-
       github.event_name == 'issues' && github.event.action == 'opened' && (
           contains(github.event.issue.labels.*.name, 'segfault') ||
@@ -45,6 +47,8 @@ jobs:
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Post to Security Channel
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
@@ -65,9 +69,11 @@ jobs:
 
   close-issue:
     name: Issue is closed
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     if: github.event_name == 'issues' && github.event.action == 'closed' && contains(github.event.issues.issue.labels.*.name, 'bug')
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: leonsteinhaeuser/project-beta-automations@939000fb1900c9fc4f7b5058a09d9f833ebc6859 # v2.2.1
         with:
           gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
@@ -83,10 +89,12 @@ jobs:
 
   waiting-for-author:
     name: Waiting for Author
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     if: github.event_name == 'issues' && github.event.action == 'labeled'
       && github.event.label.name == 'waiting-for-author'
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: leonsteinhaeuser/project-beta-automations@939000fb1900c9fc4f7b5058a09d9f833ebc6859 # v2.2.1
         with:
           gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
@@ -97,9 +105,11 @@ jobs:
 
   waiting-for-engineering:
     name: Waiting for Engineering
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Replace unreliable Azure APT mirror
         run: |
           sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -114,6 +114,13 @@ jobs:
         run: |
           sudo touch /etc/apt/apt-mirrors.txt
           sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+          # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+          # archive.ubuntu.com throttles concurrent downloads from AWS.
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+            if [ -f "$f" ]; then
+              sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+            fi
+          done
 
       - name: Configure apt retries and timeout
         run: |

--- a/.github/workflows/issue-handling.yaml
+++ b/.github/workflows/issue-handling.yaml
@@ -13,7 +13,7 @@ jobs:
     # pull requests. To avoid adding pull requests to the bug board,
     # filter out pull requests
     if: ${{ !github.event.issue.pull_request }}
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Add to bugs board
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
@@ -31,7 +31,7 @@ jobs:
 
   notify-sec:
     name: Notify security channel
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     if: >-
       github.event_name == 'issues' && github.event.action == 'opened' && (
           contains(github.event.issue.labels.*.name, 'segfault') ||
@@ -65,7 +65,7 @@ jobs:
 
   close-issue:
     name: Issue is closed
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     if: github.event_name == 'issues' && github.event.action == 'closed' && contains(github.event.issues.issue.labels.*.name, 'bug')
     steps:
       - uses: leonsteinhaeuser/project-beta-automations@939000fb1900c9fc4f7b5058a09d9f833ebc6859 # v2.2.1
@@ -83,7 +83,7 @@ jobs:
 
   waiting-for-author:
     name: Waiting for Author
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     if: github.event_name == 'issues' && github.event.action == 'labeled'
       && github.event.label.name == 'waiting-for-author'
     steps:
@@ -97,7 +97,7 @@ jobs:
 
   waiting-for-engineering:
     name: Waiting for Engineering
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     steps:
       - name: Replace unreliable Azure APT mirror

--- a/.github/workflows/label-handling.yaml
+++ b/.github/workflows/label-handling.yaml
@@ -18,7 +18,7 @@ jobs:
   #
   pr-upgrade-requires-restart:
     name: "PR: Ping database team if 'upgrade-requires-restart' label is set"
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     steps:
       - name: "PR: upgrade-requires-restart"
         if: github.event.label.name == 'upgrade-requires-restart'
@@ -42,7 +42,7 @@ jobs:
   #
   issue-add-version-labels-for-bugs:
     name: "Issue: Add TimescaleDB and Postgres version labels"
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
 
     # Only run if the issue has the "bug" label
     if: contains(github.event.issue.labels.*.name, 'bug')

--- a/.github/workflows/label-handling.yaml
+++ b/.github/workflows/label-handling.yaml
@@ -18,8 +18,10 @@ jobs:
   #
   pr-upgrade-requires-restart:
     name: "PR: Ping database team if 'upgrade-requires-restart' label is set"
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: "PR: upgrade-requires-restart"
         if: github.event.label.name == 'upgrade-requires-restart'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -42,7 +44,7 @@ jobs:
   #
   issue-add-version-labels-for-bugs:
     name: "Issue: Add TimescaleDB and Postgres version labels"
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     # Only run if the issue has the "bug" label
     if: contains(github.event.issue.labels.*.name, 'bug')
@@ -51,6 +53,8 @@ jobs:
       issues: write
       
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Extract versions from issue body
         id: extract-versions
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/label-released-prs.yaml
+++ b/.github/workflows/label-released-prs.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   label-release:
     name: Label Released PRs
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     env:
       GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
 

--- a/.github/workflows/label-released-prs.yaml
+++ b/.github/workflows/label-released-prs.yaml
@@ -16,11 +16,13 @@ on:
 jobs:
   label-release:
     name: Label Released PRs
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     env:
       GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Python Dependencies

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -14,7 +14,7 @@ name: Libfuzzer
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu22-full-x64
     name: Build PostgreSQL and TimescaleDB
     env:
       PG_SRC_DIR: pgbuild
@@ -151,7 +151,7 @@ jobs:
             ]
 
     name: Fuzz decompression ${{ matrix.case.algo }} ${{ matrix.case.pgtype }} ${{ matrix.case.bulk && 'bulk' || 'rowbyrow' }}
-    runs-on: ubuntu-22.04
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu22-full-x64
     env:
       PG_SRC_DIR: pgbuild
       PG_INSTALL_DIR: postgresql

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -14,13 +14,15 @@ name: Libfuzzer
 
 jobs:
   build:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu22-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     name: Build PostgreSQL and TimescaleDB
     env:
       PG_SRC_DIR: pgbuild
       PG_INSTALL_DIR: postgresql
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
@@ -151,13 +153,15 @@ jobs:
             ]
 
     name: Fuzz decompression ${{ matrix.case.algo }} ${{ matrix.case.pgtype }} ${{ matrix.case.bulk && 'bulk' || 'rowbyrow' }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu22-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     env:
       PG_SRC_DIR: pgbuild
       PG_INSTALL_DIR: postgresql
       JOB_NAME: Fuzz decompression ${{ matrix.case.algo }} ${{ matrix.case.pgtype }} ${{ matrix.case.bulk && 'bulk' || 'rowbyrow' }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Install Linux dependencies
       timeout-minutes: 15
       run: |

--- a/.github/workflows/libfuzzer.yaml
+++ b/.github/workflows/libfuzzer.yaml
@@ -27,6 +27,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -16,7 +16,7 @@ name: Regression Linux i386
   pull_request:
 jobs:
   config:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       pg_latest: ${{ github.event_name == 'pull_request' && steps.setter.outputs.PG_LATEST_ONLY || steps.setter.outputs.PG_LATEST }}
     steps:
@@ -27,7 +27,7 @@ jobs:
       run: python .github/gh_config_reader.py
 
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -43,7 +43,7 @@ jobs:
   regress:
     if: needs.check_paths.outputs.run_ci == 'true'
     name: PG${{ matrix.pg }} ${{ matrix.build_type }} linux-i386
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     needs: [config, check_paths]
     container:
       image: i386/debian:bookworm-slim@sha256:4d0f3abf8160f14d07208ff72dc4c46882bc5f0a259a8bb8652702c0ee2cc67a
@@ -369,7 +369,7 @@ jobs:
     name: Regression Linux i386 summary
     needs: [check_paths, regress]
     if: always()
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -103,12 +103,19 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
+    # No runs-on/action step here: the i386 container cannot execute the
+    # runner's x64 node binary until the 64-bit libraries below are installed.
     - name: Replace unreliable Azure APT mirror
       run: |
         touch /etc/apt/apt-mirrors.txt
         sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -16,10 +16,12 @@ name: Regression Linux i386
   pull_request:
 jobs:
   config:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       pg_latest: ${{ github.event_name == 'pull_request' && steps.setter.outputs.PG_LATEST_ONLY || steps.setter.outputs.PG_LATEST }}
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Read configuration
@@ -27,13 +29,15 @@ jobs:
       run: python .github/gh_config_reader.py
 
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
           || (steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
          }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -43,7 +47,7 @@ jobs:
   regress:
     if: needs.check_paths.outputs.run_ci == 'true'
     name: PG${{ matrix.pg }} ${{ matrix.build_type }} linux-i386
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
     needs: [config, check_paths]
     container:
       image: i386/debian:bookworm-slim@sha256:4d0f3abf8160f14d07208ff72dc4c46882bc5f0a259a8bb8652702c0ee2cc67a
@@ -99,6 +103,8 @@ jobs:
       fail-fast: false
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         touch /etc/apt/apt-mirrors.txt
@@ -369,8 +375,10 @@ jobs:
     name: Regression Linux i386 summary
     needs: [check_paths, regress]
     if: always()
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - run: |
           # If the detector failed, or the matrix failed, exit with error
           if [[ "${{ needs.regress.result }}" == "failure" ]]; then

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -82,6 +82,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       if: runner.os == 'Linux'

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -16,7 +16,7 @@ name: Regression
   pull_request:
 jobs:
   matrixbuilder:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -35,7 +35,7 @@ jobs:
         fi
 
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -53,7 +53,7 @@ jobs:
     # Change the JOB_NAME variable below when changing the name.
     name: PG${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.name }} ${{ matrix.os }}
     needs: [matrixbuilder, check_paths]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     # The flaky check is advisory, so its failure must not fail the summary.
     continue-on-error: ${{ contains(matrix.name, 'Flaky') }}
 
@@ -429,7 +429,7 @@ jobs:
     name: Regression summary
     needs: [check_paths, regress]
     if: always()
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -16,10 +16,12 @@ name: Regression
   pull_request:
 jobs:
   matrixbuilder:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -35,13 +37,15 @@ jobs:
         fi
 
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
           || (steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
          }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -70,6 +74,9 @@ jobs:
       fail-fast: false
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+      if: runner.environment == 'self-hosted'
+
     - name: Replace unreliable Azure APT mirror
       if: runner.os == 'Linux'
       run: |
@@ -429,8 +436,10 @@ jobs:
     name: Regression summary
     needs: [check_paths, regress]
     if: always()
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - run: |
           # If the detector failed, or the matrix failed, exit with error
           if [[ "${{ needs.regress.result }}" == "failure" ]]; then

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -47,7 +47,7 @@ env:
 
 jobs:
   config:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       have_key: ${{ secrets.ANTHROPIC_API_KEY != '' }}
       pg_latest: ${{ fromJson(steps.setter.outputs.PG18_LATEST) }}
@@ -57,6 +57,8 @@ jobs:
             && steps.filter.outputs.src == 'true') }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -72,7 +74,7 @@ jobs:
   fuzzer:
     if: needs.config.outputs.have_key == 'true' && needs.config.outputs.should_run == 'true'
     name: ${{ matrix.display_name }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-8cpu-ubuntu24/env=ue1
     needs: config
     permissions:
       contents: read
@@ -90,6 +92,8 @@ jobs:
             display_name: "Hypertable ON-OFF"
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -47,7 +47,7 @@ env:
 
 jobs:
   config:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       have_key: ${{ secrets.ANTHROPIC_API_KEY != '' }}
       pg_latest: ${{ fromJson(steps.setter.outputs.PG18_LATEST) }}
@@ -72,7 +72,7 @@ jobs:
   fuzzer:
     if: needs.config.outputs.have_key == 'true' && needs.config.outputs.should_run == 'true'
     name: ${{ matrix.display_name }}
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     needs: config
     permissions:
       contents: read

--- a/.github/workflows/llm-fuzzer.yaml
+++ b/.github/workflows/llm-fuzzer.yaml
@@ -98,6 +98,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/loader_check.yml
+++ b/.github/workflows/loader_check.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check for loader changes
     # Ignore loader changes if acknowledged already
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'upgrade-requires-restart') }}
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,7 +45,7 @@ jobs:
     name: Check if loader versions are incremented for required restart
     # If the label is present, validate the loader version is bumped
     if: ${{ contains(github.event.pull_request.labels.*.name, 'upgrade-requires-restart') }}
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/loader_check.yml
+++ b/.github/workflows/loader_check.yml
@@ -8,8 +8,10 @@ jobs:
     name: Check for loader changes
     # Ignore loader changes if acknowledged already
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'upgrade-requires-restart') }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -45,8 +47,10 @@ jobs:
     name: Check if loader versions are incremented for required restart
     # If the label is present, validate the loader version is bumped
     if: ${{ contains(github.event.pull_request.labels.*.name, 'upgrade-requires-restart') }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -11,13 +11,15 @@ name: Memory tests
 jobs:
   memory_leak:
     name: Memory leak on insert PG${{ matrix.pg }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu22-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     strategy:
       matrix:
         pg: [16, 17, 18]
       fail-fast: false
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -24,6 +24,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -11,7 +11,7 @@ name: Memory tests
 jobs:
   memory_leak:
     name: Memory leak on insert PG${{ matrix.pg }}
-    runs-on: ubuntu-22.04
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu22-full-x64
     strategy:
       matrix:
         pg: [16, 17, 18]

--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -85,6 +85,13 @@ jobs:
       - name: Replace unreliable Azure APT mirror
         run: |
           sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+          # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+          # archive.ubuntu.com throttles concurrent downloads from AWS.
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+            if [ -f "$f" ]; then
+              sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+            fi
+          done
 
       - name: Install Linux Dependencies
         # we want the right version of Postgres for handling any dump file

--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -17,7 +17,7 @@ name: Nightly - Update smoke test on release branch
 
 jobs:
   get-next-version:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       next_version: ${{ steps.fetch.outputs.next_version }}
     steps:
@@ -37,7 +37,7 @@ jobs:
         echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
 
   generate-matrix:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -66,7 +66,7 @@ jobs:
 
   test-version:
     needs: [generate-matrix, get-next-version]
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     strategy:
       # run sequentially
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/nightly_cloud_smoke_test.yaml
+++ b/.github/workflows/nightly_cloud_smoke_test.yaml
@@ -17,10 +17,12 @@ name: Nightly - Update smoke test on release branch
 
 jobs:
   get-next-version:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       next_version: ${{ steps.fetch.outputs.next_version }}
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Get next version
       # Get newest release branch with most recent commits
       id: fetch
@@ -37,10 +39,12 @@ jobs:
         echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
 
   generate-matrix:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Fetch TimescaleDB releases
         id: fetch-releases
         run: |
@@ -66,13 +70,15 @@ jobs:
 
   test-version:
     needs: [generate-matrix, get-next-version]
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     strategy:
       # run sequentially
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 1
       fail-fast: false
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout TimescaleDB
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -7,7 +7,7 @@ name: pg_ladybug
       - ?.*.x
 jobs:
   pg_ladybug:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     env:
       CC: clang-19
       CXX: clang++-19

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -7,7 +7,7 @@ name: pg_ladybug
       - ?.*.x
 jobs:
   pg_ladybug:
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     env:
       CC: clang-19
       CXX: clang++-19
@@ -20,6 +20,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/pg_ladybug.yaml
+++ b/.github/workflows/pg_ladybug.yaml
@@ -7,13 +7,15 @@ name: pg_ladybug
       - ?.*.x
 jobs:
   pg_ladybug:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     env:
       CC: clang-19
       CXX: clang++-19
       LLVM_CONFIG: llvm-config-19
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -9,13 +9,15 @@ name: pg_upgrade test
 
 jobs:
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
           || (steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
          }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -26,7 +28,7 @@ jobs:
     needs: check_paths
     if: needs.check_paths.outputs.run_ci == 'true'
     name: pg_upgrade test from PG${{ matrix.pg_version_old }} to PG${{ matrix.pg_version_new }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     strategy:
       matrix:
         include:
@@ -41,6 +43,8 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/pg_upgrade_test
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Replace unreliable Azure APT mirror
         run: |
           sudo touch /etc/apt/apt-mirrors.txt
@@ -142,8 +146,10 @@ jobs:
     name: pg_upgrade summary
     needs: [check_paths, pg_upgrade_test]
     if: always()
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - run: |
           # If the detector failed, or the matrix failed, exit with error
           if [[ "${{ needs.pg_upgrade_test.result }}" == "failure" ]]; then

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -49,6 +49,13 @@ jobs:
         run: |
           sudo touch /etc/apt/apt-mirrors.txt
           sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+          # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+          # archive.ubuntu.com throttles concurrent downloads from AWS.
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+            if [ -f "$f" ]; then
+              sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+            fi
+          done
 
       - name: Configure apt retries and timeout
         run: |

--- a/.github/workflows/pg_upgrade-test.yaml
+++ b/.github/workflows/pg_upgrade-test.yaml
@@ -9,7 +9,7 @@ name: pg_upgrade test
 
 jobs:
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -26,7 +26,7 @@ jobs:
     needs: check_paths
     if: needs.check_paths.outputs.run_ci == 'true'
     name: pg_upgrade test from PG${{ matrix.pg_version_old }} to PG${{ matrix.pg_version_new }}
-    runs-on: 'ubuntu-latest'
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     strategy:
       matrix:
         include:
@@ -142,7 +142,7 @@ jobs:
     name: pg_upgrade summary
     needs: [check_paths, pg_upgrade_test]
     if: always()
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -9,7 +9,7 @@ name: pgspot
 
 jobs:
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -25,7 +25,7 @@ jobs:
   pgspot:
     needs: check_paths
     if: needs.check_paths.outputs.run_ci == 'true'
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     env:
       # policy_compression, policy_compression_execute and policy_compaction do not have explicit
       # search_path because postgres does not allow it for procedures doing transaction control

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -9,13 +9,15 @@ name: pgspot
 
 jobs:
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
           || (steps.filter.outputs.sql == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
          }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -25,7 +27,7 @@ jobs:
   pgspot:
     needs: check_paths
     if: needs.check_paths.outputs.run_ci == 'true'
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     env:
       # policy_compression, policy_compression_execute and policy_compaction do not have explicit
       # search_path because postgres does not allow it for procedures doing transaction control
@@ -38,6 +40,8 @@ jobs:
         --proc-without-search-path '_timescaledb_functions.policy_compaction(job_id integer,config jsonb)'
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
 
     - name: Setup python 3.13
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/pr-approvals.yaml
+++ b/.github/workflows/pr-approvals.yaml
@@ -12,7 +12,7 @@ name: PR Approval Check
 jobs:
   check_approvals:
     name: Check for sufficient approvals
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-approvals.yaml
+++ b/.github/workflows/pr-approvals.yaml
@@ -12,8 +12,10 @@ name: PR Approval Check
 jobs:
   check_approvals:
     name: Check for sufficient approvals
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -18,15 +18,19 @@ jobs:
 
   assign-pr:
     name: Assign PR to author
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: toshimaru/auto-author-assign@a78a94b219445cece8ccf0d45fec60af449f212a # v3.1.0
 
   ask-review:
     name: Run pull-review
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run pull-review with docker
         env:

--- a/.github/workflows/pr-handling.yaml
+++ b/.github/workflows/pr-handling.yaml
@@ -18,13 +18,13 @@ jobs:
 
   assign-pr:
     name: Assign PR to author
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     steps:
       - uses: toshimaru/auto-author-assign@a78a94b219445cece8ccf0d45fec60af449f212a # v3.1.0
 
   ask-review:
     name: Run pull-review
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.base.ref == 'main' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -18,8 +18,10 @@ jobs:
   # but this is currently not enforced.
   count_commits:
     name: Enforce single commit pull request
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -18,7 +18,7 @@ jobs:
   # but this is currently not enforced.
   count_commits:
     name: Enforce single commit pull request
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
     - name: Checkout source
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/prerelease-sanity.yaml
+++ b/.github/workflows/prerelease-sanity.yaml
@@ -16,10 +16,12 @@ jobs:
   # separate step below.
   config:
     name: Check the configuration
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -65,9 +67,11 @@ jobs:
     name: Check Release Commit
     needs: config
     if: needs.config.outputs.should_run == 'true'
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # GitHub creates an empty merge commit even for fast-forward merges, which

--- a/.github/workflows/prerelease-sanity.yaml
+++ b/.github/workflows/prerelease-sanity.yaml
@@ -16,7 +16,7 @@ jobs:
   # separate step below.
   config:
     name: Check the configuration
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -65,7 +65,7 @@ jobs:
     name: Check Release Commit
     needs: config
     if: needs.config.outputs.should_run == 'true'
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
 
     steps:
     - name: Checkout TimescaleDB

--- a/.github/workflows/release_build_packages.yml
+++ b/.github/workflows/release_build_packages.yml
@@ -6,7 +6,7 @@ name: "Packaging: Build distributions"
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
 
     steps:
     - name: Initialize build summary

--- a/.github/workflows/release_build_packages.yml
+++ b/.github/workflows/release_build_packages.yml
@@ -6,9 +6,11 @@ name: "Packaging: Build distributions"
 
 jobs:
   update:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Initialize build summary
       run: |
         echo "# 📦 Distribution Package Build Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release_feature_freeze_ceremony.yaml
+++ b/.github/workflows/release_feature_freeze_ceremony.yaml
@@ -29,9 +29,11 @@ permissions:
 jobs:
   validate-conditions:
     name: Validate Run Conditions
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -68,12 +70,14 @@ jobs:
 
   release-feature-freeze-ceremony:
     name: Release - Feature Freeze
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     needs: validate-conditions
     environment:
       name: Release Ceremonies
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Replace unreliable Azure APT mirror
         run: |
           sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/release_feature_freeze_ceremony.yaml
+++ b/.github/workflows/release_feature_freeze_ceremony.yaml
@@ -82,6 +82,13 @@ jobs:
         run: |
           sudo touch /etc/apt/apt-mirrors.txt
           sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+          # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+          # archive.ubuntu.com throttles concurrent downloads from AWS.
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+            if [ -f "$f" ]; then
+              sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+            fi
+          done
 
       - name: Configure apt retries and timeout
         run: |

--- a/.github/workflows/release_feature_freeze_ceremony.yaml
+++ b/.github/workflows/release_feature_freeze_ceremony.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   validate-conditions:
     name: Validate Run Conditions
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,7 +68,7 @@ jobs:
 
   release-feature-freeze-ceremony:
     name: Release - Feature Freeze
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     needs: validate-conditions
     environment:
       name: Release Ceremonies

--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -20,9 +20,11 @@ permissions:
 jobs:
   docs:
     name: Post Release Ceremonies
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Generate list of GUCs for docs
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}

--- a/.github/workflows/release_post_release_ceremony.yaml
+++ b/.github/workflows/release_post_release_ceremony.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   docs:
     name: Post Release Ceremonies
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
 
     steps:
       - name: Generate list of GUCs for docs

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -17,7 +17,7 @@ name: "Packaging tests: RPM"
 jobs:
   rpm_tests:
     name: RPM ${{ matrix.image }} PG${{ matrix.pg }} ${{ matrix.license }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     container:
       image: rockylinux/${{ matrix.image }}
     strategy:

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -17,7 +17,7 @@ name: "Packaging tests: RPM"
 jobs:
   rpm_tests:
     name: RPM ${{ matrix.image }} PG${{ matrix.pg }} ${{ matrix.license }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     container:
       image: rockylinux/${{ matrix.image }}
     strategy:
@@ -34,6 +34,8 @@ jobs:
             pg: 18
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Add postgres repositories
       run: "yum install -y \"https://download.postgresql.org/pub/repos/yum/reporpms/\
         EL-$(rpm -E '%{rhel}')-x86_64/pgdg-redhat-repo-latest.noarch.rpm\""

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -87,6 +87,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -56,10 +56,12 @@ env:
   EXTENSIONS: "postgres_fdw test_decoding"
 jobs:
   config:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Read configuration
@@ -70,9 +72,7 @@ jobs:
     # Change the JOB_NAME variable below when changing the name.
     # Don't use the env variable here because the env context is not accessible.
     name: PG${{ matrix.pg }} Sanitizer ${{ matrix.os }}
-    # matrix.os is kept as a plain name for cache keys and artifact names; the
-    # runner image is derived from it here.
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=${{ matrix.os == 'ubuntu-22.04' && 'ubuntu22-full-x64' || 'ubuntu24-full-x64' }}
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     needs: config
     strategy:
       fail-fast: false
@@ -81,6 +81,8 @@ jobs:
         os: ["ubuntu-22.04"]
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -56,7 +56,7 @@ env:
   EXTENSIONS: "postgres_fdw test_decoding"
 jobs:
   config:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
@@ -70,7 +70,9 @@ jobs:
     # Change the JOB_NAME variable below when changing the name.
     # Don't use the env variable here because the env context is not accessible.
     name: PG${{ matrix.pg }} Sanitizer ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    # matrix.os is kept as a plain name for cache keys and artifact names; the
+    # runner image is derived from it here.
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=${{ matrix.os == 'ubuntu-22.04' && 'ubuntu22-full-x64' || 'ubuntu24-full-x64' }}
     needs: config
     strategy:
       fail-fast: false

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -8,13 +8,15 @@ name: Shellcheck
       - ?.*.x
 jobs:
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
           || (steps.filter.outputs.shell == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
          }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -25,9 +27,11 @@ jobs:
     name: Shellcheck
     needs: [check_paths]
     if: needs.check_paths.outputs.run_ci == 'true'
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
@@ -59,8 +63,10 @@ jobs:
     name: Shellcheck summary
     needs: [check_paths, shellcheck]
     if: always()
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - run: |
           # If the detector failed, or the matrix failed, exit with error
           if [[ "${{ needs.shellcheck.result }}" == "failure" ]]; then

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -8,7 +8,7 @@ name: Shellcheck
       - ?.*.x
 jobs:
   check_paths:
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -25,7 +25,7 @@ jobs:
     name: Shellcheck
     needs: [check_paths]
     if: needs.check_paths.outputs.run_ci == 'true'
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
 
     steps:
     - name: Replace unreliable Azure APT mirror
@@ -59,7 +59,7 @@ jobs:
     name: Shellcheck summary
     needs: [check_paths, shellcheck]
     if: always()
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -36,6 +36,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -63,6 +63,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -17,13 +17,15 @@ name: ABI Test Against Snapshot
 
 jobs:
   config:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       pg16_abi_min: ${{ steps.config.outputs.pg16_abi_min }}
       pg17_abi_min: ${{ steps.config.outputs.pg17_abi_min }}
       pg18_abi_min: ${{ steps.config.outputs.pg18_abi_min }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Read configuration
@@ -32,7 +34,7 @@ jobs:
 
   abi_snapshot_test:
     name: ABI Snapshot Test PG${{ matrix.pg }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     needs: config
 
     env:
@@ -55,6 +57,8 @@ jobs:
             abi_min: ${{ fromJson(needs.config.outputs.pg18_abi_min) }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/snapshot-abi.yaml
+++ b/.github/workflows/snapshot-abi.yaml
@@ -17,7 +17,7 @@ name: ABI Test Against Snapshot
 
 jobs:
   config:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       pg16_abi_min: ${{ steps.config.outputs.pg16_abi_min }}
       pg17_abi_min: ${{ steps.config.outputs.pg17_abi_min }}
@@ -32,7 +32,7 @@ jobs:
 
   abi_snapshot_test:
     name: ABI Snapshot Test PG${{ matrix.pg }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     needs: config
 
     env:

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -17,9 +17,7 @@ jobs:
     # Change the JOB_NAME variable below when changing the name.
     # Don't use the env variable here because the env context is not accessible.
     name: SQLsmith PG${{ matrix.pg }}
-    # matrix.os is kept as a plain name for artifact names; the runner image is
-    # derived from it here.
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=${{ matrix.os == 'ubuntu-22.04' && 'ubuntu22-full-x64' || 'ubuntu24-full-x64' }}
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     strategy:
       matrix:
         os: ["ubuntu-24.04"]
@@ -32,6 +30,8 @@ jobs:
       JOB_NAME: SQLsmith PG${{ matrix.pg }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Replace unreliable Azure APT mirror
       run: |
         sudo touch /etc/apt/apt-mirrors.txt

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -17,7 +17,9 @@ jobs:
     # Change the JOB_NAME variable below when changing the name.
     # Don't use the env variable here because the env context is not accessible.
     name: SQLsmith PG${{ matrix.pg }}
-    runs-on: ${{ matrix.os }}
+    # matrix.os is kept as a plain name for artifact names; the runner image is
+    # derived from it here.
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=${{ matrix.os == 'ubuntu-22.04' && 'ubuntu22-full-x64' || 'ubuntu24-full-x64' }}
     strategy:
       matrix:
         os: ["ubuntu-24.04"]

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -36,6 +36,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -8,8 +8,10 @@ name: 'Close stale issues and PRs'
 
 jobs:
   stale:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           stale-issue-message: "

--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -8,7 +8,7 @@ name: 'Close stale issues and PRs'
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -8,7 +8,7 @@ name: Tests should fail on old code
 jobs:
   verify-tests-fail:
     name: Verify tests fail on old code
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
 
     env:
       PG_SRC_DIR: pgbuild

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -84,6 +84,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/tests-fail-on-old-code.yaml
+++ b/.github/workflows/tests-fail-on-old-code.yaml
@@ -8,7 +8,7 @@ name: Tests should fail on old code
 jobs:
   verify-tests-fail:
     name: Verify tests fail on old code
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-8cpu-ubuntu24/env=ue1
 
     env:
       PG_SRC_DIR: pgbuild
@@ -16,6 +16,8 @@ jobs:
       CODE_PATHS: src/ tsl/src/ test/src tsl/test/src sql/
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/trigger-package-tests.yaml
+++ b/.github/workflows/trigger-package-tests.yaml
@@ -14,8 +14,10 @@ on:
 
 jobs:
   trigger_tests:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trigger-package-tests.yaml
+++ b/.github/workflows/trigger-package-tests.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   trigger_tests:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     steps:
 
     - name: Checkout TimescaleDB

--- a/.github/workflows/trigger-prerelease-tests.yaml
+++ b/.github/workflows/trigger-prerelease-tests.yaml
@@ -14,8 +14,10 @@ on:
 
 jobs:
   trigger_tests:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/trigger-prerelease-tests.yaml
+++ b/.github/workflows/trigger-prerelease-tests.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   trigger_tests:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     steps:
 
     - name: Checkout TimescaleDB

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -10,13 +10,15 @@ name: Update and Downgrade
 
 jobs:
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
           || (steps.filter.outputs.src == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
          }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -27,7 +29,7 @@ jobs:
     needs: check_paths
     if: needs.check_paths.outputs.run_ci == 'true'
     name: Update test PG${{ matrix.pg }} ${{ matrix.mode }}
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-8cpu-x64-ubuntu24/env=ue1
     strategy:
       matrix:
         pg: [16, 17, 18]
@@ -37,6 +39,8 @@ jobs:
       PG_VERSION: ${{ matrix.pg }}
       POSTGRES_HOST_AUTH_METHOD: trust
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout TimescaleDB
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -141,8 +145,10 @@ jobs:
     name: Update and Downgrade summary
     needs: [check_paths, update_test]
     if: always()
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - run: |
           # If the detector failed, or the matrix failed, exit with error
           if [[ "${{ needs.update_test.result }}" == "failure" ]]; then

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -48,6 +48,13 @@ jobs:
       run: |
         sudo touch /etc/apt/apt-mirrors.txt
         sudo sed -i.bak -e s,azure.archive.ubuntu,aws.archive.ubuntu,g /etc/apt/apt-mirrors.txt
+        # On RunsOn (AWS) runners, switch to the regional EC2 mirror since
+        # archive.ubuntu.com throttles concurrent downloads from AWS.
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$f" ]; then
+            sudo sed -i.bak -E 's,https?://(archive|security)\.ubuntu\.com/ubuntu,http://'"${RUNS_ON_AWS_REGION:-us-east-1}"'.ec2.archive.ubuntu.com/ubuntu,g' "$f"
+          fi
+        done
 
     - name: Configure apt retries and timeout
       run: |

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -10,7 +10,7 @@ name: Update and Downgrade
 
 jobs:
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -27,7 +27,7 @@ jobs:
     needs: check_paths
     if: needs.check_paths.outputs.run_ci == 'true'
     name: Update test PG${{ matrix.pg }} ${{ matrix.mode }}
-    runs-on: 'ubuntu-latest'
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     strategy:
       matrix:
         pg: [16, 17, 18]
@@ -141,7 +141,7 @@ jobs:
     name: Update and Downgrade summary
     needs: [check_paths, update_test]
     if: always()
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -15,7 +15,7 @@ name: Regression Windows
   workflow_dispatch:
 jobs:
   config:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       build_type: ${{ steps.build_type.outputs.build_type }}
       pg16_latest: ${{ steps.config.outputs.pg16_latest_win }}
@@ -23,6 +23,8 @@ jobs:
       pg18_latest: ${{ steps.config.outputs.pg18_latest_win }}
 
     steps:
+    - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
     - name: Checkout source code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Read configuration
@@ -38,7 +40,7 @@ jobs:
         fi
 
   check_paths:
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -46,6 +48,8 @@ jobs:
          }}
       run_installcheck: ${{ github.event_name == 'push' || steps.filter.outputs.windows-workflow == 'true' }}
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -55,7 +59,7 @@ jobs:
   build:
     # Change the JOB_NAME variable below when changing the name.
     name: PG${{ matrix.versions.pg }} ${{ matrix.build_type }} windows
-    runs-on: runs-on=${{ github.run_id }}/family=m7i/cpu=4/image=windows25-full-x64
+    runs-on: windows-2025
     needs: [config, check_paths]
     if: needs.check_paths.outputs.run_ci == 'true'
     strategy:
@@ -416,8 +420,10 @@ jobs:
     name: Regression Windows summary
     needs: [check_paths, build]
     if: always()
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - run: |
           # If the detector failed, or the matrix failed, exit with error
           if [[ "${{ needs.build.result }}" == "failure" ]]; then

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -15,7 +15,7 @@ name: Regression Windows
   workflow_dispatch:
 jobs:
   config:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       build_type: ${{ steps.build_type.outputs.build_type }}
       pg16_latest: ${{ steps.config.outputs.pg16_latest_win }}
@@ -38,7 +38,7 @@ jobs:
         fi
 
   check_paths:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-full-x64
     outputs:
       run_ci: >-
         ${{ github.event_name == 'push'
@@ -55,7 +55,7 @@ jobs:
   build:
     # Change the JOB_NAME variable below when changing the name.
     name: PG${{ matrix.versions.pg }} ${{ matrix.build_type }} windows
-    runs-on: windows-2025
+    runs-on: runs-on=${{ github.run_id }}/family=m7i/cpu=4/image=windows25-full-x64
     needs: [config, check_paths]
     if: needs.check_paths.outputs.run_ci == 'true'
     strategy:
@@ -416,7 +416,7 @@ jobs:
     name: Regression Windows summary
     needs: [check_paths, build]
     if: always()
-    runs-on: timescaledb-runner-arm64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-full-arm64
     steps:
       - run: |
           # If the detector failed, or the matrix failed, exit with error

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     name: Windows package PG${{ matrix.pg }}
-    runs-on: runs-on=${{ github.run_id }}/family=m7i/cpu=4/image=windows25-full-x64
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     name: Windows package PG${{ matrix.pg }}
-    runs-on: windows-2025
+    runs-on: runs-on=${{ github.run_id }}/family=m7i/cpu=4/image=windows25-full-x64
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What
Lift-and-shift migration of the GitHub Actions workflows to [RunsOn](https://runs-on.com/) **Fleet** runners, following the org convention used in `timescaledb-docker-ha` and documented in savannah-infra (`env/aws-ci/us-east-1/runson/`): every RunsOn job targets an exact fleet label (`runs-on/fleet=<name>/env=ue1`) and starts with the SHA-pinned `runs-on/action` step.

## Mapping

| Job type | Fleet |
|---|---|
| Light orchestration, was x64 (`ubuntu-latest`) | `linux-2cpu-x64` |
| Light orchestration, was arm64 (`timescaledb-runner-arm64`) | `linux-2cpu` |
| Host builds/tests, x64 (regression, sanitizer, sqlsmith, libfuzzer, memory, update/downgrade, pg_upgrade, snapshot-abi) | `linux-8cpu-x64-ubuntu24` |
| Host builds/tests, arm64 (ARM regression, tests-fail-on-old-code, llm-fuzzer, clang-tidy) | `linux-8cpu-ubuntu24` |
| Docker/container-based builds (abi, docker-images, i386 regression) | `linux-8cpu-x64` (default ubuntu26 image; host OS irrelevant) |
| Container package tests (apt/rpm installchecks) | `linux-2cpu` / `linux-2cpu-x64` |
| `windows-2025`, `macos-*` | unchanged — no Windows/macOS fleets exist |

## Notes
- **OS bump:** jobs previously pinned to `ubuntu-22.04` (regression matrix, sanitizer, libfuzzer, memory tests) now build on ubuntu 24.04 — there is no ubuntu 22.04 fleet.
- Matrix `os`/`runner` values that feed job names, cache keys and artifact names stay plain names; `gh_matrix_builder.py` emits the fleet label as a separate `runner` field (macOS configs stay GitHub-hosted, with `runner.environment` guarding the shared `runs-on/action` step). `apt-installcheck` matrix re-keyed on `arch`.
- Fleet labels added to `.github/actionlint.yaml`; legacy self-hosted labels kept for backport branches.
- All fleets are spot capacity (org default, with spot→on-demand circuit breaker). If long required checks prove flaky under spot interruption, individual jobs can move to the `-ondemand` fleets in a follow-up.
- Deliberately **not** done here (follow-ups): native ARM instead of QEMU emulation, per-job right-sizing.

## Prerequisite
The RunsOn (ue1) GitHub App must have repository access to `timescale/timescaledb`, and the `RunsOn` runner group must allow this (public) repository — otherwise jobs queue indefinitely.