### PR TITLE
Add informational views for granular refresh

### DIFF
--- a/.unreleased/pr_10589
+++ b/.unreleased/pr_10589
@@ -1,0 +1,1 @@
+Implements: #10589 Add informational views for granular refresh

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,3 @@
+DROP VIEW IF EXISTS timescaledb_information.hypertable_granular_refresh_settings;
+
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -422,6 +422,15 @@ AS SELECT * FROM timescaledb_information.hypertable_compression_settings;
 CREATE OR REPLACE VIEW timescaledb_information.chunk_columnstore_settings AS
 SELECT * FROM timescaledb_information.chunk_compression_settings;
 
+CREATE OR REPLACE VIEW timescaledb_information.hypertable_granular_refresh_settings AS
+	SELECT
+		format('%I.%I',ht.schema_name,ht.table_name)::regclass AS hypertable,
+		s.granular_refresh_column AS refresh_column,
+		s.granular_refresh_start_offset AS start_offset,
+		s.granular_refresh_end_offset AS end_offset
+	FROM _timescaledb_catalog.hypertable ht
+	INNER JOIN _timescaledb_catalog.hypertable_cagg_settings s ON (s.hypertable_id = ht.id);
+
 -- chunk statistics view
 CREATE OR REPLACE VIEW timescaledb_information.stat_chunk_activity AS
 SELECT

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -126,7 +126,11 @@ SELECT ht.schema_name AS hypertable_schema,
   mat_ht.status & 4 = 4 AS compression_enabled,
   mat_ht.schema_name AS materialization_hypertable_schema,
   mat_ht.table_name AS materialization_hypertable_name,
-  directview.viewdefinition AS view_definition
+  directview.viewdefinition AS view_definition,
+  CASE WHEN cagg.granular_refresh_enabled THEN (
+    SELECT s.granular_refresh_column
+    FROM _timescaledb_catalog.hypertable_cagg_settings s
+    WHERE s.hypertable_id = cagg.raw_hypertable_id) END AS granular_refresh_column
 FROM _timescaledb_catalog.continuous_agg cagg,
   _timescaledb_catalog.hypertable ht,
   LATERAL (

--- a/sql/views_detached.sql
+++ b/sql/views_detached.sql
@@ -68,7 +68,8 @@ SELECT
   NULL::boolean AS compression_enabled,
   NULL::name AS materialization_hypertable_schema,
   NULL::name AS materialization_hypertable_name,
-  NULL::text AS view_definition;
+  NULL::text AS view_definition,
+  NULL::name AS granular_refresh_column;
 
 CREATE OR REPLACE VIEW timescaledb_information.chunks AS
 SELECT

--- a/sql/views_detached.sql
+++ b/sql/views_detached.sql
@@ -176,6 +176,13 @@ SELECT
   NULL::text AS orderby,
   NULL::jsonb AS index;
 
+CREATE OR REPLACE VIEW timescaledb_information.hypertable_granular_refresh_settings AS
+SELECT
+    NULL::regclass AS hypertable,
+    NULL::name AS refresh_column,
+    NULL::text AS start_offset,
+    NULL::text AS end_offset;
+
 DO $$
 BEGIN
   IF EXISTS (SELECT FROM pg_class WHERE relname = 'stat_chunk_activity' AND relkind = 'v') THEN

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -392,8 +392,8 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         classid='pg_catalog.pg_class'::pg_catalog.regclass
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb')
         ORDER BY objid::regclass::text COLLATE "C";
-                          objid                          
----------------------------------------------------------
+                            objid                             
+--------------------------------------------------------------
  _timescaledb_cache.cache_inval_bgw_job
  _timescaledb_cache.cache_inval_extension
  _timescaledb_cache.cache_inval_hypertable
@@ -417,6 +417,7 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  timescaledb_information.dimensions
  timescaledb_information.hypertable_columnstore_settings
  timescaledb_information.hypertable_compression_settings
+ timescaledb_information.hypertable_granular_refresh_settings
  timescaledb_information.hypertables
  timescaledb_information.job_errors
  timescaledb_information.job_history

--- a/tsl/test/expected/cagg.out
+++ b/tsl/test/expected/cagg.out
@@ -2067,6 +2067,7 @@ view_definition                   |  SELECT time_bucket('@ 1 day'::interval, tim
                                   |     sum(humidity) AS sumh                                +
                                   |    FROM conditions                                       +
                                   |   GROUP BY (time_bucket('@ 1 day'::interval, timec));
+granular_refresh_column           | 
 
 \x OFF
 CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);

--- a/tsl/test/expected/cagg_granular_refresh_config.out
+++ b/tsl/test/expected/cagg_granular_refresh_config.out
@@ -37,6 +37,17 @@ ALTER TABLE conditions SET (
     timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
     timescaledb.granular_refresh_end_offset = '1 day'
 );
+-- Check configured settings using the view in `timescaledb_information`
+-- Report window width and end_offset since start_offset varies, but end_offset is constant
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+ window_width_matches | end_offset 
+----------------------+------------
+ t                    | 1 day
+
 CREATE MATERIALIZED VIEW cond_daily
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 day', time) AS bucket, sensor_id, avg(value)
@@ -44,6 +55,15 @@ CREATE MATERIALIZED VIEW cond_daily
   GROUP BY bucket, sensor_id
   WITH NO DATA;
 ALTER MATERIALIZED VIEW cond_daily SET (timescaledb.enable_granular_refresh = true);
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+ window_width_matches | end_offset 
+----------------------+------------
+ t                    | 1 day
+
 -- TEST 1: the tracking window is computed and pinned on the tracker.
 --
 -- The first INSERT creates the tracker and seeds its window.  The window
@@ -62,6 +82,14 @@ FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('conditions');
 
 DROP MATERIALIZED VIEW cond_daily;
 DROP TABLE conditions;
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+ window_width_matches | end_offset 
+----------------------+------------
+
 -- TEST 1b: integer-time hypertables (smallint/int/bigint) use the integer_now()
 -- watermark for the window, with the configured offsets interpreted as plain
 -- integers.  metrics_now() is a constant 1000, and offsets are 900/100, so the
@@ -84,6 +112,14 @@ ALTER TABLE metrics SET (
     timescaledb.granular_refresh_start_offset = 900,
     timescaledb.granular_refresh_end_offset = 100
 );
+SELECT start_offset::bigint - end_offset::bigint = 800 AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'metrics';
+ window_width_matches | end_offset 
+----------------------+------------
+ t                    | 100
+
 CREATE MATERIALIZED VIEW metrics_by_bucket
   WITH (timescaledb.continuous) AS
   SELECT time_bucket(100, t) AS bucket, sensor_id, avg(value)
@@ -101,6 +137,13 @@ FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('metrics');
 
 DROP MATERIALIZED VIEW metrics_by_bucket;
 DROP TABLE metrics;
+SELECT start_offset::bigint - end_offset::bigint = 800 AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'metrics';
+ window_width_matches | end_offset 
+----------------------+------------
+
 -- TEST 2: only late-arriving data (inside the window) is tracked; recent data
 -- (newer than now - 1 day) is gated out at the commit drain, so its tenant
 -- never enters the tracker.
@@ -115,6 +158,15 @@ ALTER TABLE conditions SET (
     timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
     timescaledb.granular_refresh_end_offset = '1 day'
 );
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+ window_width_matches | end_offset 
+----------------------+------------
+ t                    | 1 day
+
 CREATE MATERIALIZED VIEW cond_daily
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 day', time) AS bucket, sensor_id, avg(value)
@@ -164,6 +216,15 @@ ALTER TABLE conditions SET (
     timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
     timescaledb.granular_refresh_end_offset = '1 day'
 );
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+ window_width_matches | end_offset 
+----------------------+------------
+ t                    | 1 day
+
 CREATE MATERIALIZED VIEW cond_daily
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 day', time) AS bucket, sensor_id, avg(value)

--- a/tsl/test/expected/cagg_granular_refresh_config.out
+++ b/tsl/test/expected/cagg_granular_refresh_config.out
@@ -54,7 +54,21 @@ CREATE MATERIALIZED VIEW cond_daily
   FROM conditions
   GROUP BY bucket, sensor_id
   WITH NO DATA;
+SELECT view_name, granular_refresh_column
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'cond_daily';
+ view_name  | granular_refresh_column 
+------------+-------------------------
+ cond_daily | 
+
 ALTER MATERIALIZED VIEW cond_daily SET (timescaledb.enable_granular_refresh = true);
+SELECT view_name, granular_refresh_column
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'cond_daily';
+ view_name  | granular_refresh_column 
+------------+-------------------------
+ cond_daily | sensor_id
+
 SELECT start_offset::interval - end_offset::interval
          = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
        end_offset

--- a/tsl/test/expected/cagg_usage.out
+++ b/tsl/test/expected/cagg_usage.out
@@ -83,6 +83,7 @@ view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, ob
                                   |     (max(metric) - min(metric)) AS metric_spread                            +
                                   |    FROM device_readings                                                     +
                                   |   GROUP BY (time_bucket('@ 1 hour'::interval, observation_time)), device_id;
+granular_refresh_column           | 
 
 \x
 -- Refresh interval

--- a/tsl/test/sql/cagg_granular_refresh_config.sql
+++ b/tsl/test/sql/cagg_granular_refresh_config.sql
@@ -48,7 +48,15 @@ CREATE MATERIALIZED VIEW cond_daily
   GROUP BY bucket, sensor_id
   WITH NO DATA;
 
+SELECT view_name, granular_refresh_column
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'cond_daily';
+
 ALTER MATERIALIZED VIEW cond_daily SET (timescaledb.enable_granular_refresh = true);
+
+SELECT view_name, granular_refresh_column
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'cond_daily';
 
 SELECT start_offset::interval - end_offset::interval
          = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,

--- a/tsl/test/sql/cagg_granular_refresh_config.sql
+++ b/tsl/test/sql/cagg_granular_refresh_config.sql
@@ -33,13 +33,28 @@ ALTER TABLE conditions SET (
     timescaledb.granular_refresh_end_offset = '1 day'
 );
 
+-- Check configured settings using the view in `timescaledb_information`
+-- Report window width and end_offset since start_offset varies, but end_offset is constant
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+
 CREATE MATERIALIZED VIEW cond_daily
   WITH (timescaledb.continuous) AS
   SELECT time_bucket('1 day', time) AS bucket, sensor_id, avg(value)
   FROM conditions
   GROUP BY bucket, sensor_id
   WITH NO DATA;
+
 ALTER MATERIALIZED VIEW cond_daily SET (timescaledb.enable_granular_refresh = true);
+
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
 
 -- TEST 1: the tracking window is computed and pinned on the tracker.
 --
@@ -58,6 +73,12 @@ FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('conditions');
 DROP MATERIALIZED VIEW cond_daily;
 DROP TABLE conditions;
 
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
+
 -- TEST 1b: integer-time hypertables (smallint/int/bigint) use the integer_now()
 -- watermark for the window, with the configured offsets interpreted as plain
 -- integers.  metrics_now() is a constant 1000, and offsets are 900/100, so the
@@ -72,6 +93,11 @@ ALTER TABLE metrics SET (
     timescaledb.granular_refresh_start_offset = 900,
     timescaledb.granular_refresh_end_offset = 100
 );
+
+SELECT start_offset::bigint - end_offset::bigint = 800 AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'metrics';
 
 CREATE MATERIALIZED VIEW metrics_by_bucket
   WITH (timescaledb.continuous) AS
@@ -90,6 +116,11 @@ FROM _timescaledb_functions.hypertable_get_tenant_tracking_info('metrics');
 DROP MATERIALIZED VIEW metrics_by_bucket;
 DROP TABLE metrics;
 
+SELECT start_offset::bigint - end_offset::bigint = 800 AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'metrics';
+
 -- TEST 2: only late-arriving data (inside the window) is tracked; recent data
 -- (newer than now - 1 day) is gated out at the commit drain, so its tenant
 -- never enters the tracker.
@@ -100,6 +131,12 @@ ALTER TABLE conditions SET (
     timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
     timescaledb.granular_refresh_end_offset = '1 day'
 );
+
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
 
 CREATE MATERIALIZED VIEW cond_daily
   WITH (timescaledb.continuous) AS
@@ -145,6 +182,12 @@ ALTER TABLE conditions SET (
     timescaledb.granular_refresh_start_offset = :'granular_refresh_lookback',
     timescaledb.granular_refresh_end_offset = '1 day'
 );
+
+SELECT start_offset::interval - end_offset::interval
+         = (:granular_refresh_lookback_days - 1) * INTERVAL '1 day' AS window_width_matches,
+       end_offset
+FROM timescaledb_information.hypertable_granular_refresh_settings
+WHERE hypertable::text = 'conditions';
 
 CREATE MATERIALIZED VIEW cond_daily
   WITH (timescaledb.continuous) AS


### PR DESCRIPTION
This PR adds a new informational view `timescaledb_information.hypertable_granular_refresh_settings`. 
It also updates the existing `timescaledb_information.continuous_aggregates` view with a `granular_refresh` column.